### PR TITLE
Add transcript tools to moderation UI

### DIFF
--- a/src/admin/dashboard.html
+++ b/src/admin/dashboard.html
@@ -1207,6 +1207,69 @@
       color: #93c5fd;
     }
 
+    .transcript-panel {
+      margin-top: 12px;
+      padding: 12px;
+      background: #111;
+      border: 1px solid #27272a;
+      border-radius: 6px;
+    }
+
+    .transcript-panel-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
+      margin-bottom: 8px;
+    }
+
+    .transcript-panel-title {
+      font-size: 12px;
+      font-weight: 600;
+      color: #e4e4e7;
+      letter-spacing: 0.02em;
+      text-transform: uppercase;
+    }
+
+    .transcript-panel-links {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      font-size: 11px;
+    }
+
+    .transcript-panel-links a {
+      color: #93c5fd;
+      text-decoration: none;
+    }
+
+    .transcript-panel-links a:hover {
+      text-decoration: underline;
+    }
+
+    .transcript-panel-meta {
+      margin-bottom: 8px;
+      font-size: 11px;
+      color: #71717a;
+    }
+
+    .transcript-panel-text {
+      margin: 0;
+      max-height: 180px;
+      overflow-y: auto;
+      white-space: pre-wrap;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 12px;
+      line-height: 1.55;
+      color: #d4d4d8;
+    }
+
+    .transcript-panel-empty {
+      font-size: 12px;
+      color: #71717a;
+      line-height: 1.5;
+    }
+
     /* Modal */
     .modal {
       display: none;
@@ -1663,6 +1726,7 @@
     let currentLookupSha = null;
     let currentLookupVideo = null;
     const nostrContextCache = new Map(); // Cache Nostr contexts to avoid redundant fetches
+    const transcriptCache = new Map();
     const LOOKUP_HELP_TEXT = 'Paste a divine.video link or 64-character SHA to jump straight to moderation.';
 
     // Pagination state
@@ -1953,6 +2017,106 @@
       }
     }
 
+    async function fetchTranscriptData(sha256) {
+      if (transcriptCache.has(sha256)) {
+        return transcriptCache.get(sha256);
+      }
+
+      const promise = (async () => {
+        const response = await fetch(`/admin/api/transcript/${sha256}`);
+        if (response.status === 404) {
+          return { sha256, found: false };
+        }
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+        return response.json();
+      })();
+
+      transcriptCache.set(sha256, promise);
+      return promise;
+    }
+
+    function attachTranscriptTrack(sha256, transcriptData) {
+      if (!transcriptData?.found) {
+        return;
+      }
+
+      const video = document.querySelector(`#lookup-result .video-card[data-sha256="${sha256}"] video`);
+      if (!video || video.querySelector('track[data-transcript-track="true"]')) {
+        return;
+      }
+
+      const track = document.createElement('track');
+      track.kind = 'subtitles';
+      track.label = 'Transcript';
+      track.srclang = 'en';
+      track.src = transcriptData.subtitleUrl;
+      track.default = true;
+      track.dataset.transcriptTrack = 'true';
+      track.addEventListener('load', () => {
+        try {
+          track.track.mode = 'showing';
+        } catch (error) {
+          console.warn('Unable to enable transcript track:', error);
+        }
+      });
+      video.appendChild(track);
+
+      if (track.track) {
+        try {
+          track.track.mode = 'showing';
+        } catch (error) {
+          console.warn('Unable to show transcript track:', error);
+        }
+      }
+    }
+
+    function createTranscriptPanelHTML(sha256, transcriptData) {
+      if (!transcriptData?.found) {
+        return '';
+      }
+
+      const transcriptText = transcriptData.transcriptText?.trim();
+      const transcriptBody = transcriptText
+        ? `<pre class="transcript-panel-text">${escapeHtml(transcriptText)}</pre>`
+        : '<div class="transcript-panel-empty">Transcript file exists but contains no extractable text.</div>';
+
+      return `
+        <div class="transcript-panel">
+          <div class="transcript-panel-header">
+            <span class="transcript-panel-title">Transcript</span>
+            <div class="transcript-panel-links">
+              <a href="${transcriptData.subtitleUrl}" target="_blank" rel="noopener noreferrer">Open VTT</a>
+            </div>
+          </div>
+          <div class="transcript-panel-meta">Subtitles are attached to the player for this lookup.</div>
+          ${transcriptBody}
+        </div>
+      `;
+    }
+
+    async function loadTranscriptData(sha256) {
+      const container = document.getElementById(`transcript-detail-${sha256}`);
+      if (!container || container.dataset.loaded === 'true') {
+        return;
+      }
+
+      container.dataset.loaded = 'true';
+
+      try {
+        const transcriptData = await fetchTranscriptData(sha256);
+        if (!transcriptData?.found) {
+          return;
+        }
+
+        container.innerHTML = createTranscriptPanelHTML(sha256, transcriptData);
+        attachTranscriptTrack(sha256, transcriptData);
+      } catch (error) {
+        console.error('Failed to load transcript:', error);
+      }
+    }
+
     function isFocusedLookupResult(sha256) {
       return currentLookupSha === sha256;
     }
