### PR TITLE
feat: DM gaps — category templates, profile resolution, messages UI

### DIFF
--- a/docs/dm-gaps-plan.md
+++ b/docs/dm-gaps-plan.md
@@ -1,0 +1,317 @@
+# DM System — Remaining Gaps Implementation Plan
+
+## Gap 1: Category-Specific Message Templates with Policy Links
+
+**Problem:** Current templates are generic one-liners. Creators get "Reason: nudity" with no context about what policy was violated or how to appeal.
+
+**File:** `src/nostr/dm-sender.mjs`
+
+### Changes
+
+Replace the flat `TEMPLATES` object (lines 31-43) with a richer template system:
+
+```js
+const CATEGORY_TEMPLATES = {
+  nudity: {
+    reason: 'sexual or nude content',
+    policy: 'https://divine.video/policies#sexual-content',
+  },
+  ai_generated: {
+    reason: 'AI-generated content without disclosure',
+    policy: 'https://divine.video/policies#ai-content',
+  },
+  deepfake: {
+    reason: 'deepfake or manipulated media',
+    policy: 'https://divine.video/policies#manipulated-media',
+  },
+  offensive: {
+    reason: 'offensive or hateful content',
+    policy: 'https://divine.video/policies#hate-speech',
+  },
+  self_harm: {
+    reason: 'content depicting self-harm',
+    policy: 'https://divine.video/policies#self-harm',
+    extra: '\n\nIf you or someone you know is struggling, please reach out: 988 Suicide & Crisis Lifeline (call or text 988).',
+  },
+  scam: {
+    reason: 'fraudulent or scam content',
+    policy: 'https://divine.video/policies#fraud',
+  },
+};
+```
+
+Add a `selectTemplate(action, reason, categories)` function:
+
+```js
+export function selectTemplate(action, reason, categories) {
+  // Try to match a specific category
+  let categoryInfo = null;
+  if (categories && typeof categories === 'string') {
+    try {
+      const parsed = JSON.parse(categories);
+      // categories is stored as JSON object with category keys
+      for (const cat of Object.keys(parsed)) {
+        if (CATEGORY_TEMPLATES[cat]) {
+          categoryInfo = CATEGORY_TEMPLATES[cat];
+          break;
+        }
+      }
+    } catch { /* not JSON, try as plain string */ }
+    if (!categoryInfo && CATEGORY_TEMPLATES[categories]) {
+      categoryInfo = CATEGORY_TEMPLATES[categories];
+    }
+  }
+
+  const specificReason = categoryInfo?.reason || reason || 'content policy violation';
+  const policyLink = categoryInfo?.policy || 'https://divine.video/policies';
+  const extra = categoryInfo?.extra || '';
+
+  const templates = {
+    PERMANENT_BAN: `Your video has been removed for: ${specificReason}.\n\nPolicy: ${policyLink}\n\nIf you believe this is an error, reply to this message to appeal.${extra}`,
+    AGE_RESTRICTED: `Your video has been age-restricted: ${specificReason}. It remains available but will only be shown to users who have confirmed their age.\n\nPolicy: ${policyLink}`,
+    QUARANTINE: `Your video has been temporarily hidden pending review: ${specificReason}. A moderator will review it shortly — you can reply with context.\n\nPolicy: ${policyLink}`,
+  };
+
+  return templates[action] || null;
+}
+```
+
+Update `sendModerationDM()` to accept and use `categories`:
+
+```js
+export async function sendModerationDM(recipientPubkey, sha256, action, reason, env, ctx, categories) {
+  // ... existing validation ...
+  const message = selectTemplate(action, reason, categories);
+  // (instead of TEMPLATES[action](reason))
+```
+
+Update callsite in `handleModerationResult()` (index.mjs ~line 2690):
+
+```js
+await sendModerationDM(uploadedBy, sha256, action, reason, env, null, result.categories);
+```
+
+And in admin manual moderate (~line 921):
+
+```js
+// Fetch categories from D1 for the template
+const catRow = await env.BLOSSOM_DB.prepare('SELECT categories FROM moderation_results WHERE sha256 = ?').bind(sha256).first();
+await sendModerationDM(uploaderRow.uploaded_by, sha256, action, reason, env, null, catRow?.categories);
+```
+
+**Keep the old `getMessageForAction()` as-is** for backward compat with tests — just have `sendModerationDM` prefer `selectTemplate` over it.
+
+### Test updates
+
+Add tests in `dm-sender.test.mjs`:
+- `selectTemplate('PERMANENT_BAN', null, '{"nudity": 0.95}')` → contains "sexual" and policy link
+- `selectTemplate('PERMANENT_BAN', null, '{"self_harm": 0.8}')` → contains crisis hotline
+- `selectTemplate('QUARANTINE', 'custom reason', null)` → falls back to custom reason
+- `selectTemplate('PERMANENT_BAN', null, null)` → uses default "content policy violation"
+
+---
+
+## Gap 2: User Profile Resolution (Kind 0 Metadata)
+
+**Problem:** The messages UI shows raw hex pubkeys like `a1b2c3d4...` instead of display names/avatars.
+
+### New file: `src/nostr/profile-resolver.mjs`
+
+```js
+/**
+ * Resolve Nostr profile (kind 0) for a pubkey.
+ * Returns { name, display_name, picture, nip05 } or null.
+ * Cached in KV for 1 hour.
+ */
+export async function resolveProfile(pubkey, env) {
+  // 1. Check KV cache
+  const cacheKey = `profile:${pubkey}`;
+  if (env.MODERATION_KV) {
+    const cached = await env.MODERATION_KV.get(cacheKey);
+    if (cached) return JSON.parse(cached);
+  }
+
+  // 2. Query relay.divine.video for kind 0
+  //    Same WebSocket pattern as queryRelayList() in dm-sender.mjs
+  //    Filter: { kinds: [0], authors: [pubkey], limit: 1 }
+  //    Parse event.content as JSON -> extract name, display_name, picture, nip05
+
+  // 3. Cache result in KV (1hr TTL, cache nulls as empty object to avoid re-querying)
+
+  // 4. Return profile object or null
+}
+
+/**
+ * Batch resolve profiles for multiple pubkeys.
+ * Queries relay once with authors=[...pubkeys].
+ */
+export async function resolveProfiles(pubkeys, env) {
+  // Check KV cache for each, collect misses
+  // Query relay for all misses in one REQ
+  // Cache results, return map of pubkey -> profile
+}
+```
+
+### API endpoint: `GET /admin/api/profiles?pubkeys=aaa,bbb,ccc`
+
+Add in `src/index.mjs` (after the messages endpoints, ~line 1851):
+
+```js
+if (url.pathname === '/admin/api/profiles' && request.method === 'GET') {
+  const authError = await requireAuth(request, env);
+  if (authError) return authError;
+
+  const pubkeys = (url.searchParams.get('pubkeys') || '').split(',').filter(Boolean).slice(0, 50);
+  const { resolveProfiles } = await import('./nostr/profile-resolver.mjs');
+  const profiles = await resolveProfiles(pubkeys, env);
+  return new Response(JSON.stringify(profiles), { headers: { 'Content-Type': 'application/json' } });
+}
+```
+
+### Frontend changes (messages.html)
+
+After fetching conversations, call `/admin/api/profiles?pubkeys=...` with all participant pubkeys, then update the UI:
+
+```js
+let profileCache = {};
+
+async function fetchProfiles(pubkeys) {
+  if (!pubkeys.length) return;
+  const unique = [...new Set(pubkeys)].filter(p => !profileCache[p]);
+  if (!unique.length) return;
+  const res = await fetch('/admin/api/profiles?pubkeys=' + unique.join(','));
+  if (res.ok) {
+    const data = await res.json();
+    Object.assign(profileCache, data);
+  }
+}
+```
+
+Update `renderConversations()` to show display name + small avatar instead of truncated hex:
+
+```js
+const profile = profileCache[pubkey];
+const displayName = profile?.display_name || profile?.name || truncatePubkey(pubkey);
+const avatar = profile?.picture
+  ? `<img src="${profile.picture}" style="width:24px;height:24px;border-radius:50%;object-fit:cover;">`
+  : '';
+```
+
+Update `thread-pubkey` header to show full profile info.
+
+---
+
+## Gap 3: Search by Name in Messages UI
+
+**Problem:** No way to find a conversation except scrolling.
+
+### Frontend-only change (messages.html)
+
+Add a search input above the conversation list:
+
+```html
+<div class="conversation-list-header">
+  <span>Conversations</span>
+  <input type="text" id="search-input" placeholder="Search by name or pubkey..."
+    oninput="filterConversations(this.value)">
+</div>
+```
+
+Add CSS for the search input (compact, fits in header).
+
+Add filter function:
+
+```js
+function filterConversations(query) {
+  const q = query.toLowerCase().trim();
+  if (!q) {
+    renderConversations();
+    return;
+  }
+
+  const filtered = conversations.filter(conv => {
+    const pubkey = conv.participant_pubkey || conv.pubkey || '';
+    const profile = profileCache[pubkey];
+    const name = (profile?.display_name || profile?.name || '').toLowerCase();
+    const nip05 = (profile?.nip05 || '').toLowerCase();
+    return pubkey.includes(q) || name.includes(q) || nip05.includes(q);
+  });
+
+  renderConversationList(filtered);
+}
+```
+
+Split `renderConversations()` so it can take an optional filtered list:
+
+```js
+function renderConversations() {
+  renderConversationList(conversations);
+}
+
+function renderConversationList(list) {
+  // ... existing render logic, using `list` instead of `conversations`
+}
+```
+
+This is purely client-side filtering — no backend changes needed since profiles are already fetched for display.
+
+---
+
+## Gap 4: "Message Creator" Link on Video Detail Cards
+
+**Problem:** When reviewing a video, there's no quick way to message the uploader.
+
+### Backend: Include `uploaded_by` in decisions query
+
+Update the SELECT in the decisions list endpoint (~line 2066):
+
+```sql
+SELECT sha256, action, provider, scores, moderated_at, reviewed_by, reviewed_at, uploaded_by
+FROM moderation_results
+```
+
+### Frontend: Add link in dashboard.html video cards
+
+In the `renderVideoCard()` function (~line 2360, after the "View on divine.video" link):
+
+```js
+${video.uploaded_by ? `
+  <div class="divine-link">
+    <a href="/admin/messages?pubkey=${video.uploaded_by}" target="_blank" rel="noopener noreferrer">
+      Message Creator →
+    </a>
+  </div>
+` : ''}
+```
+
+### Messages page: Handle `?pubkey=` query param
+
+In `messages.html`, at init time:
+
+```js
+// Check for pre-selected pubkey from URL
+const urlParams = new URLSearchParams(window.location.search);
+const preselectedPubkey = urlParams.get('pubkey');
+
+async function init() {
+  await fetchConversations();
+  if (preselectedPubkey) {
+    await selectConversation(preselectedPubkey);
+  }
+}
+
+init();
+```
+
+This replaces the current bare `fetchConversations()` call at the bottom. If the pubkey has no existing conversation, `selectConversation` will show an empty thread — the moderator can still compose a new message.
+
+---
+
+## Implementation Order
+
+1. **Gap 2 (Profile resolver)** — needed by Gap 3 (search needs names to search)
+2. **Gap 3 (Search)** — purely frontend, quick once profiles work
+3. **Gap 1 (Category templates)** — backend only, independent
+4. **Gap 4 (Message Creator link)** — small changes in both dashboard.html and messages.html
+
+Total: ~4 files modified, 1 new file created. No new dependencies.

