### PR TITLE
Split moderation API and admin hosts

### DIFF
--- a/ADMIN_DASHBOARD_SUMMARY.md
+++ b/ADMIN_DASHBOARD_SUMMARY.md
@@ -36,7 +36,7 @@ wrangler secret put ADMIN_PASSWORD_HASH
 wrangler deploy
 ```
 
-Done! Access at: `https://your-worker.workers.dev/admin`
+Done! Access at: `https://moderation.admin.divine.video/admin`
 
 ## Files Created
 

--- a/ADMIN_SETUP.md
+++ b/ADMIN_SETUP.md
@@ -67,10 +67,10 @@ wrangler deploy
 Once deployed, access the dashboard at:
 
 ```
-https://divine-moderation-service.your-account.workers.dev/admin
+https://moderation.admin.divine.video/admin
 ```
 
-Or your custom domain if configured.
+For local development, use your Wrangler dev URL instead.
 
 ### Login
 

--- a/CDN_INTEGRATION.md
+++ b/CDN_INTEGRATION.md
@@ -514,7 +514,7 @@ wrangler tail divine-moderation-service
 
 ```bash
 # Check moderation result
-curl https://your-cdn.workers.dev/check-result/abc123...
+curl https://moderation-api.divine.video/check-result/abc123...
 
 # Or use wrangler
 wrangler kv:key get --namespace-id=eee0... "moderation:abc123..."

--- a/CLOUDFLARE_ACCESS_SETUP.md
+++ b/CLOUDFLARE_ACCESS_SETUP.md
@@ -1,6 +1,6 @@
 # Cloudflare Access Setup
 
-This protects `admin.divine.video` and `*.admin.divine.video` with Cloudflare Access, allowing only `@divine.video` email addresses.
+This protects `moderation.admin.divine.video` with Cloudflare Access, allowing only `@divine.video` email addresses.
 
 ## Quick Setup
 
@@ -29,13 +29,12 @@ export CLOUDFLARE_API_TOKEN="your-api-token-here"
 
 ## What This Does
 
-1. **Creates an Access Application** for `admin.divine.video` (and all subdomains)
+1. **Creates an Access Application** for `moderation.admin.divine.video`
 2. **Creates an Access Policy** that allows all `@divine.video` email addresses
 3. Configures 24-hour session duration
 
-**Protected domains:**
-- `https://admin.divine.video`
-- `https://*.admin.divine.video` (any subdomain)
+**Protected domain:**
+- `https://moderation.admin.divine.video`
 
 ## After Running the Script
 
@@ -56,11 +55,11 @@ Or add:
 
 ### Set Up DNS
 
-Point `admin.divine.video` to your admin application:
+Point `moderation.admin.divine.video` to your admin application:
 
 ```bash
 # If using Cloudflare Workers:
-# Add a CNAME record: admin.divine.video → divine-moderation-service.protestnet.workers.dev
+# Add a route/CNAME for moderation.admin.divine.video to this worker
 
 # Or if using a custom origin server:
 # Add an A/AAAA record pointing to your server
@@ -68,7 +67,7 @@ Point `admin.divine.video` to your admin application:
 
 ### Test It
 
-1. Visit: https://admin.divine.video
+1. Visit: https://moderation.admin.divine.video/admin
 2. You'll be redirected to Cloudflare Access login
 3. Enter your `@divine.video` email
 4. Verify with the code sent to your email
@@ -76,8 +75,8 @@ Point `admin.divine.video` to your admin application:
 
 ## Other Domains (Not Protected)
 
-Only `admin.divine.video` and its subdomains are protected. Your other services remain publicly accessible:
-- `divine-moderation-service.protestnet.workers.dev` - Public moderation API
+Only `moderation.admin.divine.video` is protected. Your other services remain publicly accessible:
+- `moderation-api.divine.video` - Public and service-facing moderation API
 - `cdn.divine.video` - Public video CDN
 
 ## Optional: Remove Old Auth System

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ wrangler kv:namespace create MODERATION_KV
 wrangler queues create video-moderation-queue
 
 # Set secrets
+wrangler secret put SERVICE_API_TOKEN         # Bearer token for moderation-api.divine.video
 wrangler secret put CF_ACCESS_CLIENT_ID        # Cloudflare Access service token ID
 wrangler secret put CF_ACCESS_CLIENT_SECRET    # Cloudflare Access service token secret
 wrangler secret put SIGHTENGINE_API_USER
@@ -65,6 +66,10 @@ wrangler secret put FARO_RELAY_URL
 # Deploy
 wrangler deploy
 ```
+
+Production hostnames:
+- `https://moderation-api.divine.video` for public and service-facing API routes
+- `https://moderation.admin.divine.video` for the admin dashboard behind Cloudflare Access
 
 ### Configuration
 

--- a/docs/funnelcake-agent-briefing.md
+++ b/docs/funnelcake-agent-briefing.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-02-27
 **Service:** `divine-moderation-service` (Cloudflare Worker, deployed)
-**Base URL:** `https://moderation.admin.divine.video`
+**Base URL:** `https://moderation-api.divine.video`
 
 ---
 
@@ -18,7 +18,7 @@ The divine-moderation-service now produces three layers of classification data f
 
 Pre-formatted for gorse/funnelcake. Returns labels, features, description, and safety info in one call.
 
-**Auth:** Cloudflare Zero Trust JWT (`cf-access-client-id` + `cf-access-client-secret` headers), or set `ALLOW_DEV_ACCESS=true` on the worker for local dev.
+**Auth:** `Authorization: Bearer $SERVICE_API_TOKEN`. Requests forwarded through Cloudflare Access may also use `cf-access-jwt-assertion`. For local dev, set `ALLOW_DEV_ACCESS=true`.
 
 **Response:**
 ```json
@@ -221,13 +221,12 @@ When funnelcake sees a new kind 34236 video event on `wss://relay.divine.video`:
 
 ## Authentication
 
-All `/api/v1/*` endpoints (except `/check-result`) require Cloudflare Zero Trust JWT.
+All `/api/v1/*` endpoints (except `/check-result`) require a bearer token or a Cloudflare Access JWT.
 