@@ -1994,17 +2158,21 @@
 
     function hydrateRenderedVideo(video) {
       const nostrContainer = document.getElementById(`nostr-${video.sha256}`);
-      if (!nostrContainer) return;
-
-      if (video.nostrContext) {
-        nostrContainer.innerHTML = createNostrMetadataHTML(video.nostrContext);
-        updateDivineLink(video.sha256, video.nostrContext);
-      } else {
-        nostrContainer.innerHTML = '<div class="nostr-not-found" style="opacity:0.5">Loading...</div>';
-        loadNostrContext(video.sha256, nostrContainer);
+      if (nostrContainer) {
+        if (video.nostrContext) {
+          nostrContainer.innerHTML = createNostrMetadataHTML(video.nostrContext);
+          updateDivineLink(video.sha256, video.nostrContext);
+        } else {
+          nostrContainer.innerHTML = '<div class="nostr-not-found" style="opacity:0.5">Loading...</div>';
+          loadNostrContext(video.sha256, nostrContainer);
+        }
       }
 
-      loadClassifierData(video.sha256);
+      loadTranscriptData(video.sha256);
+
+      if (video.status !== 'UNTRIAGED') {
+        loadClassifierData(video.sha256);
+      }
 
       const aiScore = video.scores?.ai_generated || 0;
       const deepfakeScore = video.scores?.deepfake || 0;
@@ -2022,8 +2190,8 @@
       const result = document.getElementById('lookup-result');
       const meta = document.getElementById('lookup-result-meta');
       const renderVideo = video.status === 'UNTRIAGED'
-        ? { ...video, showDirectActions: true }
-        : video;
+        ? { ...video, showDirectActions: true, showTranscriptTools: true }
+        : { ...video, showTranscriptTools: true };
 
       result.innerHTML = video.status === 'UNTRIAGED'
         ? createTriageCard(renderVideo)
@@ -2036,9 +2204,7 @@
       syncLookupUrl(video.lookupId || video.sha256);
 
       setTimeout(setupVideoPauseHandlers, 100);
-      if (video.status !== 'UNTRIAGED') {
-        hydrateRenderedVideo(video);
-      }
+      hydrateRenderedVideo(renderVideo);
     }
 
     async function lookupVideo(inputValue = null) {
@@ -2265,7 +2431,7 @@
     }
 
     function createTriageCard(video) {
-      const { sha256, cdnUrl, thumbnailUrl, receivedAt, nostrContext, showDirectActions } = video;
+      const { sha256, cdnUrl, thumbnailUrl, receivedAt, nostrContext, showDirectActions, showTranscriptTools } = video;
 
       // Format timestamp
       const timestamp = receivedAt ? new Date(receivedAt).toLocaleString() : 'Unknown';
@@ -2311,6 +2477,9 @@
           '<button class="action-btn ban" onclick="lookupModerationAction(\'' + sha256 + '\', \'PERMANENT_BAN\', this)">Block</button>' +
         '</div>'
       ) : '';
+      const transcriptTools = showTranscriptTools
+        ? '<div id="transcript-detail-' + sha256 + '"></div>'
+        : '';
       const uploaderEnforcementPanel = createUploaderEnforcementPanel(video);
 
       return '<div class="video-card triage" data-sha256="' + sha256 + '" style="border-color: #8b5cf6;">' +
@@ -2341,6 +2510,7 @@
           '</div>' +
           uploaderEnforcementPanel +
           directActions +
+          transcriptTools +
         '</div>' +
       '</div>';
     }
