### PR TITLE
Guard notifyBlossom() against internal classification actions

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -2341,6 +2341,16 @@ async function notifyBlossom(sha256, action, env) {
     return { success: true, skipped: true };
   }
 
+  // Only forward actions that Blossom understands. Blossom has four states
+  // (Active/Restricted/Pending/Banned) and returns 400 for unrecognized actions.
+  // REVIEW and QUARANTINE are internal classification tiers; content in those
+  // states stays publicly accessible (equivalent to Blossom's Pending).
+  const blossomActions = ['SAFE', 'AGE_RESTRICTED', 'PERMANENT_BAN'];
+  if (!blossomActions.includes(action)) {
+    console.log(`[BLOSSOM] Skipping notification for internal action: ${action}`);
+    return { success: true, skipped: true };
+  }
+
   try {
     const headers = {
       'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary

`notifyBlossom()` was sending all classification actions to Blossom's `/admin/moderate` webhook, but Blossom only understands three actions: SAFE, AGE_RESTRICTED, and PERMANENT_BAN. It returns 400 for REVIEW and QUARANTINE, causing silent failures on every video classified into those tiers.

Now guards inside the function to only forward actions Blossom recognizes. REVIEW and QUARANTINE are internal classification tiers; content in those states stays publicly accessible (equivalent to Blossom's Pending state).

Closes #15
Parent epic: divinevideo/support-trust-safety#101

## Deploy and verify

- [x] Deployed to production
- [x] Worker healthy, no errors in logs
- [x] No 400s from Blossom for REVIEW/QUARANTINE (guard prevents the call)
- [x] SAFE/AGE_RESTRICTED/PERMANENT_BAN path unchanged
- [x] Mark PR ready for review