### PR TITLE
feat: admin lookup, uploader enforcement, and relay ban enforcement

### DIFF
--- a/src/admin/dashboard.html
+++ b/src/admin/dashboard.html
@@ -80,6 +80,67 @@
       flex-wrap: wrap;
     }
 
+    .lookup-panel {
+      background: linear-gradient(135deg, #111827, #0a0a0a);
+      border: 1px solid #24324a;
+      border-radius: 10px;
+      padding: 16px;
+      margin-bottom: 20px;
+    }
+
+    .lookup-form {
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+      align-items: end;
+    }
+
+    .lookup-input-group {
+      flex: 1 1 420px;
+      display: flex;
+      flex-direction: column;
+      gap: 5px;
+    }
+
+    .lookup-actions {
+      display: flex;
+      flex-direction: column;
+      gap: 5px;
+    }
+
+    .lookup-action-row {
+      display: flex;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+
+    .lookup-status {
+      margin-top: 10px;
+      font-size: 13px;
+      color: #9ca3af;
+    }
+
+    .lookup-result-section {
+      margin-bottom: 24px;
+    }
+
+    .lookup-result-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 10px;
+      color: #cbd5e1;
+      font-size: 13px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+
+    .lookup-result-grid {
+      display: grid;
+      grid-template-columns: minmax(300px, 420px);
+      gap: 20px;
+    }
+
     .control-group {
       display: flex;
       flex-direction: column;
@@ -478,6 +539,10 @@
       border-top: 1px solid #333;
     }
 
+    .action-buttons.compact {
+      flex-wrap: wrap;
+    }
+
     .action-btn {
       flex: 1;
       padding: 6px 10px;
@@ -513,6 +578,15 @@
       background: #3a2205;
     }
 
+    .action-btn.review {
+      border-color: #7c3aed;
+      color: #c4b5fd;
+    }
+
+    .action-btn.review:hover {
+      background: #24123d;
+    }
+
     .action-btn.ban {
       border-color: #991b1b;
       color: #ef4444;
@@ -529,6 +603,104 @@
 
     .action-btn.edit:hover {
       background: #1a2a4a;
+    }
+
+    .action-btn.user {
+      border-color: #0f766e;
+      color: #5eead4;
+    }
+
+    .action-btn.user:hover {
+      background: #082f2c;
+    }
+
+    .action-btn.secondary {
+      border-color: #475569;
+      color: #cbd5e1;
+    }
+
+    .action-btn.secondary:hover {
+      background: #111827;
+    }
+
+    .uploader-enforcement {
+      margin-top: 10px;
+      padding: 12px;
+      background: #0a0f1a;
+      border: 1px solid #1f2937;
+      border-radius: 6px;
+    }
+
+    .uploader-enforcement-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 8px;
+      margin-bottom: 8px;
+      font-size: 11px;
+      color: #94a3b8;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+
+    .uploader-enforcement-pubkey {
+      font-family: monospace;
+      color: #e2e8f0;
+      text-transform: none;
+      letter-spacing: 0;
+    }
+
+    .uploader-enforcement-badges {
+      display: flex;
+      gap: 6px;
+      flex-wrap: wrap;
+      margin-bottom: 8px;
+    }
+
+    .uploader-enforcement-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      padding: 3px 8px;
+      border-radius: 999px;
+      font-size: 10px;
+      font-weight: 600;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      border: 1px solid #334155;
+      background: #111827;
+      color: #cbd5e1;
+    }
+
+    .uploader-enforcement-badge.approval {
+      border-color: #7c3aed;
+      color: #d8b4fe;
+      background: #1e1033;
+    }
+
+    .uploader-enforcement-badge.relay-ban {
+      border-color: #991b1b;
+      color: #fca5a5;
+      background: #2b0d0d;
+    }
+
+    .uploader-enforcement-badge.risk-high {
+      border-color: #b45309;
+      color: #fdba74;
+      background: #2c1403;
+    }
+
+    .uploader-enforcement-badge.risk-elevated {
+      border-color: #1d4ed8;
+      color: #93c5fd;
+      background: #0f1d38;
+    }
+
+    .uploader-enforcement-stats {
+      font-size: 12px;
+      color: #94a3b8;
+      margin-bottom: 8px;
+      line-height: 1.5;
     }
 
     /* Override badge */
@@ -1356,6 +1528,32 @@
     </div>
   </div>
 
+  <div class="lookup-panel">
+    <div class="lookup-form">
+      <div class="lookup-input-group">
+        <label for="lookup-input">Open Video</label>
+        <input id="lookup-input" type="text" placeholder="Paste divine.video/video/... or 64-char SHA-256" autocomplete="off">
+      </div>
+      <div class="lookup-actions">
+        <label>&nbsp;</label>
+        <div class="lookup-action-row">
+          <button onclick="lookupVideo()">Open</button>
+          <button onclick="pasteAndLookupVideo()" style="background: #334155;">Paste</button>
+          <button id="lookup-clear-btn" onclick="clearLookupResult({ clearInput: true })" style="display: none; background: #3f3f46;">Clear</button>
+        </div>
+      </div>
+    </div>
+    <div id="lookup-status" class="lookup-status">Paste a divine.video link or 64-character SHA to jump straight to moderation.</div>
+  </div>
+
+  <div id="lookup-result-section" class="lookup-result-section" style="display: none;">
+    <div class="lookup-result-header">
+      <span>Focused Result</span>
+      <span id="lookup-result-meta"></span>
+    </div>
+    <div id="lookup-result" class="lookup-result-grid"></div>
+  </div>
+
   <div class="controls">
     <div class="control-group">
       <label for="sort-by">Sort By</label>
@@ -1462,7 +1660,10 @@
 
   <script>
     let allVideos = [];
+    let currentLookupSha = null;
+    let currentLookupVideo = null;
     const nostrContextCache = new Map(); // Cache Nostr contexts to avoid redundant fetches
+    const LOOKUP_HELP_TEXT = 'Paste a divine.video link or 64-character SHA to jump straight to moderation.';
 
     // Pagination state
     let paginationState = {
@@ -1673,6 +1874,180 @@
     let triageHasMore = true;
     let realStats = null;
 
+    function getVideoBySha(sha256) {
+      return allVideos.find(v => v.sha256 === sha256)
+        || (currentLookupVideo && currentLookupVideo.sha256 === sha256 ? currentLookupVideo : null);
+    }
+
+    function upsertVideo(video) {
+      const index = allVideos.findIndex(v => v.sha256 === video.sha256);
+      if (index === -1) {
+        allVideos.unshift(video);
+      } else {
+        allVideos[index] = { ...allVideos[index], ...video };
+      }
+    }
+
+    function normalizeLookupInput(value) {
+      if (!value) return null;
+
+      const trimmed = value.trim();
+      if (!trimmed) return null;
+
+      try {
+        const parsed = new URL(trimmed);
+        const pathParts = parsed.pathname.split('/').filter(Boolean);
+        if (pathParts.length >= 2 && pathParts[0] === 'video') {
+          return decodeURIComponent(pathParts[pathParts.length - 1]);
+        }
+      } catch {
+        // Non-URL input
+      }
+
+      const match = trimmed.match(/[a-f0-9]{64}/i);
+      if (match) {
+        return match[0].toLowerCase();
+      }
+
+      return trimmed;
+    }
+
+    function setLookupStatus(message, isError = false) {
+      const status = document.getElementById('lookup-status');
+      status.textContent = message;
+      status.style.color = isError ? '#fca5a5' : '#9ca3af';
+    }
+
+    function syncLookupUrl(sha256) {
+      const nextUrl = new URL(window.location.href);
+      if (sha256) {
+        nextUrl.searchParams.set('lookup', sha256);
+      } else {
+        nextUrl.searchParams.delete('lookup');
+      }
+      const search = nextUrl.searchParams.toString();
+      window.history.replaceState({}, '', `${nextUrl.pathname}${search ? `?${search}` : ''}`);
+    }
+
+    function clearLookupResult(options = {}) {
+      const { clearInput = false, clearStatus = true } = options;
+      currentLookupSha = null;
+      currentLookupVideo = null;
+      document.getElementById('lookup-result').innerHTML = '';
+      document.getElementById('lookup-result-section').style.display = 'none';
+      document.getElementById('lookup-result-meta').textContent = '';
+      document.getElementById('lookup-clear-btn').style.display = 'none';
+      syncLookupUrl(null);
+      if (clearInput) {
+        document.getElementById('lookup-input').value = '';
+      }
+      if (clearStatus) {
+        setLookupStatus(LOOKUP_HELP_TEXT);
+      }
+    }
+
+    function removeLookupResultIfMatches(sha256) {
+      if (currentLookupSha === sha256) {
+        clearLookupResult({ clearStatus: false });
+        setLookupStatus(`Cleared focused result for ${sha256.substring(0, 16)}...`);
+      }
+    }
+
+    function hydrateRenderedVideo(video) {
+      const nostrContainer = document.getElementById(`nostr-${video.sha256}`);
+      if (!nostrContainer) return;
+
+      if (video.nostrContext) {
+        nostrContainer.innerHTML = createNostrMetadataHTML(video.nostrContext);
+        updateDivineLink(video.sha256, video.nostrContext);
+      } else {
+        nostrContainer.innerHTML = '<div class="nostr-not-found" style="opacity:0.5">Loading...</div>';
+        loadNostrContext(video.sha256, nostrContainer);
+      }
+
+      loadClassifierData(video.sha256);
+
+      const aiScore = video.scores?.ai_generated || 0;
+      const deepfakeScore = video.scores?.deepfake || 0;
+      if (aiScore >= 0.3 || deepfakeScore >= 0.3) {
+        loadRealnessResult(video.sha256);
+      }
+    }
+
+    function renderLookupResult(video) {
+      currentLookupSha = video.sha256;
+      currentLookupVideo = video;
+      upsertVideo(video);
+
+      const section = document.getElementById('lookup-result-section');
+      const result = document.getElementById('lookup-result');
+      const meta = document.getElementById('lookup-result-meta');
+      const renderVideo = video.status === 'UNTRIAGED'
+        ? { ...video, showDirectActions: true }
+        : video;
+
+      result.innerHTML = video.status === 'UNTRIAGED'
+        ? createTriageCard(renderVideo)
+        : createVideoCard(renderVideo);
+
+      section.style.display = 'block';
+      meta.textContent = `${video.sha256.substring(0, 16)}...${video.status === 'UNTRIAGED' ? ' · needs triage' : ` · ${video.action}`}`;
+      document.getElementById('lookup-clear-btn').style.display = 'inline-block';
+      setLookupStatus(`Opened ${video.sha256.substring(0, 16)}...`);
+      syncLookupUrl(video.lookupId || video.sha256);
+
+      setTimeout(setupVideoPauseHandlers, 100);
+      if (video.status !== 'UNTRIAGED') {
+        hydrateRenderedVideo(video);
+      }
+    }
+
+    async function lookupVideo(inputValue = null) {
+      const input = document.getElementById('lookup-input');
+      const rawValue = inputValue ?? input.value;
+      const sha256 = normalizeLookupInput(rawValue);
+
+      if (!sha256) {
+        setLookupStatus('Paste a divine.video/video/... URL or a 64-character SHA-256 hash.', true);
+        return;
+      }
+
+      input.value = sha256;
+      setLookupStatus(`Opening ${sha256.substring(0, 16)}...`);
+
+      try {
+        const response = await fetch(`/admin/api/video/${encodeURIComponent(sha256)}`);
+        if (response.status === 401) {
+          window.location.href = '/admin/login';
+          return;
+        }
+
+        const data = await response.json();
+        if (!response.ok) {
+          throw new Error(data.error || `HTTP ${response.status}`);
+        }
+
+        renderLookupResult(data.video);
+      } catch (error) {
+        clearLookupResult({ clearStatus: false });
+        setLookupStatus(`Lookup failed: ${error.message}`, true);
+      }
+    }
+
+    async function pasteAndLookupVideo() {
+      try {
+        const clipboardText = await navigator.clipboard.readText();
+        if (!clipboardText) {
+          setLookupStatus('Clipboard is empty.', true);
+          return;
+        }
+        document.getElementById('lookup-input').value = clipboardText.trim();
+        await lookupVideo(clipboardText);
+      } catch (error) {
+        setLookupStatus('Clipboard read failed. Paste into the field and press Open.', true);
+      }
+    }
+
     // Load REAL stats from the stats API - actual totals, not page counts
     async function loadRealStats() {
       try {
@@ -1779,8 +2154,79 @@
     }
     setupTriageInfiniteScroll();
 
+    function truncateHex(value, start = 12, end = 8) {
+      if (!value || value.length <= start + end + 3) {
+        return value || '';
+      }
+      return value.slice(0, start) + '...' + value.slice(-end);
+    }
+
+    function createUploaderEnforcementPanel(video) {
+      const pubkey = video.uploaded_by || null;
+      const eventId = video.eventId || video.nostrContext?.eventId || null;
+      const enforcement = video.uploaderEnforcement || null;
+      const stats = video.uploaderStats || null;
+
+      if (!video.lookupId && !enforcement && !stats && !eventId) {
+        return '';
+      }
+
+      if (!pubkey && !eventId) {
+        return '';
+      }
+
+      const badges = [];
+      if (enforcement?.approval_required) {
+        badges.push('<span class="uploader-enforcement-badge approval">Approval Required</span>');
+      }
+      if (enforcement?.relay_banned) {
+        badges.push('<span class="uploader-enforcement-badge relay-ban">Relay Banned</span>');
+      }
+      if (stats?.risk_level === 'high') {
+        badges.push('<span class="uploader-enforcement-badge risk-high">Risk High</span>');
+      } else if (stats?.risk_level === 'elevated') {
+        badges.push('<span class="uploader-enforcement-badge risk-elevated">Risk Elevated</span>');
+      }
+      if (badges.length === 0) {
+        badges.push('<span class="uploader-enforcement-badge">No User Enforcement</span>');
+      }
+
+      const statBits = [];
+      if (stats) {
+        statBits.push(`flagged ${stats.flagged_count || 0}`);
+        statBits.push(`restricted ${stats.restricted_count || 0}`);
+        statBits.push(`banned ${stats.banned_count || 0}`);
+      }
+
+      const approvalButton = pubkey
+        ? `<button class="action-btn review" onclick="toggleApprovalRequired('${pubkey}', ${enforcement?.approval_required ? 'false' : 'true'}, this)">${enforcement?.approval_required ? 'Approval Off' : 'Require Approval'}</button>`
+        : '';
+      const relayButton = pubkey
+        ? `<button class="action-btn ban" onclick="toggleRelayBan('${pubkey}', ${enforcement?.relay_banned ? 'false' : 'true'}, this)">${enforcement?.relay_banned ? 'Unban User' : 'Ban User'}</button>`
+        : '';
+      const deleteButton = eventId
+        ? `<button class="action-btn secondary" onclick="deleteNostrEvent('${eventId}', this)">Delete Event</button>`
+        : '';
+
+      return `
+        <div class="uploader-enforcement">
+          <div class="uploader-enforcement-header">
+            <span>User Controls</span>
+            ${pubkey ? `<span class="uploader-enforcement-pubkey" title="${pubkey}">${truncateHex(pubkey)}</span>` : ''}
+          </div>
+          <div class="uploader-enforcement-badges">${badges.join('')}</div>
+          ${statBits.length > 0 ? `<div class="uploader-enforcement-stats">${statBits.join(' · ')}</div>` : ''}
+          <div class="action-buttons compact">
+            ${approvalButton}
+            ${relayButton}
+            ${deleteButton}
+          </div>
+        </div>
+      `;
+    }
+
     function createTriageCard(video) {
-      const { sha256, cdnUrl, thumbnailUrl, receivedAt, nostrContext } = video;
+      const { sha256, cdnUrl, thumbnailUrl, receivedAt, nostrContext, showDirectActions } = video;
 
       // Format timestamp
       const timestamp = receivedAt ? new Date(receivedAt).toLocaleString() : 'Unknown';
@@ -1790,8 +2236,8 @@
       const videoUrl = cdnUrl || 'https://media.divine.video/' + sha256 + '.mp4';
       const thumbUrl = thumbnailUrl || '';
 
-      // Link to divine.video with sha256 (will resolve to event)
-      const divineUrl = 'https://divine.video/video/' + sha256;
+      // Prefer resolved public URL when available (older imports often use stable IDs, not blob hashes)
+      const divineUrl = video.divineUrl || 'https://divine.video/video/' + sha256;
 
       // Nostr context display
       const author = nostrContext?.author || null;
@@ -1819,7 +2265,16 @@
         description = escapeHtml(content.substring(0, 100));
       }
 
-      return '<div class="video-card triage" style="border-color: #8b5cf6;">' +
+      const directActions = showDirectActions ? (
+        '<div class="action-buttons">' +
+          '<button class="action-btn review" onclick="lookupModerationAction(\'' + sha256 + '\', \'QUARANTINE\', this)">Warn</button>' +
+          '<button class="action-btn age-restrict" onclick="lookupModerationAction(\'' + sha256 + '\', \'AGE_RESTRICTED\', this)">Restrict</button>' +
+          '<button class="action-btn ban" onclick="lookupModerationAction(\'' + sha256 + '\', \'PERMANENT_BAN\', this)">Block</button>' +
+        '</div>'
+      ) : '';
+      const uploaderEnforcementPanel = createUploaderEnforcementPanel(video);
+
+      return '<div class="video-card triage" data-sha256="' + sha256 + '" style="border-color: #8b5cf6;">' +
         '<div class="video-thumbnail">' +
           '<video src="' + videoUrl + '" muted loop preload="metadata" poster="' + thumbUrl + '" controls onmouseenter="this.play()" onmouseleave="this.pause(); this.currentTime=0;"></video>' +
           '<div class="video-overlay">' +
@@ -1845,6 +2300,8 @@
               '✅ Safe' +
             '</button>' +
           '</div>' +
+          uploaderEnforcementPanel +
+          directActions +
         '</div>' +
       '</div>';
     }
@@ -1889,10 +2346,19 @@
       button.disabled = true;
 
       try {
+        const video = getVideoBySha(sha256);
+        const payload = { sha256 };
+        if (video?.cdnUrl) {
+          payload.videoUrl = video.cdnUrl;
+        }
+        if (video?.uploaded_by) {
+          payload.uploadedBy = video.uploaded_by;
+        }
+
         const response = await fetch('/admin/api/queue-moderation', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ sha256 })
+          body: JSON.stringify(payload)
         });
 
         if (response.ok) {
@@ -1906,6 +2372,7 @@
               card.style.transform = 'scale(0.9)';
               setTimeout(() => card.remove(), 300);
             }
+            removeLookupResultIfMatches(sha256);
             loadRealStats();
           }, 1000);
         } else {
@@ -1936,21 +2403,32 @@
       button.disabled = true;
 
       try {
+        const video = getVideoBySha(sha256);
         const response = await fetch('/admin/api/moderate/' + sha256, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ action: 'SAFE' })
+          body: JSON.stringify({
+            action: 'SAFE',
+            videoUrl: video?.cdnUrl,
+            uploadedBy: video?.uploaded_by || null
+          })
         });
 
         if (response.ok) {
           button.innerHTML = '✅ Done!';
-          // Remove this card after a moment
-          setTimeout(() => {
-            const card = button.closest('.video-card');
-            if (card) {
-              card.style.opacity = '0';
-              card.style.transform = 'scale(0.9)';
-              setTimeout(() => card.remove(), 300);
+          setTimeout(async () => {
+            if (currentLookupSha === sha256) {
+              const reloadId = currentLookupVideo?.lookupId || sha256;
+              await lookupVideo(reloadId);
+              setLookupStatus(`Approved ${sha256.substring(0, 16)}...`);
+            } else {
+              const card = button.closest('.video-card');
+              if (card) {
+                card.style.opacity = '0';
+                card.style.transform = 'scale(0.9)';
+                setTimeout(() => card.remove(), 300);
+              }
+              removeLookupResultIfMatches(sha256);
             }
             loadRealStats();
           }, 500);
@@ -1967,6 +2445,154 @@
           button.innerHTML = originalText;
           button.disabled = false;
         }, 2000);
+      }
+    }
+
+    async function lookupModerationAction(sha256, action, button) {
+      const originalText = button.innerHTML;
+      button.innerHTML = '⏳...';
+      button.disabled = true;
+
+      try {
+        const video = getVideoBySha(sha256);
+        const response = await fetch('/admin/api/moderate/' + sha256, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            action,
+            reason: 'Direct lookup moderation action: ' + action,
+            videoUrl: video?.cdnUrl,
+            uploadedBy: video?.uploaded_by || null
+          })
+        });
+
+        if (!response.ok) {
+          const data = await response.json().catch(() => ({}));
+          throw new Error(data.error || `HTTP ${response.status}`);
+        }
+
+        loadRealStats();
+
+        if (currentLookupSha === sha256) {
+          const reloadId = currentLookupVideo?.lookupId || sha256;
+          await lookupVideo(reloadId);
+        } else {
+          const card = button.closest('.video-card');
+          if (card) {
+            card.style.opacity = '0';
+            card.style.transform = 'scale(0.9)';
+            setTimeout(() => card.remove(), 300);
+          }
+        }
+
+        const actionLabel = action === 'QUARANTINE'
+          ? 'warned'
+          : action === 'AGE_RESTRICTED'
+            ? 'restricted'
+            : action === 'PERMANENT_BAN'
+              ? 'blocked'
+              : action.toLowerCase();
+        setLookupStatus(`Applied ${actionLabel} to ${sha256.substring(0, 16)}...`);
+      } catch (error) {
+        button.innerHTML = originalText;
+        button.disabled = false;
+        setLookupStatus(`Action failed: ${error.message}`, true);
+      }
+    }
+
+    async function updateUploaderEnforcement(pubkey, payload, button, successMessage) {
+      const originalText = button.innerHTML;
+      button.innerHTML = '⏳...';
+      button.disabled = true;
+
+      try {
+        const response = await fetch('/admin/api/uploader/' + encodeURIComponent(pubkey) + '/enforcement', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        });
+
+        const data = await response.json().catch(() => ({}));
+        if (!response.ok) {
+          throw new Error(data.error || `HTTP ${response.status}`);
+        }
+
+        if (currentLookupVideo?.uploaded_by === pubkey) {
+          const reloadId = currentLookupVideo.lookupId || currentLookupVideo.sha256;
+          await lookupVideo(reloadId);
+        } else {
+          await loadVideos();
+        }
+
+        button.innerHTML = originalText;
+        button.disabled = false;
+        setLookupStatus(successMessage);
+      } catch (error) {
+        button.innerHTML = originalText;
+        button.disabled = false;
+        setLookupStatus(`User action failed: ${error.message}`, true);
+      }
+    }
+
+    async function toggleApprovalRequired(pubkey, enabled, button) {
+      await updateUploaderEnforcement(
+        pubkey,
+        {
+          approvalRequired: enabled,
+          reason: enabled ? 'Uploader set to manual approval mode' : 'Uploader removed from manual approval mode'
+        },
+        button,
+        enabled
+          ? `Approval required enabled for ${truncateHex(pubkey)}`
+          : `Approval required cleared for ${truncateHex(pubkey)}`
+      );
+    }
+
+    async function toggleRelayBan(pubkey, enabled, button) {
+      await updateUploaderEnforcement(
+        pubkey,
+        {
+          relayBanned: enabled,
+          reason: enabled ? 'Banned from relay by moderator' : 'Relay ban removed by moderator'
+        },
+        button,
+        enabled
+          ? `Relay ban applied to ${truncateHex(pubkey)}`
+          : `Relay ban removed for ${truncateHex(pubkey)}`
+      );
+    }
+
+    async function deleteNostrEvent(eventId, button) {
+      const originalText = button.innerHTML;
+      button.innerHTML = '⏳...';
+      button.disabled = true;
+
+      try {
+        const response = await fetch('/admin/api/event/' + encodeURIComponent(eventId) + '/delete', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            reason: 'Deleted from moderation dashboard'
+          })
+        });
+
+        const data = await response.json().catch(() => ({}));
+        if (!response.ok) {
+          throw new Error(data.error || `HTTP ${response.status}`);
+        }
+
+        if (currentLookupVideo) {
+          const reloadId = currentLookupVideo.lookupId || currentLookupVideo.sha256;
+          await lookupVideo(reloadId);
+        }
+
+        button.innerHTML = originalText;
+        button.disabled = false;
+        setLookupStatus(`Deleted relay event ${truncateHex(eventId, 10, 6)}`);
+      } catch (error) {
+        button.innerHTML = originalText;
+        button.disabled = false;
+        setLookupStatus(`Event action failed: ${error.message}`, true);
       }
     }
 