@@ -2862,7 +3032,7 @@
     }
 
     function createVideoCard(video) {
-      const { sha256, cdnUrl, action, scores, reason, processedAt, detailedCategories, provider, manualOverride, overriddenAt, previousAction } = video;
+      const { sha256, cdnUrl, action, scores, reason, processedAt, detailedCategories, provider, manualOverride, overriddenAt, previousAction, showTranscriptTools } = video;
 
       const timestamp = processedAt
         ? new Date(processedAt).toLocaleString()
@@ -2993,6 +3163,8 @@
             <div id="classifier-inline-${sha256}"></div>
 
             <div id="classifier-detail-${sha256}"></div>
+
+            ${showTranscriptTools ? `<div id="transcript-detail-${sha256}"></div>` : ''}
 
             ${nip85TagsHTML}
 

--- a/src/admin/swipe-review.html
+++ b/src/admin/swipe-review.html
@@ -403,6 +403,57 @@
       color: #c4b5fd;
     }
 
+    .transcript-panel {
+      margin-bottom: 12px;
+      padding: 10px 12px;
+      background: #111;
+      border: 1px solid #2a2a2a;
+      border-radius: 6px;
+    }
+
+    .transcript-panel-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+      margin-bottom: 8px;
+    }
+
+    .transcript-panel-title {
+      font-size: 12px;
+      font-weight: 600;
+      color: #f4f4f5;
+      text-transform: uppercase;
+      letter-spacing: 0.02em;
+    }
+
+    .transcript-panel-link {
+      font-size: 11px;
+      color: #93c5fd;
+      text-decoration: none;
+    }
+
+    .transcript-panel-link:hover {
+      text-decoration: underline;
+    }
+
+    .transcript-panel-text {
+      margin: 0;
+      max-height: 160px;
+      overflow-y: auto;
+      white-space: pre-wrap;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 12px;
+      line-height: 1.55;
+      color: #d4d4d8;
+    }
+
+    .transcript-panel-empty {
+      font-size: 12px;
+      color: #71717a;
+      line-height: 1.5;
+    }
+
     .keyboard-hints kbd {
       display: inline-block;
       padding: 3px 6px;
@@ -544,6 +595,7 @@
     let currentIndex = 0;
     let reviewedCount = 0;
     let currentToast = null;
+    const transcriptCache = new Map();
 
     // Touch/mouse state
     let isDragging = false;
@@ -659,6 +711,19 @@
         });
       }
 