-For service-to-service auth, use a Cloudflare Access service token:
+For service-to-service auth, use the worker's bearer token:
 ```bash
-curl -H "cf-access-client-id: $CF_CLIENT_ID" \
-     -H "cf-access-client-secret: $CF_CLIENT_SECRET" \
-     "https://moderation.admin.divine.video/api/v1/classifier/{sha256}/recommendations"
+curl -H "Authorization: Bearer $SERVICE_API_TOKEN" \
+     "https://moderation-api.divine.video/api/v1/classifier/{sha256}/recommendations"
 ```
 
 For local development with `ALLOW_DEV_ACCESS=true`:

--- a/docs/funnelcake-gorse-integration.md
+++ b/docs/funnelcake-gorse-integration.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-02-27
 **Service:** `divine-moderation-service` (Cloudflare Worker)
-**Base URL:** `https://moderation.admin.divine.video`
+**Base URL:** `https://moderation-api.divine.video`
 
 ---
 
@@ -12,13 +12,12 @@
 
 **Purpose:** Returns full Hive AI classifier data for a video — all 75+ moderation classes with per-frame confidence scores, scene classification (IAB categories), and VTT topic extraction.
 
-**Authentication:** Cloudflare Zero Trust JWT (`cf-access-jwt-assertion` header). In dev, set `ALLOW_DEV_ACCESS=true`.
+**Authentication:** `Authorization: Bearer $SERVICE_API_TOKEN`. Requests forwarded through Cloudflare Access may also use `cf-access-jwt-assertion`. In dev, set `ALLOW_DEV_ACCESS=true`.
 
 ```bash
 # Production
-curl -H "cf-access-client-id: $CF_CLIENT_ID" \
-     -H "cf-access-client-secret: $CF_CLIENT_SECRET" \
-     "https://moderation.admin.divine.video/api/v1/classifier/abc123def456..."
+curl -H "Authorization: Bearer $SERVICE_API_TOKEN" \
+     "https://moderation-api.divine.video/api/v1/classifier/abc123def456..."
 
 # Development
 curl "http://localhost:8787/api/v1/classifier/abc123def456..."
@@ -92,7 +91,8 @@ curl "http://localhost:8787/api/v1/classifier/abc123def456..."
 **Purpose:** Returns classification data pre-formatted for recommendation systems.
 
 ```bash
-curl "https://moderation.admin.divine.video/api/v1/classifier/abc123.../recommendations"
+curl -H "Authorization: Bearer $SERVICE_API_TOKEN" \
+     "https://moderation-api.divine.video/api/v1/classifier/abc123.../recommendations"
 ```
 
 **Response (200):**
@@ -124,7 +124,7 @@ curl "https://moderation.admin.divine.video/api/v1/classifier/abc123.../recommen
 **Purpose:** Returns the moderation action and safety scores. No auth required.
 
 ```bash
-curl "https://moderation.admin.divine.video/check-result/abc123def456..."
+curl "https://moderation-api.divine.video/check-result/abc123def456..."
 ```
 
 **Response (200):**

--- a/docs/trust-safety-report.md
+++ b/docs/trust-safety-report.md
@@ -233,7 +233,7 @@ Pre-formatted classification data for recommendation systems. Includes:
 Paginated list of moderation decisions. Useful for bulk audit/export.
 
 ### `GET /check-result/{sha256}` (public)
-Quick safety check — returns action, scores, and moderation status.
+Quick safety check — returns action, scores, and moderation status from `https://moderation-api.divine.video/check-result/{sha256}`.
 
 ---
 

--- a/scripts/backfill-moderation.mjs
+++ b/scripts/backfill-moderation.mjs
@@ -10,6 +10,10 @@ import path from 'path';
 
 const CHECKPOINT_FILE = '.backfill-checkpoint.json';
 
+function getApiToken(options = {}) {
+  return options.apiToken || process.env.MODERATION_API_TOKEN || process.env.SERVICE_API_TOKEN || null;
+}
+
 /**
  * Load checkpoint from disk
  */
@@ -151,16 +155,23 @@ async function checkModerated(sha256, workerUrl) {
   }
 
   const data = await response.json();
-  return data.moderation !== null;
+  return data.moderated === true;
 }
 
 /**
  * Queue video for moderation
  */
