### PR TITLE
fix: forward QUARANTINE to Blossom webhook

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -2814,11 +2814,12 @@ async function notifyBlossom(sha256, action, env) {
     return { success: true, skipped: true };
   }
 
-  // Only forward actions that Blossom understands. Blossom has four states
-  // (Active/Restricted/Pending/Banned) and returns 400 for unrecognized actions.
-  // REVIEW and QUARANTINE are internal classification tiers; content in those
-  // states stays publicly accessible (equivalent to Blossom's Pending).
-  const blossomActions = ['SAFE', 'AGE_RESTRICTED', 'PERMANENT_BAN'];
+  // Forward actions that Blossom understands. Blossom maps:
+  //   SAFE/APPROVE → Active, AGE_RESTRICTED/RESTRICT → Restricted,
+  //   QUARANTINE → Restricted (shadow-restricted, needs review),
+  //   PERMANENT_BAN/BLOCK → Banned
+  // REVIEW is the only internal-only tier that stays publicly accessible.
+  const blossomActions = ['SAFE', 'AGE_RESTRICTED', 'PERMANENT_BAN', 'QUARANTINE'];
   if (!blossomActions.includes(action)) {
     console.log(`[BLOSSOM] Skipping notification for internal action: ${action}`);
     return { success: true, skipped: true };


### PR DESCRIPTION
## Summary
- AI-generated content (100% AI score from HiveAI) was classified as `QUARANTINE` but `notifyBlossom()` excluded it from the webhook allowlist (`['SAFE', 'AGE_RESTRICTED', 'PERMANENT_BAN']`)
- Content stayed in `pending` status on Blossom and was served publicly
- Added `QUARANTINE` to the forwarded actions list so Blossom shadow-restricts it (maps to `Restricted` status)

## Related
- Blossom-side fix: added `QUARANTINE` action handling in webhook handler (on `feat/provenance-audit-system` branch in divine-blossom)
- Both changes are already deployed to production

## Test plan
- [x] Verified QUARANTINE webhook callback returns 200 with `status: restricted`
- [x] Deployed to Cloudflare Workers production
- [ ] Upload test AI-generated content and verify it gets auto-restricted

🤖 Generated with [Claude Code](https://claude.com/claude-code)