+      if (video.transcriptData !== null && !video.transcriptData) {
+        fetchTranscriptData(video.sha256).then(transcriptData => {
+          video.transcriptData = transcriptData;
+          if (currentIndex < reviewQueue.length && reviewQueue[currentIndex].sha256 === video.sha256) {
+            renderTranscriptIntoCard(card, transcriptData);
+          }
+        }).catch(() => {
+          video.transcriptData = { sha256: video.sha256, found: false };
+        });
+      } else if (video.transcriptData) {
+        renderTranscriptIntoCard(card, video.transcriptData);
+      }
+
       // Async-load nostr context if not already present (for flagged videos from DB)
       if (!video.nostrContext && !video._nostrContextFetched) {
         video._nostrContextFetched = true;
@@ -694,6 +759,14 @@
       if (!next.classifierSummary) {
         fetchClassifierSummary(next.sha256).then(summary => {
           if (summary) next.classifierSummary = summary;
+        });
+      }
+
+      if (next.transcriptData !== null && !next.transcriptData) {
+        fetchTranscriptData(next.sha256).then(transcriptData => {
+          next.transcriptData = transcriptData;
+        }).catch(() => {
+          next.transcriptData = { sha256: next.sha256, found: false };
         });
       }
 
@@ -782,6 +855,88 @@
       }
     }
 
