### PR TITLE
feat: unified moderation contract (vocabulary, label writer, ClickHouse)

### DIFF
--- a/scripts/backfill-moderation-labels.mjs
+++ b/scripts/backfill-moderation-labels.mjs
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Backfill script to populate ClickHouse moderation_labels from existing D1 moderation_results
+// ABOUTME: Reads decisions via the moderation service API, normalizes labels, and batch inserts
+
+import { normalizeLabel, classifierCategoryToLabels } from '../src/moderation/vocabulary.mjs';
+
+const BATCH_SIZE = 100;
+const THRESHOLD = 0.5;
+
+const SOURCE_METADATA = {
+  source_id: 'divine-hive',
+  source_owner: 'divine',
+  source_type: 'machine-labeler',
+  transport: 'moderation-api',
+};
+
+function getConfig() {
+  const apiUrl = process.env.MODERATION_API_URL || 'https://moderation.api.divine.video';
+  const apiToken = process.env.MODERATION_API_TOKEN || process.env.SERVICE_API_TOKEN;
+  const clickhouseUrl = process.env.CLICKHOUSE_URL;
+  const clickhouseUser = process.env.CLICKHOUSE_USER || 'default';
+  const clickhousePassword = process.env.CLICKHOUSE_PASSWORD;
+
+  if (!apiToken) {
+    console.error('[BACKFILL] MODERATION_API_TOKEN or SERVICE_API_TOKEN is required');
+    process.exit(1);
+  }
+  if (!clickhouseUrl || !clickhousePassword) {
+    console.error('[BACKFILL] CLICKHOUSE_URL and CLICKHOUSE_PASSWORD are required');
+    process.exit(1);
+  }
+
+  return { apiUrl, apiToken, clickhouseUrl, clickhouseUser, clickhousePassword };
+}
+
+/**
+ * Fetch decisions from the moderation service API with pagination
+ */
+async function fetchDecisions(apiUrl, apiToken, cursor = null, limit = BATCH_SIZE) {
+  const params = new URLSearchParams({ limit: String(limit) });
+  if (cursor) params.set('cursor', cursor);
+
+  const url = `${apiUrl}/api/v1/decisions?${params}`;
+  const resp = await fetch(url, {
+    headers: {
+      'Authorization': `Bearer ${apiToken}`,
+      'Content-Type': 'application/json',
+    },
+  });
+
+  if (!resp.ok) {
+    throw new Error(`Failed to fetch decisions: ${resp.status} ${await resp.text()}`);
+  }
+
+  return resp.json();
+}
+
+/**
+ * Convert a moderation decision row into ClickHouse label rows
+ */
+function decisionToLabelRows(decision) {
+  const rows = [];
+  const scores = typeof decision.scores === 'string'
+    ? JSON.parse(decision.scores)
+    : decision.scores || {};
+
+  const reviewState = decision.reviewed_by ? 'human-confirmed' : 'automated';
+
+  for (const [cat, score] of Object.entries(scores)) {
+    if (typeof score !== 'number' || score < THRESHOLD) continue;
+    const labels = classifierCategoryToLabels(cat, score);
+    for (const label of labels) {
+      rows.push({
+        sha256: decision.sha256,
+        label: normalizeLabel(label),
+        ...SOURCE_METADATA,
+        confidence: score,
+        operation: 'apply',
+        review_state: reviewState,
+        action: decision.action || '',
+        updated_at: decision.moderated_at || new Date().toISOString(),
+      });
+    }
+  }
+
+  return rows;
+}
+
+/**
+ * Write a batch of label rows to ClickHouse
+ */
+async function writeToClickHouse(rows, config) {
+  if (rows.length === 0) return;
+
+  const query = 'INSERT INTO moderation_labels FORMAT JSONEachRow';
+  const body = rows.map(r => JSON.stringify(r)).join('\n');
+
+  const resp = await fetch(`${config.clickhouseUrl}/?database=default&query=${encodeURIComponent(query)}`, {
+    method: 'POST',
+    headers: {
+      'X-ClickHouse-User': config.clickhouseUser,
+      'X-ClickHouse-Key': config.clickhousePassword,
+      'Content-Type': 'application/x-ndjson',
+    },
+    body,
+  });
+
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(`ClickHouse write failed: ${resp.status} ${text}`);
+  }
+}
+
+async function main() {
+  const config = getConfig();
+  console.log('[BACKFILL] Starting moderation labels backfill');
+  console.log(`[BACKFILL] API: ${config.apiUrl}`);
+  console.log(`[BACKFILL] ClickHouse: ${config.clickhouseUrl}`);
+
+  let cursor = null;
+  let totalDecisions = 0;
+  let totalLabelsWritten = 0;
+  let batchNumber = 0;
+
+  while (true) {
+    batchNumber++;
+    const data = await fetchDecisions(config.apiUrl, config.apiToken, cursor);
+    const decisions = data.decisions || data.results || [];
+
+    if (decisions.length === 0) {
+      console.log('[BACKFILL] No more decisions to process');
+      break;
+    }
+
+    // Convert all decisions in this batch to label rows
+    const allRows = [];
+    for (const decision of decisions) {
+      const rows = decisionToLabelRows(decision);
+      allRows.push(...rows);
+    }
+
+    // Write batch to ClickHouse
+    if (allRows.length > 0) {
+      await writeToClickHouse(allRows, config);
+    }
+
+    totalDecisions += decisions.length;
+    totalLabelsWritten += allRows.length;
+
+    console.log(
+      `[BACKFILL] Batch ${batchNumber}: processed ${decisions.length} decisions, ` +
+      `wrote ${allRows.length} labels (total: ${totalDecisions} decisions, ${totalLabelsWritten} labels)`
+    );
+
+    // Check for next page
+    cursor = data.cursor || data.next_cursor;
+    if (!cursor || decisions.length < BATCH_SIZE) {
+      break;
+    }
+  }
+
+  console.log(`[BACKFILL] Complete! Processed ${totalDecisions} decisions, wrote ${totalLabelsWritten} labels`);
+}
+
+main().catch(err => {
+  console.error('[BACKFILL] Fatal error:', err);
+  process.exit(1);
+});

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -2049,6 +2049,18 @@ async function runMigration() {
       });
     }
 