@@ -2095,30 +2721,7 @@
       // Set up video pause handlers after rendering
       setTimeout(setupVideoPauseHandlers, 100);
 
-      // Render Nostr context — use cached data or fetch from API
-      videos.forEach((video) => {
-        const nostrContainer = document.getElementById(`nostr-${video.sha256}`);
-        if (!nostrContainer) return;
-
-        if (video.nostrContext) {
-          nostrContainer.innerHTML = createNostrMetadataHTML(video.nostrContext);
-          updateDivineLink(video.sha256, video.nostrContext);
-        } else {
-          // Async fetch nostr context for moderated videos
-          nostrContainer.innerHTML = '<div class="nostr-not-found" style="opacity:0.5">Loading...</div>';
-          loadNostrContext(video.sha256, nostrContainer);
-        }
-
-        // Load classifier inline summary + detail panels (async, non-blocking)
-        loadClassifierData(video.sha256);
-
-        // Load realness secondary verification for AI-flagged videos
-        const aiScore = video.scores?.ai_generated || 0;
-        const deepfakeScore = video.scores?.deepfake || 0;
-        if (aiScore >= 0.3 || deepfakeScore >= 0.3) {
-          loadRealnessResult(video.sha256);
-        }
-      });
+      videos.forEach(hydrateRenderedVideo);
     }
 
     function updateDivineLink(sha256, metadata) {
@@ -2323,9 +2926,10 @@
 
       // Generate moderation history
       const historyHTML = createModerationHistory(video);
+      const uploaderEnforcementPanel = createUploaderEnforcementPanel(video);
 
       return `
-        <div class="video-card ${actionClass}">
+        <div class="video-card ${actionClass}" data-sha256="${sha256}">
           <div class="video-thumbnail">
             <video src="${adminVideoUrl}" muted loop preload="auto" controls onmouseenter="this.play()" onmouseleave="this.pause()"></video>
             <div class="video-overlay">
@@ -2376,6 +2980,8 @@
               </a>
             </div>
             ` : ''}