--- a/src/admin/dashboard.html
+++ b/src/admin/dashboard.html
@@ -2369,6 +2369,13 @@
                 View on divine.video →
               </a>
             </div>
+            ${video.uploaded_by ? `
+            <div class="divine-link">
+              <a href="/admin/messages?pubkey=${video.uploaded_by}" target="_blank" rel="noopener noreferrer">
+                Message Creator →
+              </a>
+            </div>
+            ` : ''}
 
             <div class="action-buttons">
               <button class="action-btn approve" onclick="quickAction('${sha256}', 'SAFE')">Approve</button>

--- a/src/admin/messages.html
+++ b/src/admin/messages.html
@@ -94,6 +94,34 @@
       color: #888;
       text-transform: uppercase;
       letter-spacing: 0.5px;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    .conversation-list-header input {
+      width: 100%;
+      padding: 6px 10px;
+      background: #1a1a1a;
+      border: 1px solid #333;
+      border-radius: 4px;
+      color: #fff;
+      font-size: 12px;
+      text-transform: none;
+      letter-spacing: normal;
+      outline: none;
+    }
+
+    .conversation-list-header input:focus {
+      border-color: #2563eb;
+    }
+
+    .conv-avatar {
+      width: 24px;
+      height: 24px;
+      border-radius: 50%;
+      object-fit: cover;
+      flex-shrink: 0;
     }
 
     .conversation-items {
@@ -423,7 +451,11 @@
   <div class="main-container">
     <!-- Left Panel -->
     <div class="conversation-list">
-      <div class="conversation-list-header">Conversations</div>
+      <div class="conversation-list-header">
+        <span>Conversations</span>
+        <input type="text" id="search-input" placeholder="Search by name or pubkey..."
+          oninput="filterConversations(this.value)">
+      </div>
       <div class="conversation-items" id="conversation-items">
         <div class="loading-state" id="conv-loading">
           <div class="spinner"></div>
@@ -465,6 +497,7 @@
   <script>
     let selectedPubkey = null;
     let conversations = [];
+    let profileCache = {};
 
     // --- Helpers ---
 
@@ -503,6 +536,56 @@
       return messageType.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
     }
 