+    async function fetchTranscriptData(sha256) {
+      if (transcriptCache.has(sha256)) {
+        return transcriptCache.get(sha256);
+      }
+
+      const promise = (async () => {
+        const resp = await fetch(`/admin/api/transcript/${sha256}`);
+        if (resp.status === 404) {
+          return { sha256, found: false };
+        }
+        if (!resp.ok) {
+          throw new Error(`HTTP ${resp.status}`);
+        }
+        return resp.json();
+      })();
+
+      transcriptCache.set(sha256, promise);
+      return promise;
+    }
+
+    function createTranscriptHTML(transcriptData) {
+      if (!transcriptData?.found) {
+        return '<div class="transcript-panel-empty">No transcript available for this video.</div>';
+      }
+
+      const transcriptText = transcriptData.transcriptText?.trim();
+      const body = transcriptText
+        ? `<pre class="transcript-panel-text">${escapeHtml(transcriptText)}</pre>`
+        : '<div class="transcript-panel-empty">Transcript file exists but contains no extractable text.</div>';
+
+      return `
+        <div class="transcript-panel-header">
+          <span class="transcript-panel-title">Transcript</span>
+          <a class="transcript-panel-link" href="${escapeHtml(transcriptData.subtitleUrl)}" target="_blank" rel="noopener noreferrer">Open VTT</a>
+        </div>
+        ${body}
+      `;
+    }
+
+    function attachTranscriptTrack(card, transcriptData) {
+      if (!card || !transcriptData?.found) {
+        return;
+      }
+
+      const video = card.querySelector('video');
+      if (!video || video.querySelector('track[data-transcript-track="true"]')) {
+        return;
+      }
+
+      const track = document.createElement('track');
+      track.kind = 'subtitles';
+      track.label = 'Transcript';
+      track.srclang = 'en';
+      track.src = transcriptData.subtitleUrl;
+      track.default = true;
+      track.dataset.transcriptTrack = 'true';
+      track.addEventListener('load', () => {
+        try {
+          track.track.mode = 'showing';
+        } catch (error) {
+          console.warn('Unable to enable transcript track:', error);
+        }
+      });
+      video.appendChild(track);
+
+      if (track.track) {
+        try {
+          track.track.mode = 'showing';
+        } catch (error) {
+          console.warn('Unable to show transcript track:', error);
+        }
+      }
+    }
+
+    function renderTranscriptIntoCard(card, transcriptData) {
+      const container = card?.querySelector('.transcript-panel');
+      if (!container) return;
+
+      container.innerHTML = createTranscriptHTML(transcriptData);
+      attachTranscriptTrack(card, transcriptData);
+    }
+
     function createClassifierHTML(classifierSummary) {
       if (!classifierSummary) return '';
       const { description, topics, primaryTopic, mood, hasSpeech } = classifierSummary;
@@ -839,6 +994,9 @@
 
       // Classifier summary (VLM description + topics)
       const classifierHTML = createClassifierHTML(classifierSummary);
+      const transcriptHTML = video.transcriptData
+        ? createTranscriptHTML(video.transcriptData)
+        : '<div class="transcript-panel-empty">Loading transcript…</div>';
 
       // Provider info with AI source detection
       let providerHTML = '';
@@ -925,6 +1083,8 @@
             <div class="video-hash">${sha256}</div>
 
             ${classifierHTML}
+
+            <div class="transcript-panel">${transcriptHTML}</div>
 
             ${scoreEntries.length > 0 ? `
               <div class="scores-grid">

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -24,6 +24,7 @@ import { formatForStorage, formatForGorse, formatForFunnelcake } from './classif
 import { topicsToLabels, topicsToWeightedFeatures } from './classification/topic-extractor.mjs';
 import { getKVThresholds, setKVThresholds, DEFAULT_THRESHOLDS } from './moderation/classifier.mjs';
 import { isValidSha256, isValidLookupIdentifier, isValidPubkey, parseMaybeJson, getEventTagValue, parseImetaParams, extractShaFromUrl, extractMediaShaFromEvent } from './validation.mjs';
+import { parseVttText } from './moderation/text-classifier.mjs';
 /**
  * NIP-32 label mapping for content categories
  * Maps internal category names to NIP-32/NIP-56 compatible labels
@@ -235,6 +236,44 @@ function getRelayAdminHeaders(env) {
   }
 
   return headers;
+}
+
+function getTranscriptSourceUrl(sha256, env) {
+  return `https://${env.CDN_DOMAIN || 'media.divine.video'}/${sha256}.vtt`;
+}
+
+function getAdminTranscriptProxyUrl(sha256) {
+  return `/admin/transcript/${sha256}.vtt`;
+}
+
+async function fetchTranscriptAsset(sha256, env) {
+  const sourceUrl = getTranscriptSourceUrl(sha256, env);
+  const response = await fetch(sourceUrl);
+
+  if (response.status === 404) {
+    return {
+      found: false,
+      sha256,
+      sourceUrl,
+      subtitleUrl: getAdminTranscriptProxyUrl(sha256),
+      vttContent: null,
+      transcriptText: ''
+    };
+  }
+
+  if (!response.ok) {
+    throw new Error(`Transcript fetch failed with HTTP ${response.status}`);
+  }
+
+  const vttContent = await response.text();
+  return {
+    found: true,
+    sha256,
+    sourceUrl,
+    subtitleUrl: getAdminTranscriptProxyUrl(sha256),
+    vttContent,
+    transcriptText: parseVttText(vttContent).trim()
+  };
 }
 
 async function callRelayAdminAction(env, payload) {
@@ -1596,6 +1635,52 @@ export default {
       }
     }
 
+    if (url.pathname.startsWith('/admin/api/transcript/')) {
+      const authError = await requireAuth(request, env);
+      if (authError) {
+        return authError;
+      }
+
+      const sha256 = url.pathname.split('/')[4];
+      if (!sha256 || sha256.length !== 64) {
+        return new Response(JSON.stringify({ error: 'Invalid sha256 hash' }), {
+          status: 400,
+          headers: JSON_HEADERS
+        });
+      }
+
+      try {
+        const transcript = await fetchTranscriptAsset(sha256, env);
+        if (!transcript.found) {
+          return new Response(JSON.stringify({
+            sha256,
+            found: false,
+            subtitleUrl: transcript.subtitleUrl,
+            sourceUrl: transcript.sourceUrl
+          }), {
+            status: 404,
+            headers: JSON_HEADERS
+          });
+        }
+
+        return new Response(JSON.stringify({
+          sha256,
+          found: true,
+          subtitleUrl: transcript.subtitleUrl,
+          sourceUrl: transcript.sourceUrl,
+          transcriptText: transcript.transcriptText
+        }), {
+          headers: JSON_HEADERS
+        });
+      } catch (error) {
+        console.error(`[ADMIN] Error fetching transcript for ${sha256}:`, error);
+        return new Response(JSON.stringify({ error: error.message }), {
+          status: 500,
+          headers: JSON_HEADERS
+        });
+      }
+    }
+
     // Get current moderation thresholds (KV overrides + defaults)
     if (url.pathname === '/admin/api/thresholds' && request.method === 'GET') {
       const authError = await requireAuth(request, env);
@@ -1830,6 +1915,35 @@ export default {
           status: 502,
           headers: { 'Content-Type': 'application/json' }
         });
+      }
+    }
+
+    if (url.pathname.startsWith('/admin/transcript/')) {
+      const authError = await requireAuth(request, env);
+      if (authError) {
+        return new Response('Unauthorized', { status: 401 });
+      }
+
+      const sha256 = url.pathname.split('/')[3].replace('.vtt', '');
+      if (!isValidSha256(sha256)) {
+        return new Response('Invalid sha256 hash', { status: 400 });
+      }
+
+      try {
+        const transcript = await fetchTranscriptAsset(sha256, env);
+        if (!transcript.found || !transcript.vttContent) {
+          return new Response('Transcript not found', { status: 404 });
+        }
+
+        return new Response(transcript.vttContent, {
+          headers: {
+            'Content-Type': 'text/vtt; charset=utf-8',
+            'Cache-Control': 'private, no-store'
+          }
+        });
+      } catch (error) {
+        console.error(`[ADMIN] Transcript proxy error for ${sha256}:`, error);
+        return new Response('Failed to fetch transcript', { status: 502 });
       }
     }
 

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -512,6 +512,82 @@ describe('Admin video lookup', () => {
   });
 });
 
