### PR TITLE
fix: accept any video URL format, wire Osprey ban pipeline

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -11,6 +11,8 @@ import { requireAuth, getAuthenticatedUser } from './admin/auth.mjs';
 import { verifyZeroTrustJWT } from './admin/zerotrust.mjs';
 import { fetchNostrEventBySha256, parseVideoEventMetadata } from './nostr/relay-client.mjs';
 import { pollRelayForVideos, getLastPollTimestamp, setLastPollTimestamp, getPollingStatus } from './nostr/relay-poller.mjs';
+import { getPublicKey } from 'nostr-tools/pure';
+import { hexToBytes, bytesToHex } from '@noble/hashes/utils';
 import dashboardHTML from './admin/dashboard.html';
 import swipeReviewHTML from './admin/swipe-review.html';
 import { initReportsTable, addReport } from './reports.mjs';
@@ -361,7 +363,7 @@ export default {
             thumbnailUrl: row.thumbnail_url,
             receivedAt: row.received_at,
             status: 'UNTRIAGED',
-            cdnUrl: `https://${env.CDN_DOMAIN}/${row.sha256}.mp4`,
+            cdnUrl: `https://${env.CDN_DOMAIN}/${row.sha256}`,
             nostrContext: {
               title: nostr.title,
               author: nostr.author,
@@ -869,6 +871,22 @@ export default {
       console.log(`[ADMIN] Thresholds reset to defaults`);
 
       return new Response(JSON.stringify({ success: true, thresholds: DEFAULT_THRESHOLDS, source: 'defaults' }), {
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+
+    // Get moderation service's Nostr pubkey (for adding to relay ADMIN_PUBKEYS)
+    if (url.pathname === '/admin/api/nostr-pubkey') {
+      const authError = await requireAuth(request, env);
+      if (authError) return authError;
+
+      if (!env.NOSTR_PRIVATE_KEY) {
+        return new Response(JSON.stringify({ error: 'NOSTR_PRIVATE_KEY not configured' }), {
+          status: 500, headers: { 'Content-Type': 'application/json' }
+        });
+      }
+      const pubkey = bytesToHex(getPublicKey(hexToBytes(env.NOSTR_PRIVATE_KEY)));
+      return new Response(JSON.stringify({ pubkey, note: 'Add this to ADMIN_PUBKEYS on the funnelcake relay' }), {
         headers: { 'Content-Type': 'application/json' }
       });
     }

--- a/src/moderation/pipeline.mjs
+++ b/src/moderation/pipeline.mjs
@@ -32,7 +32,7 @@ export async function classifyVideoOnly(sha256, env, options = {}) {
   }
 
   // Resolve video URL — use explicit URL, or try Nostr metadata, fall back to CDN
-  let videoUrl = options.videoUrl || `https://${env.CDN_DOMAIN}/${sha256}.mp4`;
+  let videoUrl = options.videoUrl || `https://${env.CDN_DOMAIN}/${sha256}`;
   if (!options.videoUrl) {
     try {
       const relays = env.NOSTR_RELAY_URL ? [env.NOSTR_RELAY_URL] : ['wss://relay.divine.video'];
@@ -125,7 +125,7 @@ export async function moderateVideo(videoData, env, fetchFn = fetch) {
 
   // Step 1: Determine video URL - prefer metadata.videoUrl if provided (e.g., from relay-poller)
   let nostrContext = null;
-  let videoUrl = metadata?.videoUrl || `https://${env.CDN_DOMAIN}/${sha256}.mp4`; // Default fallback
+  let videoUrl = metadata?.videoUrl || `https://${env.CDN_DOMAIN}/${sha256}`; // Default: blossom content-addressed URL
   let nostrEventId = metadata?.eventId || null;
 
   // If we don't have a video URL from metadata, try to fetch from Nostr relay

--- a/src/moderation/pipeline.test.mjs
+++ b/src/moderation/pipeline.test.mjs
@@ -130,7 +130,7 @@ describe('Moderation Pipeline', () => {
     // Check that Sightengine was called with correct URL (URL encoded)
     const callUrl = mockFetch.mock.calls[0][0];
     const decodedUrl = decodeURIComponent(callUrl);
-    expect(decodedUrl).toContain(`https://cdn.divine.video/${sha256}.mp4`);
+    expect(decodedUrl).toContain(`https://cdn.divine.video/${sha256}`);
   });
 
   it('should include metadata in result', async () => {

--- a/src/nostr/relay-client.mjs
+++ b/src/nostr/relay-client.mjs
@@ -211,10 +211,10 @@ export function parseVideoEventMetadata(event) {
         break;
       case 'imeta':
         // Extract URL from imeta tag - format: "url https://..."
-        // This is the ACTUAL video file URL (e.g., cdn.divine.video)
+        // Blossom URLs use content-addressed hashes without file extensions
         for (let i = 1; i < tag.length; i++) {
           const param = tag[i];
-          if (param && param.startsWith('url ') && param.includes('.mp4')) {
+          if (param && param.startsWith('url ') && param.length > 4) {
             metadata.url = param.substring(4).trim();
             break;
           }

--- a/src/nostr/relay-poller.mjs
+++ b/src/nostr/relay-poller.mjs
@@ -246,24 +246,37 @@ function extractVideoUrlFromEvent(event, env) {
     return null;
   }
 
-  // Check 'r' tags for video URL
+  // Check imeta tag for URL first (most reliable — includes mime type context)
   for (const tag of event.tags) {
-    if (tag[0] === 'r' && tag[1]) {
-      const url = tag[1];
-      if (url.includes('.mp4') || url.includes('/video/')) {
-        return url;
+    if (tag[0] === 'imeta') {
+      let imetaUrl = null;
+      let isVideo = false;
+      for (let i = 1; i < tag.length; i++) {
+        const param = tag[i];
+        if (param && param.startsWith('url ')) {
+          imetaUrl = param.substring(4).trim();
+        }
+        if (param && (param.startsWith('m video/') || param === 'm video/mp4')) {
+          isVideo = true;
+        }
+      }
+      // Accept if URL looks like video or mime says video
+      if (imetaUrl && (isVideo || imetaUrl.includes('.mp4') || imetaUrl.includes('/video/'))) {
+        return imetaUrl;
+      }
+      // For kind 34236 (video events), accept any imeta URL — it's already a video event
+      if (imetaUrl) {
+        return imetaUrl;
       }
     }
   }
 
-  // Check imeta tag for URL
+  // Check 'r' tags for video URL (blossom URLs may not have .mp4 extension)
   for (const tag of event.tags) {
-    if (tag[0] === 'imeta') {
-      for (let i = 1; i < tag.length; i++) {
-        const param = tag[i];
-        if (param && param.startsWith('url ')) {
-          return param.substring(4).trim();
-        }
+    if (tag[0] === 'r' && tag[1]) {
+      const url = tag[1];
+      if (url.startsWith('http')) {
+        return url;
       }
     }
   }
@@ -271,7 +284,7 @@ function extractVideoUrlFromEvent(event, env) {
   // Fallback: construct URL from SHA256
   const sha256 = extractSha256FromImeta(event);
   if (sha256 && env.CDN_DOMAIN) {
-    return `https://${env.CDN_DOMAIN}/${sha256}.mp4`;
+    return `https://${env.CDN_DOMAIN}/${sha256}`;
   }
 
   return null;

--- a/src/nostr/relay-poller.test.mjs
+++ b/src/nostr/relay-poller.test.mjs
@@ -111,6 +111,34 @@ describe('Relay Poller - SHA256 Extraction', () => {
 });
 
 describe('Relay Poller - Video URL Extraction', () => {
+  // Helper that mirrors the extractVideoUrlFromEvent logic
+  function extractVideoUrlFromEvent(event, env = {}) {
+    if (!event || !event.tags) return null;
+
+    // Check imeta tag for URL first (most reliable)
+    for (const tag of event.tags) {
+      if (tag[0] === 'imeta') {
+        let imetaUrl = null;
+        for (let i = 1; i < tag.length; i++) {
+          const param = tag[i];
+          if (param && param.startsWith('url ')) {
+            imetaUrl = param.substring(4).trim();
+          }
+        }
+        if (imetaUrl) return imetaUrl;
+      }
+    }
+
+    // Check r tags (any http URL)
+    for (const tag of event.tags) {
+      if (tag[0] === 'r' && tag[1] && tag[1].startsWith('http')) {
+        return tag[1];
+      }
+    }
+
+    return null;
+  }
+
   it('should extract video URL from r tag', () => {
     const event = {
       tags: [
@@ -119,17 +147,7 @@ describe('Relay Poller - Video URL Extraction', () => {
       ]
     };
 
-    let url = null;
-    for (const tag of event.tags) {
-      if (tag[0] === 'r' && tag[1]) {
-        const candidate = tag[1];
-        if (candidate.includes('.mp4') || candidate.includes('/video/')) {
-          url = candidate;
-          break;
-        }
-      }
-    }
-
+    const url = extractVideoUrlFromEvent(event);
     expect(url).toBe('https://cdn.divine.video/test.mp4');
   });
 
@@ -140,20 +158,43 @@ describe('Relay Poller - Video URL Extraction', () => {
       ]
     };
 
-    let url = null;
-    for (const tag of event.tags) {
-      if (tag[0] === 'imeta') {
-        for (let i = 1; i < tag.length; i++) {
-          const param = tag[i];
-          if (param && param.startsWith('url ')) {
-            url = param.substring(4).trim();
-            break;
-          }
-        }
-      }
-    }
-
+    const url = extractVideoUrlFromEvent(event);
     expect(url).toBe('https://cdn.divine.video/video123.mp4');
+  });
+
+  it('should extract blossom URL without file extension from imeta', () => {
+    const event = {
+      tags: [
+        ['imeta', 'url https://blossom.example.com/abcdef1234567890', 'm video/mp4', 'x abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890']
+      ]
+    };
+
+    const url = extractVideoUrlFromEvent(event);
+    expect(url).toBe('https://blossom.example.com/abcdef1234567890');
+  });
+
+  it('should extract blossom URL without file extension from r tag', () => {
+    const event = {
+      tags: [
+        ['r', 'https://blossom.other.server/abcdef1234567890'],
+        ['title', 'External Video']
+      ]
+    };
+
+    const url = extractVideoUrlFromEvent(event);
+    expect(url).toBe('https://blossom.other.server/abcdef1234567890');
+  });
+
+  it('should prefer imeta URL over r tag URL', () => {
+    const event = {
+      tags: [
+        ['r', 'https://old.server.com/video'],
+        ['imeta', 'url https://blossom.server.com/abc123', 'm video/mp4', 'x abc123']
+      ]
+    };
+
+    const url = extractVideoUrlFromEvent(event);
+    expect(url).toBe('https://blossom.server.com/abc123');
   });
 });
 


### PR DESCRIPTION
## Summary
- **Remove .mp4 extension requirement** from video URL extraction — blossom servers use content-addressed URLs without file extensions, so videos from non-CDN servers were silently dropped and never sent to HiveAI for moderation
- **Add `/admin/api/nostr-pubkey` endpoint** for labeling the moderation service pubkey in Osprey
- **CDN fallback URLs** now use `/{sha256}` instead of `/{sha256}.mp4`

## Companion changes (already pushed)
- **osprey** (2ff1de8): new SML rule for AI-flagged content, fix relay_manager_sink endpoint/payload, fix nostr-kafka-bridge report_reason parsing
- **divine-iac-coreconfig** (676c72f): fix DIVINE_RELAY_MANAGER_URL to point to Cloudflare Worker

## Test plan
- [x] All 247 tests pass
- [ ] Deploy and verify videos from non-CDN blossom servers get moderated
- [ ] Moderate an AI video → verify NIP-56 published → Osprey processes → event banned
- [ ] Label moderation service pubkey via `/admin/api/nostr-pubkey`

🤖 Generated with [Claude Code](https://claude.com/claude-code)