### PR TITLE
feat: QUARANTINE enforcement — Blossom restriction + RD auto-escalation

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -3314,11 +3314,24 @@ async function runMigration() {
           const cached = await env.MODERATION_KV.get(key.name);
           if (!cached) continue;
           const parsed = JSON.parse(cached);
-          if (parsed.status !== 'pending') continue;
 
           const sha256 = key.name.replace('rd:', '');
-          const { pollRealityDefender } = await import('./moderation/realness-client.mjs');
-          const result = await pollRealityDefender(sha256, env);
+
+          // Two cases to handle:
+          // 1. pending → poll RD API for results
+          // 2. complete + likely_ai but not yet escalated → retry escalation
+          let result = null;
+          if (parsed.status === 'pending') {
+            const { pollRealityDefender } = await import('./moderation/realness-client.mjs');
+            result = await pollRealityDefender(sha256, env);
+          } else if (parsed.status === 'complete' && parsed.verdict === 'likely_ai' && !parsed.escalated) {
+            // Previous escalation attempt failed — retry
+            result = parsed;
+            console.log(`[CRON] Retrying failed escalation for ${sha256}`);
+          } else {
+            continue; // complete + escalated, or complete + authentic — nothing to do
+          }
+
           if (result && result.status === 'complete') {
             polled++;
             console.log(`[CRON] Reality Defender result for ${sha256}: ${result.verdict} (score=${result.score})`);
@@ -3326,13 +3339,6 @@ async function runMigration() {
             // Auto-escalate confirmed fakes if content is still quarantined.
             // De-escalation (AUTHENTIC → SAFE) requires moderator action.
             // Human decisions are never overridden.
-            //
-            // Note: pollRealityDefender() caches the complete result to rd:{sha256}
-            // before we reach this block. If any step below fails (KV, D1, Blossom),
-            // the cron won't retry because the rd: key is no longer 'pending'.
-            // Fallback: manual moderator action via the admin dashboard.
-            // KV and D1 may temporarily diverge on partial failure — acceptable
-            // given the dual-store architecture; dashboard reads KV first.
             if (result.verdict === 'likely_ai') {
               const moderationData = await env.MODERATION_KV.get(`moderation:${sha256}`);
               if (moderationData) {
@@ -3401,8 +3407,27 @@ async function runMigration() {
                     }
                   }
 
+                  // Mark escalation complete so cron doesn't retry
+                  const rdCached = await env.MODERATION_KV.get(`rd:${sha256}`);
+                  if (rdCached) {
+                    const rdData = JSON.parse(rdCached);
+                    rdData.escalated = true;
+                    await env.MODERATION_KV.put(`rd:${sha256}`, JSON.stringify(rdData), {
+                      expirationTtl: 86400 * 7
+                    });
+                  }
+
                   escalated++;
                 } else {
+                  // Human already resolved — mark so we don't re-check
+                  const rdCached = await env.MODERATION_KV.get(`rd:${sha256}`);
+                  if (rdCached) {
+                    const rdData = JSON.parse(rdCached);
+                    rdData.escalated = true; // nothing to escalate, but stop retrying
+                    await env.MODERATION_KV.put(`rd:${sha256}`, JSON.stringify(rdData), {
+                      expirationTtl: 86400 * 7
+                    });
+                  }
                   console.log(`[CRON] Skipping auto-escalation for ${sha256}: no longer quarantined (action=${moderation.action})`);
                 }
               }

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -815,6 +815,88 @@ describe('RD auto-escalation cron integration', () => {
       expect(blossomPayloads).toHaveLength(1);
       expect(blossomPayloads[0].action).toBe('PERMANENT_BAN');
       expect(blossomPayloads[0].sha256).toBe(SHA256);
+
+      // Verify rd: entry marked as escalated (prevents retry)
+      const rdAfter = JSON.parse(kvStore.get(`rd:${SHA256}`));
+      expect(rdAfter.escalated).toBe(true);
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  it('retries escalation when rd: is complete but escalation previously failed', async () => {
+    const kvStore = new Map();
+    const blossomPayloads = [];
+
+    // Simulate a previous run where RD completed but escalation failed:
+    // rd: is complete+likely_ai but NOT escalated, content still quarantined
+    kvStore.set(`rd:${SHA256}`, JSON.stringify({
+      status: 'complete', verdict: 'likely_ai', score: 0.92, requestId: 'rd-req-retry'
+    }));
+    kvStore.set(`moderation:${SHA256}`, JSON.stringify({
+      action: 'QUARANTINE',
+      category: 'ai_generated',
+      uploadedBy: 'ab'.repeat(32),
+    }));
+    kvStore.set(`quarantine:${SHA256}`, JSON.stringify({ category: 'ai_generated' }));
+
+    const env = {
+      REALITY_DEFENDER_API_KEY: 'fake-rd-key',
+      BLOSSOM_WEBHOOK_URL: 'https://mock-blossom.test/admin/moderate',
+      BLOSSOM_WEBHOOK_SECRET: 'test-secret',
+      BLOSSOM_DB: {
+        prepare(sql) {
+          return {
+            bind(...args) { return this; },
+            async run() { return { success: true }; },
+            async first() { return null; },
+            async all() { return { results: [] }; }
+          };
+        },
+        async batch() { return []; }
+      },
+      MODERATION_KV: {
+        store: kvStore,
+        async get(key) { return kvStore.get(key) ?? null; },
+        async put(key, value) { kvStore.set(key, value); },
+        async delete(key) { kvStore.delete(key); },
+        async list({ prefix } = {}) {
+          const keys = [...kvStore.keys()]
+            .filter(k => !prefix || k.startsWith(prefix))
+            .map(name => ({ name }));
+          return { keys, list_complete: true, cursor: null };
+        }
+      },
+      MODERATION_QUEUE: { async send() {} },
+    };
+
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = async (url, init) => {
+      if (url === env.BLOSSOM_WEBHOOK_URL) {
+        blossomPayloads.push(JSON.parse(init.body));
+        return new Response(JSON.stringify({ success: true }), { status: 200 });
+      }
+      return new Response('{}', { status: 200 });
+    };
+
+    try {
+      await worker.scheduled(
+        { cron: '*/5 * * * *', scheduledTime: Date.now() },
+        env,
+        { waitUntil: () => {} }
+      );
+
+      // Verify escalation happened on retry
+      const moderation = JSON.parse(kvStore.get(`moderation:${SHA256}`));
+      expect(moderation.action).toBe('PERMANENT_BAN');
+
+      // Verify Blossom was notified
+      expect(blossomPayloads).toHaveLength(1);
+      expect(blossomPayloads[0].action).toBe('PERMANENT_BAN');
+
+      // Verify rd: now marked as escalated
+      const rdAfter = JSON.parse(kvStore.get(`rd:${SHA256}`));
+      expect(rdAfter.escalated).toBe(true);
     } finally {
       globalThis.fetch = origFetch;
     }


### PR DESCRIPTION
## Summary

Closes the quarantine enforcement gap: when content is classified QUARANTINE by the AI pipeline, it is now restricted on the CDN and auto-escalated to PERMANENT_BAN when Reality Defender confirms it as AI-generated.

- **notifyBlossom()**: Replaced allowlist with `BLOSSOM_ACTION_MAP`. QUARANTINE now maps to Blossom's `RESTRICT` action (owner can view, public gets 404). Previously, quarantined content stayed publicly accessible.
- **RD auto-escalation**: Extended the Reality Defender cron to auto-escalate `likely_ai` verdicts from QUARANTINE → PERMANENT_BAN (updates KV, D1, notifies Blossom, sends creator DM). Human decisions are never overridden — if a moderator already acted, auto-escalation is skipped.
- **DM timing**: Removed QUARANTINE from DM triggers in both `handleModerationResult()` and the admin moderate endpoint. DMs are premature before secondary verification; they now fire when quarantine resolves to PERMANENT_BAN via auto-escalation.

### Bug found during testing

The admin moderate endpoint (`/admin/api/moderate/{sha256}`, line 914) still had QUARANTINE in its DM trigger list even after removing it from `handleModerationResult()`. Integration tests caught this — DMs were firing prematurely when a moderator manually set QUARANTINE via the dashboard. Fixed in the second commit.

Design spec: `support-trust-safety/docs/superpowers/specs/2026-03-12-quarantine-enforcement-design.md`

## ClickHouse label key audit (Task 3 — no code change)

Audited the label pipeline end-to-end. Finding: moderation service kind 1985 labels never include an `e` tag (`publisher.mjs:294-296` — `nostrEventId` is never passed from `index.mjs:1072-1078`). Since funnelcake's `content_labels_mv` requires `length(arrayFilter(t -> t[1] = 'e', tags)) > 0`, all moderation-service labels are silently dropped from `content_labels` and never reach `nsfw_labeled_events_set` for feed filtering. Labels DO reach the separate `moderation_labels` table via direct ClickHouse HTTP API. Fix requires sha256→eventID lookup (Osprey territory). Documented in analysis doc and design spec.

## Test results

### Unit + integration tests — 348/348 passing (21 files)

Replaced pure-function unit tests with integration tests that exercise real code paths through the worker:

**notifyBlossom integration** (3 tests via admin moderate endpoint):
- QUARANTINE → verifies actual HTTP payload to Blossom contains `action: "RESTRICT"` (not `"QUARANTINE"`)
- PERMANENT_BAN → verifies payload contains `action: "PERMANENT_BAN"` unchanged
- REVIEW → verifies no HTTP request sent to Blossom at all

**DM exclusion** (2 tests via admin moderate endpoint):
- QUARANTINE with `MODERATOR_NSEC` set → `dm_sent: false` (caught the admin path bug)
- PERMANENT_BAN with `MODERATOR_NSEC` set → DM path entered

**RD auto-escalation cron** (3 tests via `worker.scheduled()` with mocked KV/D1/fetch):
- `likely_ai` + still QUARANTINE → full escalation path verified: KV updated to PERMANENT_BAN, `quarantine:` key deleted, `permanent-ban:` key created with `autoEscalated: true`, D1 UPDATE executed with `reality-defender-auto`, Blossom notified with PERMANENT_BAN
- `likely_ai` + moderator already changed to SAFE → human decision preserved, no Blossom notification
- `authentic` + still QUARANTINE → remains QUARANTINE (de-escalation requires human)

### Local webhook payload verification (manual, via mock HTTP server)

Ran `wrangler dev` with `BLOSSOM_WEBHOOK_URL` pointed at a local HTTP server that captured request bodies:

| Action | Payload received by Blossom | Result |
|--------|---------------------------|--------|
| QUARANTINE | `{ "sha256": "...", "action": "RESTRICT", "timestamp": "..." }` | Pass — mapped correctly |
| PERMANENT_BAN | `{ "sha256": "...", "action": "PERMANENT_BAN", "timestamp": "..." }` | Pass — passthrough |
| REVIEW | No request received | Pass — correctly skipped |

### Remaining verification (post-deploy)

- [ ] Deploy to production (`npx wrangler deploy`)
- [ ] `wrangler tail` — monitor logs for next QUARANTINE classification
- [ ] Verify Blossom receives RESTRICT action (check Blossom logs or admin UI)
- [ ] Wait for RD cron cycle (~5 min) on a quarantined item and verify auto-escalation
- [ ] Verify no regressions on SAFE/AGE_RESTRICTED/PERMANENT_BAN flows

No staging environment exists for this worker (single-env wrangler.toml with production routes only).