+
+            ${uploaderEnforcementPanel}
 
             <div class="action-buttons">
               <button class="action-btn approve" onclick="quickAction('${sha256}', 'SAFE')">Approve</button>
@@ -2888,7 +3494,7 @@
 
     async function verifyCategory(sha256, category, status) {
       // Find the video in allVideos
-      const video = allVideos.find(v => v.sha256 === sha256);
+      const video = getVideoBySha(sha256);
       if (!video) {
         console.error('Video not found:', sha256);
         return;
@@ -3151,18 +3757,18 @@
 
     // Quick action - change moderation action without modal
     async function quickAction(sha256, action) {
-      const video = allVideos.find(v => v.sha256 === sha256);
+      const video = getVideoBySha(sha256);
       if (!video) return;
 
       const previousAction = video.action;
       const previousData = { ...video };
 
       // Find and fade out the card immediately
-      const card = document.querySelector(`.video-card:has([onclick*="${sha256}"])`);
-      if (card) {
+      const cards = Array.from(document.querySelectorAll(`.video-card[data-sha256="${sha256}"]`));
+      cards.forEach(card => {
         card.style.opacity = '0.5';
         card.style.pointerEvents = 'none';
-      }
+      });
 
       try {
         const response = await fetch(`/admin/api/moderate/${sha256}`, {
@@ -3179,18 +3785,19 @@
         console.log('Action updated:', result);
 
         // Remove card from grid with animation
-        if (card) {
+        cards.forEach(card => {
           card.style.transition = 'all 0.3s ease-out';
           card.style.transform = 'scale(0.9)';
           card.style.opacity = '0';
           setTimeout(() => card.remove(), 300);
-        }
+        });
 
         // Remove from allVideos array
         const idx = allVideos.findIndex(v => v.sha256 === sha256);
         if (idx !== -1) {
           allVideos.splice(idx, 1);
         }
+        removeLookupResultIfMatches(sha256);
 
         // Store for undo
         lastAction = { sha256, previousAction, previousData, newAction: action };
@@ -3208,10 +3815,10 @@
       } catch (error) {
         console.error('Failed to update action:', error);
         // Revert card visibility
-        if (card) {
+        cards.forEach(card => {
           card.style.opacity = '1';
           card.style.pointerEvents = 'auto';
-        }
+        });
         alert('Failed to update: ' + error.message);
       }
     }
@@ -3304,7 +3911,7 @@
 
     // Open modal to edit scores
     function openEditModal(sha256) {
-      const video = allVideos.find(v => v.sha256 === sha256);
+      const video = getVideoBySha(sha256);
       if (!video) return;
 
       currentEditingSha256 = sha256;
@@ -3386,7 +3993,12 @@
         console.log('Scores updated:', result);
 
         closeEditModal();
-        await loadVideos(paginationState.currentCursor);
+        if (document.getElementById('filter-action').value !== 'TRIAGE') {
+          await loadVideos(paginationState.currentCursor);
+        }
+        if (currentLookupSha === currentEditingSha256) {
+          await lookupVideo(currentEditingSha256);
+        }
         alert('Successfully updated scores and action');
       } catch (error) {
         console.error('Failed to update:', error);
@@ -3430,10 +4042,23 @@
     });
 
     // Load TRIAGE videos by default (new videos needing moderation)
+    document.getElementById('lookup-input').addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        lookupVideo();
+      }
+    });
+
     loadTriageVideos();
     loadRealStats();
     // Set filter dropdown to TRIAGE
     document.getElementById('filter-action').value = 'TRIAGE';