+    // --- Profile Resolution ---
+
+    async function fetchProfiles(pubkeys) {
+      if (!pubkeys.length) return;
+      const unique = [...new Set(pubkeys)].filter(p => !profileCache[p]);
+      if (!unique.length) return;
+      try {
+        const res = await fetch('/admin/api/profiles?pubkeys=' + unique.join(','));
+        if (res.ok) {
+          const data = await res.json();
+          Object.assign(profileCache, data);
+        }
+      } catch (err) {
+        console.error('fetchProfiles error:', err);
+      }
+    }
+
+    function displayName(pubkey) {
+      const profile = profileCache[pubkey];
+      return profile?.display_name || profile?.name || truncatePubkey(pubkey);
+    }
+
+    function avatarHtml(pubkey) {
+      const profile = profileCache[pubkey];
+      if (profile?.picture) {
+        return `<img class="conv-avatar" src="${escapeHtml(profile.picture)}" alt="">`;
+      }
+      return '';
+    }
+
+    // --- Search / Filter ---
+
+    function filterConversations(query) {
+      const q = query.toLowerCase().trim();
+      if (!q) {
+        renderConversationList(conversations);
+        return;
+      }
+
+      const filtered = conversations.filter(conv => {
+        const pubkey = conv.participant_pubkey || conv.pubkey || '';
+        const profile = profileCache[pubkey];
+        const name = (profile?.display_name || profile?.name || '').toLowerCase();
+        const nip05 = (profile?.nip05 || '').toLowerCase();
+        return pubkey.includes(q) || name.includes(q) || nip05.includes(q);
+      });
+
+      renderConversationList(filtered);
+    }
+
     // --- Fetch conversations ---
 
     async function fetchConversations() {
@@ -515,6 +598,11 @@
         if (!res.ok) throw new Error('Failed to fetch conversations');
         const data = await res.json();
         conversations = data.conversations || data || [];
+
+        // Fetch profiles for all participants
+        const pubkeys = conversations.map(c => c.participant_pubkey || c.pubkey).filter(Boolean);
+        await fetchProfiles(pubkeys);
+
         renderConversations();
       } catch (err) {
         container.innerHTML = '<div class="empty-state">Failed to load conversations</div>';
@@ -523,14 +611,18 @@
     }
 
     function renderConversations() {
+      renderConversationList(conversations);
+    }
+
+    function renderConversationList(list) {
       const container = document.getElementById('conversation-items');
 
-      if (!conversations.length) {
+      if (!list.length) {
         container.innerHTML = '<div class="empty-state">No conversations yet</div>';
         return;
       }
 
-      container.innerHTML = conversations.map(conv => {
+      container.innerHTML = list.map(conv => {
         const pubkey = conv.participant_pubkey || conv.pubkey || '';
         const preview = (conv.latest_message || conv.preview || '').slice(0, 80);
         const ts = conv.last_message_at || conv.updated_at || conv.created_at;
@@ -542,7 +634,8 @@
           <div class="conversation-item ${isActive ? 'active' : ''}" onclick="selectConversation('${pubkey}')">
             <div class="pubkey">
               ${unread ? '<span class="unread-dot"></span>' : ''}
-              ${truncatePubkey(pubkey)}
+              ${avatarHtml(pubkey)}
+              ${escapeHtml(displayName(pubkey))}
             </div>
             <div class="preview">${escapeHtml(preview) || '(no messages)'}</div>
             <div class="meta">
@@ -571,7 +664,16 @@
       const content = document.getElementById('thread-content');
       content.style.display = 'flex';
 
-      document.getElementById('thread-pubkey').textContent = truncatePubkey(pubkey);
+      const profile = profileCache[pubkey];
+      const threadHeader = document.getElementById('thread-pubkey');
+      if (profile) {
+        threadHeader.innerHTML = (profile.picture ? `<img class="conv-avatar" src="${escapeHtml(profile.picture)}" alt=""> ` : '')
+          + escapeHtml(profile.display_name || profile.name || truncatePubkey(pubkey))
+          + (profile.nip05 ? ` <span style="color:#888;font-size:12px;">(${escapeHtml(profile.nip05)})</span>` : '')
+          + ` <span style="color:#555;font-size:11px;font-family:monospace;">${truncatePubkey(pubkey)}</span>`;
+      } else {
+        threadHeader.textContent = truncatePubkey(pubkey);
+      }
       document.getElementById('compose-input').value = '';
       document.getElementById('compose-sha256').value = '';
 
@@ -703,7 +805,18 @@
     });
 
     // --- Init ---
-    fetchConversations();
+    (async function init() {
+      const urlParams = new URLSearchParams(window.location.search);
+      const preselectedPubkey = urlParams.get('pubkey');
+
+      await fetchConversations();
+
+      if (preselectedPubkey) {
+        // Fetch profile for the preselected pubkey if not already cached
+        await fetchProfiles([preselectedPubkey]);
+        await selectConversation(preselectedPubkey);
+      }
+    })();
   </script>
 </body>
 </html>

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -491,7 +491,7 @@ export default {
 
       // Query D1 with pagination
       const query = `
-        SELECT sha256, action, provider, scores, categories, moderated_at, reviewed_by, reviewed_at
+        SELECT sha256, action, provider, scores, categories, moderated_at, reviewed_by, reviewed_at, uploaded_by
         FROM moderation_results
         ${whereClause}
         ORDER BY moderated_at DESC
@@ -513,7 +513,8 @@ export default {
         processedAt: new Date(row.moderated_at).getTime(),
         moderated_at: row.moderated_at,
         reviewed_by: row.reviewed_by,
-        reviewed_at: row.reviewed_at
+        reviewed_at: row.reviewed_at,
+        uploaded_by: row.uploaded_by || null
       }));
 
       // Classifier summaries fetched client-side via /admin/api/classifier/{sha256}
@@ -914,11 +915,11 @@ export default {
         try {
           // Look up uploaded_by from D1
           const uploaderRow = await env.BLOSSOM_DB.prepare(
-            'SELECT uploaded_by FROM moderation_results WHERE sha256 = ?'
+            'SELECT uploaded_by, categories FROM moderation_results WHERE sha256 = ?'
           ).bind(sha256).first();
           if (uploaderRow?.uploaded_by) {
             const { sendModerationDM } = await import('./nostr/dm-sender.mjs');
-            await sendModerationDM(uploaderRow.uploaded_by, sha256, action, reason || 'Manual moderator action', env, null);
+            await sendModerationDM(uploaderRow.uploaded_by, sha256, action, reason || 'Manual moderator action', env, null, uploaderRow?.categories);
             dmSent = true;
             console.log(`[ADMIN] DM sent to creator ${uploaderRow.uploaded_by.substring(0, 16)}...`);
           }
@@ -1850,6 +1851,20 @@ async function runMigration() {
       return new Response(JSON.stringify({ success: true }), { headers: { 'Content-Type': 'application/json' } });
     }
 
+    // Admin API: Resolve Nostr profiles for pubkeys
+    if (url.pathname === '/admin/api/profiles' && request.method === 'GET') {
+      const authError = await requireAuth(request, env);
+      if (authError) return authError;
+
+      const pubkeys = (url.searchParams.get('pubkeys') || '').split(',').filter(Boolean).slice(0, 50);
+      if (pubkeys.length === 0) {
+        return new Response(JSON.stringify({}), { headers: { 'Content-Type': 'application/json' } });
+      }
+      const { resolveProfiles } = await import('./nostr/profile-resolver.mjs');
+      const profiles = await resolveProfiles(pubkeys, env);
+      return new Response(JSON.stringify(profiles), { headers: { 'Content-Type': 'application/json' } });
+    }
+
     // Admin API: Get divine-realness AI verification results for a video
     if (url.pathname.startsWith('/admin/api/realness/') && request.method === 'GET') {
       const authError = await requireAuth(request, env);
@@ -2089,7 +2104,7 @@ async function runMigration() {
         const limit = Math.min(parseInt(url.searchParams.get('limit') || '50', 10), 200);
         const offset = parseInt(url.searchParams.get('offset') || '0', 10);
 
-        let query = 'SELECT sha256, action, provider, scores, moderated_at, reviewed_by, reviewed_at FROM moderation_results';
+        let query = 'SELECT sha256, action, provider, scores, moderated_at, reviewed_by, reviewed_at, uploaded_by FROM moderation_results';
         const conditions = [];
         const bindings = [];
 
@@ -2776,7 +2791,7 @@ async function handleModerationResult(result, env) {
   if (['PERMANENT_BAN', 'AGE_RESTRICTED', 'QUARANTINE'].includes(action) && uploadedBy && env.MODERATOR_NSEC) {
     try {
       const { sendModerationDM } = await import('./nostr/dm-sender.mjs');
-      await sendModerationDM(uploadedBy, sha256, action, reason, env, null);
+      await sendModerationDM(uploadedBy, sha256, action, reason, env, null, result.categories);
       console.log(`[MODERATION] ${sha256} - DM notification sent to creator ${uploadedBy.substring(0, 16)}...`);
     } catch (dmErr) {
       console.error(`[MODERATION] ${sha256} - DM notification failed:`, dmErr.message);

--- a/src/nostr/dm-sender.mjs
+++ b/src/nostr/dm-sender.mjs
@@ -42,6 +42,74 @@ const TEMPLATES = {
     `Thank you for your report. After review, the reported content has been ${action}. We appreciate your help keeping the community safe.`,
 };
 
+// --- Category-Specific Templates ---
+
+const CATEGORY_TEMPLATES = {
+  nudity: {
+    reason: 'sexual or nude content',
+    policy: 'https://divine.video/policies#sexual-content',
+  },
+  ai_generated: {
+    reason: 'AI-generated content without disclosure',
+    policy: 'https://divine.video/policies#ai-content',
+  },
+  deepfake: {
+    reason: 'deepfake or manipulated media',
+    policy: 'https://divine.video/policies#manipulated-media',
+  },
+  offensive: {
+    reason: 'offensive or hateful content',
+    policy: 'https://divine.video/policies#hate-speech',
+  },
+  self_harm: {
+    reason: 'content depicting self-harm',
+    policy: 'https://divine.video/policies#self-harm',
+    extra: '\n\nIf you or someone you know is struggling, please reach out: 988 Suicide & Crisis Lifeline (call or text 988).',
+  },
+  scam: {
+    reason: 'fraudulent or scam content',
+    policy: 'https://divine.video/policies#fraud',
+  },
+};
+
+/**
+ * Select a category-specific template for a moderation action.
+ * Falls back to generic reason if no category match.
+ * @param {string} action - PERMANENT_BAN, AGE_RESTRICTED, or QUARANTINE
+ * @param {string|null} reason - Human-readable reason
+ * @param {string|null} categories - JSON string of categories or plain category string
+ * @returns {string|null} Message text or null if action has no template
+ */
+export function selectTemplate(action, reason, categories) {
+  let categoryInfo = null;
+  if (categories && typeof categories === 'string') {
+    try {
+      const parsed = JSON.parse(categories);
+      for (const cat of Object.keys(parsed)) {
+        if (CATEGORY_TEMPLATES[cat]) {
+          categoryInfo = CATEGORY_TEMPLATES[cat];
+          break;
+        }
+      }
+    } catch { /* not JSON, try as plain string */ }
+    if (!categoryInfo && CATEGORY_TEMPLATES[categories]) {
+      categoryInfo = CATEGORY_TEMPLATES[categories];
+    }
+  }
+
+  const specificReason = categoryInfo?.reason || reason || 'content policy violation';
+  const policyLink = categoryInfo?.policy || 'https://divine.video/policies';
+  const extra = categoryInfo?.extra || '';
+
+  const templates = {
+    PERMANENT_BAN: `Your video has been removed for: ${specificReason}.\n\nPolicy: ${policyLink}\n\nIf you believe this is an error, reply to this message to appeal.${extra}`,
+    AGE_RESTRICTED: `Your video has been age-restricted: ${specificReason}. It remains available but will only be shown to users who have confirmed their age.\n\nPolicy: ${policyLink}`,
+    QUARANTINE: `Your video has been temporarily hidden pending review: ${specificReason}. A moderator will review it shortly — you can reply with context.\n\nPolicy: ${policyLink}`,
+  };
+
+  return templates[action] || null;
+}
+
 /**
  * Get message text for a given moderation action.
  * @param {string} action - PERMANENT_BAN, AGE_RESTRICTED, or QUARANTINE
@@ -421,9 +489,10 @@ function publishToSingleRelay(event, relayUrl, env) {
  * @param {string} reason - Human-readable reason
  * @param {Object} env - Cloudflare Workers env
  * @param {Object} ctx - Execution context (for waitUntil)
+ * @param {string} [categories] - JSON string of categories from moderation result
  * @returns {Promise<{ sent: boolean, reason?: string }>}
  */
-export async function sendModerationDM(recipientPubkey, sha256, action, reason, env, ctx) {
+export async function sendModerationDM(recipientPubkey, sha256, action, reason, env, ctx, categories) {
   try {
     // Validate inputs
     if (!recipientPubkey || typeof recipientPubkey !== 'string') {
@@ -442,12 +511,11 @@ export async function sendModerationDM(recipientPubkey, sha256, action, reason, 
       return { sent: false, reason: err.message };
     }
 
-    // Build message from template
-    const templateFn = TEMPLATES[action];
-    if (!templateFn) {
+    // Build message: prefer category-specific template, fall back to generic
+    const message = selectTemplate(action, reason, categories);
+    if (!message) {
       return { sent: false, reason: `Unknown action: ${action}` };
     }
-    const message = templateFn(reason || 'content policy violation');
 
     // Check rate limit
     const withinLimit = await checkRateLimit(recipientPubkey, env);

--- a/src/nostr/dm-sender.test.mjs
+++ b/src/nostr/dm-sender.test.mjs
@@ -13,7 +13,8 @@ import {
   getModeratorKeys,
   checkRateLimit,
   discoverUserRelays,
-  sendModerationDM
+  sendModerationDM,
+  selectTemplate
 } from './dm-sender.mjs';
 
 // Generate a stable test nsec for use across tests
@@ -245,5 +246,78 @@ describe('DM Sender - Error Handling', () => {
     const result = await sendModerationDM('b'.repeat(64), 'c'.repeat(64), 'PERMANENT_BAN', 'test reason', env, ctx);
     // Should not throw — either succeeds or returns failure gracefully
     expect(result).toBeDefined();
+  });
+});
+
+describe('DM Sender - selectTemplate (Category-Specific)', () => {
+  it('should include policy link and specific reason for nudity category', () => {
+    const msg = selectTemplate('PERMANENT_BAN', null, '{"nudity": 0.95}');
+
+    expect(msg).toContain('sexual or nude content');
+    expect(msg).toContain('https://divine.video/policies#sexual-content');
+    expect(msg).toContain('appeal');
+  });
+
+  it('should include crisis hotline for self_harm category', () => {
+    const msg = selectTemplate('PERMANENT_BAN', null, '{"self_harm": 0.8}');
+
+    expect(msg).toContain('self-harm');
+    expect(msg).toContain('988');
+    expect(msg).toContain('https://divine.video/policies#self-harm');
+  });
+
+  it('should fall back to custom reason when no category match', () => {
+    const msg = selectTemplate('QUARANTINE', 'custom reason', null);
+
+    expect(msg).toContain('custom reason');
+    expect(msg).toContain('https://divine.video/policies');
+  });
+
+  it('should use default reason when no category and no reason', () => {
+    const msg = selectTemplate('PERMANENT_BAN', null, null);
+
+    expect(msg).toContain('content policy violation');
+    expect(msg).toContain('https://divine.video/policies');
+  });
+
+  it('should return null for unknown action', () => {
+    const msg = selectTemplate('SAFE', null, null);
+    expect(msg).toBeNull();
+  });
+
+  it('should handle plain string category', () => {
+    const msg = selectTemplate('AGE_RESTRICTED', null, 'offensive');
+
+    expect(msg).toContain('offensive or hateful content');
+    expect(msg).toContain('https://divine.video/policies#hate-speech');
+  });
+
+  it('should handle ai_generated category', () => {
+    const msg = selectTemplate('PERMANENT_BAN', null, '{"ai_generated": 0.9}');
+
+    expect(msg).toContain('AI-generated');
+    expect(msg).toContain('https://divine.video/policies#ai-content');
+  });
+
+  it('should handle scam category', () => {
+    const msg = selectTemplate('PERMANENT_BAN', null, 'scam');
+
+    expect(msg).toContain('fraudulent or scam');
+    expect(msg).toContain('https://divine.video/policies#fraud');
+  });
+
+  it('should produce AGE_RESTRICTED template', () => {
+    const msg = selectTemplate('AGE_RESTRICTED', null, '{"nudity": 0.7}');
+
+    expect(msg).toContain('age-restricted');
+    expect(msg).toContain('confirmed their age');
+  });
+
+  it('should produce QUARANTINE template', () => {
+    const msg = selectTemplate('QUARANTINE', null, '{"deepfake": 0.85}');
+
+    expect(msg).toContain('temporarily hidden');
+    expect(msg).toContain('manipulated media');
+    expect(msg).toContain('reply with context');
   });
 });

--- a/src/nostr/profile-resolver.mjs
+++ b/src/nostr/profile-resolver.mjs
@@ -1,0 +1,168 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Resolves Nostr profiles (kind 0) for pubkeys via relay query.
+// ABOUTME: Caches results in KV for 1 hour. Supports batch resolution.
+
+const DIVINE_RELAY = 'wss://relay.divine.video';
+const RELAY_TIMEOUT_MS = 5000;
+const PROFILE_CACHE_TTL = 3600; // 1 hour
+
+/**
+ * Resolve a single Nostr profile (kind 0) for a pubkey.
+ * @param {string} pubkey - Hex pubkey
+ * @param {Object} env - Cloudflare Workers env (needs MODERATION_KV)
+ * @returns {Promise<{name?: string, display_name?: string, picture?: string, nip05?: string} | null>}
+ */
+export async function resolveProfile(pubkey, env) {
+  const profiles = await resolveProfiles([pubkey], env);
+  return profiles[pubkey] || null;
+}
+
+/**
+ * Batch resolve profiles for multiple pubkeys.
+ * Checks KV cache first, queries relay for misses in one REQ.
+ * @param {string[]} pubkeys - Array of hex pubkeys
+ * @param {Object} env
+ * @returns {Promise<Object>} Map of pubkey -> profile object
+ */
+export async function resolveProfiles(pubkeys, env) {
+  if (!pubkeys || pubkeys.length === 0) return {};
+
+  const results = {};
+  const misses = [];
+
+  // Check KV cache for each pubkey
+  if (env.MODERATION_KV) {
+    await Promise.all(pubkeys.map(async (pubkey) => {
+      try {
+        const cached = await env.MODERATION_KV.get(`profile:${pubkey}`);
+        if (cached !== null) {
+          const parsed = JSON.parse(cached);
+          // Empty object means "no profile found" (negative cache)
+          if (Object.keys(parsed).length > 0) {
+            results[pubkey] = parsed;
+          }
+        } else {
+          misses.push(pubkey);
+        }
+      } catch {
+        misses.push(pubkey);
+      }
+    }));
+  } else {
+    misses.push(...pubkeys);
+  }
+
+  if (misses.length === 0) return results;
+
+  // Query relay for all misses in one REQ
+  try {
+    const profiles = await queryProfiles(misses, env);
+
+    // Cache results (including negative caches for misses)
+    for (const pubkey of misses) {
+      const profile = profiles[pubkey] || null;
+      if (profile) {
+        results[pubkey] = profile;
+      }
+
+      // Cache in KV (cache nulls as empty object to avoid re-querying)
+      if (env.MODERATION_KV) {
+        try {
+          await env.MODERATION_KV.put(
+            `profile:${pubkey}`,
+            JSON.stringify(profile || {}),
+            { expirationTtl: PROFILE_CACHE_TTL }
+          );
+        } catch (err) {
+          console.error('[PROFILE] Failed to cache profile:', err.message);
+        }
+      }
+    }
+  } catch (err) {
+    console.error('[PROFILE] Failed to query profiles from relay:', err.message);
+  }
+
+  return results;
+}
+
+/**
+ * Query relay for kind 0 profiles for multiple pubkeys.
+ * @param {string[]} pubkeys
+ * @param {Object} env
+ * @returns {Promise<Object>} Map of pubkey -> {name, display_name, picture, nip05}
+ */
+async function queryProfiles(pubkeys, env) {
+  return new Promise((resolve) => {
+    let ws;
+    const profiles = {};
+    const timeout = setTimeout(() => {
+      if (ws) {
+        try { ws.close(); } catch (_) { /* ignore */ }
+      }
+      resolve(profiles);
+    }, RELAY_TIMEOUT_MS);
+
+    try {
+      const headers = {};
+      if (env.CF_ACCESS_CLIENT_ID && env.CF_ACCESS_CLIENT_SECRET) {
+        headers['CF-Access-Client-Id'] = env.CF_ACCESS_CLIENT_ID;
+        headers['CF-Access-Client-Secret'] = env.CF_ACCESS_CLIENT_SECRET;
+      }
+
+      ws = new WebSocket(DIVINE_RELAY, { headers });
+
+      ws.addEventListener('open', () => {
+        const filter = { kinds: [0], authors: pubkeys, limit: pubkeys.length };
+        const subId = 'profile-' + Date.now().toString(36);
+        ws.send(JSON.stringify(['REQ', subId, filter]));
+      });
+
+      ws.addEventListener('message', (event) => {
+        try {
+          const msg = JSON.parse(event.data);
+
+          if (msg[0] === 'EVENT') {
+            const nostrEvent = msg[2];
+            if (nostrEvent && nostrEvent.kind === 0 && nostrEvent.pubkey) {
+              try {
+                const content = JSON.parse(nostrEvent.content);
+                profiles[nostrEvent.pubkey] = {
+                  name: content.name || null,
+                  display_name: content.display_name || content.displayName || null,
+                  picture: content.picture || null,
+                  nip05: content.nip05 || null,
+                };
+              } catch {
+                // Invalid JSON in profile content
+              }
+            }
+          }
+
+          if (msg[0] === 'EOSE') {
+            clearTimeout(timeout);
+            try { ws.close(); } catch (_) { /* ignore */ }
+            resolve(profiles);
+          }
+        } catch {
+          // Ignore parse errors
+        }
+      });
+
+      ws.addEventListener('error', () => {
+        clearTimeout(timeout);
+        resolve(profiles);
+      });
+
+      ws.addEventListener('close', () => {
+        clearTimeout(timeout);
+        resolve(profiles);
+      });
+    } catch (err) {
+      clearTimeout(timeout);
+      console.error('[PROFILE] WebSocket error:', err.message);
+      resolve(profiles);
+    }
+  });
+}


### PR DESCRIPTION
## Summary

- **Category-specific DM templates**: New `CATEGORY_TEMPLATES` map and `selectTemplate()` function in `dm-sender.mjs` — moderation DMs now include the specific policy violated (e.g., nudity, deepfake, self-harm with crisis hotline), a link to the relevant policy page, and action-specific messaging
- **Profile resolver**: New `src/nostr/profile-resolver.mjs` — batch resolves Nostr kind 0 profiles via relay query with KV caching (1hr TTL). Powers display names and avatars in the messages UI
- **Messages UI improvements**: Search/filter by name, pubkey, or NIP-05; avatar + display name rendering; `?pubkey=` deep linking for direct navigation from dashboard
- **"Message Creator" link**: Dashboard video cards now show a "Message Creator" link when `uploaded_by` is available, linking directly to the messages page
- **Categories in DM pipeline**: `uploaded_by` added to decisions list queries; `categories` passed through to `sendModerationDM` in both automated pipeline and admin moderate handler

## Files changed

- `src/nostr/dm-sender.mjs` — Added `CATEGORY_TEMPLATES`, `selectTemplate()`, updated `sendModerationDM` signature (7th `categories` param)
- `src/nostr/dm-sender.test.mjs` — 10 new tests for `selectTemplate` (31 total)
- `src/nostr/profile-resolver.mjs` — **New file** — batch profile resolution with KV cache
- `src/admin/messages.html` — Profile display, search, `?pubkey=` deep linking
- `src/admin/dashboard.html` — "Message Creator" link on video cards
- `src/index.mjs` — `uploaded_by` in queries, `GET /admin/api/profiles` endpoint, categories passed to DM sender
- `docs/dm-gaps-plan.md` — **New file** — implementation plan for DM gaps

## Test plan

- [x] All 340 tests pass (21 test files)
- [ ] Verify profile resolution works against relay.divine.video in staging
- [ ] Verify "Message Creator" link appears on video cards with `uploaded_by`
- [ ] Verify `?pubkey=` deep linking opens correct conversation
- [ ] Verify category-specific DM includes correct policy link

🤖 Generated with [Claude Code](https://claude.com/claude-code)