### PR TITLE
feat: shareable permalinks for dashboard and review queue

### DIFF
--- a/src/admin/dashboard.html
+++ b/src/admin/dashboard.html
@@ -3891,7 +3891,7 @@
       if (sort) document.getElementById('sort-by').value = sort;
       if (minScore) document.getElementById('min-score').value = minScore;
 
-      return !!action; // true if we should load with a filter
+      return !!(action || category || sort || minScore);
     }
 
     function copyDashboardPermalink(sha256, btn) {
@@ -4368,7 +4368,8 @@
     // Restore filters from URL, or default to TRIAGE
     const hasUrlFilter = restoreFiltersFromUrl();
     if (hasUrlFilter) {
-      const action = document.getElementById('filter-action').value;
+      const action = document.getElementById('filter-action').value || 'all';
+      document.getElementById('filter-action').value = action;
       lastActionFilter = action;
       loadVideos(undefined, action);
       updateActiveStatCard();

--- a/src/admin/swipe-review.html
+++ b/src/admin/swipe-review.html
@@ -1096,7 +1096,7 @@
 
             <div class="video-hash" style="display: flex; align-items: center; gap: 8px;">
               ${sha256}
-              <button onclick="copyPermalink('${sha256}')" style="background: none; border: 1px solid #555; color: #aaa; padding: 2px 8px; border-radius: 4px; cursor: pointer; font-size: 11px;">📋 Link</button>
+              <button onclick="copyPermalink('${sha256}', this)" style="background: none; border: 1px solid #555; color: #aaa; padding: 2px 8px; border-radius: 4px; cursor: pointer; font-size: 11px;">📋 Link</button>
             </div>
 
             ${classifierHTML}
@@ -1435,11 +1435,10 @@
       return div.innerHTML;
     }
 
-    function copyPermalink(sha256) {
+    function copyPermalink(sha256, btn) {
       const url = new URL(window.location);
       url.searchParams.set('sha256', sha256);
       navigator.clipboard.writeText(url.toString()).then(() => {
-        const btn = event.target;
         btn.textContent = '✓ Copied';
         setTimeout(() => { btn.textContent = '📋 Link'; }, 1500);
       }).catch(() => { /* clipboard not available */ });


### PR DESCRIPTION
Closes #40

moderators need to share specific items with each other. adds permalinks and copy-link buttons to both admin UIs.

### swipe review (`/admin/review`)

- URL tracks current video as `?sha256=<hash>`, updates on swipe
- deep link: `?sha256=<hash>` jumps to that video in the queue
- 📋 Link button on each card copies the permalink

### dashboard (`/admin/dashboard`)

- 🔗 copy-link button on triage and moderated video cards (copies `?lookup=<sha256>` URL)
- filter state syncs to URL: `?action=QUARANTINE&category=nudity&sort=highest-score&min=0.5`
- navigating to a URL with filter params restores the dropdowns and loads the matching view

### testing

516/516 tests passing. verified locally with `wrangler dev --local` + seeded D1 data:
- filter restore from URL params (action, category, sort, min score)
- permalink copy buttons on dashboard cards
- swipe review URL tracking and deep linking
- videos render with scores, badges, action buttons