+
+    const initialLookup = new URLSearchParams(window.location.search).get('lookup');
+    if (initialLookup) {
+      document.getElementById('lookup-input').value = initialLookup;
+      lookupVideo(initialLookup);
+    }
 
     // Fetch unread message count for badge
     (async function() {

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -18,6 +18,7 @@ import swipeReviewHTML from './admin/swipe-review.html';
 import messagesHTML from './admin/messages.html';
 import { initReportsTable, addReport } from './reports.mjs';
 import { initOffenderTable, updateUploaderStats, getUploaderStats } from './offender-tracker.mjs';
+import { initUploaderEnforcementTable, getUploaderEnforcement, setUploaderEnforcement, applyUploaderEnforcementToResult } from './uploader-enforcement.mjs';
 import { formatForStorage, formatForGorse, formatForFunnelcake } from './classification/pipeline.mjs';
 import { topicsToLabels, topicsToWeightedFeatures } from './classification/topic-extractor.mjs';
 import { getKVThresholds, setKVThresholds, DEFAULT_THRESHOLDS } from './moderation/classifier.mjs';
@@ -43,6 +44,7 @@ const CATEGORY_TO_LABEL = {
 
 const ADMIN_HOSTNAME = 'moderation.admin.divine.video';
 const API_HOSTNAME = 'moderation-api.divine.video';
+const DEFAULT_RELAY_ADMIN_URL = 'https://relay.admin.divine.video';
 const JSON_HEADERS = { 'Content-Type': 'application/json' };
 const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]']);
 
@@ -203,6 +205,416 @@ function verifyLegacyBearerAuth(request, env) {
   }
 
   return null;
+}
+
+function isValidSha256(value) {
+  return typeof value === 'string' && /^[0-9a-f]{64}$/i.test(value);
+}
+
+function isValidLookupIdentifier(value) {
+  return typeof value === 'string' && value.length > 0 && value.length <= 255;
+}
+
+function isValidPubkey(value) {
+  return isValidSha256(value);
+}
+
+function parseMaybeJson(value, fallback) {
+  if (value == null) {
+    return fallback;
+  }
+
+  if (typeof value === 'string') {
+    try {
+      return JSON.parse(value);
+    } catch {
+      return fallback;
+    }
+  }
+
+  return value;
+}
+
+function getEventTagValue(tags, key) {
+  return tags?.find((tag) => tag[0] === key)?.[1] || null;
+}
+
+function parseImetaParams(tags) {
+  const imetaTag = tags?.find((tag) => tag[0] === 'imeta');
+  if (!imetaTag) {
+    return {};
+  }
+
+  const params = {};
+  for (let i = 1; i < imetaTag.length; i++) {
+    const entry = imetaTag[i];
+    if (!entry || typeof entry !== 'string') {
+      continue;
+    }
+
+    const separatorIndex = entry.indexOf(' ');
+    if (separatorIndex === -1) {
+      continue;
+    }
+
+    const key = entry.slice(0, separatorIndex);
+    const value = entry.slice(separatorIndex + 1).trim();
+    if (key && value) {
+      params[key] = value;
+    }
+  }
+
+  return params;
+}
+
+function extractShaFromUrl(url) {
+  if (typeof url !== 'string') {
+    return null;
+  }
+
+  const match = url.match(/[0-9a-f]{64}/i);
+  return match ? match[0].toLowerCase() : null;
+}
+
+function extractMediaShaFromEvent(event) {
+  const tags = event?.tags || [];
+  const imeta = parseImetaParams(tags);
+  return extractShaFromUrl(imeta.x)
+    || extractShaFromUrl(getEventTagValue(tags, 'x'))
+    || extractShaFromUrl(imeta.url)
+    || extractShaFromUrl(getEventTagValue(tags, 'url'))
+    || null;
+}
+
+function buildFunnelcakeVideoLookup(eventResponse, identifier) {
+  if (!eventResponse?.event) {
+    return null;
+  }
+
+  const event = eventResponse.event;
+  const stats = eventResponse.stats || {};
+  const tags = event.tags || [];
+  const metadata = parseVideoEventMetadata(event) || {};
+  const imeta = parseImetaParams(tags);
+  const mediaSha = extractMediaShaFromEvent(event);
+  const videoUrl = metadata.url || imeta.url || getEventTagValue(tags, 'url') || null;
+  const thumbnailUrl = imeta.image || getEventTagValue(tags, 'thumb') || getEventTagValue(tags, 'image') || null;
+  const stableId = getEventTagValue(tags, 'd') || event.id || identifier;
+
+  return {
+    eventId: event.id,
+    stableId,
+    lookupId: identifier,
+    mediaSha,
+    videoUrl,
+    thumbnailUrl,
+    uploadedBy: event.pubkey || null,
+    createdAt: event.created_at ? new Date(event.created_at * 1000).toISOString() : null,
+    nostrContext: {
+      title: metadata.title || null,
+      author: metadata.author || stats.author_name || null,
+      client: metadata.client || null,
+      content: metadata.content || event.content || null,
+      pubkey: event.pubkey ? `${event.pubkey.substring(0, 16)}...` : null,
+      eventId: event.id,
+      platform: metadata.platform || null
+    },
+    divineUrl: `https://divine.video/video/${encodeURIComponent(stableId)}`
+  };
+}
+
+async function fetchFunnelcakeLookupVideo(identifier) {
+  const response = await fetch(`https://relay.divine.video/api/videos/${encodeURIComponent(identifier)}`, {
+    headers: {
+      'Accept': 'application/json'
+    }
+  });
+
+  if (response.status === 404) {
+    return null;
+  }
+
+  if (!response.ok) {
+    throw new Error(`Funnelcake lookup failed with HTTP ${response.status}`);
+  }
+
+  return buildFunnelcakeVideoLookup(await response.json(), identifier);
+}
+
+function mergeLookupMetadata(baseVideo, funnelcakeVideo) {
+  if (!funnelcakeVideo) {
+    return baseVideo;
+  }
+
+  return {
+    ...baseVideo,
+    cdnUrl: baseVideo.cdnUrl || funnelcakeVideo.videoUrl || baseVideo.cdnUrl,
+    thumbnailUrl: baseVideo.thumbnailUrl || funnelcakeVideo.thumbnailUrl || null,
+    uploaded_by: baseVideo.uploaded_by || funnelcakeVideo.uploadedBy || null,
+    divineUrl: funnelcakeVideo.divineUrl || baseVideo.divineUrl,
+    lookupId: funnelcakeVideo.lookupId || baseVideo.lookupId,
+    nostrContext: {
+      ...(funnelcakeVideo.nostrContext || {}),
+      ...(baseVideo.nostrContext || {})
+    }
+  };
+}
+
+function getRelayAdminUrl(env) {
+  return env.RELAY_ADMIN_URL || DEFAULT_RELAY_ADMIN_URL;
+}
+
+function getRelayAdminHeaders(env) {
+  const headers = {
+    'Content-Type': 'application/json'
+  };
+
+  if (env.CF_ACCESS_CLIENT_ID && env.CF_ACCESS_CLIENT_SECRET) {
+    headers['CF-Access-Client-Id'] = env.CF_ACCESS_CLIENT_ID;
+    headers['CF-Access-Client-Secret'] = env.CF_ACCESS_CLIENT_SECRET;
+  }
+
+  return headers;
+}
+
+async function callRelayAdminAction(env, payload) {
+  const response = await fetch(`${getRelayAdminUrl(env)}/api/moderate`, {
+    method: 'POST',
+    headers: getRelayAdminHeaders(env),
+    body: JSON.stringify(payload)
+  });
+
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok || data?.success === false) {
+    throw new Error(data?.error || `Relay admin error: HTTP ${response.status}`);
+  }
+
+  return data;
+}
+
+/**
+ * Look up the Nostr event for a SHA256 and delete it from the relay.
+ * Used to enforce PERMANENT_BAN on content that may be hosted externally.
+ */
+async function deleteEventFromRelayBySha256(sha256, env, source = 'unknown') {
+  try {
+    const event = await fetchNostrEventBySha256(sha256, ['wss://relay.divine.video'], env);
+    if (!event?.id) {
+      console.log(`[RELAY-ENFORCE] ${sha256} - No relay event found, skipping delete`);
+      return { success: false, reason: 'no_event_found' };
+    }
+
+    const result = await callRelayAdminAction(env, {
+      action: 'delete_event',
+      eventId: event.id,
+      reason: `PERMANENT_BAN enforcement (${source})`
+    });
+    console.log(`[RELAY-ENFORCE] ${sha256} - Deleted event ${event.id} from relay`);
+    return { success: true, eventId: event.id, result };
+  } catch (error) {
+    console.error(`[RELAY-ENFORCE] ${sha256} - Failed to delete from relay:`, error.message);
+    return { success: false, error: error.message };
+  }
+}
+
+async function fetchLookupNostrContext(hash, env) {
+  try {
+    const event = await fetchNostrEventBySha256(hash, ['wss://relay.divine.video'], env);
+    if (!event) {
+      return null;
+    }
+
+    const metadata = parseVideoEventMetadata(event) || {};
+    const tags = event.tags || [];
+    const stableId = getEventTagValue(tags, 'd') || event.id || hash;
+
+    return {
+      eventId: event.id,
+      uploadedBy: event.pubkey || null,
+      divineUrl: `https://divine.video/video/${encodeURIComponent(stableId)}`,
+      nostrContext: {
+        title: metadata.title || null,
+        author: metadata.author || null,
+        client: metadata.client || null,
+        content: metadata.content || event.content || null,
+        pubkey: event.pubkey ? `${event.pubkey.substring(0, 16)}...` : null,
+        eventId: event.id,
+        platform: metadata.platform || null
+      }
+    };
+  } catch (error) {
+    console.error(`[ADMIN] Failed to fetch Nostr context for ${hash}:`, error.message);
+    return null;
+  }
+}
+
+async function enrichAdminLookupVideo(video, env) {
+  if (!video) {
+    return null;
+  }
+
+  let enriched = { ...video };
+
+  if (enriched.sha256 && (!enriched.eventId || !enriched.divineUrl || !enriched.nostrContext)) {
+    const nostrContext = await fetchLookupNostrContext(enriched.sha256, env);
+    if (nostrContext) {
+      enriched = {
+        ...enriched,
+        eventId: enriched.eventId || nostrContext.eventId,
+        divineUrl: enriched.divineUrl || nostrContext.divineUrl,
+        nostrContext: {
+          ...(nostrContext.nostrContext || {}),
+          ...(enriched.nostrContext || {})
+        },
+        uploaded_by: enriched.uploaded_by || nostrContext.uploadedBy || null
+      };
+    }
+  }
+
+  if (enriched.uploaded_by) {
+    const [uploaderStats, uploaderEnforcement] = await Promise.all([
+      getUploaderStats(env.BLOSSOM_DB, enriched.uploaded_by).catch(() => null),
+      getUploaderEnforcement(env.BLOSSOM_DB, enriched.uploaded_by).catch(() => null)
+    ]);
+
+    enriched = {
+      ...enriched,
+      uploaderStats,
+      uploaderEnforcement: uploaderEnforcement || {
+        pubkey: enriched.uploaded_by,
+        approval_required: false,
+        relay_banned: false
+      }
+    };
+  }
+
+  return enriched;
+}
+
+async function getAdminLookupVideo(identifier, env, options = {}) {
+  const { allowFunnelcakeFallback = true } = options;
+  const hash = isValidSha256(identifier) ? identifier.toLowerCase() : null;
+  const cdnUrl = `https://${env.CDN_DOMAIN || 'media.divine.video'}/${hash}`;
+  if (hash) {
+    const moderatedRow = await env.BLOSSOM_DB.prepare(`
+      SELECT sha256, action, provider, scores, categories, moderated_at, reviewed_by, reviewed_at, review_notes, uploaded_by
+      FROM moderation_results
+      WHERE sha256 = ?
+    `).bind(hash).first();
+
+    const kvModerationRaw = await env.MODERATION_KV.get(`moderation:${hash}`);
+    const kvModeration = parseMaybeJson(kvModerationRaw, null);
+
+    if (moderatedRow || kvModeration) {
+      const moderatedAt = kvModeration?.moderated_at || moderatedRow?.moderated_at || null;
+      return enrichAdminLookupVideo({
+        sha256: hash,
+        action: kvModeration?.action || moderatedRow?.action || 'REVIEW',
+        provider: kvModeration?.provider || moderatedRow?.provider || null,
+        scores: parseMaybeJson(kvModeration?.scores, null) || parseMaybeJson(moderatedRow?.scores, {}),
+        categories: parseMaybeJson(kvModeration?.categories, null) || parseMaybeJson(moderatedRow?.categories, []),
+        processedAt: moderatedAt ? new Date(moderatedAt).getTime() : null,
+        moderated_at: moderatedAt,
+        reviewed_by: moderatedRow?.reviewed_by || kvModeration?.reviewedBy || kvModeration?.overriddenBy || null,
+        reviewed_at: moderatedRow?.reviewed_at || null,
+        uploaded_by: moderatedRow?.uploaded_by || kvModeration?.uploadedBy || null,
+        reason: kvModeration?.reason || moderatedRow?.review_notes || null,
+        manualOverride: Boolean(kvModeration?.manualOverride),
+        overriddenAt: kvModeration?.overriddenAt || moderatedRow?.reviewed_at || null,
+        previousAction: kvModeration?.previousAction || null,
+        detailedCategories: parseMaybeJson(kvModeration?.detailedCategories, null),
+        categoryVerifications: parseMaybeJson(kvModeration?.categoryVerifications, {}) || {},
+        cdnUrl
+      }, env);
+    }
+
+    const untriagedRow = await env.BLOSSOM_DB.prepare(`
+      SELECT sha256, video_guid, hls_url, mp4_url, thumbnail_url, received_at, status_name
+      FROM bunny_webhook_events e1
+      WHERE e1.sha256 = ?
+        AND received_at = (
+          SELECT MAX(received_at) FROM bunny_webhook_events e2 WHERE e2.sha256 = e1.sha256
+        )
+      LIMIT 1
+    `).bind(hash).first();
+
+    if (untriagedRow && !['error', 'deleted'].includes(untriagedRow.status_name)) {
+      let nostrContext = null;
+      let eventId = null;
+      let divineUrl = null;
+      let uploaderPubkey = null;
+      try {
+        const event = await fetchNostrEventBySha256(hash, ['wss://relay.divine.video'], env);
+        if (event) {
+          const metadata = parseVideoEventMetadata(event);
+          const stableId = getEventTagValue(event.tags || [], 'd') || event.id || hash;
+          eventId = event.id;
+          divineUrl = `https://divine.video/video/${encodeURIComponent(stableId)}`;
+          uploaderPubkey = event.pubkey || null;
+          nostrContext = {
+            title: metadata?.title || null,
+            author: metadata?.author || null,
+            client: metadata?.client || null,
+            content: metadata?.content || event.content || null,
+            pubkey: event.pubkey ? `${event.pubkey.substring(0, 16)}...` : null,
+            eventId
+          };
+        }
+      } catch (error) {
+        console.error(`[ADMIN] Failed to fetch Nostr context for ${hash}:`, error.message);
+      }
+
+      return enrichAdminLookupVideo({
+        sha256: hash,
+        videoGuid: untriagedRow.video_guid,
+        hlsUrl: untriagedRow.hls_url,
+        mp4Url: untriagedRow.mp4_url,
+        thumbnailUrl: untriagedRow.thumbnail_url,
+        receivedAt: untriagedRow.received_at,
+        status: 'UNTRIAGED',
+        cdnUrl,
+        nostrContext,
+        eventId,
+        divineUrl,
+        uploaded_by: uploaderPubkey
+      }, env);
+    }
+  }
+
+  if (!allowFunnelcakeFallback) {
+    return null;
+  }
+
+  const funnelcakeVideo = await fetchFunnelcakeLookupVideo(identifier);
+  if (!funnelcakeVideo) {
+    return null;
+  }
+
+  if (funnelcakeVideo.mediaSha) {
+    const resolvedByMediaSha = await getAdminLookupVideo(funnelcakeVideo.mediaSha, env, {
+      allowFunnelcakeFallback: false
+    });
+    if (resolvedByMediaSha) {
+      return enrichAdminLookupVideo(mergeLookupMetadata(resolvedByMediaSha, funnelcakeVideo), env);
+    }
+  }
+
+  if (!funnelcakeVideo.mediaSha) {
+    return null;
+  }
+
+  return enrichAdminLookupVideo({
+    sha256: funnelcakeVideo.mediaSha,
+    receivedAt: funnelcakeVideo.createdAt,
+    status: 'UNTRIAGED',
+    cdnUrl: funnelcakeVideo.videoUrl || `https://${env.CDN_DOMAIN || 'media.divine.video'}/${funnelcakeVideo.mediaSha}`,
+    thumbnailUrl: funnelcakeVideo.thumbnailUrl,
+    nostrContext: funnelcakeVideo.nostrContext,
+    uploaded_by: funnelcakeVideo.uploadedBy,
+    divineUrl: funnelcakeVideo.divineUrl,
+    lookupId: funnelcakeVideo.lookupId,
+    eventId: funnelcakeVideo.eventId
+  }, env);
 }
 
 async function handleLegacyScan(request, env) {
@@ -393,6 +805,7 @@ export default {
 
     // Ensure offender tracking table exists (idempotent)
     await initOffenderTable(env.BLOSSOM_DB);
+    await initUploaderEnforcementTable(env.BLOSSOM_DB);
 
     // Ensure reports table exists
     await initReportsTable(env.BLOSSOM_DB);
@@ -650,6 +1063,7 @@ export default {
               const metadata = parseVideoEventMetadata(event);
               return {
                 sha256: row.sha256,
+                eventId: event.id,
                 title: metadata?.title || null,
                 author: metadata?.author || null,
                 client: metadata?.client || null,
@@ -678,6 +1092,8 @@ export default {
             receivedAt: row.received_at,
             status: 'UNTRIAGED',
             cdnUrl: `https://${env.CDN_DOMAIN}/${row.sha256}`,
+            eventId: nostr.eventId || null,
+            uploaded_by: nostr.pubkey || null,
             nostrContext: {
               title: nostr.title,
               author: nostr.author,
@@ -719,6 +1135,127 @@ export default {
       }
     }
 
+    if (url.pathname.startsWith('/admin/api/video/') && request.method === 'GET') {
+      const authError = await requireAuth(request, env);
+      if (authError) {
+        console.log(`[${requestId}] Unauthorized access to ${url.pathname}`);
+        return authError;
+      }
+
+      const identifier = decodeURIComponent(url.pathname.split('/')[4] || '');
+      if (!isValidLookupIdentifier(identifier)) {
+        return new Response(JSON.stringify({ error: 'Invalid video lookup identifier' }), {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }
+
+      try {
+        const video = await getAdminLookupVideo(identifier, env);
+        if (!video) {
+          return new Response(JSON.stringify({ error: 'Video not found', identifier }), {
+            status: 404,
+            headers: { 'Content-Type': 'application/json' }
+          });
+        }
+
+        return new Response(JSON.stringify({ video }), {
+          headers: { 'Content-Type': 'application/json' }
+        });
+      } catch (error) {
+        console.error(`[${requestId}] Failed admin lookup for ${identifier}:`, error);
+        return new Response(JSON.stringify({ error: error.message }), {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }
+    }
+
+    if (url.pathname.startsWith('/admin/api/uploader/') && url.pathname.endsWith('/enforcement') && request.method === 'POST') {
+      const authError = await requireAuth(request, env);
+      if (authError) {
+        return authError;
+      }
+
+      const pubkey = url.pathname.split('/')[4];
+      if (!isValidPubkey(pubkey)) {
+        return new Response(JSON.stringify({ error: 'Invalid uploader pubkey' }), {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }
+
+      const body = await request.json();
+      const hasApprovalUpdate = typeof body.approvalRequired === 'boolean';
+      const hasRelayUpdate = typeof body.relayBanned === 'boolean';
+
+      if (!hasApprovalUpdate && !hasRelayUpdate && body.notes == null) {
+        return new Response(JSON.stringify({ error: 'No enforcement update provided' }), {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }
+
+      const moderatorEmail = getAuthenticatedUser(request) || 'admin';
+      const current = await getUploaderEnforcement(env.BLOSSOM_DB, pubkey);
+
+      if (hasRelayUpdate && body.relayBanned !== Boolean(current?.relay_banned)) {
+        await callRelayAdminAction(env, {
+          action: body.relayBanned ? 'ban_pubkey' : 'allow_pubkey',
+          pubkey,
+          reason: body.reason || `Moderator action by ${moderatorEmail}`
+        });
+      }
+
+      const enforcement = await setUploaderEnforcement(env.BLOSSOM_DB, pubkey, {
+        approval_required: hasApprovalUpdate ? body.approvalRequired : undefined,
+        approval_reason: hasApprovalUpdate ? (body.reason || null) : undefined,
+        relay_banned: hasRelayUpdate ? body.relayBanned : undefined,
+        relay_ban_reason: hasRelayUpdate ? (body.reason || null) : undefined,
+        notes: body.notes,
+        updated_by: moderatorEmail
+      });
+
+      return new Response(JSON.stringify({
+        success: true,
+        pubkey,
+        enforcement
+      }), {
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+
+    if (url.pathname.startsWith('/admin/api/event/') && url.pathname.endsWith('/delete') && request.method === 'POST') {
+      const authError = await requireAuth(request, env);
+      if (authError) {
+        return authError;
+      }
+
+      const eventId = url.pathname.split('/')[4];
+      if (!isValidSha256(eventId)) {
+        return new Response(JSON.stringify({ error: 'Invalid event id' }), {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }
+
+      const body = await request.json().catch(() => ({}));
+      const moderatorEmail = getAuthenticatedUser(request) || 'admin';
+      const relayResult = await callRelayAdminAction(env, {
+        action: 'delete_event',
+        eventId,
+        reason: body.reason || `Deleted by moderator ${moderatorEmail}`
+      });
+
+      return new Response(JSON.stringify({
+        success: true,
+        eventId,
+        relayResult
+      }), {
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+
     // Queue an untriaged video for moderation
     if (url.pathname === '/admin/api/queue-moderation' && request.method === 'POST') {
       const authError = await requireAuth(request, env);
@@ -726,8 +1263,8 @@ export default {
         return authError;
       }
 
-      const { sha256 } = await request.json();
-      if (!sha256) {
+      const { sha256, videoUrl, uploadedBy } = await request.json();
+      if (!isValidSha256(sha256)) {
         return new Response(JSON.stringify({ error: 'sha256 required' }), {
           status: 400,
           headers: { 'Content-Type': 'application/json' }
@@ -738,8 +1275,12 @@ export default {
       await env.MODERATION_QUEUE.send({
         sha256,
         r2Key: `videos/${sha256}.mp4`,
+        uploadedBy: isValidPubkey(uploadedBy) ? uploadedBy : undefined,
         uploadedAt: Date.now(),
-        metadata: { source: 'admin-dashboard' }
+        metadata: {
+          source: 'admin-dashboard',
+          ...(videoUrl ? { videoUrl } : {})
+        }
       });
 
       return new Response(JSON.stringify({ success: true, sha256, message: 'Queued for moderation' }), {
@@ -755,7 +1296,7 @@ export default {
       }
 
       const sha256 = url.pathname.split('/')[4];
-      const { action, reason, scores } = await request.json();
+      const { action, reason, scores, videoUrl, uploadedBy } = await request.json();
 
       // Validate action
       if (!['SAFE', 'REVIEW', 'QUARANTINE', 'AGE_RESTRICTED', 'PERMANENT_BAN'].includes(action)) {
@@ -768,7 +1309,7 @@ export default {
       // Get existing moderation result — check D1 first, fall back to KV
       let existing = null;
       const d1Row = await env.BLOSSOM_DB.prepare(
-        'SELECT sha256, action, provider, scores, categories, moderated_at, reviewed_by, reviewed_at FROM moderation_results WHERE sha256 = ?'
+        'SELECT sha256, action, provider, scores, categories, moderated_at, reviewed_by, reviewed_at, uploaded_by FROM moderation_results WHERE sha256 = ?'
       ).bind(sha256).first();
 
       if (d1Row) {
@@ -788,10 +1329,15 @@ export default {
       }
 
       if (!existing) {
-        return new Response(JSON.stringify({ error: 'Moderation result not found for this video' }), {
-          status: 404,
-          headers: { 'Content-Type': 'application/json' }
-        });
+        existing = {
+          action: null,
+          scores: {},
+          provider: 'manual',
+          categories: [],
+          moderated_at: new Date().toISOString(),
+          cdnUrl: videoUrl || `https://${env.CDN_DOMAIN}/${sha256}`,
+          uploadedBy: isValidPubkey(uploadedBy) ? uploadedBy : null
+        };
       }
 
       const previousAction = existing.action;
@@ -827,15 +1373,34 @@ export default {
 
       // Update D1 with new action
       await env.BLOSSOM_DB.prepare(`
-        UPDATE moderation_results
-        SET action = ?, review_notes = ?, reviewed_by = ?, reviewed_at = ?
-        WHERE sha256 = ?
+        INSERT INTO moderation_results (
+          sha256, action, provider, scores, categories, raw_response, moderated_at, reviewed_by, reviewed_at, review_notes, uploaded_by
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(sha256) DO UPDATE SET
+          action = excluded.action,
+          provider = excluded.provider,
+          scores = excluded.scores,
+          categories = excluded.categories,
+          reviewed_by = excluded.reviewed_by,
+          reviewed_at = excluded.reviewed_at,
+          review_notes = excluded.review_notes,
+          uploaded_by = COALESCE(moderation_results.uploaded_by, excluded.uploaded_by)
       `).bind(
+        sha256,
         action,
-        reason || 'Manual override by moderator',
+        updated.provider || 'manual',
+        JSON.stringify(updated.scores || {}),
+        JSON.stringify(updated.categories || []),
+        JSON.stringify({
+          source: 'admin-manual',
+          reason: updated.reason,
+          previousAction: previousAction || null
+        }),
+        existing.moderated_at || new Date().toISOString(),
         'admin',
         new Date().toISOString(),
-        sha256
+        reason || 'Manual override by moderator',
+        d1Row?.uploaded_by || updated.uploadedBy || null
       ).run();
 
       // Update action-specific KV keys
@@ -866,13 +1431,14 @@ export default {
       }
 
       // Notify Blossom of the moderation decision.
-      // Relay notification intentionally removed: notifyRelay() called /api/admin/purge
-      // which never existed in divine-relay-manager. There's no relay-manager endpoint
-      // that accepts a sha256 and propagates enforcement to Funnelcake (the missing link
-      // is sha256-to-event-ID lookup). Osprey's rules pipeline will handle relay-side
-      // enforcement when operational, since it sees events in Kafka and can correlate
-      // media hashes to event IDs natively.
       const blossomResult = await notifyBlossom(sha256, action, env);
+
+      // For PERMANENT_BAN: also delete the event from the relay (funnelcake).
+      // This is critical for externally-hosted content where Blossom can't enforce the ban.
+      let relayDeleteResult = null;
+      if (action === 'PERMANENT_BAN') {
+        relayDeleteResult = await deleteEventFromRelayBySha256(sha256, env, 'admin-moderate');
+      }
 
       if (!blossomResult.success && !blossomResult.skipped) {
         console.warn(`[ADMIN] Blossom notification failed: ${blossomResult.error}`);
@@ -907,7 +1473,7 @@ export default {
         }
       }
 
-      console.log(`[ADMIN] Updated ${sha256} from ${previousAction} to ${action} (blossom: ${blossomResult.success})`);
+      console.log(`[ADMIN] Updated ${sha256} from ${previousAction} to ${action} (blossom: ${blossomResult.success}, relayDelete: ${relayDeleteResult?.success ?? 'n/a'})`);
 
       // DM creator about moderation action (non-blocking)
       let dmSent = false;
@@ -935,6 +1501,8 @@ export default {
         previousAction,
         message: `Content updated to ${action}`,
         blossom_notified: blossomResult.success || false,
+        relay_event_deleted: relayDeleteResult?.success || false,
+        relay_event_id: relayDeleteResult?.eventId || null,
         report_published: reportPublished,
         dm_sent: dmSent
       }), {
@@ -2530,6 +3098,22 @@ async function runMigration() {
           metadata
         }, env);
 
+        if (result.uploadedBy) {
+          try {
+            const uploaderEnforcement = await getUploaderEnforcement(env.BLOSSOM_DB, result.uploadedBy);
+            const enforcedResult = applyUploaderEnforcementToResult(result, uploaderEnforcement);
+            if (enforcedResult.applied) {
+              console.log(
+                `[MODERATION] Enforcement applied for uploader ${result.uploadedBy.substring(0, 16)}... `
+                + `(${enforcedResult.mode}: ${enforcedResult.previousAction} -> ${enforcedResult.result.action})`
+              );
+              Object.assign(result, enforcedResult.result);
+            }
+          } catch (enforcementErr) {
+            console.error(`[MODERATION] Failed to apply uploader enforcement:`, enforcementErr.message);
+          }
+        }
+
         console.log(`[MODERATION] Step 5: Analysis complete for ${sha256}`);
         console.log(`[MODERATION] Result: action=${result.action}, severity=${result.severity}`);
         console.log(`[MODERATION] Scores: nudity=${result.scores.nudity}, violence=${result.scores.violence}, ai=${result.scores.ai_generated}`);
@@ -2780,11 +3364,19 @@ async function handleModerationResult(result, env) {
     console.log(`[MODERATION] ${sha256} approved (no notification needed)`);
   }
 
-  // Notify Blossom (relay notification removed — see comment in admin moderate handler)
   const blossomResult = await notifyBlossom(sha256, action, env);
 
   if (!blossomResult.success && !blossomResult.skipped) {
     console.warn(`[MODERATION] Blossom notification failed: ${blossomResult.error}`);
+  }
+
+  // For PERMANENT_BAN: delete the event from the relay so externally-hosted content
+  // is no longer discoverable via funnelcake.
+  if (action === 'PERMANENT_BAN') {
+    const relayDeleteResult = await deleteEventFromRelayBySha256(sha256, env, 'auto-moderation');
+    if (relayDeleteResult?.success) {
+      console.log(`[MODERATION] ${sha256} - Relay event ${relayDeleteResult.eventId} deleted`);
+    }
   }
 
   // Send DM to creator for non-SAFE actions (non-blocking)

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -9,7 +9,7 @@ import worker from './index.mjs';
 
 const SHA256 = 'a'.repeat(64);
 
-function createDbMock({ moderationResults = new Map() } = {}) {
+function createDbMock({ moderationResults = new Map(), webhookEvents = new Map() } = {}) {
   return {
     prepare(sql) {
       let bindings = [];
@@ -25,6 +25,9 @@ function createDbMock({ moderationResults = new Map() } = {}) {
         async first() {
           if (sql.includes('FROM moderation_results') && sql.includes('WHERE sha256 = ?')) {
             return moderationResults.get(bindings[0]) ?? null;
+          }
+          if (sql.includes('FROM bunny_webhook_events')) {
+            return webhookEvents.get(bindings[0]) ?? null;
           }
           return null;
         },
@@ -244,5 +247,193 @@ describe('HTTP hostname routing', () => {
       action: 'PERMANENT_BAN',
       blocked: true
     });
+  });
+});
+
+describe('Admin video lookup', () => {
+  it('returns a moderated video and merges KV override fields', async () => {
+    const env = createEnv({
+      BLOSSOM_DB: createDbMock({
+        moderationResults: new Map([[SHA256, {
+          sha256: SHA256,
+          action: 'REVIEW',
+          provider: 'hiveai',
+          scores: JSON.stringify({ nudity: 0.4 }),
+          categories: JSON.stringify(['nudity']),
+          moderated_at: '2026-03-07T00:00:00.000Z',
+          reviewed_by: 'admin',
+          reviewed_at: '2026-03-07T01:00:00.000Z',
+          review_notes: 'legacy note',
+          uploaded_by: 'npub123'
+        }]])
+      }),
+      MODERATION_KV: {
+        async get(key) {
+          if (key === `moderation:${SHA256}`) {
+            return JSON.stringify({
+              action: 'AGE_RESTRICTED',
+              scores: { nudity: 0.91, ai_generated: 0.2 },
+              manualOverride: true,
+              previousAction: 'REVIEW',
+              overriddenAt: 1741305600000,
+              reason: 'Manual override'
+            });
+          }
+          return null;
+        },
+        async put() {},
+        async delete() {},
+        async list() { return { keys: [], list_complete: true, cursor: null }; }
+      }
+    });
+
+    const response = await worker.fetch(
+      new Request(`https://moderation.admin.divine.video/admin/api/video/${SHA256}`, {
+        headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
+      }),
+      env
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      video: {
+        sha256: SHA256,
+        action: 'AGE_RESTRICTED',
+        manualOverride: true,
+        previousAction: 'REVIEW',
+        reason: 'Manual override',
+        scores: {
+          nudity: 0.91
+        }
+      }
+    });
+  });
+
+  it('returns an untriaged video by sha lookup', async () => {
+    const env = createEnv({
+      CDN_DOMAIN: 'media.divine.video',
+      BLOSSOM_DB: createDbMock({
+        webhookEvents: new Map([[SHA256, {
+          sha256: SHA256,
+          video_guid: 'video-guid-1',
+          hls_url: 'https://example.com/video.m3u8',
+          mp4_url: 'https://example.com/video.mp4',
+          thumbnail_url: 'https://example.com/thumb.jpg',
+          received_at: '2026-03-08T00:00:00.000Z',
+          status_name: 'finished'
+        }]])
+      })
+    });
+
+    const response = await worker.fetch(
+      new Request(`https://moderation.admin.divine.video/admin/api/video/${SHA256}`, {
+        headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
+      }),
+      env
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      video: {
+        sha256: SHA256,
+        status: 'UNTRIAGED',
+        videoGuid: 'video-guid-1',
+        cdnUrl: `https://media.divine.video/${SHA256}`
+      }
+    });
+  });
+
+  it('falls back to funnelcake lookup for imported videos', async () => {
+    const mediaSha = 'b'.repeat(64);
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (url) => {
+      if (String(url) === `https://relay.divine.video/api/videos/${SHA256}`) {
+        return new Response(JSON.stringify({
+          event: {
+            id: SHA256,
+            pubkey: 'c'.repeat(64),
+            created_at: 1773503656,
+            kind: 34235,
+            tags: [
+              ['d', 'video-imported-stable-id'],
+              ['title', 'Imported archive video'],
+              ['client', 'Plebs'],
+              ['imeta', `url https://blossom.primal.net/${mediaSha}.mp4`, `x ${mediaSha}`, 'image https://blossom.primal.net/thumb.png']
+            ],
+            content: 'archive description',
+            sig: 'd'.repeat(128)
+          },
+          stats: {
+            author_name: 'Archive User'
+          }
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    };
+
+    try {
+      const response = await worker.fetch(
+        new Request(`https://moderation.admin.divine.video/admin/api/video/${SHA256}`, {
+          headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
+        }),
+        createEnv()
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toMatchObject({
+        video: {
+          sha256: mediaSha,
+          status: 'UNTRIAGED',
+          cdnUrl: `https://blossom.primal.net/${mediaSha}.mp4`,
+          thumbnailUrl: 'https://blossom.primal.net/thumb.png',
+          uploaded_by: 'c'.repeat(64),
+          divineUrl: 'https://divine.video/video/video-imported-stable-id',
+          lookupId: SHA256
+        }
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('rejects oversized admin lookup identifiers', async () => {
+    const identifier = 'x'.repeat(256);
+    const response = await worker.fetch(
+      new Request(`https://moderation.admin.divine.video/admin/api/video/${identifier}`, {
+        headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
+      }),
+      createEnv()
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Invalid video lookup identifier'
+    });
+  });
+
+  it('returns 404 when the lookup identifier is unknown', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () => new Response('not found', { status: 404 });
+
+    try {
+      const response = await worker.fetch(
+        new Request(`https://moderation.admin.divine.video/admin/api/video/${SHA256}`, {
+          headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
+        }),
+        createEnv()
+      );
+
+      expect(response.status).toBe(404);
+      await expect(response.json()).resolves.toEqual({
+        error: 'Video not found',
+        identifier: SHA256
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });

--- a/src/uploader-enforcement.mjs
+++ b/src/uploader-enforcement.mjs
@@ -1,0 +1,192 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Stores uploader-level enforcement state for approval gating and relay bans
+
+function normalizeRow(row) {
+  if (!row) {
+    return null;
+  }
+
+  return {
+    pubkey: row.pubkey,
+    approval_required: Boolean(row.approval_required),
+    approval_reason: row.approval_reason || null,
+    approval_updated_at: row.approval_updated_at || null,
+    approval_updated_by: row.approval_updated_by || null,
+    relay_banned: Boolean(row.relay_banned),
+    relay_ban_reason: row.relay_ban_reason || null,
+    relay_ban_updated_at: row.relay_ban_updated_at || null,
+    relay_ban_updated_by: row.relay_ban_updated_by || null,
+    notes: row.notes || null,
+    created_at: row.created_at || null,
+    updated_at: row.updated_at || null
+  };
+}
+
+export async function initUploaderEnforcementTable(db) {
+  await db.prepare(`
+    CREATE TABLE IF NOT EXISTS uploader_enforcement (
+      pubkey TEXT PRIMARY KEY,
+      approval_required INTEGER DEFAULT 0,
+      approval_reason TEXT,
+      approval_updated_at TEXT,
+      approval_updated_by TEXT,
+      relay_banned INTEGER DEFAULT 0,
+      relay_ban_reason TEXT,
+      relay_ban_updated_at TEXT,
+      relay_ban_updated_by TEXT,
+      notes TEXT,
+      created_at TEXT,
+      updated_at TEXT
+    )
+  `).run();
+
+  await db.prepare(`
+    CREATE INDEX IF NOT EXISTS idx_uploader_enforcement_approval
+    ON uploader_enforcement(approval_required)
+  `).run();
+
+  await db.prepare(`
+    CREATE INDEX IF NOT EXISTS idx_uploader_enforcement_relay
+    ON uploader_enforcement(relay_banned)
+  `).run();
+}
+
+export async function getUploaderEnforcement(db, pubkey) {
+  if (!pubkey) {
+    return null;
+  }
+
+  const row = await db.prepare(
+    'SELECT * FROM uploader_enforcement WHERE pubkey = ?'
+  ).bind(pubkey).first();
+
+  return normalizeRow(row);
+}
+
+export async function setUploaderEnforcement(db, pubkey, updates) {
+  const now = new Date().toISOString();
+  const existing = await getUploaderEnforcement(db, pubkey);
+
+  const next = {
+    pubkey,
+    approval_required: updates.approval_required ?? existing?.approval_required ?? false,
+    approval_reason: updates.approval_required !== undefined
+      ? (updates.approval_reason ?? (updates.approval_required ? existing?.approval_reason : null) ?? null)
+      : (existing?.approval_reason ?? null),
+    approval_updated_at: updates.approval_required !== undefined
+      ? now
+      : (existing?.approval_updated_at ?? null),
+    approval_updated_by: updates.approval_required !== undefined
+      ? (updates.updated_by ?? null)
+      : (existing?.approval_updated_by ?? null),
+    relay_banned: updates.relay_banned ?? existing?.relay_banned ?? false,
+    relay_ban_reason: updates.relay_banned !== undefined
+      ? (updates.relay_ban_reason ?? (updates.relay_banned ? existing?.relay_ban_reason : null) ?? null)
+      : (existing?.relay_ban_reason ?? null),
+    relay_ban_updated_at: updates.relay_banned !== undefined
+      ? now
+      : (existing?.relay_ban_updated_at ?? null),
+    relay_ban_updated_by: updates.relay_banned !== undefined
+      ? (updates.updated_by ?? null)
+      : (existing?.relay_ban_updated_by ?? null),
+    notes: updates.notes ?? existing?.notes ?? null,
+    created_at: existing?.created_at ?? now,
+    updated_at: now
+  };
+
+  await db.prepare(`
+    INSERT INTO uploader_enforcement (
+      pubkey,
+      approval_required,
+      approval_reason,
+      approval_updated_at,
+      approval_updated_by,
+      relay_banned,
+      relay_ban_reason,
+      relay_ban_updated_at,
+      relay_ban_updated_by,
+      notes,
+      created_at,
+      updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(pubkey) DO UPDATE SET
+      approval_required = excluded.approval_required,
+      approval_reason = excluded.approval_reason,
+      approval_updated_at = excluded.approval_updated_at,
+      approval_updated_by = excluded.approval_updated_by,
+      relay_banned = excluded.relay_banned,
+      relay_ban_reason = excluded.relay_ban_reason,
+      relay_ban_updated_at = excluded.relay_ban_updated_at,
+      relay_ban_updated_by = excluded.relay_ban_updated_by,
+      notes = excluded.notes,
+      updated_at = excluded.updated_at
+  `).bind(
+    next.pubkey,
+    next.approval_required ? 1 : 0,
+    next.approval_reason,
+    next.approval_updated_at,
+    next.approval_updated_by,
+    next.relay_banned ? 1 : 0,
+    next.relay_ban_reason,
+    next.relay_ban_updated_at,
+    next.relay_ban_updated_by,
+    next.notes,
+    next.created_at,
+    next.updated_at
+  ).run();
+
+  return next;
+}
+
+export function applyUploaderEnforcementToResult(result, enforcement) {
+  if (!result || !enforcement) {
+    return { result, applied: false };
+  }
+
+  if (enforcement.relay_banned && result.action !== 'PERMANENT_BAN') {
+    const nextResult = {
+      ...result,
+      action: 'PERMANENT_BAN',
+      severity: 'high',
+      reason: result.reason
+        ? `${result.reason} | uploader relay-banned`
+        : 'Uploader is relay-banned',
+      rawResponse: {
+        ...(result.rawResponse || {}),
+        uploaderEnforcement: {
+          relay_banned: true,
+          originalAction: result.action
+        }
+      }
+    };
+
+    return { result: nextResult, applied: true, mode: 'relay_banned', previousAction: result.action };
+  }
+
+  if (
+    enforcement.approval_required
+    && !['QUARANTINE', 'AGE_RESTRICTED', 'PERMANENT_BAN'].includes(result.action)
+  ) {
+    const nextResult = {
+      ...result,
+      action: 'QUARANTINE',
+      severity: result.severity === 'high' ? result.severity : 'medium',
+      reason: result.reason
+        ? `${result.reason} | uploader requires manual approval`
+        : 'Uploader requires manual approval',
+      rawResponse: {
+        ...(result.rawResponse || {}),
+        uploaderEnforcement: {
+          approval_required: true,
+          originalAction: result.action
+        }
+      }
+    };
+
+    return { result: nextResult, applied: true, mode: 'approval_required', previousAction: result.action };
+  }
+
+  return { result, applied: false };
+}

--- a/src/uploader-enforcement.test.mjs
+++ b/src/uploader-enforcement.test.mjs
@@ -1,0 +1,315 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Verifies uploader enforcement state and admin endpoints for relay/user actions
+
+import { describe, expect, it } from 'vitest';
+import worker from './index.mjs';
+import { applyUploaderEnforcementToResult, getUploaderEnforcement, setUploaderEnforcement } from './uploader-enforcement.mjs';
+
+const SHA256 = 'a'.repeat(64);
+const PUBKEY = 'b'.repeat(64);
+const EVENT_ID = 'c'.repeat(64);
+
+function createDbMock({
+  moderationResults = new Map(),
+  webhookEvents = new Map(),
+  uploaderEnforcements = new Map(),
+  uploaderStats = new Map()
+} = {}) {
+  return {
+    prepare(sql) {
+      let bindings = [];
+
+      return {
+        bind(...args) {
+          bindings = args;
+          return this;
+        },
+        async run() {
+          if (sql.includes('INSERT INTO uploader_enforcement')) {
+            uploaderEnforcements.set(bindings[0], {
+              pubkey: bindings[0],
+              approval_required: bindings[1],
+              approval_reason: bindings[2],
+              approval_updated_at: bindings[3],
+              approval_updated_by: bindings[4],
+              relay_banned: bindings[5],
+              relay_ban_reason: bindings[6],
+              relay_ban_updated_at: bindings[7],
+              relay_ban_updated_by: bindings[8],
+              notes: bindings[9],
+              created_at: bindings[10],
+              updated_at: bindings[11]
+            });
+          }
+
+          return { success: true, meta: { changes: 1 } };
+        },
+        async first() {
+          if (sql.includes('FROM moderation_results') && sql.includes('WHERE sha256 = ?')) {
+            return moderationResults.get(bindings[0]) ?? null;
+          }
+          if (sql.includes('FROM bunny_webhook_events')) {
+            return webhookEvents.get(bindings[0]) ?? null;
+          }
+          if (sql.includes('FROM uploader_enforcement')) {
+            return uploaderEnforcements.get(bindings[0]) ?? null;
+          }
+          if (sql.includes('FROM uploader_stats')) {
+            return uploaderStats.get(bindings[0]) ?? null;
+          }
+          return null;
+        },
+        async all() {
+          return { results: [] };
+        }
+      };
+    },
+    async batch() {
+      return [];
+    }
+  };
+}
+
+function createEnv(overrides = {}) {
+  return {
+    ALLOW_DEV_ACCESS: 'false',
+    SERVICE_API_TOKEN: 'test-service-token',
+    CDN_DOMAIN: 'media.divine.video',
+    BLOSSOM_DB: createDbMock(),
+    MODERATION_KV: {
+      async get() { return null; },
+      async put() {},
+      async delete() {},
+      async list() { return { keys: [], list_complete: true, cursor: null }; }
+    },
+    MODERATION_QUEUE: {
+      async send() {}
+    },
+    ...overrides
+  };
+}
+
+describe('uploader enforcement logic', () => {
+  it('stores and reads uploader enforcement rows', async () => {
+    const db = createDbMock();
+
+    const saved = await setUploaderEnforcement(db, PUBKEY, {
+      approval_required: true,
+      approval_reason: 'Manual approval required',
+      relay_banned: false,
+      updated_by: 'mod@divine.video'
+    });
+
+    const fetched = await getUploaderEnforcement(db, PUBKEY);
+
+    expect(saved).toMatchObject({
+      pubkey: PUBKEY,
+      approval_required: true,
+      approval_reason: 'Manual approval required',
+      relay_banned: false
+    });
+    expect(fetched).toMatchObject({
+      pubkey: PUBKEY,
+      approval_required: true,
+      approval_reason: 'Manual approval required',
+      approval_updated_by: 'mod@divine.video'
+    });
+  });
+
+  it('forces approval-required uploads into quarantine', () => {
+    const result = applyUploaderEnforcementToResult({
+      sha256: SHA256,
+      action: 'SAFE',
+      severity: 'low',
+      reason: 'No issues found',
+      rawResponse: {}
+    }, {
+      approval_required: true,
+      relay_banned: false
+    });
+
+    expect(result.applied).toBe(true);
+    expect(result.mode).toBe('approval_required');
+    expect(result.result.action).toBe('QUARANTINE');
+    expect(result.result.reason).toContain('manual approval');
+  });
+
+  it('forces relay-banned uploads into permanent ban', () => {
+    const result = applyUploaderEnforcementToResult({
+      sha256: SHA256,
+      action: 'REVIEW',
+      severity: 'medium',
+      reason: 'Borderline content',
+      rawResponse: {}
+    }, {
+      approval_required: false,
+      relay_banned: true
+    });
+
+    expect(result.applied).toBe(true);
+    expect(result.mode).toBe('relay_banned');
+    expect(result.result.action).toBe('PERMANENT_BAN');
+    expect(result.result.reason).toContain('relay-banned');
+  });
+});
+
+describe('admin uploader enforcement routes', () => {
+  it('updates uploader enforcement and syncs relay bans', async () => {
+    const originalFetch = globalThis.fetch;
+    const fetchCalls = [];
+    globalThis.fetch = async (input, init) => {
+      fetchCalls.push({ input: String(input), init });
+      return new Response(JSON.stringify({ success: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    };
+
+    try {
+      const db = createDbMock();
+      const response = await worker.fetch(
+        new Request(`https://moderation.admin.divine.video/admin/api/uploader/${PUBKEY}/enforcement`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Cf-Access-Authenticated-User-Email': 'mod@divine.video'
+          },
+          body: JSON.stringify({
+            approvalRequired: true,
+            relayBanned: true,
+            reason: 'Escalated by trust and safety'
+          })
+        }),
+        createEnv({
+          BLOSSOM_DB: db,
+          RELAY_ADMIN_URL: 'https://relay.admin.divine.video',
+          CF_ACCESS_CLIENT_ID: 'client-id',
+          CF_ACCESS_CLIENT_SECRET: 'client-secret'
+        })
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toMatchObject({
+        success: true,
+        pubkey: PUBKEY,
+        enforcement: {
+          approval_required: true,
+          relay_banned: true
+        }
+      });
+      expect(fetchCalls).toHaveLength(1);
+      expect(fetchCalls[0].input).toBe('https://relay.admin.divine.video/api/moderate');
+      expect(fetchCalls[0].init.headers['CF-Access-Client-Id']).toBe('client-id');
+      expect(JSON.parse(fetchCalls[0].init.body)).toMatchObject({
+        action: 'ban_pubkey',
+        pubkey: PUBKEY
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('returns uploader enforcement and stats in focused lookup responses', async () => {
+    const env = createEnv({
+      BLOSSOM_DB: createDbMock({
+        moderationResults: new Map([[SHA256, {
+          sha256: SHA256,
+          action: 'SAFE',
+          provider: 'hiveai',
+          scores: JSON.stringify({ nudity: 0.01 }),
+          categories: JSON.stringify(['safe']),
+          moderated_at: '2026-03-07T00:00:00.000Z',
+          reviewed_by: null,
+          reviewed_at: null,
+          uploaded_by: PUBKEY
+        }]]),
+        uploaderEnforcements: new Map([[PUBKEY, {
+          pubkey: PUBKEY,
+          approval_required: 1,
+          approval_reason: 'Manual approval required',
+          approval_updated_at: '2026-03-14T00:00:00.000Z',
+          approval_updated_by: 'mod@divine.video',
+          relay_banned: 0,
+          relay_ban_reason: null,
+          relay_ban_updated_at: null,
+          relay_ban_updated_by: null,
+          notes: null,
+          created_at: '2026-03-14T00:00:00.000Z',
+          updated_at: '2026-03-14T00:00:00.000Z'
+        }]]),
+        uploaderStats: new Map([[PUBKEY, {
+          pubkey: PUBKEY,
+          total_scanned: 12,
+          flagged_count: 3,
+          banned_count: 1,
+          restricted_count: 1,
+          review_count: 1,
+          last_flagged_at: '2026-03-10T00:00:00.000Z',
+          risk_level: 'high'
+        }]])
+      })
+    });
+
+    const response = await worker.fetch(
+      new Request(`https://moderation.admin.divine.video/admin/api/video/${SHA256}`, {
+        headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
+      }),
+      env
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      video: {
+        uploaded_by: PUBKEY,
+        uploaderEnforcement: {
+          approval_required: true,
+          relay_banned: false
+        },
+        uploaderStats: {
+          risk_level: 'high',
+          flagged_count: 3
+        }
+      }
+    });
+  });
+
+  it('deletes relay events through relay admin', async () => {
+    const originalFetch = globalThis.fetch;
+    const fetchCalls = [];
+    globalThis.fetch = async (input, init) => {
+      fetchCalls.push({ input: String(input), init });
+      return new Response(JSON.stringify({ success: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    };
+
+    try {
+      const response = await worker.fetch(
+        new Request(`https://moderation.admin.divine.video/admin/api/event/${EVENT_ID}/delete`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Cf-Access-Authenticated-User-Email': 'mod@divine.video'
+          },
+          body: JSON.stringify({ reason: 'Delete bad event' })
+        }),
+        createEnv({
+          RELAY_ADMIN_URL: 'https://relay.admin.divine.video'
+        })
+      );
+
+      expect(response.status).toBe(200);
+      expect(fetchCalls).toHaveLength(1);
+      expect(JSON.parse(fetchCalls[0].init.body)).toMatchObject({
+        action: 'delete_event',
+        eventId: EVENT_ID,
+        reason: 'Delete bad event'
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- **Admin video lookup & moderation**: Direct SHA256/URL lookup with inline moderation actions (approve, quarantine, ban) and full detail view including AI detection scores, Reality Defender verification, moderation history, and NIP-85 content labels
- **Uploader enforcement system**: New `uploader-enforcement.mjs` module for per-uploader policies — relay ban (forces all content to PERMANENT_BAN) and approval-required (forces QUARANTINE) with relay admin API integration
- **Relay event deletion on PERMANENT_BAN**: Bridges the SHA256→Event ID gap by looking up the Nostr event on `relay.divine.video` and calling the relay admin API to delete it. Critical for enforcing bans on externally-hosted content that Blossom CDN can't block
- **Dashboard enhancements**: Uploader enforcement controls (relay ban toggle, approval-required toggle), "Message Creator" links, expanded video detail cards with classifier data and recommendations

## Key changes

- `deleteEventFromRelayBySha256()` — new helper that resolves SHA256 to Nostr event ID and deletes from relay via admin API
- Both admin moderate handler and automated pipeline (`handleModerationResult`) now auto-delete relay events on PERMANENT_BAN
- API response includes `relay_event_deleted` and `relay_event_id` fields
- 508 new lines of test coverage across `index.test.mjs` and `uploader-enforcement.test.mjs`

## Test plan

- [x] All 691 tests pass
- [ ] Verify PERMANENT_BAN from dashboard deletes event from relay
- [ ] Verify externally-hosted AI-generated content is no longer discoverable after ban
- [ ] Verify relay ban toggle on uploader card propagates to relay admin API
- [ ] Verify approval-required toggle forces new uploads to QUARANTINE

🤖 Generated with [Claude Code](https://claude.com/claude-code)