### PR TITLE
fix: replace per-video mute handlers with global sound toggle

### DIFF
--- a/src/admin/dashboard.html
+++ b/src/admin/dashboard.html
@@ -1497,6 +1497,7 @@
         <button onclick="window.location.href='/admin/messages'" style="background: #333; color: #e0e0e0; border: none; padding: 8px 16px; border-radius: 6px; cursor: pointer; position: relative;">Messages <span id="unread-badge" style="display:none; position:absolute; top:-4px; right:-4px; background:#ef4444; color:white; font-size:10px; font-weight:700; padding:2px 6px; border-radius:10px; min-width:16px; text-align:center;"></span></button>
         <button class="btn-primary" onclick="window.location.href='/admin/review'" style="background: #2563eb; color: white; border: none; padding: 8px 16px; border-radius: 6px; cursor: pointer;">Quick Review</button>
         <button onclick="openThresholdsModal()" style="background: #333; color: #e0e0e0; border: none; padding: 8px 16px; border-radius: 6px; cursor: pointer;">Settings</button>
+        <button id="global-mute-toggle" onclick="toggleGlobalMute()" style="border: 1px solid #555; color: white; padding: 8px 16px; border-radius: 6px; cursor: pointer;"></button>
         <button class="logout" onclick="logout()">Logout</button>
       </div>
     </div>
@@ -3667,25 +3668,36 @@
       });
     }
 
-    // Save mute preference when user changes it via native controls
-    function setupMutePreference(video) {
-      if (video.dataset.muteHandler) return;
-      video.dataset.muteHandler = 'true';
+    // Global sound toggle. Persists to localStorage. The button click is a
+    // user gesture, which lets the browser allow unmuted hover-autoplay.
+    function toggleGlobalMute() {
+      const soundOn = localStorage.getItem('divine-mod-muted') === 'false';
+      const newMuted = soundOn;
+      localStorage.setItem('divine-mod-muted', newMuted ? 'true' : 'false');
 
-      video.addEventListener('volumechange', function() {
-        localStorage.setItem('divine-mod-muted', video.muted);
+      document.querySelectorAll('video').forEach(v => {
+        v.muted = newMuted;
       });
+
+      updateMuteToggleButton();
     }
 
-    // Apply saved mute preference (call in response to user gesture)
-    function applySavedMutePreference(video) {
-      const pref = localStorage.getItem('divine-mod-muted');
-      if (pref === 'false') {
+    function updateMuteToggleButton() {
+      const btn = document.getElementById('global-mute-toggle');
+      if (!btn) return;
+      const soundOn = localStorage.getItem('divine-mod-muted') === 'false';
+      btn.textContent = soundOn ? '🔊 Sound On' : '🔇 Sound Off';
+      btn.style.background = soundOn ? '#166534' : '#333';
+    }
+
+    // Apply saved mute preference to a video element (for dynamically added videos)
+    function applyMutePreference(video) {
+      if (localStorage.getItem('divine-mod-muted') === 'false') {
         video.muted = false;
       }
     }
 
-    // Auto-pause other videos when one starts playing, apply mute preference on interaction
+    // Auto-pause other videos when one starts playing
     function setupVideoPauseHandlers() {
       const videos = document.querySelectorAll('video');
 
@@ -3704,14 +3716,8 @@
           });
         });
 
-        // Apply saved mute preference on user click (counts as user gesture,
-        // so browser allows unmuting). Hover-autoplay stays muted.
-        video.addEventListener('click', function() {
-          applySavedMutePreference(video);
-        });
-
-        // Save preference when user mutes/unmutes via native controls
-        setupMutePreference(video);
+        // Apply mute preference to newly rendered videos
+        applyMutePreference(video);
       });
     }
 
@@ -4122,6 +4128,7 @@
 
     loadTriageVideos();
     loadRealStats();
+    updateMuteToggleButton();
     // Set filter dropdown to TRIAGE
     document.getElementById('filter-action').value = 'TRIAGE';
 


### PR DESCRIPTION
follow-up to PR #37. the per-video click/volumechange approach doesn't work in practice: click events don't fire on `<video controls>` (native controls consume them), and volumechange from hover-autoplay overwrites the saved preference.

replaces with a Sound On/Off toggle button in the toolbar. the button click is a user gesture, so the browser allows unmuting all videos on the page. hover-autoplay inherits the unmuted state. preference persists to localStorage, applies to dynamically loaded video cards. per-browser, per-user.

514/514 tests passing.