### PR TITLE
fix: exclude reviewed items from flagged/quarantine queues

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -166,9 +166,9 @@ export default {
       const params = [];
 
       if (actionFilter === 'FLAGGED') {
-        whereClause = "WHERE action IN ('REVIEW', 'AGE_RESTRICTED', 'PERMANENT_BAN')";
+        whereClause = "WHERE action IN ('REVIEW', 'AGE_RESTRICTED', 'PERMANENT_BAN') AND reviewed_by IS NULL";
       } else if (actionFilter === 'QUARANTINE') {
-        whereClause = "WHERE action IN ('AGE_RESTRICTED', 'PERMANENT_BAN')";
+        whereClause = "WHERE action IN ('AGE_RESTRICTED', 'PERMANENT_BAN') AND reviewed_by IS NULL";
       } else if (actionFilter !== 'all') {
         whereClause = 'WHERE action = ?';
         params.push(actionFilter.toUpperCase());


### PR DESCRIPTION
## Summary

- The FLAGGED and QUARANTINE video queries in `/admin/api/videos` returned items already human-reviewed, causing banned/approved videos to reappear in the swipe review queue after page refresh.
- Adds `AND reviewed_by IS NULL` to both query filters.
- AI pipeline inserts leave `reviewed_by` as NULL. The `/admin/api/moderate` endpoint sets it to `'admin'` on review.

Reported by Aleysha on Feb 28: "the ban action is not working. It says that it is, but when I refresh the page, it is the same videos pending moderation."

## Plan

1. Deploy to production
2. Verify in swipe review UI
3. Mark PR as ready for review

## Test plan

- [x] Deploy to production (`wrangler deploy`)
- [x] Open swipe review queue, ban a video, refresh page. Video should not reappear.
- [x] Approve a video, refresh. Video should not reappear.
- [x] Age-restrict a video, refresh. Video should not reappear.
- [x] Dashboard `/admin` stats still show correct counts (uses separate queries).
- [x] Mark PR ready for review