-async function queueModeration(sha256, workerUrl) {
+async function queueModeration(sha256, workerUrl, apiToken) {
+  if (!apiToken) {
+    throw new Error('Missing API token. Set SERVICE_API_TOKEN or pass --token before queueing moderation.');
+  }
+
   const response = await fetch(`${workerUrl}/test-moderate`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${apiToken}`
+    },
     body: JSON.stringify({ sha256 })
   });
 
@@ -177,7 +188,7 @@ async function queueModeration(sha256, workerUrl) {
 async function backfillModeration(options = {}) {
   const {
     relayUrl = 'wss://relay.divine.video',
-    workerUrl = 'https://divine-moderation-service.protestnet.workers.dev',
+    workerUrl = 'https://moderation-api.divine.video',
     batchSize = 100,
     maxTotal = null,
     since = null,
@@ -186,6 +197,11 @@ async function backfillModeration(options = {}) {
     resume = true,
     countOnly = false
   } = options;
+  const apiToken = getApiToken(options);
+
+  if (!dryRun && !countOnly && !apiToken) {
+    throw new Error('Missing API token. Set SERVICE_API_TOKEN or MODERATION_API_TOKEN, or pass --token.');
+  }
 
   // Try to load checkpoint
   let checkpoint = null;
@@ -273,7 +289,7 @@ async function backfillModeration(options = {}) {
             globalStats.needsModeration++;
 
             if (!dryRun) {
-              await queueModeration(video.sha256, workerUrl);
+              await queueModeration(video.sha256, workerUrl, apiToken);
               globalStats.queued++;
               console.log(`[BACKFILL] ⏩ ${video.sha256.substring(0, 16)}... queued for moderation`);
 
@@ -391,6 +407,9 @@ if (import.meta.url === `file://${process.argv[1]}`) {
     } else if (args[i] === '--worker' && args[i + 1]) {
       options.workerUrl = args[i + 1];
       i++;
+    } else if (args[i] === '--token' && args[i + 1]) {
+      options.apiToken = args[i + 1];
+      i++;
     } else if (args[i] === '--dry-run') {
       options.dryRun = true;
     } else if (args[i] === '--count-only') {
@@ -411,7 +430,8 @@ Options:
   --since <timestamp>   Unix timestamp (exact seconds) - only fetch events after this time
   --until <timestamp>   Unix timestamp (exact seconds) - only fetch events before this time
   --relay <url>         Nostr relay URL (default: wss://relay.divine.video)
-  --worker <url>        Worker URL (default: https://divine-moderation-service.protestnet.workers.dev)
+  --worker <url>        API URL (default: https://moderation-api.divine.video)
+  --token <token>       Bearer token for authenticated API endpoints
   --dry-run             Check what would be moderated without actually queuing
   --count-only          Just count total videos, skip moderation checks (fast)
   --no-resume           Start from beginning, ignore saved checkpoint
@@ -431,7 +451,7 @@ Examples:
   node scripts/backfill-moderation.mjs --max-total 500 --dry-run
 
   # Process all videos (will auto-resume if interrupted)
-  node scripts/backfill-moderation.mjs
+  SERVICE_API_TOKEN=... node scripts/backfill-moderation.mjs
 
   # Process from specific timestamp (e.g., Dec 1, 2024 = 1733011200)
   node scripts/backfill-moderation.mjs --since 1733011200

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -40,6 +40,11 @@ const CATEGORY_TO_LABEL = {
   'gambling': { label: 'gambling', namespace: 'content-warning' }
 };
 
+const ADMIN_HOSTNAME = 'moderation.admin.divine.video';
+const API_HOSTNAME = 'moderation-api.divine.video';
+const JSON_HEADERS = { 'Content-Type': 'application/json' };
+const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]']);
+
 /**
  * Generate NIP-32 style label tags based on scores and human verifications
  * @param {Object} scores - AI-generated scores for each category
@@ -88,40 +93,321 @@ function generateNIP85Tags(scores, categoryVerifications = {}) {
   return tags;
 }
 
+function isLocalHostname(hostname) {
+  return LOCAL_HOSTNAMES.has(hostname) || hostname.endsWith('.localhost');
+}
+
+function isApiSurfacePath(pathname) {
+  return pathname === '/'
+    || pathname === '/health'
+    || pathname === '/test-moderate'
+    || pathname === '/test-kv'
+    || pathname.startsWith('/check-result/')
+    || pathname.startsWith('/api/v1/');
+}
+
+function isAdminSurfacePath(pathname) {
+  return pathname === '/' || pathname.startsWith('/admin');
+}
+
+function jsonError(message, status = 400) {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: JSON_HEADERS
+  });
+}
+
+function jsonResponse(status, data, headers = {}) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { ...JSON_HEADERS, ...headers }
+  });
+}
+
+function corsResponse(response) {
+  const headers = new Headers(response.headers);
+  headers.set('Access-Control-Allow-Origin', '*');
+  headers.set('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+  headers.set('Access-Control-Allow-Headers', 'Authorization, Content-Type');
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers
+  });
+}
+
+function getConfiguredBearerTokens(env) {
+  return [env.SERVICE_API_TOKEN, env.API_BEARER_TOKEN, env.MODERATION_API_KEY]
+    .filter((value, index, all) => typeof value === 'string' && value.length > 0 && all.indexOf(value) === index);
+}
+
+function hostMismatchResponse(requestId, hostname, pathname, expectedHost) {
+  console.log(`[${requestId}] Rejected ${pathname} on ${hostname}; expected ${expectedHost}`);
+  return jsonError(`Not found on ${hostname}. Use https://${expectedHost}${pathname}`, 404);
+}
+
+async function authenticateApiRequest(request, env) {
+  if (env.ALLOW_DEV_ACCESS === 'true') {
+    return { valid: true, email: 'dev@localhost', isServiceToken: false };
+  }
+
+  const authHeader = request.headers.get('Authorization');
+  const bearerToken = authHeader && authHeader.startsWith('Bearer ') ? authHeader.slice(7) : null;
+  const configuredTokens = getConfiguredBearerTokens(env);
+  if (bearerToken && configuredTokens.includes(bearerToken)) {
+    return { valid: true, email: 'service@internal', isServiceToken: true };
+  }
+
+  const jwtToken = request.headers.get('cf-access-jwt-assertion');
+  if (jwtToken) {
+    try {
+      return await verifyZeroTrustJWT(jwtToken, env);
+    } catch (error) {
+      return { valid: false, error: error.message };
+    }
+  }
+
+  if (configuredTokens.length === 0) {
+    return { valid: false, error: 'No bearer token configured (SERVICE_API_TOKEN/API_BEARER_TOKEN/MODERATION_API_KEY)' };
+  }
+
+  return { valid: false, error: 'Missing bearer token or Cloudflare Access JWT' };
+}
+
+function apiUnauthorizedResponse(verification) {
+  return jsonError(`Unauthorized - ${verification.error}`, 401);
+}
+
+function authSourceFromVerification(verification) {
+  return verification.email
+    ? `user:${verification.email}`
+    : `service-token:${verification.payload?.sub || 'unknown'}`;
+}
+
+function verifyLegacyBearerAuth(request, env) {
+  const configuredTokens = getConfiguredBearerTokens(env);
+  if (configuredTokens.length === 0) {
+    console.error('[AUTH] No legacy bearer token configured');
+    return jsonResponse(500, { error: 'Server misconfigured — no auth token set' });
+  }
+
+  const authHeader = request.headers.get('Authorization');
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return jsonResponse(401, { error: 'Missing Authorization: Bearer <token>' });
+  }
+
+  const token = authHeader.slice(7);
+  if (!configuredTokens.includes(token)) {
+    return jsonResponse(403, { error: 'Invalid token' });
+  }
+
+  return null;
+}
+
+async function handleLegacyScan(request, env) {
+  const body = await request.json();
+  const { sha256, url: videoUrl, source, pubkey, metadata } = body;
+
+  if (!sha256 || !/^[0-9a-f]{64}$/i.test(sha256)) {
+    return jsonResponse(400, { error: 'sha256 required (64 hex characters)' });
+  }
+
+  const hash = sha256.toLowerCase();
+  const existing = await env.BLOSSOM_DB.prepare(
+    'SELECT sha256, action FROM moderation_results WHERE sha256 = ?'
+  ).bind(hash).first();
+
+  if (existing) {
+    return jsonResponse(200, {
+      sha256: hash,
+      status: 'already_moderated',
+      action: existing.action,
+      queued: false
+    });
+  }
+
+  const resolvedVideoUrl = videoUrl || `https://media.divine.video/${hash}`;
+  await env.MODERATION_QUEUE.send({
+    sha256: hash,
+    r2Key: `blobs/${hash}`,
+    uploadedBy: pubkey || undefined,
+    uploadedAt: Date.now(),
+    metadata: {
+      ...(metadata || {}),
+      source: source || 'api',
+      videoUrl: resolvedVideoUrl
+    }
+  });
+
+  console.log(`[SCAN] Queued ${hash} from ${source || 'api'}`);
+  return jsonResponse(202, {
+    sha256: hash,
+    status: 'queued',
+    queued: true,
+    videoUrl: resolvedVideoUrl
+  });
+}
+
+async function handleLegacyBatchScan(request, env) {
+  const body = await request.json();
+  const { videos, source: defaultSource } = body;
+
+  if (!Array.isArray(videos) || videos.length === 0) {
+    return jsonResponse(400, { error: 'videos array required' });
+  }
+
+  if (videos.length > 100) {
+    return jsonResponse(400, { error: 'Maximum 100 videos per batch' });
+  }
+
+  const results = [];
+  let queued = 0;
+  let skipped = 0;
+  let errors = 0;
+
+  for (const video of videos) {
+    const { sha256, url: videoUrl, source, pubkey, metadata } = video;
+
+    if (!sha256 || !/^[0-9a-f]{64}$/i.test(sha256)) {
+      results.push({ sha256, status: 'error', error: 'Invalid sha256' });
+      errors++;
+      continue;
+    }
+
+    const hash = sha256.toLowerCase();
+    const existing = await env.BLOSSOM_DB.prepare(
+      'SELECT sha256, action FROM moderation_results WHERE sha256 = ?'
+    ).bind(hash).first();
+
+    if (existing) {
+      results.push({ sha256: hash, status: 'already_moderated', action: existing.action });
+      skipped++;
+      continue;
+    }
+
+    const resolvedVideoUrl = videoUrl || `https://media.divine.video/${hash}`;
+    await env.MODERATION_QUEUE.send({
+      sha256: hash,
+      r2Key: `blobs/${hash}`,
+      uploadedBy: pubkey || undefined,
+      uploadedAt: Date.now(),
+      metadata: {
+        ...(metadata || {}),
+        source: source || defaultSource || 'batch-api',
+        videoUrl: resolvedVideoUrl
+      }
+    });
+
+    results.push({ sha256: hash, status: 'queued' });
+    queued++;
+  }
+
+  console.log(`[BATCH] Queued ${queued}, skipped ${skipped}, errors ${errors}`);
+  return jsonResponse(202, {
+    total: videos.length,
+    queued,
+    skipped,
+    errors,
+    results
+  });
+}
+
+async function handleLegacyStatus(sha256, env) {
+  if (!sha256 || !/^[0-9a-f]{64}$/i.test(sha256)) {
+    return jsonResponse(400, { error: 'Invalid sha256' });
+  }
+
+  const hash = sha256.toLowerCase();
+  const result = await env.BLOSSOM_DB.prepare(`
+    SELECT sha256, action, provider, scores, categories, moderated_at, reviewed_by, reviewed_at
+    FROM moderation_results
+    WHERE sha256 = ?
+  `).bind(hash).first();
+
+  if (!result) {
+    return jsonResponse(200, {
+      sha256: hash,
+      moderated: false,
+      action: null,
+      message: 'No moderation result found'
+    });
+  }
+
+  return jsonResponse(200, {
+    sha256: hash,
+    moderated: true,
+    action: result.action,
+    provider: result.provider,
+    scores: result.scores ? JSON.parse(result.scores) : null,
+    categories: result.categories ? JSON.parse(result.categories) : null,
+    moderated_at: result.moderated_at,
+    reviewed_by: result.reviewed_by,
+    reviewed_at: result.reviewed_at,
+    blocked: result.action === 'PERMANENT_BAN',
+    age_restricted: result.action === 'AGE_RESTRICTED',
+    needs_review: result.action === 'REVIEW'
+  });
+}
+
 export default {
   /**
    * HTTP handler for testing and admin dashboard
    */
   async fetch(request, env) {
-    // Ensure offender tracking table exists (idempotent)
-    await initOffenderTable(env.BLOSSOM_DB);
-
     const url = new URL(request.url);
     const startTime = Date.now();
     const requestId = crypto.randomUUID().substring(0, 8);
+    const hostname = url.hostname;
+    const isLocalRequest = isLocalHostname(hostname);
 
     // Log all incoming requests
     console.log(`[${requestId}] ${request.method} ${url.pathname}${url.search ? '?' + url.search.substring(0, 100) : ''}`);
 
-    // Block unauthenticated requests on workers.dev (bypass CF Access)
-    // Requests via custom domain go through CF Access at the edge.
-    // Workers.dev requests must include a valid Bearer token.
-    const hostname = url.hostname;
+    // Do not expose the workers.dev hostname in production.
     if (hostname.endsWith('.workers.dev')) {
-      const authHeader = request.headers.get('Authorization');
-      const token = authHeader && authHeader.startsWith('Bearer ') ? authHeader.slice(7) : null;
-      const isHealthCheck = url.pathname === '/health' || url.pathname === '/';
-      if (!isHealthCheck && (!token || !env.SERVICE_API_TOKEN || token !== env.SERVICE_API_TOKEN)) {
-        console.log(`[${requestId}] Blocked unauthenticated workers.dev request to ${url.pathname}`);
-        return new Response(JSON.stringify({ error: 'Unauthorized — Bearer token required' }), {
-          status: 401,
-          headers: { 'Content-Type': 'application/json' }
-        });
+      console.log(`[${requestId}] Rejected workers.dev request to ${url.pathname}`);
+      return new Response('Not Found', { status: 404 });
+    }
+
+    if (!isLocalRequest && hostname !== API_HOSTNAME && hostname !== ADMIN_HOSTNAME) {
+      console.log(`[${requestId}] Rejected unknown hostname ${hostname}`);
+      return new Response('Not Found', { status: 404 });
+    }
+
+    if (!isLocalRequest && hostname === ADMIN_HOSTNAME) {
+      if (url.pathname === '/') {
+        return Response.redirect(`${url.origin}/admin`, 302);
+      }
+
+      if (!isAdminSurfacePath(url.pathname)) {
+        const expectedHost = isApiSurfacePath(url.pathname) ? API_HOSTNAME : ADMIN_HOSTNAME;
+        return hostMismatchResponse(requestId, hostname, url.pathname, expectedHost);
       }
     }
 
+    if (!isLocalRequest && hostname === API_HOSTNAME && !isApiSurfacePath(url.pathname)) {
+      const expectedHost = url.pathname.startsWith('/admin') ? ADMIN_HOSTNAME : API_HOSTNAME;
+      return hostMismatchResponse(requestId, hostname, url.pathname, expectedHost);
+    }
+
+    // Ensure offender tracking table exists (idempotent)
+    await initOffenderTable(env.BLOSSOM_DB);
+
     // Ensure reports table exists
     await initReportsTable(env.BLOSSOM_DB);
+
+    if (url.pathname === '/health') {
+      return corsResponse(jsonResponse(200, {
+        status: 'ok',
+        service: hostname === API_HOSTNAME || isLocalRequest ? 'divine-moderation-api' : 'divine-moderation-service',
+        timestamp: new Date().toISOString(),
+        hostname
+      }));
+    }
+
+    if (request.method === 'OPTIONS' && url.pathname.startsWith('/api/v1/')) {
+      return corsResponse(new Response(null, { status: 204 }));
+    }
 
     // Admin dashboard routes
     if (url.pathname === '/admin' || url.pathname === '/admin/') {
@@ -1081,6 +1367,11 @@ export default {
 
     // Test endpoint to manually trigger moderation
     if (url.pathname === '/test-moderate' && request.method === 'POST') {
+      const verification = await authenticateApiRequest(request, env);
+      if (!verification.valid) {
+        return apiUnauthorizedResponse(verification);
+      }
+
       const body = await request.json();
       const { sha256, force } = body;
 
@@ -1105,6 +1396,11 @@ export default {
 
     // Test KV write
     if (url.pathname === '/test-kv') {
+      const verification = await authenticateApiRequest(request, env);
+      if (!verification.valid) {
+        return apiUnauthorizedResponse(verification);
+      }
+
       try {
         await env.MODERATION_KV.put('test-key', JSON.stringify({ test: true, timestamp: Date.now() }));
         const readBack = await env.MODERATION_KV.get('test-key');
@@ -1474,23 +1770,49 @@ async function runMigration() {
     }
 
     // API: Submit a user report for a piece of content (NIP-56)
-    // Auth: Verify Zero Trust JWT using jose library
-    if (url.pathname === '/api/v1/report' && request.method === 'POST') {
-      let verification = { valid: false, error: 'Not verified' };
+    // Auth: Bearer token or Cloudflare Access JWT
+    if (url.pathname === '/api/v1/scan' && request.method === 'POST') {
+      const authError = verifyLegacyBearerAuth(request, env);
+      if (authError) return corsResponse(authError);
 
-      if (env.ALLOW_DEV_ACCESS === 'true') {
-        verification = { valid: true, email: 'dev@localhost', isServiceToken: false };
-      } else {
-        const jwtToken = request.headers.get('cf-access-jwt-assertion');
-        verification = await verifyZeroTrustJWT(jwtToken, env);
+      try {
+        return corsResponse(await handleLegacyScan(request, env));
+      } catch (error) {
+        console.error('[SCAN] Error:', error);
+        return corsResponse(jsonResponse(500, { error: error.message }));
       }
+    }
 
+    if (url.pathname === '/api/v1/batch-scan' && request.method === 'POST') {
+      const authError = verifyLegacyBearerAuth(request, env);
+      if (authError) return corsResponse(authError);
+
+      try {
+        return corsResponse(await handleLegacyBatchScan(request, env));
+      } catch (error) {
+        console.error('[BATCH] Error:', error);
+        return corsResponse(jsonResponse(500, { error: error.message }));
+      }
+    }
+
+    if (url.pathname.startsWith('/api/v1/status/') && request.method === 'GET') {
+      const authError = verifyLegacyBearerAuth(request, env);
+      if (authError) return corsResponse(authError);
+
+      try {
+        const sha256 = url.pathname.split('/')[4];
+        return corsResponse(await handleLegacyStatus(sha256, env));
+      } catch (error) {
+        console.error('[STATUS] Error:', error);
+        return corsResponse(jsonResponse(500, { error: error.message }));
+      }
+    }
+
+    if (url.pathname === '/api/v1/report' && request.method === 'POST') {
+      const verification = await authenticateApiRequest(request, env);
       if (!verification.valid) {
-        console.log(`[API] JWT verification failed for /api/v1/report: ${verification.error}`);
-        return new Response(JSON.stringify({ error: `Unauthorized - ${verification.error}` }), {
-          status: 401,
-          headers: { 'Content-Type': 'application/json' }
-        });
+        console.log(`[API] Authentication failed for /api/v1/report: ${verification.error}`);
+        return apiUnauthorizedResponse(verification);
       }
 
       try {
@@ -1520,35 +1842,16 @@ async function runMigration() {
     }
 
     // API: Update moderation status (for external services)
-    // Auth: Verify Zero Trust JWT using jose library
+    // Auth: Bearer token or Cloudflare Access JWT
     if (url.pathname === '/api/v1/moderate' && request.method === 'POST') {
-      let verification = { valid: false, error: 'Not verified' };
-
-      // In development without Zero Trust, allow if explicitly configured
-      if (env.ALLOW_DEV_ACCESS === 'true') {
-        console.log('[API] Development mode - bypassing JWT verification');
-        verification = { valid: true, email: 'dev@localhost', isServiceToken: false };
-      } else {
-        const jwtToken = request.headers.get('cf-access-jwt-assertion');
-
-        // Verify JWT signature, issuer, and audience
-        verification = await verifyZeroTrustJWT(jwtToken, env);
-      }
-
+      const verification = await authenticateApiRequest(request, env);
       if (!verification.valid) {
-        console.log(`[API] JWT verification failed: ${verification.error}`);
-        return new Response(JSON.stringify({
-          error: `Unauthorized - ${verification.error}`
-        }), {
-          status: 401,
-          headers: { 'Content-Type': 'application/json' }
-        });
+        console.log(`[API] Authentication failed: ${verification.error}`);
+        return apiUnauthorizedResponse(verification);
       }
 
       // Determine auth source for logging
-      const authSource = verification.email
-        ? `user:${verification.email}`
-        : `service-token:${verification.payload?.sub || 'unknown'}`;
+      const authSource = authSourceFromVerification(verification);
 
       try {
         const body = await request.json();
@@ -1666,27 +1969,11 @@ async function runMigration() {
     }
 
     // API: Moderation decisions list (for divine-relay-manager integration)
-    // Auth: Verify Zero Trust JWT
+    // Auth: Bearer token or Cloudflare Access JWT
     if (url.pathname === '/api/v1/decisions' && request.method === 'GET') {
-      let verification = { valid: false, error: 'Not verified' };
-      if (env.ALLOW_DEV_ACCESS === 'true') {
-        verification = { valid: true, email: 'dev@localhost', isServiceToken: false };
-      } else {
-        const jwtToken = request.headers.get('cf-access-jwt-assertion');
-        if (jwtToken) {
-          try {
-            verification = await verifyZeroTrustJWT(jwtToken, env);
-          } catch (e) {
-            verification = { valid: false, error: e.message };
-          }
-        }
-      }
-
+      const verification = await authenticateApiRequest(request, env);
       if (!verification.valid) {
-        return new Response(JSON.stringify({ error: 'Authentication required' }), {
-          status: 401,
-          headers: { 'Content-Type': 'application/json' }
-        });
+        return apiUnauthorizedResponse(verification);
       }
 
       try {
@@ -1744,7 +2031,7 @@ async function runMigration() {
     }
 
     // API: Single moderation decision lookup (for divine-relay-manager integration)
-    // Auth: Verify Zero Trust JWT
+    // Auth: Bearer token or Cloudflare Access JWT
     if (url.pathname.startsWith('/api/v1/decisions/') && request.method === 'GET') {
       const sha256 = url.pathname.split('/')[4];
 
@@ -1755,25 +2042,9 @@ async function runMigration() {
         });
       }
 
-      let verification = { valid: false, error: 'Not verified' };
-      if (env.ALLOW_DEV_ACCESS === 'true') {
-        verification = { valid: true, email: 'dev@localhost', isServiceToken: false };
-      } else {
-        const jwtToken = request.headers.get('cf-access-jwt-assertion');
-        if (jwtToken) {
-          try {
-            verification = await verifyZeroTrustJWT(jwtToken, env);
-          } catch (e) {
-            verification = { valid: false, error: e.message };
-          }
-        }
-      }
-
+      const verification = await authenticateApiRequest(request, env);
       if (!verification.valid) {
-        return new Response(JSON.stringify({ error: 'Authentication required' }), {
-          status: 401,
-          headers: { 'Content-Type': 'application/json' }
-        });
+        return apiUnauthorizedResponse(verification);
       }
 
       try {
@@ -1805,7 +2076,7 @@ async function runMigration() {
     }
 
     // API: Quarantine/unquarantine content
-    // Auth: Verify Zero Trust JWT
+    // Auth: Bearer token or Cloudflare Access JWT
     if (url.pathname.startsWith('/api/v1/quarantine/') && request.method === 'POST') {
       const sha256 = url.pathname.split('/')[4];
 
@@ -1816,25 +2087,9 @@ async function runMigration() {
         });
       }
 
-      let verification = { valid: false, error: 'Not verified' };
-      if (env.ALLOW_DEV_ACCESS === 'true') {
-        verification = { valid: true, email: 'dev@localhost', isServiceToken: false };
-      } else {
-        const jwtToken = request.headers.get('cf-access-jwt-assertion');
-        if (jwtToken) {
-          try {
-            verification = await verifyZeroTrustJWT(jwtToken, env);
-          } catch (e) {
-            verification = { valid: false, error: e.message };
-          }
-        }
-      }
-
+      const verification = await authenticateApiRequest(request, env);
       if (!verification.valid) {
-        return new Response(JSON.stringify({ error: 'Authentication required' }), {
-          status: 401,
-          headers: { 'Content-Type': 'application/json' }
-        });
+        return apiUnauthorizedResponse(verification);
       }
 
       try {
@@ -1842,9 +2097,7 @@ async function runMigration() {
         const { quarantine, reason } = body;
         const newAction = quarantine === false ? 'REVIEW' : 'QUARANTINE';
 
-        const authSource = verification.email
-          ? `user:${verification.email}`
-          : `service-token:${verification.payload?.sub || 'unknown'}`;
+        const authSource = authSourceFromVerification(verification);
 
         // Update D1
         await env.BLOSSOM_DB.prepare(`
@@ -1897,30 +2150,9 @@ async function runMigration() {
     // API: Classify-only endpoint — run VLM classification without full moderation
     // Used by funnelcake janitor for bulk backfill of ~21k existing videos
     if (url.pathname === '/api/v1/classify' && request.method === 'POST') {
-      // Require authentication (Zero Trust JWT, bearer token, or dev access)
-      let verification = { valid: false, error: 'Not verified' };
-      if (env.ALLOW_DEV_ACCESS === 'true') {
-        verification = { valid: true, email: 'dev@localhost', isServiceToken: false };
-      } else {
-        const authHeader = request.headers.get('Authorization');
-        if (authHeader && authHeader.startsWith('Bearer ') && env.SERVICE_API_TOKEN) {
-          const token = authHeader.slice(7);
-          if (token === env.SERVICE_API_TOKEN) {
-            verification = { valid: true, email: 'service@internal', isServiceToken: true };
-          }
-        }
-        if (!verification.valid) {
-          try {
-            verification = await verifyZeroTrustJWT(request, env);
-          } catch (e) {
-            verification = { valid: false, error: e.message };
-          }
-        }
-      }
+      const verification = await authenticateApiRequest(request, env);
       if (!verification.valid) {
-        return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-          status: 401, headers: { 'Content-Type': 'application/json' }
-        });
+        return apiUnauthorizedResponse(verification);
       }
 
       try {
@@ -1980,7 +2212,7 @@ async function runMigration() {
     }
 
     // API: Classifier endpoints for recommendation system data
-    // Auth: Verify Zero Trust JWT for access control
+    // Auth: Bearer token or Cloudflare Access JWT
     if (url.pathname.startsWith('/api/v1/classifier/')) {
       // Parse the path segments: /api/v1/classifier/{sha256}[/recommendations]
       const pathParts = url.pathname.split('/').filter(Boolean);
@@ -1995,37 +2227,9 @@ async function runMigration() {
         });
       }
 
-      // Require authentication (Zero Trust JWT, bearer token, or dev access)
-      let verification = { valid: false, error: 'Not verified' };
-      if (env.ALLOW_DEV_ACCESS === 'true') {
-        verification = { valid: true, email: 'dev@localhost', isServiceToken: false };
-      } else {
-        // Check bearer token auth first (for service-to-service calls via workers.dev)
-        const authHeader = request.headers.get('Authorization');
-        if (authHeader && authHeader.startsWith('Bearer ') && env.SERVICE_API_TOKEN) {
-          const token = authHeader.slice(7);
-          if (token === env.SERVICE_API_TOKEN) {
-            verification = { valid: true, email: 'service@internal', isServiceToken: true };
-          }
-        }
-        // Fall back to Zero Trust JWT (for requests via CF Access edge)
-        if (!verification.valid) {
-          const jwtToken = request.headers.get('cf-access-jwt-assertion');
-          if (jwtToken) {
-            try {
-              verification = await verifyZeroTrustJWT(jwtToken, env);
-            } catch (e) {
-              verification = { valid: false, error: e.message };
-            }
-          }
-        }
-      }
-
+      const verification = await authenticateApiRequest(request, env);
       if (!verification.valid) {
-        return new Response(JSON.stringify({ error: 'Authentication required' }), {
-          status: 401,
-          headers: { 'Content-Type': 'application/json' }
-        });
+        return apiUnauthorizedResponse(verification);
       }
 
       try {
@@ -2115,7 +2319,7 @@ async function runMigration() {
       }
     }
 
-    return new Response('Divine Moderation Service\n\nEndpoints:\nPOST /test-moderate {"sha256":"..."}\nGET  /check-result/{sha256}\nGET  /api/v1/decisions (authenticated - paginated moderation decisions)\nGET  /api/v1/decisions/{sha256} (authenticated - single decision lookup)\nPOST /api/v1/quarantine/{sha256} (authenticated - quarantine/unquarantine)\nGET  /api/v1/classifier/{sha256} (authenticated - all classification layers)\nGET  /api/v1/classifier/{sha256}/recommendations (authenticated - pre-formatted for gorse/funnelcake)\nGET  /admin (password protected)', {
+    return new Response('Divine Moderation API\n\nPublic endpoints:\nGET  /health\nGET  /check-result/{sha256}\n\nAuthenticated endpoints:\nPOST /test-moderate {"sha256":"..."}\nGET  /api/v1/decisions\nGET  /api/v1/decisions/{sha256}\nPOST /api/v1/quarantine/{sha256}\nPOST /api/v1/moderate\nPOST /api/v1/report\nPOST /api/v1/classify\nGET  /api/v1/classifier/{sha256}\nGET  /api/v1/classifier/{sha256}/recommendations\n\nAdmin UI: https://moderation.admin.divine.video/admin', {
       headers: { 'Content-Type': 'text/plain' }
     });
   },
@@ -2442,4 +2646,3 @@ async function notifyBlossom(sha256, action, env) {
     return { success: false, error: error.message };
   }
 }
-

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -1,0 +1,248 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Request routing tests for API/admin hostname separation
+// ABOUTME: Verifies public API exposure, admin isolation, and workers.dev disablement
+
+import { describe, expect, it } from 'vitest';
+import worker from './index.mjs';
+
+const SHA256 = 'a'.repeat(64);
+
+function createDbMock({ moderationResults = new Map() } = {}) {
+  return {
+    prepare(sql) {
+      let bindings = [];
+
+      return {
+        bind(...args) {
+          bindings = args;
+          return this;
+        },
+        async run() {
+          return { success: true };
+        },
+        async first() {
+          if (sql.includes('FROM moderation_results') && sql.includes('WHERE sha256 = ?')) {
+            return moderationResults.get(bindings[0]) ?? null;
+          }
+          return null;
+        },
+        async all() {
+          return { results: [] };
+        }
+      };
+    },
+    async batch() {
+      return [];
+    }
+  };
+}
+
+function createEnv(overrides = {}) {
+  return {
+    ALLOW_DEV_ACCESS: 'false',
+    SERVICE_API_TOKEN: 'test-service-token',
+    BLOSSOM_DB: createDbMock(),
+    MODERATION_KV: {
+      async get() { return null; },
+      async put() {},
+      async delete() {},
+      async list() { return { keys: [], list_complete: true, cursor: null }; }
+    },
+    MODERATION_QUEUE: {
+      async send() {}
+    },
+    ...overrides
+  };
+}
+
+describe('HTTP hostname routing', () => {
+  it('returns 404 for workers.dev requests', async () => {
+    const response = await worker.fetch(
+      new Request(`https://divine-moderation-service.protestnet.workers.dev/check-result/${SHA256}`),
+      createEnv()
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it('serves public moderation status on moderation-api host', async () => {
+    const env = createEnv({
+      BLOSSOM_DB: createDbMock({
+        moderationResults: new Map([[SHA256, {
+          sha256: SHA256,
+          action: 'SAFE',
+          provider: 'hiveai',
+          scores: JSON.stringify({ nudity: 0.01 }),
+          categories: JSON.stringify(['safe']),
+          moderated_at: '2026-03-07T00:00:00.000Z',
+          reviewed_by: null,
+          reviewed_at: null
+        }]])
+      })
+    });
+
+    const response = await worker.fetch(
+      new Request(`https://moderation-api.divine.video/check-result/${SHA256}`),
+      env
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      sha256: SHA256,
+      moderated: true,
+      action: 'SAFE',
+      status: 'safe'
+    });
+  });
+
+  it('rejects admin routes on moderation-api host', async () => {
+    const response = await worker.fetch(
+      new Request('https://moderation-api.divine.video/admin'),
+      createEnv()
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it('rejects public status routes on moderation.admin host', async () => {
+    const response = await worker.fetch(
+      new Request(`https://moderation.admin.divine.video/check-result/${SHA256}`),
+      createEnv()
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toMatchObject({
+      error: `Not found on moderation.admin.divine.video. Use https://moderation-api.divine.video/check-result/${SHA256}`
+    });
+  });
+
+  it('requires auth for test-moderate on moderation-api host', async () => {
+    const response = await worker.fetch(
+      new Request('https://moderation-api.divine.video/test-moderate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sha256: SHA256 })
+      }),
+      createEnv()
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it('returns legacy health payload on moderation-api host', async () => {
+    const response = await worker.fetch(
+      new Request('https://moderation-api.divine.video/health'),
+      createEnv()
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
+    await expect(response.json()).resolves.toMatchObject({
+      status: 'ok',
+      service: 'divine-moderation-api',
+      hostname: 'moderation-api.divine.video'
+    });
+  });
+
+  it('queues legacy /api/v1/scan requests', async () => {
+    const queued = [];
+    const env = createEnv({
+      MODERATION_API_KEY: 'legacy-token',
+      MODERATION_QUEUE: {
+        async send(message) {
+          queued.push(message);
+        }
+      }
+    });
+
+    const response = await worker.fetch(
+      new Request('https://moderation-api.divine.video/api/v1/scan', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer legacy-token'
+        },
+        body: JSON.stringify({ sha256: SHA256, source: 'blossom' })
+      }),
+      env
+    );
+
+    expect(response.status).toBe(202);
+    expect(queued).toHaveLength(1);
+    expect(queued[0]).toMatchObject({
+      sha256: SHA256,
+      r2Key: `blobs/${SHA256}`,
+      metadata: {
+        source: 'blossom',
+        videoUrl: `https://media.divine.video/${SHA256}`
+      }
+    });
+  });
+
+  it('returns legacy 401 shape for unauthenticated /api/v1/scan', async () => {
+    const response = await worker.fetch(
+      new Request('https://moderation-api.divine.video/api/v1/scan', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sha256: SHA256 })
+      }),
+      createEnv()
+    );
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
+    await expect(response.json()).resolves.toEqual({
+      error: 'Missing Authorization: Bearer <token>'
+    });
+  });
+
+  it('returns legacy 403 shape for invalid /api/v1/status token', async () => {
+    const response = await worker.fetch(
+      new Request(`https://moderation-api.divine.video/api/v1/status/${SHA256}`, {
+        headers: { 'Authorization': 'Bearer wrong-token' }
+      }),
+      createEnv()
+    );
+
+    expect(response.status).toBe(403);
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
+    await expect(response.json()).resolves.toEqual({
+      error: 'Invalid token'
+    });
+  });
+
+  it('returns legacy /api/v1/status payloads', async () => {
+    const env = createEnv({
+      MODERATION_API_KEY: 'legacy-token',
+      BLOSSOM_DB: createDbMock({
+        moderationResults: new Map([[SHA256, {
+          sha256: SHA256,
+          action: 'PERMANENT_BAN',
+          provider: 'hiveai',
+          scores: JSON.stringify({ nudity: 0.99 }),
+          categories: JSON.stringify(['nudity']),
+          moderated_at: '2026-03-07T00:00:00.000Z',
+          reviewed_by: 'user:test',
+          reviewed_at: '2026-03-07T00:01:00.000Z'
+        }]])
+      })
+    });
+
+    const response = await worker.fetch(
+      new Request(`https://moderation-api.divine.video/api/v1/status/${SHA256}`, {
+        headers: { 'Authorization': 'Bearer legacy-token' }
+      }),
+      env
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      sha256: SHA256,
+      moderated: true,
+      action: 'PERMANENT_BAN',
+      blocked: true
+    });
+  });
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -7,10 +7,10 @@ main = "src/index.mjs"
 compatibility_date = "2024-10-01"
 compatibility_flags = ["nodejs_compat"]
 
-# Enable workers.dev subdomain for service-to-service bearer token auth
-workers_dev = true
+# Serve production traffic only on divine.video hostnames.
+workers_dev = false
 
-# Custom domain (requires divine.video zone in the same Cloudflare account)
+# Custom domains (requires divine.video zone in the same Cloudflare account)
 routes = [
   { pattern = "moderation.admin.divine.video/*", zone_name = "divine.video" }
 ]
@@ -91,6 +91,7 @@ RELAY_POLLING_LIMIT = "100"                       # Max events to fetch per poll
 crons = ["*/5 * * * *"]
 
 # Secrets (set with: wrangler secret put <NAME>)
+# SERVICE_API_TOKEN - bearer token for authenticated requests to moderation-api.divine.video
 # POLICY_AUD - Zero Trust application audience tag (from Access > Applications > moderation.admin.divine.video > Overview)
 # CF_ACCESS_CLIENT_ID - Cloudflare Access service token ID for relay.divine.video
 # CF_ACCESS_CLIENT_SECRET - Cloudflare Access service token secret for relay.divine.video


### PR DESCRIPTION
## Summary
- enforce the `moderation-api.divine.video` vs `moderation.admin.divine.video` host boundary in the worker
- disable `workers.dev` and keep the legacy scan/status surface on the public API host
- tighten auth around debug and API routes while updating docs and the moderation backfill script
- add hostname routing tests

## Verification
- `npm test -- src/index.test.mjs`
- worker already deployed during the hostname split rollout