+describe('Admin transcript access', () => {
+  it('returns parsed transcript text for admin transcript lookup', async () => {
+    const vttText = `WEBVTT
+
+00:00:00.000 --> 00:00:02.000
+Hello world
+
+00:00:02.000 --> 00:00:04.000
+This is a test`;
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (url) => {
+      if (String(url) === `https://media.divine.video/${SHA256}.vtt`) {
+        return new Response(vttText, {
+          status: 200,
+          headers: { 'Content-Type': 'text/vtt' }
+        });
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    };
+
+    try {
+      const response = await worker.fetch(
+        new Request(`https://moderation.admin.divine.video/admin/api/transcript/${SHA256}`, {
+          headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
+        }),
+        createEnv({ CDN_DOMAIN: 'media.divine.video' })
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({
+        sha256: SHA256,
+        found: true,
+        subtitleUrl: `/admin/transcript/${SHA256}.vtt`,
+        sourceUrl: `https://media.divine.video/${SHA256}.vtt`,
+        transcriptText: 'Hello world This is a test'
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('proxies raw VTT content through the admin transcript route', async () => {
+    const vttText = `WEBVTT
+
+00:00:00.000 --> 00:00:02.000
+Hello world`;
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (url) => {
+      if (String(url) === `https://media.divine.video/${SHA256}.vtt`) {
+        return new Response(vttText, {
+          status: 200,
+          headers: { 'Content-Type': 'text/vtt' }
+        });
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    };
+
+    try {
+      const response = await worker.fetch(
+        new Request(`https://moderation.admin.divine.video/admin/transcript/${SHA256}.vtt`, {
+          headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
+        }),
+        createEnv({ CDN_DOMAIN: 'media.divine.video' })
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('Content-Type')).toBe('text/vtt; charset=utf-8');
+      await expect(response.text()).resolves.toBe(vttText);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
 describe('notifyBlossom integration via admin moderate endpoint', () => {
   // Exercises the real notifyBlossom() code path through the admin API.
   // A mock fetch interceptor captures the webhook payload Blossom would receive.


### PR DESCRIPTION
## Summary
- add authenticated admin transcript endpoints for JSON transcript lookup and VTT proxying
- show raw transcript panels in dashboard lookup and swipe review
- attach subtitle tracks to the moderation players when a transcript exists

## Testing
- npm test
- node --check src/index.mjs
- inline admin HTML script parse
