### PR TITLE
feat: copy transcript button for moderation translation workflow

### DIFF
--- a/src/admin/dashboard.html
+++ b/src/admin/dashboard.html
@@ -2088,7 +2088,7 @@
           <div class="transcript-panel-header">
             <span class="transcript-panel-title">Transcript</span>
             <div class="transcript-panel-links">
-              ${transcriptText ? `<button onclick="copyTranscriptText('${sha256}', this)" style="background: none; border: 1px solid #555; color: #aaa; padding: 2px 8px; border-radius: 4px; cursor: pointer; font-size: 11px;">📋 Copy</button>` : ''}
+              ${transcriptText ? `<button data-sha256="${sha256}" onclick="copyTranscriptText(this)" style="background: none; border: 1px solid #555; color: #aaa; padding: 2px 8px; border-radius: 4px; cursor: pointer; font-size: 11px;">📋 Copy</button>` : ''}
               <a href="${transcriptData.subtitleUrl}" target="_blank" rel="noopener noreferrer">Open VTT</a>
             </div>
           </div>
@@ -3552,7 +3552,7 @@
         html += '<div class="classifier-panel">'
           + '<div class="classifier-panel-header" onclick="toggleClassifierPanel(\'transcript-' + sha256 + '\')">'
           + '<span class="classifier-panel-title">Transcript Analysis</span>'
-          + (topics.has_speech ? '<button onclick="event.stopPropagation(); copyTranscriptText(\'' + sha256 + '\', this)" style="background: none; border: 1px solid #555; color: #aaa; padding: 1px 6px; border-radius: 3px; cursor: pointer; font-size: 10px; margin-left: auto; margin-right: 8px;" title="Copy transcript text">📋 Copy</button>' : '')
+          + (topics.has_speech ? '<button data-sha256="' + sha256 + '" onclick="event.stopPropagation(); copyTranscriptText(this)" style="background: none; border: 1px solid #555; color: #aaa; padding: 1px 6px; border-radius: 3px; cursor: pointer; font-size: 10px; margin-left: auto; margin-right: 8px;" title="Copy transcript text">📋 Copy</button>' : '')
           + '<span class="classifier-panel-toggle" id="toggle-transcript-' + sha256 + '">&#9660;</span>'
           + '</div>'
           + '<div class="classifier-panel-body" id="body-transcript-' + sha256 + '">'
@@ -3627,7 +3627,7 @@
             <div class="classifier-panel">
               <div class="classifier-panel-header" onclick="toggleClassifierPanel('transcript-${sha256}')">
                 <span class="classifier-panel-title">Transcript Analysis</span>
-                ${topics.has_speech ? `<button onclick="event.stopPropagation(); copyTranscriptText('${sha256}', this)" style="background: none; border: 1px solid #555; color: #aaa; padding: 1px 6px; border-radius: 3px; cursor: pointer; font-size: 10px; margin-left: auto; margin-right: 8px;" title="Copy transcript text">📋 Copy</button>` : ''}
+                ${topics.has_speech ? `<button data-sha256="${sha256}" onclick="event.stopPropagation(); copyTranscriptText(this)" style="background: none; border: 1px solid #555; color: #aaa; padding: 1px 6px; border-radius: 3px; cursor: pointer; font-size: 10px; margin-left: auto; margin-right: 8px;" title="Copy transcript text">📋 Copy</button>` : ''}
                 <span class="classifier-panel-toggle" id="toggle-transcript-${sha256}">▼</span>
               </div>
               <div class="classifier-panel-body" id="body-transcript-${sha256}">
@@ -3913,7 +3913,8 @@
       }).catch(() => { /* clipboard not available */ });
     }
 
-    async function copyTranscriptText(sha256, btn) {
+    async function copyTranscriptText(btn) {
+      const sha256 = btn.dataset.sha256;
       try {
         const data = await fetchTranscriptData(sha256);
         if (!data?.transcriptText) {

--- a/src/admin/swipe-review.html
+++ b/src/admin/swipe-review.html
@@ -909,7 +909,7 @@
       return `
         <div class="transcript-panel-header">
           <span class="transcript-panel-title">Transcript</span>
-          ${transcriptText ? `<button onclick="copyTranscript(this, '${escapeHtml(transcriptData.sha256)}')" style="background: none; border: 1px solid #555; color: #aaa; padding: 2px 8px; border-radius: 4px; cursor: pointer; font-size: 11px;">📋 Copy</button>` : ''}
+          ${transcriptText ? `<button data-sha256="${escapeHtml(transcriptData.sha256)}" onclick="copyTranscript(this)" style="background: none; border: 1px solid #555; color: #aaa; padding: 2px 8px; border-radius: 4px; cursor: pointer; font-size: 11px;">📋 Copy</button>` : ''}
           <a class="transcript-panel-link" href="${escapeHtml(transcriptData.subtitleUrl)}" target="_blank" rel="noopener noreferrer">Open VTT</a>
         </div>
         ${body}
@@ -1459,16 +1459,22 @@
       }).catch(() => { /* clipboard not available */ });
     }
 
-    function copyTranscript(btn, sha256) {
-      const cached = transcriptCache.get(sha256);
-      if (!cached) return;
-      cached.then(data => {
-        if (!data?.transcriptText) return;
-        navigator.clipboard.writeText(data.transcriptText).then(() => {
-          btn.textContent = '✓ Copied';
+    async function copyTranscript(btn) {
+      const sha256 = btn.dataset.sha256;
+      try {
+        const data = await (transcriptCache.get(sha256) || fetchTranscriptData(sha256));
+        if (!data?.transcriptText) {
+          btn.textContent = '✗ None';
           setTimeout(() => { btn.textContent = '📋 Copy'; }, 1500);
-        }).catch(() => { /* clipboard not available */ });
-      });
+          return;
+        }
+        await navigator.clipboard.writeText(data.transcriptText);
+        btn.textContent = '✓ Copied';
+        setTimeout(() => { btn.textContent = '📋 Copy'; }, 1500);
+      } catch {
+        btn.textContent = '✗ Error';
+        setTimeout(() => { btn.textContent = '📋 Copy'; }, 1500);
+      }
     }
 
     function logout() {


### PR DESCRIPTION
### User story

Moderators encounter foreign-language content and need to copy transcript text for translation (paste into Google Translate, DeepL, etc). This is an easy win and the first step of a path we can escalate on as needed and justifiable (see support-trust-safety docs/superpowers/specs/2026-03-18-transcript-translation-options.md).

### What changed

Copy button (📋 Copy) added in three places:

- **Quick Review** transcript panel header (next to "Open VTT")
- **Dashboard card** Transcript Analysis accordion header (fetches text on click, doesn't expand the card)
- **Dashboard lookup** full transcript panel (next to "Open VTT")

Button only appears when the video has speech detected. Copies plain text to clipboard. Shows "✓ Copied" feedback, or "✗ None" if no transcript text available.

### Testing

516/516 tests passing. Verified locally with mock transcript data injected via Playwright: copy button renders in transcript panel, click copies text to clipboard, feedback shows "✓ Copied".

### Context

Aleysha is hitting foreign-language content in moderation. Transcripts exist (Whisper auto-generates VTT) but are in the original language. This gives her a one-click way to grab the text and paste into any translation tool. A future PR could add inline translation (Level 2 of the proposal).

Stacked on PR #43 (View on Divine links).