### PR TITLE
feat: Reality Defender secondary verification for AI content

### DIFF
--- a/src/admin/dashboard.html
+++ b/src/admin/dashboard.html
@@ -2111,6 +2111,13 @@
 
         // Load classifier inline summary + detail panels (async, non-blocking)
         loadClassifierData(video.sha256);
+
+        // Load realness secondary verification for AI-flagged videos
+        const aiScore = video.scores?.ai_generated || 0;
+        const deepfakeScore = video.scores?.deepfake || 0;
+        if (aiScore >= 0.3 || deepfakeScore >= 0.3) {
+          loadRealnessResult(video.sha256);
+        }
       });
     }
 
@@ -2312,7 +2319,7 @@
       const providerBadgeHTML = createProviderBadge(provider);
 
       // Generate AI detection alert for ai_generated or deepfake
-      const aiDetectionHTML = createAIDetectionAlert(scores, detailedCategories);
+      const aiDetectionHTML = createAIDetectionAlert(scores, detailedCategories, sha256);
 
       // Generate moderation history
       const historyHTML = createModerationHistory(video);
@@ -2403,7 +2410,7 @@
       return `<span class="provider-badge ${badgeClass}">${icon} ${displayName}</span>`;
     }
 
-    function createAIDetectionAlert(scores, detailedCategories) {
+    function createAIDetectionAlert(scores, detailedCategories, sha256) {
       if (!scores) return '';
 
       const aiScore = scores.ai_generated || 0;
@@ -2442,8 +2449,68 @@
         <div class="ai-detection-alert ${alertClass}">
           <div class="ai-detection-title">${title}</div>
           <div class="ai-detection-details">${details.join(' · ')}</div>
+          <div class="realness-result" id="realness-${sha256}" style="margin-top:6px;font-size:11px;color:#888;">
+            Loading secondary verification...
+          </div>
         </div>
       `;
+    }
+
+    async function loadRealnessResult(sha256) {
+      const container = document.getElementById(`realness-${sha256}`);
+      if (!container) return;
+
+      try {
+        const resp = await fetch(`/admin/api/realness/${sha256}`);
+        if (resp.status === 404) {
+          container.innerHTML = '<span style="color:#666;">No secondary verification available</span>';
+          return;
+        }
+        if (!resp.ok) throw new Error('fetch failed');
+        const data = await resp.json();
+
+        const verdictColors = {
+          authentic: '#22c55e',
+          likely_ai: '#ef4444',
+          disputed: '#f59e0b',
+          uncertain: '#888',
+          pending: '#666',
+        };
+
+        const verdictLabels = {
+          authentic: 'AUTHENTIC',
+          likely_ai: 'LIKELY AI',
+          disputed: 'DISPUTED (providers disagree)',
+          uncertain: 'UNCERTAIN',
+          pending: 'PENDING...',
+        };
+
+        let html = `<strong style="color:${verdictColors[data.overallVerdict] || '#888'}">Secondary: ${verdictLabels[data.overallVerdict] || data.overallVerdict}</strong>`;
+
+        // Show per-provider details (prioritize Reality Defender, it's the key new signal)
+        const providerDetails = [];
+        for (const [name, info] of Object.entries(data.providers || {})) {
+          // Skip Hive from realness — we already have Hive from primary moderation
+          if (name === 'hive') continue;
+          const label = name.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+          if (info.status === 'complete') {
+            const scoreStr = info.score != null ? ` ${(info.score * 100).toFixed(0)}%` : '';
+            const color = info.verdict === 'authentic' ? '#22c55e' : info.verdict === 'likely_ai' ? '#ef4444' : '#888';
+            providerDetails.push(`<span style="color:${color}">${label}: ${info.verdict}${scoreStr}</span>`);
+          } else if (info.status === 'pending') {
+            providerDetails.push(`<span style="color:#666">${label}: pending</span>`);
+          } else if (info.status === 'error') {
+            providerDetails.push(`<span style="color:#666">${label}: error</span>`);
+          }
+        }
+        if (providerDetails.length > 0) {
+          html += '<br>' + providerDetails.join(' · ');
+        }
+
+        container.innerHTML = html;
+      } catch (err) {
+        container.innerHTML = '<span style="color:#666;">Verification unavailable</span>';
+      }
     }
 
     function createModerationHistory(video) {

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1850,6 +1850,20 @@ async function runMigration() {
       return new Response(JSON.stringify({ success: true }), { headers: { 'Content-Type': 'application/json' } });
     }
 
+    // Admin API: Get divine-realness AI verification results for a video
+    if (url.pathname.startsWith('/admin/api/realness/') && request.method === 'GET') {
+      const authError = await requireAuth(request, env);
+      if (authError) return authError;
+
+      const sha256 = url.pathname.split('/').pop();
+      const { getRealnessResult } = await import('./moderation/realness-client.mjs');
+      const result = await getRealnessResult(sha256, env);
+      if (!result) {
+        return new Response(JSON.stringify({ error: 'No realness verification found' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response(JSON.stringify(result), { headers: { 'Content-Type': 'application/json' } });
+    }
+
     // API: Submit a user report for a piece of content (NIP-56)
     // Auth: Bearer token or Cloudflare Access JWT
     if (url.pathname === '/api/v1/scan' && request.method === 'POST') {
@@ -2679,6 +2693,33 @@ async function runMigration() {
         console.log(`[CRON] DM inbox sync: ${syncResult.synced} new, ${syncResult.skipped} deduped, ${syncResult.errors} errors`);
       } catch (err) {
         console.error('[CRON] DM inbox sync failed:', err);
+      }
+    }
+
+    // Poll pending Reality Defender results and update moderation decisions
+    if (env.REALITY_DEFENDER_API_KEY && env.MODERATION_KV) {
+      try {
+        const pendingKeys = await env.MODERATION_KV.list({ prefix: 'rd:', limit: 20 });
+        let polled = 0;
+        for (const key of pendingKeys.keys) {
+          const cached = await env.MODERATION_KV.get(key.name);
+          if (!cached) continue;
+          const parsed = JSON.parse(cached);
+          if (parsed.status !== 'pending') continue;
+
+          const sha256 = key.name.replace('rd:', '');
+          const { pollRealityDefender } = await import('./moderation/realness-client.mjs');
+          const result = await pollRealityDefender(sha256, env);
+          if (result && result.status === 'complete') {
+            polled++;
+            console.log(`[CRON] Reality Defender result for ${sha256}: ${result.verdict} (score=${result.score})`);
+          }
+        }
+        if (polled > 0) {
+          console.log(`[CRON] Polled ${polled} Reality Defender results`);
+        }
+      } catch (err) {
+        console.error('[CRON] Reality Defender polling failed:', err);
       }
     }
   }

--- a/src/moderation/classifier.mjs
+++ b/src/moderation/classifier.mjs
@@ -224,6 +224,7 @@ export function classifyModerationResult(moderationData, env = {}) {
 
   // Determine action based on category and score
   let action, severity, reason, category;
+  let requiresSecondaryVerification = false;
 
   // Check for PERMANENT_BAN categories (self-harm, hate speech)
   if (scores.self_harm >= (thresholds.self_harm?.high || DEFAULT_SELF_HARM_HIGH)) {
@@ -245,16 +246,18 @@ export function classifyModerationResult(moderationData, env = {}) {
     reason = 'Extreme gore content detected - immediate removal required';
   }
   else if (scores.ai_generated >= (thresholds.ai_generated?.high || DEFAULT_AI_GENERATED_HIGH)) {
-    action = 'PERMANENT_BAN';
-    severity = 'critical';
+    action = 'QUARANTINE';
+    severity = 'high';
     category = 'ai_generated';
-    reason = 'AI-generated content detected - not permitted on platform';
+    reason = 'AI-generated content detected by primary provider - quarantined pending secondary verification';
+    requiresSecondaryVerification = true;
   }
-  else if (scores.deepfake >= (thresholds.deepfake?.high || DEFAULT_AI_GENERATED_HIGH)) {
-    action = 'PERMANENT_BAN';
-    severity = 'critical';
+  else if (scores.deepfake >= (thresholds.deepfake?.high || DEFAULT_DEEPFAKE_HIGH)) {
+    action = 'QUARANTINE';
+    severity = 'high';
     category = 'deepfake';
-    reason = 'Deepfake content detected - not permitted on platform';
+    reason = 'Deepfake content detected by primary provider - quarantined pending secondary verification';
+    requiresSecondaryVerification = true;
   }
   // Check for text-based PERMANENT_BAN (hate speech or threats in transcript)
   else if (text_scores && text_scores.hate_speech > (parseFloat(env.TEXT_HATE_SPEECH_THRESHOLD_HIGH) || DEFAULT_TEXT_HATE_SPEECH_HIGH)) {
@@ -325,7 +328,8 @@ export function classifyModerationResult(moderationData, env = {}) {
     primaryConcern,
     category,
     scores,
-    flaggedFrames
+    flaggedFrames,
+    requiresSecondaryVerification
   };
 }
 

--- a/src/moderation/classifier.test.mjs
+++ b/src/moderation/classifier.test.mjs
@@ -173,7 +173,7 @@ describe('Moderation Classifier', () => {
     expect(result.flaggedFrames).toEqual(flaggedFrames);
   });
 
-  it('should classify high AI-generated score as PERMANENT_BAN', () => {
+  it('should classify high AI-generated score as QUARANTINE pending secondary verification', () => {
     const result = classifyModerationResult({
       maxScores: {
         nudity: 0.1,
@@ -182,10 +182,12 @@ describe('Moderation Classifier', () => {
       }
     });
 
-    expect(result.action).toBe('PERMANENT_BAN');
-    expect(result.severity).toBe('critical');
+    expect(result.action).toBe('QUARANTINE');
+    expect(result.severity).toBe('high');
     expect(result.category).toBe('ai_generated');
     expect(result.reason).toContain('AI-generated');
+    expect(result.reason).toContain('secondary verification');
+    expect(result.requiresSecondaryVerification).toBe(true);
   });
 
   it('should classify medium AI-generated score as REVIEW', () => {
@@ -284,7 +286,7 @@ describe('Moderation Classifier', () => {
     expect(result.severity).toBe('high');
   });
 
-  it('should classify very high deepfake score as PERMANENT_BAN', () => {
+  it('should classify very high deepfake score as QUARANTINE pending secondary verification', () => {
     const result = classifyModerationResult({
       maxScores: {
         deepfake: 0.96,
@@ -293,9 +295,10 @@ describe('Moderation Classifier', () => {
       }
     });
 
-    expect(result.action).toBe('PERMANENT_BAN');
-    expect(result.severity).toBe('critical');
+    expect(result.action).toBe('QUARANTINE');
+    expect(result.severity).toBe('high');
     expect(result.category).toBe('deepfake');
+    expect(result.requiresSecondaryVerification).toBe(true);
   });
 
   it('should classify medium deepfake score (0.85) as QUARANTINE not ban', () => {

--- a/src/moderation/pipeline.mjs
+++ b/src/moderation/pipeline.mjs
@@ -268,6 +268,22 @@ export async function moderateVideo(videoData, env, fetchFn = fetch) {
     text_scores: textScores
   }, effectiveEnv);
 
+  // Step 4.5: If AI-flagged, submit to Reality Defender for secondary verification (fire-and-forget)
+  if (classification.requiresSecondaryVerification && env.REALITY_DEFENDER_API_KEY) {
+    try {
+      const { submitToRealityDefender } = await import('./realness-client.mjs');
+      const rdResult = await submitToRealityDefender(sha256, videoUrl, env);
+      if (rdResult.submitted) {
+        console.log(`[MODERATION] ${sha256} - Submitted to Reality Defender for secondary AI verification (requestId=${rdResult.requestId})`);
+      } else if (!rdResult.cached) {
+        console.warn(`[MODERATION] ${sha256} - Failed to submit to Reality Defender: ${rdResult.error}`);
+      }
+    } catch (err) {
+      console.error(`[MODERATION] ${sha256} - Reality Defender submission error:`, err.message);
+      // Non-fatal: don't block moderation if Reality Defender is unavailable
+    }
+  }
+
   // Step 5: Return complete result
   return {
     // Classification

--- a/src/moderation/realness-client.mjs
+++ b/src/moderation/realness-client.mjs
@@ -1,0 +1,251 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Reality Defender API client for secondary AI-generated content verification
+// ABOUTME: Called when Hive flags content as AI-generated to get a second opinion
+
+const RD_API_BASE = 'https://api.prd.realitydefender.xyz';
+const SUBMIT_TIMEOUT_MS = 30000;
+const POLL_TIMEOUT_MS = 10000;
+const KV_RESULT_TTL = 86400 * 7; // Cache results for 7 days
+
+/**
+ * Submit a video to Reality Defender for AI-generated verification.
+ * Downloads the video, uploads to RD's presigned S3 URL, then stores the requestId in KV.
+ *
+ * @param {string} sha256 - Video hash
+ * @param {string} videoUrl - URL to the video file
+ * @param {Object} env - Cloudflare Workers env (needs REALITY_DEFENDER_API_KEY)
+ * @returns {Promise<{ submitted: boolean, requestId?: string, error?: string }>}
+ */
+export async function submitToRealityDefender(sha256, videoUrl, env) {
+  if (!env.REALITY_DEFENDER_API_KEY) {
+    return { submitted: false, error: 'REALITY_DEFENDER_API_KEY not configured' };
+  }
+
+  try {
+    // Check if we already have a result or pending submission
+    if (env.MODERATION_KV) {
+      const cached = await env.MODERATION_KV.get(`rd:${sha256}`);
+      if (cached) {
+        const parsed = JSON.parse(cached);
+        if (parsed.status === 'complete') {
+          console.log(`[RD] Already have result for ${sha256}: ${parsed.verdict}`);
+          return { submitted: false, error: 'Already have result', cached: true };
+        }
+        if (parsed.status === 'pending' && parsed.requestId) {
+          console.log(`[RD] Already submitted ${sha256}, requestId=${parsed.requestId}`);
+          return { submitted: true, requestId: parsed.requestId };
+        }
+      }
+    }
+
+    // Step 1: Download the video
+    const videoResponse = await fetch(videoUrl);
+    if (!videoResponse.ok) {
+      return { submitted: false, error: `Failed to fetch video: ${videoResponse.status}` };
+    }
+    const videoBlob = await videoResponse.blob();
+
+    // Ensure filename has a video extension (Reality Defender requires it)
+    let filename = videoUrl.split('/').pop() || 'video.mp4';
+    if (!filename.match(/\.(mp4|mov|avi|webm|mkv)$/i)) {
+      filename = filename + '.mp4';
+    }
+
+    // Step 2: Get presigned URL from Reality Defender
+    const presignedResponse = await fetch(`${RD_API_BASE}/api/files/aws-presigned`, {
+      method: 'POST',
+      headers: {
+        'X-API-KEY': env.REALITY_DEFENDER_API_KEY,
+        'Content-Type': 'application/json',
+        'User-Agent': 'divine-moderation-service/1.0',
+        'Accept': 'application/json',
+      },
+      body: JSON.stringify({ fileName: filename }),
+    });
+
+    if (!presignedResponse.ok) {
+      const errorText = await presignedResponse.text();
+      return { submitted: false, error: `Presigned URL failed: ${presignedResponse.status} - ${errorText}` };
+    }
+
+    const presignedData = await presignedResponse.json();
+
+    // Step 3: Upload video to the presigned S3 URL
+    const uploadResponse = await fetch(presignedData.response.signedUrl, {
+      method: 'PUT',
+      body: videoBlob,
+    });
+
+    if (!uploadResponse.ok) {
+      const uploadError = await uploadResponse.text();
+      return { submitted: false, error: `S3 upload failed: ${uploadResponse.status} - ${uploadError}` };
+    }
+
+    const requestId = presignedData.requestId;
+
+    // Store pending status in KV for later polling
+    if (env.MODERATION_KV) {
+      await env.MODERATION_KV.put(`rd:${sha256}`, JSON.stringify({
+        status: 'pending',
+        requestId,
+        submittedAt: new Date().toISOString(),
+      }), { expirationTtl: KV_RESULT_TTL });
+    }
+
+    console.log(`[RD] Submitted ${sha256} to Reality Defender, requestId=${requestId}`);
+    return { submitted: true, requestId };
+  } catch (err) {
+    console.error(`[RD] Submit error for ${sha256}:`, err.message);
+    return { submitted: false, error: err.message };
+  }
+}
+
+/**
+ * Poll Reality Defender for results of a previously submitted video.
+ * Updates KV cache with the result.
+ *
+ * @param {string} sha256 - Video hash
+ * @param {Object} env - Cloudflare Workers env
+ * @returns {Promise<Object|null>} Result or null if not ready/not found
+ */
+export async function pollRealityDefender(sha256, env) {
+  if (!env.REALITY_DEFENDER_API_KEY) {
+    return null;
+  }
+
+  // Get requestId from KV
+  let requestId = null;
+  if (env.MODERATION_KV) {
+    const cached = await env.MODERATION_KV.get(`rd:${sha256}`);
+    if (cached) {
+      const parsed = JSON.parse(cached);
+      if (parsed.status === 'complete') {
+        return parsed; // Already have final result
+      }
+      requestId = parsed.requestId;
+    }
+  }
+
+  if (!requestId) {
+    return null;
+  }
+
+  try {
+    const response = await fetch(`${RD_API_BASE}/api/media/users/${requestId}`, {
+      method: 'GET',
+      headers: {
+        'X-API-KEY': env.REALITY_DEFENDER_API_KEY,
+        'Content-Type': 'application/json',
+        'User-Agent': 'divine-moderation-service/1.0',
+        'Accept': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      console.error(`[RD] Poll failed: ${response.status}`);
+      return null;
+    }
+
+    const data = await response.json();
+
+    // Check if results are ready
+    const rdStatus = data.resultsSummary?.status;
+    if (!rdStatus) {
+      console.log(`[RD] ${sha256} still processing`);
+      return { status: 'pending', requestId };
+    }
+
+    // Extract score (0-100 scale → normalized to 0-1)
+    const finalScore = data.resultsSummary?.metadata?.finalScore ?? 0;
+    let score = finalScore / 100;
+
+    // Map Reality Defender status to verdict
+    let verdict = 'uncertain';
+    if (rdStatus === 'AUTHENTIC') {
+      verdict = 'authentic';
+      if (score === 0) score = 0.1;
+    } else if (rdStatus === 'FAKE') {
+      verdict = 'likely_ai';
+      if (score === 0) score = 0.95;
+    } else if (rdStatus === 'SUSPICIOUS') {
+      verdict = 'likely_ai';
+      if (score === 0) score = 0.7;
+    }
+
+    const result = {
+      status: 'complete',
+      requestId,
+      provider: 'reality_defender',
+      score,
+      verdict,
+      rdStatus,
+      completedAt: new Date().toISOString(),
+    };
+
+    // Cache result in KV
+    if (env.MODERATION_KV) {
+      await env.MODERATION_KV.put(`rd:${sha256}`, JSON.stringify(result), {
+        expirationTtl: KV_RESULT_TTL,
+      });
+    }
+
+    console.log(`[RD] ${sha256} result: ${rdStatus} score=${score} verdict=${verdict}`);
+    return result;
+  } catch (err) {
+    console.error(`[RD] Poll error for ${sha256}:`, err.message);
+    return null;
+  }
+}
+
+/**
+ * Get the Reality Defender result for a video (from KV cache or by polling).
+ * Used by the admin dashboard to display secondary verification.
+ *
+ * @param {string} sha256 - Video hash
+ * @param {Object} env
+ * @returns {Promise<Object|null>}
+ */
+export async function getRealnessResult(sha256, env) {
+  // Check KV cache first
+  if (env.MODERATION_KV) {
+    const cached = await env.MODERATION_KV.get(`rd:${sha256}`);
+    if (cached) {
+      const parsed = JSON.parse(cached);
+
+      // If pending, try to poll for results
+      if (parsed.status === 'pending' && parsed.requestId && env.REALITY_DEFENDER_API_KEY) {
+        const polled = await pollRealityDefender(sha256, env);
+        if (polled && polled.status === 'complete') {
+          return formatForDashboard(polled);
+        }
+        return formatForDashboard(parsed);
+      }
+
+      return formatForDashboard(parsed);
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Format a Reality Defender result for the admin dashboard.
+ */
+function formatForDashboard(result) {
+  return {
+    status: result.status,
+    overallVerdict: result.verdict || 'pending',
+    providers: {
+      reality_defender: {
+        status: result.status,
+        score: result.score ?? null,
+        verdict: result.verdict ?? null,
+        rdStatus: result.rdStatus ?? null,
+      },
+    },
+    submittedAt: result.submittedAt,
+    completedAt: result.completedAt,
+  };
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -108,4 +108,5 @@ crons = ["*/5 * * * *"]
 #   Pricing: ~$0.001/video (much cheaper than V2 scene classification)
 # HIVE_VLM_PROMPT - (optional) Custom prompt for VLM classification (overrides default)
 # RELAY_ADMIN_URL - Funnelcake admin API endpoint for cache purge / event deletion
+# REALITY_DEFENDER_API_KEY - Reality Defender API key for secondary AI verification (api.prd.realitydefender.xyz)
 # ADMIN_PASSWORD_HASH - SHA-256 hash of admin dashboard password


### PR DESCRIPTION
## Summary
- **AI-generated/deepfake content is now quarantined** instead of auto-banned, pending secondary verification from Reality Defender
- New `realness-client.mjs` handles the Reality Defender API flow: get presigned URL, upload to S3, poll for results
- Pipeline automatically submits flagged videos to Reality Defender when `REALITY_DEFENDER_API_KEY` is configured
- Admin dashboard displays Reality Defender verdict inline on AI-flagged video cards
- Cron job polls pending Reality Defender results every 5 minutes
- **Bug fix**: deepfake threshold was incorrectly using `DEFAULT_AI_GENERATED_HIGH` (0.8) instead of `DEFAULT_DEEPFAKE_HIGH` (0.95)

## Changed files
- `src/moderation/realness-client.mjs` — new Reality Defender API client (submit, poll, get results)
- `src/moderation/classifier.mjs` — AI-generated/deepfake → QUARANTINE + `requiresSecondaryVerification` flag
- `src/moderation/classifier.test.mjs` — updated tests for new quarantine behavior
- `src/moderation/pipeline.mjs` — Step 4.5: submit to Reality Defender after classification
- `src/admin/dashboard.html` — show Reality Defender verdict on AI-flagged cards
- `src/index.mjs` — `/admin/api/realness/:sha256` endpoint + cron polling block
- `wrangler.toml` — document `REALITY_DEFENDER_API_KEY` secret

## Test plan
- [x] All 330 tests pass (including updated classifier tests)
- [ ] Deploy with `REALITY_DEFENDER_API_KEY` secret set
- [ ] Verify AI-flagged videos get QUARANTINE instead of PERMANENT_BAN
- [ ] Verify Reality Defender submission appears in logs
- [ ] Verify dashboard shows "Loading secondary verification..." then result
- [ ] Verify cron polls and updates pending results

🤖 Generated with [Claude Code](https://claude.com/claude-code)