+    // API: Canonical moderation vocabulary (public, no auth required)
+    if (url.pathname === '/api/v1/moderation/vocabulary' && request.method === 'GET') {
+      const { CANONICAL_LABELS, ALIASES } = await import('./moderation/vocabulary.mjs');
+      return corsResponse(new Response(JSON.stringify({
+        labels: [...CANONICAL_LABELS],
+        aliases: { ...ALIASES },
+        version: '1.0',
+      }), {
+        headers: { 'Content-Type': 'application/json' }
+      }));
+    }
+
     // API: Moderation decisions list (for divine-relay-manager integration)
     // Auth: Bearer token or Cloudflare Access JWT
     if (url.pathname === '/api/v1/decisions' && request.method === 'GET') {
@@ -2329,15 +2341,16 @@ async function runMigration() {
         // GET /api/v1/classifier/{sha256}/recommendations — pre-formatted for gorse/funnelcake
         if (subRoute === 'recommendations') {
           const parsed = JSON.parse(classifierData);
+          const { classifierCategoryToLabels } = await import('./moderation/vocabulary.mjs');
 
-          // Collect labels from all three classification layers
-          const allLabels = [];
+          // Collect content labels from all classification layers
+          const contentLabels = [];
           const allFeatures = {};
 
           // Layer 1: VLM scene classification labels (topics, setting, objects, activities, mood)
           if (parsed.sceneClassification) {
             const sceneLabels = formatForGorse(parsed.sceneClassification);
-            allLabels.push(...sceneLabels);
+            contentLabels.push(...sceneLabels);
             const sceneFeatures = formatForFunnelcake(parsed.sceneClassification);
             Object.assign(allFeatures, sceneFeatures);
           }
@@ -2345,18 +2358,30 @@ async function runMigration() {
           // Layer 2: VTT topic labels
           if (parsed.topicProfile) {
             const topicLabels = topicsToLabels(parsed.topicProfile);
-            allLabels.push(...topicLabels);
+            contentLabels.push(...topicLabels);
             const topicFeatures = topicsToWeightedFeatures(parsed.topicProfile);
             Object.assign(allFeatures, topicFeatures);
           }
 
-          // Layer 3: Raw moderation scores as features (for safety signals)
+          // Layer 3: Raw moderation scores — extract moderation labels and content features
+          const moderationLabels = [];
+          const moderationSources = {};
           if (parsed.rawClassifierData) {
-            // Extract top-level moderation scores for safety signals
             const rawData = parsed.rawClassifierData;
             if (rawData.maxScores) {
               for (const [key, value] of Object.entries(rawData.maxScores)) {
                 if (typeof value === 'number') {
+                  // Check if this category maps to a moderation label
+                  const modLabels = classifierCategoryToLabels(key, value);
+                  if (modLabels.length > 0 && value >= 0.5) {
+                    for (const ml of modLabels) {
+                      if (!moderationLabels.includes(ml)) {
+                        moderationLabels.push(ml);
+                        moderationSources[ml] = ['divine-hive'];
+                      }
+                    }
+                  }
+                  // Keep all scores as features for compatibility
                   allFeatures[key] = value;
                 }
               }
@@ -2365,16 +2390,39 @@ async function runMigration() {
 
           // Determine safety from moderation result
           const moderationResult = await env.BLOSSOM_DB.prepare(
-            'SELECT action FROM moderation_results WHERE sha256 = ?'
+            'SELECT action, scores FROM moderation_results WHERE sha256 = ?'
           ).bind(sha256).first();
 
           const action = moderationResult?.action || 'UNKNOWN';
           const isSafe = action === 'SAFE';
 
+          // Also extract moderation labels from D1 moderation scores
+          if (moderationResult?.scores) {
+            try {
+              const scores = JSON.parse(moderationResult.scores);
+              for (const [cat, score] of Object.entries(scores)) {
+                if (typeof score === 'number' && score >= 0.5) {
+                  const modLabels = classifierCategoryToLabels(cat, score);
+                  for (const ml of modLabels) {
+                    if (!moderationLabels.includes(ml)) {
+                      moderationLabels.push(ml);
+                      moderationSources[ml] = ['divine-hive'];
+                    }
+                  }
+                }
+              }
+            } catch (e) {
+              // Ignore parse errors
+            }
+          }
+
           return new Response(JSON.stringify({
             sha256,
+            content_labels: [...new Set(contentLabels)],
+            moderation_labels: moderationLabels,
+            moderation_sources: moderationSources,
             gorse: {
-              labels: [...new Set(allLabels)],  // deduplicate
+              labels: [...new Set(contentLabels)],  // content labels only, no moderation
               features: allFeatures
             },
             description: parsed.sceneClassification?.description || null,
@@ -2400,7 +2448,7 @@ async function runMigration() {
       }
     }
 
-    return new Response('Divine Moderation API\n\nPublic endpoints:\nGET  /health\nGET  /check-result/{sha256}\n\nAuthenticated endpoints:\nPOST /test-moderate {"sha256":"..."}\nGET  /api/v1/decisions\nGET  /api/v1/decisions/{sha256}\nPOST /api/v1/quarantine/{sha256}\nPOST /api/v1/moderate\nPOST /api/v1/report\nPOST /api/v1/classify\nGET  /api/v1/classifier/{sha256}\nGET  /api/v1/classifier/{sha256}/recommendations\n\nAdmin UI: https://moderation.admin.divine.video/admin', {
+    return new Response('Divine Moderation API\n\nPublic endpoints:\nGET  /health\nGET  /check-result/{sha256}\nGET  /api/v1/moderation/vocabulary\n\nAuthenticated endpoints:\nPOST /test-moderate {"sha256":"..."}\nGET  /api/v1/decisions\nGET  /api/v1/decisions/{sha256}\nPOST /api/v1/quarantine/{sha256}\nPOST /api/v1/moderate\nPOST /api/v1/report\nPOST /api/v1/classify\nGET  /api/v1/classifier/{sha256}\nGET  /api/v1/classifier/{sha256}/recommendations\n\nAdmin UI: https://moderation.admin.divine.video/admin', {
       headers: { 'Content-Type': 'text/plain' }
     });
   },
@@ -2692,6 +2740,19 @@ async function handleModerationResult(result, env) {
     } catch (dmErr) {
       console.error(`[MODERATION] ${sha256} - DM notification failed:`, dmErr.message);
     }
+  }
+
+  // Write normalized moderation labels to ClickHouse
+  try {
+    const { writeModerationLabels } = await import('./moderation/label-writer.mjs');
+    await writeModerationLabels(sha256, result, env, {
+      sourceId: result.provider || 'divine-hive',
+      sourceOwner: 'divine',
+      sourceType: 'machine-labeler',
+      transport: 'moderation-api',
+    });
+  } catch (err) {
+    console.error('[MODERATION] Failed to write moderation labels:', err.message);
   }
 
   console.log(`[MODERATION] handleModerationResult finished for ${sha256}`);

--- a/src/moderation/label-writer.mjs
+++ b/src/moderation/label-writer.mjs
@@ -1,0 +1,86 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: ClickHouse label writer for moderation labels
+// ABOUTME: Writes normalized, source-aware moderation rows to the shared moderation_labels table
+
+import { normalizeLabel, classifierCategoryToLabels } from './vocabulary.mjs';
+
+/**
+ * Write normalized moderation labels to the ClickHouse moderation_labels table.
+ *
+ * Only writes labels with scores >= 0.5 (meaningful confidence).
+ * Gracefully handles errors (logs, does not throw).
+ *
+ * @param {string} sha256 - Content hash
+ * @param {Object} classification - Moderation classification result
+ * @param {string} classification.action - Moderation action (SAFE, QUARANTINE, etc.)
+ * @param {Object} classification.scores - Category scores { nudity: 0.9, violence: 0.1, ... }
+ * @param {string} [classification.reviewed_by] - If set, marks as human-confirmed
+ * @param {string} [classification.provider] - Provider ID
+ * @param {Object} env - Worker environment bindings
+ * @param {Object} [source] - Source metadata
+ * @param {string} [source.sourceId] - Source identifier
+ * @param {string} [source.sourceOwner] - Source owner type
+ * @param {string} [source.sourceType] - Source type
+ * @param {string} [source.transport] - Transport mechanism
+ * @param {string} [source.operation] - Operation type (apply/clear)
+ */
+export async function writeModerationLabels(sha256, classification, env, source) {
+  if (!env.CLICKHOUSE_URL || !env.CLICKHOUSE_PASSWORD) return;
+
+  const { action, scores, category, severity } = classification;
+  const reviewState = classification.reviewed_by ? 'human-confirmed' : 'automated';
+  const sourceId = source?.sourceId || classification.provider || 'divine-hive';
+  const sourceOwner = source?.sourceOwner || 'divine';
+  const sourceType = source?.sourceType || 'machine-labeler';
+  const transport = source?.transport || 'moderation-api';
+  const operation = source?.operation || 'apply';
+
+  // Build label rows from scores above threshold
+  const rows = [];
+  const thresholdForLabel = 0.5; // Only write labels with meaningful confidence
+
+  for (const [cat, score] of Object.entries(scores || {})) {
+    if (score < thresholdForLabel) continue;
+    const labels = classifierCategoryToLabels(cat, score);
+    for (const label of labels) {
+      rows.push({
+        sha256,
+        label: normalizeLabel(label),
+        source_id: sourceId,
+        source_owner: sourceOwner,
+        source_type: sourceType,
+        transport,
+        confidence: score,
+        operation,
+        review_state: reviewState,
+        action: action || '',
+      });
+    }
+  }
+
+  if (rows.length === 0) return;
+
+  const query = 'INSERT INTO moderation_labels FORMAT JSONEachRow';
+
+  try {
+    const resp = await fetch(`${env.CLICKHOUSE_URL}/?database=default&query=${encodeURIComponent(query)}`, {
+      method: 'POST',
+      headers: {
+        'X-ClickHouse-User': env.CLICKHOUSE_USER || 'default',
+        'X-ClickHouse-Key': env.CLICKHOUSE_PASSWORD,
+        'Content-Type': 'application/x-ndjson',
+      },
+      body: rows.map(r => JSON.stringify({
+        ...r,
+        updated_at: new Date().toISOString(),
+      })).join('\n'),
+    });
+    if (!resp.ok) {
+      console.error('[LABELS] ClickHouse write failed:', resp.status, await resp.text());
+    }
+  } catch (err) {
+    console.error('[LABELS] ClickHouse write error:', err.message);
+  }
+}

--- a/src/moderation/label-writer.test.mjs
+++ b/src/moderation/label-writer.test.mjs
@@ -1,0 +1,238 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Tests for ClickHouse moderation label writer
+// ABOUTME: Verifies skip conditions, threshold filtering, normalization, source metadata, and error handling
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { writeModerationLabels } from './label-writer.mjs';
+
+describe('writeModerationLabels', () => {
+  let mockEnv;
+  let fetchSpy;
+
+  beforeEach(() => {
+    mockEnv = {
+      CLICKHOUSE_URL: 'https://clickhouse.example.com:8443',
+      CLICKHOUSE_PASSWORD: 'test-password',
+      CLICKHOUSE_USER: 'default',
+    };
+
+    fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(''),
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+  });
+
+  it('should skip when CLICKHOUSE_URL is not configured', async () => {
+    delete mockEnv.CLICKHOUSE_URL;
+    await writeModerationLabels('abc123', { action: 'QUARANTINE', scores: { nudity: 0.9 } }, mockEnv);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('should skip when CLICKHOUSE_PASSWORD is not configured', async () => {
+    delete mockEnv.CLICKHOUSE_PASSWORD;
+    await writeModerationLabels('abc123', { action: 'QUARANTINE', scores: { nudity: 0.9 } }, mockEnv);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('should skip when scores are empty', async () => {
+    await writeModerationLabels('abc123', { action: 'SAFE', scores: {} }, mockEnv);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('should skip when scores are undefined', async () => {
+    await writeModerationLabels('abc123', { action: 'SAFE' }, mockEnv);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('should filter out scores below 0.5 threshold', async () => {
+    await writeModerationLabels('abc123', {
+      action: 'SAFE',
+      scores: { nudity: 0.3, violence: 0.1 },
+    }, mockEnv);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('should write labels for scores at or above 0.5', async () => {
+    await writeModerationLabels('abc123', {
+      action: 'QUARANTINE',
+      scores: { nudity: 0.9, violence: 0.3 },
+    }, mockEnv);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, opts] = fetchSpy.mock.calls[0];
+    expect(url).toContain('clickhouse.example.com');
+    expect(opts.method).toBe('POST');
+
+    const body = opts.body;
+    const rows = body.split('\n').map(line => JSON.parse(line));
+    expect(rows).toHaveLength(1);
+    expect(rows[0].label).toBe('nudity');
+    expect(rows[0].sha256).toBe('abc123');
+    expect(rows[0].confidence).toBe(0.9);
+  });
+
+  it('should normalize labels via classifierCategoryToLabels', async () => {
+    await writeModerationLabels('abc123', {
+      action: 'QUARANTINE',
+      scores: { gore: 0.8, weapon: 0.7 },
+    }, mockEnv);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const body = fetchSpy.mock.calls[0][1].body;
+    const rows = body.split('\n').map(line => JSON.parse(line));
+    expect(rows).toHaveLength(2);
+
+    const labels = rows.map(r => r.label);
+    expect(labels).toContain('graphic-media');
+    expect(labels).toContain('violence');
+  });
+
+  it('should use provided source metadata', async () => {
+    await writeModerationLabels('abc123', {
+      action: 'AGE_RESTRICTED',
+      scores: { nudity: 0.95 },
+    }, mockEnv, {
+      sourceId: 'blacksky-v1',
+      sourceOwner: 'partner',
+      sourceType: 'machine-labeler',
+      transport: 'partner-api',
+    });
+
+    const body = fetchSpy.mock.calls[0][1].body;
+    const row = JSON.parse(body);
+    expect(row.source_id).toBe('blacksky-v1');
+    expect(row.source_owner).toBe('partner');
+    expect(row.source_type).toBe('machine-labeler');
+    expect(row.transport).toBe('partner-api');
+  });
+
+  it('should default source metadata when not provided', async () => {
+    await writeModerationLabels('abc123', {
+      action: 'QUARANTINE',
+      scores: { nudity: 0.8 },
+      provider: 'divine-hive',
+    }, mockEnv);
+
+    const body = fetchSpy.mock.calls[0][1].body;
+    const row = JSON.parse(body);
+    expect(row.source_id).toBe('divine-hive');
+    expect(row.source_owner).toBe('divine');
+    expect(row.source_type).toBe('machine-labeler');
+    expect(row.transport).toBe('moderation-api');
+  });
+
+  it('should set review_state to human-confirmed when reviewed_by is present', async () => {
+    await writeModerationLabels('abc123', {
+      action: 'QUARANTINE',
+      scores: { nudity: 0.9 },
+      reviewed_by: 'moderator@example.com',
+    }, mockEnv);
+
+    const body = fetchSpy.mock.calls[0][1].body;
+    const row = JSON.parse(body);
+    expect(row.review_state).toBe('human-confirmed');
+  });
+
+  it('should set review_state to automated when reviewed_by is not present', async () => {
+    await writeModerationLabels('abc123', {
+      action: 'QUARANTINE',
+      scores: { nudity: 0.9 },
+    }, mockEnv);
+
+    const body = fetchSpy.mock.calls[0][1].body;
+    const row = JSON.parse(body);
+    expect(row.review_state).toBe('automated');
+  });
+
+  it('should default operation to apply', async () => {
+    await writeModerationLabels('abc123', {
+      action: 'QUARANTINE',
+      scores: { nudity: 0.9 },
+    }, mockEnv);
+
+    const body = fetchSpy.mock.calls[0][1].body;
+    const row = JSON.parse(body);
+    expect(row.operation).toBe('apply');
+  });
+
+  it('should support clear operation via source metadata', async () => {
+    await writeModerationLabels('abc123', {
+      action: 'SAFE',
+      scores: { nudity: 0.9 },
+    }, mockEnv, {
+      operation: 'clear',
+    });
+
+    const body = fetchSpy.mock.calls[0][1].body;
+    const row = JSON.parse(body);
+    expect(row.operation).toBe('clear');
+  });
+
+  it('should include updated_at timestamp in each row', async () => {
+    await writeModerationLabels('abc123', {
+      action: 'QUARANTINE',
+      scores: { nudity: 0.9 },
+    }, mockEnv);
+
+    const body = fetchSpy.mock.calls[0][1].body;
+    const row = JSON.parse(body);
+    expect(row.updated_at).toBeDefined();
+    // Should be a valid ISO date string
+    expect(new Date(row.updated_at).toISOString()).toBe(row.updated_at);
+  });
+
+  it('should handle ClickHouse errors gracefully without throwing', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve('Internal Server Error'),
+    });
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    // Should not throw
+    await writeModerationLabels('abc123', {
+      action: 'QUARANTINE',
+      scores: { nudity: 0.9 },
+    }, mockEnv);
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[LABELS] ClickHouse write failed:'),
+      500,
+      'Internal Server Error'
+    );
+    consoleSpy.mockRestore();
+  });
+
+  it('should handle fetch network errors gracefully without throwing', async () => {
+    fetchSpy.mockRejectedValue(new Error('Network error'));
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    // Should not throw
+    await writeModerationLabels('abc123', {
+      action: 'QUARANTINE',
+      scores: { nudity: 0.9 },
+    }, mockEnv);
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[LABELS] ClickHouse write error:'),
+      'Network error'
+    );
+    consoleSpy.mockRestore();
+  });
+
+  it('should include action in each row', async () => {
+    await writeModerationLabels('abc123', {
+      action: 'PERMANENT_BAN',
+      scores: { nudity: 0.99 },
+    }, mockEnv);
+
+    const body = fetchSpy.mock.calls[0][1].body;
+    const row = JSON.parse(body);
+    expect(row.action).toBe('PERMANENT_BAN');
+  });
+});

--- a/src/moderation/vocabulary.mjs
+++ b/src/moderation/vocabulary.mjs
@@ -1,0 +1,75 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Canonical moderation vocabulary module
+// ABOUTME: Single source of truth for moderation label vocabulary and normalization
+
+export const CANONICAL_LABELS = [
+  'nudity', 'sexual', 'porn', 'graphic-media', 'violence',
+  'self-harm', 'drugs', 'alcohol', 'tobacco', 'gambling',
+  'profanity', 'hate', 'harassment', 'flashing-lights',
+  'ai-generated', 'deepfake', 'misleading', 'spam', 'scam',
+];
+
+export const ALIASES = {
+  pornography: 'porn',
+  explicit: 'porn',
+  'graphic-violence': 'graphic-media',
+  gore: 'graphic-media',
+  nsfw: 'nudity',
+  offensive: 'hate',
+  'hate-speech': 'hate',
+  hate_speech: 'hate',
+  self_harm: 'self-harm',
+  ai_generated: 'ai-generated',
+  recreational_drug: 'drugs',
+  weapon: 'violence',
+};
+
+/**
+ * Normalize a label to its canonical form.
+ * Lowercases, converts snake_case to kebab-case, and resolves aliases.
+ * @param {string} label - The label to normalize
+ * @returns {string} The canonical label
+ */
+export function normalizeLabel(label) {
+  const lower = label.toLowerCase().replace(/_/g, '-');
+  return ALIASES[lower] || ALIASES[label] || lower;
+}
+
+/**
+ * Check if a label is (or normalizes to) a canonical moderation label.
+ * @param {string} label - The label to check
+ * @returns {boolean}
+ */
+export function isCanonicalLabel(label) {
+  return CANONICAL_LABELS.includes(normalizeLabel(label));
+}
+
+/**
+ * Map a classifier category to canonical moderation labels.
+ * @param {string} category - The classifier category (e.g. 'nudity', 'gore', 'weapon')
+ * @param {number} [scores] - Optional score value (unused, reserved for future threshold logic)
+ * @returns {string[]} Array of canonical moderation labels
+ */
+export function classifierCategoryToLabels(category, scores) {
+  const map = {
+    nudity: ['nudity'],
+    violence: ['violence'],
+    gore: ['graphic-media'],
+    offensive: ['hate'],
+    self_harm: ['self-harm'],
+    ai_generated: ['ai-generated'],
+    deepfake: ['deepfake'],
+    weapon: ['violence'],
+    recreational_drug: ['drugs'],
+    alcohol: ['alcohol'],
+    tobacco: ['tobacco'],
+    gambling: ['gambling'],
+  };
+  const labels = [];
+  if (map[category]) {
+    labels.push(...map[category]);
+  }
+  return labels;
+}

--- a/src/moderation/vocabulary.test.mjs
+++ b/src/moderation/vocabulary.test.mjs
@@ -1,0 +1,144 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Tests for canonical moderation vocabulary module
+// ABOUTME: Verifies label normalization, alias resolution, and classifier category mapping
+
+import { describe, it, expect } from 'vitest';
+import {
+  CANONICAL_LABELS,
+  ALIASES,
+  normalizeLabel,
+  isCanonicalLabel,
+  classifierCategoryToLabels,
+} from './vocabulary.mjs';
+
+describe('CANONICAL_LABELS', () => {
+  it('should contain exactly 19 labels', () => {
+    expect(CANONICAL_LABELS).toHaveLength(19);
+  });
+
+  it('should include key moderation labels', () => {
+    expect(CANONICAL_LABELS).toContain('nudity');
+    expect(CANONICAL_LABELS).toContain('porn');
+    expect(CANONICAL_LABELS).toContain('graphic-media');
+    expect(CANONICAL_LABELS).toContain('violence');
+    expect(CANONICAL_LABELS).toContain('self-harm');
+    expect(CANONICAL_LABELS).toContain('drugs');
+    expect(CANONICAL_LABELS).toContain('hate');
+    expect(CANONICAL_LABELS).toContain('spam');
+    expect(CANONICAL_LABELS).toContain('ai-generated');
+    expect(CANONICAL_LABELS).toContain('deepfake');
+  });
+
+  it('should all be lowercase kebab-case strings', () => {
+    for (const label of CANONICAL_LABELS) {
+      expect(label).toBe(label.toLowerCase());
+      expect(label).not.toMatch(/_/);
+    }
+  });
+});
+
+describe('normalizeLabel', () => {
+  it('should resolve aliases to canonical labels', () => {
+    expect(normalizeLabel('pornography')).toBe('porn');
+    expect(normalizeLabel('explicit')).toBe('porn');
+    expect(normalizeLabel('gore')).toBe('graphic-media');
+    expect(normalizeLabel('graphic-violence')).toBe('graphic-media');
+    expect(normalizeLabel('nsfw')).toBe('nudity');
+    expect(normalizeLabel('offensive')).toBe('hate');
+    expect(normalizeLabel('hate-speech')).toBe('hate');
+    expect(normalizeLabel('weapon')).toBe('violence');
+    expect(normalizeLabel('recreational_drug')).toBe('drugs');
+  });
+
+  it('should convert snake_case to kebab-case', () => {
+    expect(normalizeLabel('hate_speech')).toBe('hate');
+    expect(normalizeLabel('self_harm')).toBe('self-harm');
+    expect(normalizeLabel('ai_generated')).toBe('ai-generated');
+  });
+
+  it('should lowercase input', () => {
+    expect(normalizeLabel('NUDITY')).toBe('nudity');
+    expect(normalizeLabel('Violence')).toBe('violence');
+    expect(normalizeLabel('PORN')).toBe('porn');
+  });
+
+  it('should pass through already-canonical labels unchanged', () => {
+    expect(normalizeLabel('nudity')).toBe('nudity');
+    expect(normalizeLabel('porn')).toBe('porn');
+    expect(normalizeLabel('violence')).toBe('violence');
+    expect(normalizeLabel('self-harm')).toBe('self-harm');
+  });
+
+  it('should pass through unknown labels in kebab-case', () => {
+    expect(normalizeLabel('unknown_label')).toBe('unknown-label');
+    expect(normalizeLabel('custom')).toBe('custom');
+  });
+});
+
+describe('isCanonicalLabel', () => {
+  it('should return true for canonical labels', () => {
+    expect(isCanonicalLabel('nudity')).toBe(true);
+    expect(isCanonicalLabel('porn')).toBe(true);
+    expect(isCanonicalLabel('self-harm')).toBe(true);
+    expect(isCanonicalLabel('ai-generated')).toBe(true);
+  });
+
+  it('should return true for aliases (after normalization)', () => {
+    expect(isCanonicalLabel('pornography')).toBe(true);
+    expect(isCanonicalLabel('gore')).toBe(true);
+    expect(isCanonicalLabel('nsfw')).toBe(true);
+    expect(isCanonicalLabel('weapon')).toBe(true);
+  });
+
+  it('should return true for snake_case variants', () => {
+    expect(isCanonicalLabel('self_harm')).toBe(true);
+    expect(isCanonicalLabel('ai_generated')).toBe(true);
+    expect(isCanonicalLabel('hate_speech')).toBe(true);
+  });
+
+  it('should return false for non-canonical labels', () => {
+    expect(isCanonicalLabel('unknown')).toBe(false);
+    expect(isCanonicalLabel('custom-label')).toBe(false);
+    expect(isCanonicalLabel('topic:sports')).toBe(false);
+  });
+});
+
+describe('classifierCategoryToLabels', () => {
+  it('should map nudity to nudity', () => {
+    expect(classifierCategoryToLabels('nudity')).toEqual(['nudity']);
+  });
+
+  it('should map gore to graphic-media', () => {
+    expect(classifierCategoryToLabels('gore')).toEqual(['graphic-media']);
+  });
+
+  it('should map weapon to violence', () => {
+    expect(classifierCategoryToLabels('weapon')).toEqual(['violence']);
+  });
+
+  it('should map offensive to hate', () => {
+    expect(classifierCategoryToLabels('offensive')).toEqual(['hate']);
+  });
+
+  it('should map self_harm to self-harm', () => {
+    expect(classifierCategoryToLabels('self_harm')).toEqual(['self-harm']);
+  });
+
+  it('should map ai_generated to ai-generated', () => {
+    expect(classifierCategoryToLabels('ai_generated')).toEqual(['ai-generated']);
+  });
+
+  it('should map substance categories', () => {
+    expect(classifierCategoryToLabels('recreational_drug')).toEqual(['drugs']);
+    expect(classifierCategoryToLabels('alcohol')).toEqual(['alcohol']);
+    expect(classifierCategoryToLabels('tobacco')).toEqual(['tobacco']);
+    expect(classifierCategoryToLabels('gambling')).toEqual(['gambling']);
+  });
+
+  it('should return empty array for unknown categories', () => {
+    expect(classifierCategoryToLabels('unknown')).toEqual([]);
+    expect(classifierCategoryToLabels('topic:sports')).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the moderation service side of the unified moderation contract spec (`docs/moderation-service-implementation.md`):

- **`src/moderation/vocabulary.mjs`** — Canonical 19-label moderation vocabulary with alias normalization (snake_case→kebab-case, `gore`→`graphic-media`, etc.) and classifier-to-label mapping
- **`src/moderation/label-writer.mjs`** — Writes source-aware, normalized moderation labels to ClickHouse `moderation_labels` table (JSONEachRow format, 0.5 confidence threshold, explicit source metadata)
- **`GET /api/v1/moderation/vocabulary`** — Public endpoint returning canonical labels, aliases, and version for Funnelcake/client validation
- **`/api/v1/classifier/{sha256}/recommendations`** — Now separates `moderation_labels` from `content_labels`; `gorse.labels` excludes moderation labels
- **`handleModerationResult()`** — Wired label writer after existing D1 write (fire-and-forget, non-blocking)
- **`scripts/backfill-moderation-labels.mjs`** — One-time migration from D1 `moderation_results` to ClickHouse `moderation_labels`
- **37 new tests** (20 vocabulary + 17 label writer), all 330 tests passing

## Test plan

- [x] `npm test` — all 330 tests pass (37 new)
- [ ] Deploy to staging, verify `/api/v1/moderation/vocabulary` returns expected JSON
- [ ] Verify moderation pipeline writes labels to ClickHouse after classification
- [ ] Run backfill script against staging D1 data
- [ ] Verify `/api/v1/classifier/{sha256}/recommendations` separates moderation vs content labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)