### PR TITLE
fix: delete all relay event versions

### DIFF
--- a/src/admin/dashboard.html
+++ b/src/admin/dashboard.html
@@ -2412,7 +2412,7 @@
         ? `<button class="action-btn ban" onclick="toggleRelayBan('${pubkey}', ${enforcement?.relay_banned ? 'false' : 'true'}, this)">${enforcement?.relay_banned ? 'Unban User' : 'Ban User'}</button>`
         : '';
       const deleteButton = eventId
-        ? `<button class="action-btn secondary" onclick="deleteNostrEvent('${eventId}', this)">Delete Event</button>`
+        ? `<button class="action-btn secondary" onclick="deleteNostrEvent('${video.sha256 || ''}', '${eventId}', this)">Delete Event</button>`
         : '';
 
       return `
@@ -2770,7 +2770,7 @@
       );
     }
 
-    async function deleteNostrEvent(eventId, button) {
+    async function deleteNostrEvent(sha256, eventId, button) {
       const originalText = button.innerHTML;
       button.innerHTML = '⏳...';
       button.disabled = true;
@@ -2780,7 +2780,8 @@
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
-            reason: 'Deleted from moderation dashboard'
+            reason: 'Deleted from moderation dashboard',
+            sha256: sha256 || null
           })
         });
 
@@ -2796,7 +2797,11 @@
 
         button.innerHTML = originalText;
         button.disabled = false;
-        setLookupStatus(`Deleted relay event ${truncateHex(eventId, 10, 6)}`);
+        const deletedCount = data?.relayResult?.deletedCount || 1;
+        const statusLabel = deletedCount > 1
+          ? `Deleted ${deletedCount} relay event versions for ${truncateHex(eventId, 10, 6)}`
+          : `Deleted relay event ${truncateHex(eventId, 10, 6)}`;
+        setLookupStatus(statusLabel);
       } catch (error) {
         button.innerHTML = originalText;
         button.disabled = false;

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -10,7 +10,7 @@ import { publishToFaro, publishToContentRelay, publishLabelEvent } from './nostr
 import { requireAuth, getAuthenticatedUser } from './admin/auth.mjs';
 import { verifyZeroTrustJWT } from './admin/zerotrust.mjs';
 import { getConfiguredBearerTokens, authenticateApiRequest, apiUnauthorizedResponse, authSourceFromVerification, verifyLegacyBearerAuth } from './auth-api.mjs';
-import { fetchNostrEventBySha256, parseVideoEventMetadata } from './nostr/relay-client.mjs';
+import { fetchNostrEventBySha256, fetchNostrVideoEventsByDTag, parseVideoEventMetadata } from './nostr/relay-client.mjs';
 import { pollRelayForVideos, getLastPollTimestamp, setLastPollTimestamp, getPollingStatus } from './nostr/relay-poller.mjs';
 import { getPublicKey } from 'nostr-tools/pure';
 import { hexToBytes, bytesToHex } from '@noble/hashes/utils';
@@ -292,25 +292,84 @@ async function callRelayAdminAction(env, payload) {
   return data;
 }
 
+async function deleteRelayEventIds(eventIds, env, reason) {
+  const uniqueEventIds = [...new Set(
+    (eventIds || []).filter((eventId) => typeof eventId === 'string' && isValidSha256(eventId))
+  )];
+
+  if (uniqueEventIds.length === 0) {
+    return {
+      success: false,
+      reason: 'no_event_found',
+      eventId: null,
+      eventIds: [],
+      deletedCount: 0,
+      attemptedCount: 0,
+      failures: []
+    };
+  }
+
+  const deletedEventIds = [];
+  const failures = [];
+
+  for (const eventId of uniqueEventIds) {
+    try {
+      await callRelayAdminAction(env, {
+        action: 'delete_event',
+        eventId,
+        reason
+      });
+      deletedEventIds.push(eventId);
+    } catch (error) {
+      failures.push({
+        eventId,
+        error: error instanceof Error ? error.message : String(error)
+      });
+    }
+  }
+
+  return {
+    success: failures.length === 0,
+    eventId: deletedEventIds[0] || uniqueEventIds[0],
+    eventIds: deletedEventIds,
+    deletedCount: deletedEventIds.length,
+    attemptedCount: uniqueEventIds.length,
+    failures
+  };
+}
+
 /**
- * Look up the Nostr event for a SHA256 and delete it from the relay.
+ * Look up all Nostr event versions for a SHA256 d-tag and delete them from the relay.
  * Used to enforce PERMANENT_BAN on content that may be hosted externally.
  */
-async function deleteEventFromRelayBySha256(sha256, env, source = 'unknown') {
+async function deleteEventFromRelayBySha256(sha256, env, source = 'unknown', reasonOverride = null) {
   try {
-    const event = await fetchNostrEventBySha256(sha256, ['wss://relay.divine.video'], env);
-    if (!event?.id) {
-      console.log(`[RELAY-ENFORCE] ${sha256} - No relay event found, skipping delete`);
+    const events = await fetchNostrVideoEventsByDTag(sha256, ['wss://relay.divine.video'], env, { limit: 50 });
+    const fallbackEvent = events.length === 0
+      ? await fetchNostrEventBySha256(sha256, ['wss://relay.divine.video'], env)
+      : null;
+    const eventIds = events.length > 0
+      ? events.map((event) => event?.id)
+      : [fallbackEvent?.id];
+
+    if (eventIds.filter(Boolean).length === 0) {
+      console.log(`[RELAY-ENFORCE] ${sha256} - No relay events found for d-tag, skipping delete`);
       return { success: false, reason: 'no_event_found' };
     }
 
-    const result = await callRelayAdminAction(env, {
-      action: 'delete_event',
-      eventId: event.id,
-      reason: `PERMANENT_BAN enforcement (${source})`
-    });
-    console.log(`[RELAY-ENFORCE] ${sha256} - Deleted event ${event.id} from relay`);
-    return { success: true, eventId: event.id, result };
+    const result = await deleteRelayEventIds(
+      eventIds,
+      env,
+      reasonOverride || `PERMANENT_BAN enforcement (${source})`
+    );
+
+    if (result.success) {
+      console.log(`[RELAY-ENFORCE] ${sha256} - Deleted ${result.deletedCount}/${result.attemptedCount} relay event version(s)`);
+    } else {
+      console.warn(`[RELAY-ENFORCE] ${sha256} - Partial relay delete ${result.deletedCount}/${result.attemptedCount}`, result.failures);
+    }
+
+    return result;
   } catch (error) {
     console.error(`[RELAY-ENFORCE] ${sha256} - Failed to delete from relay:`, error.message);
     return { success: false, error: error.message };
@@ -1141,11 +1200,22 @@ export default {
 
       const body = await request.json().catch(() => ({}));
       const moderatorEmail = getAuthenticatedUser(request) || 'admin';
-      const relayResult = await callRelayAdminAction(env, {
-        action: 'delete_event',
-        eventId,
-        reason: body.reason || `Deleted by moderator ${moderatorEmail}`
-      });
+      const reason = body.reason || `Deleted by moderator ${moderatorEmail}`;
+      const relayResult = isValidSha256(body.sha256)
+        ? await deleteEventFromRelayBySha256(body.sha256, env, 'admin-delete-event', reason)
+        : await deleteRelayEventIds([eventId], env, reason);
+
+      if (!relayResult.success) {
+        return new Response(JSON.stringify({
+          success: false,
+          eventId,
+          relayResult,
+          error: relayResult.error || relayResult.reason || 'Failed to delete relay event'
+        }), {
+          status: 502,
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }
 
       return new Response(JSON.stringify({
         success: true,

--- a/src/nostr/relay-client.mjs
+++ b/src/nostr/relay-client.mjs
@@ -4,8 +4,106 @@
 // ABOUTME: Nostr relay WebSocket client for fetching event context
 // ABOUTME: Connects to relay.divine.video to get kind 34236 video events by SHA256
 
+async function queryRelay(relayUrl, filter, env = {}, options = {}) {
+  return new Promise((resolve, reject) => {
+    let ws;
+    let settled = false;
+    let subscriptionId = null;
+    const collectAll = Boolean(options.collectAll);
+    const events = [];
+    let firstEvent = null;
+    const timeout = setTimeout(() => {
+      try {
+        if (ws) ws.close();
+      } catch {}
+      finish(new Error('WebSocket timeout'));
+    }, 5000); // 5 second timeout - should be fast with direct query
+
+    function finish(resultOrError) {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+
+      if (resultOrError instanceof Error) {
+        reject(resultOrError);
+        return;
+      }
+
+      resolve(resultOrError);
+    }
+
+    try {
+      // Build WebSocket URL with Cloudflare Access headers
+      const headers = {};
+      if (env.CF_ACCESS_CLIENT_ID && env.CF_ACCESS_CLIENT_SECRET) {
+        headers['CF-Access-Client-Id'] = env.CF_ACCESS_CLIENT_ID;
+        headers['CF-Access-Client-Secret'] = env.CF_ACCESS_CLIENT_SECRET;
+      }
+
+      ws = new WebSocket(relayUrl, { headers });
+
+      ws.addEventListener('open', () => {
+        subscriptionId = Math.random().toString(36).substring(7);
+        const reqMessage = JSON.stringify([
+          'REQ',
+          subscriptionId,
+          filter
+        ]);
+
+        console.log(`[NOSTR] Querying ${relayUrl}: ${JSON.stringify(filter)}`);
+        ws.send(reqMessage);
+      });
+
+      ws.addEventListener('message', (msg) => {
+        try {
+          const data = JSON.parse(msg.data);
+
+          if (data[0] === 'EVENT' && data[1] === subscriptionId) {
+            const event = data[2];
+            if (collectAll) {
+              if (event?.id && !events.some((existing) => existing.id === event.id)) {
+                events.push(event);
+              }
+            } else if (!firstEvent) {
+              firstEvent = event;
+              try {
+                ws.close();
+              } catch {}
+              finish(event);
+            }
+          }
+
+          if (data[0] === 'EOSE' && data[1] === subscriptionId) {
+            try {
+              ws.close();
+            } catch {}
+            finish(collectAll ? events : firstEvent);
+          }
+        } catch (err) {
+          console.error('[NOSTR] Failed to parse message:', err);
+        }
+      });
+
+      ws.addEventListener('error', (err) => {
+        finish(err instanceof Error ? err : new Error('WebSocket error'));
+      });
+
+      ws.addEventListener('close', () => {
+        finish(collectAll ? events : firstEvent);
+      });
+
+    } catch (error) {
+      finish(error instanceof Error ? error : new Error('WebSocket setup failed'));
+    }
+  });
+}
+
 /**
- * Fetch Nostr event for a video SHA256 from relay
+ * Fetch Nostr event for a video SHA256 from relay.
+ * The d-tag in kind 34236 video events contains the SHA256 hash directly.
+ *
  * @param {string} sha256 - Video hash
  * @param {string[]} relays - Relay URLs to query
  * @param {Object} env - Environment variables (for Cloudflare Access tokens)
@@ -14,7 +112,11 @@
 export async function fetchNostrEventBySha256(sha256, relays = ['wss://relay.divine.video'], env = {}) {
   for (const relay of relays) {
     try {
-      const event = await fetchFromRelay(relay, sha256, env);
+      const event = await queryRelay(relay, {
+        kinds: [34236],
+        '#d': [sha256],
+        limit: 1
+      }, env);
       if (event) {
         return event;
       }
@@ -27,90 +129,33 @@ export async function fetchNostrEventBySha256(sha256, relays = ['wss://relay.div
 }
 
 /**
- * Connect to a single relay and query for event using efficient #d tag filter
- * The 'd' tag in kind 34236 events contains the SHA256 hash directly
+ * Fetch all addressable video event versions for a d-tag / SHA256.
+ *
+ * @param {string} dTag - Addressable event d-tag, which for Divine videos is the media SHA256
+ * @param {string[]} relays - Relay URLs to query
+ * @param {Object} env - Environment variables (for Cloudflare Access tokens)
+ * @param {Object} options - Query options
+ * @returns {Promise<Object[]>} Matching video events
  */
-async function fetchFromRelay(relayUrl, sha256, env = {}) {
-  return new Promise((resolve, reject) => {
-    let ws;
-    const timeout = setTimeout(() => {
-      if (ws) ws.close();
-      reject(new Error('WebSocket timeout'));
-    }, 5000); // 5 second timeout - should be fast with direct query
+export async function fetchNostrVideoEventsByDTag(dTag, relays = ['wss://relay.divine.video'], env = {}, options = {}) {
+  const limit = Number.isInteger(options.limit) && options.limit > 0 ? options.limit : 50;
 
+  for (const relay of relays) {
     try {
-      // Build WebSocket URL with Cloudflare Access headers
-      const headers = {};
-      if (env.CF_ACCESS_CLIENT_ID && env.CF_ACCESS_CLIENT_SECRET) {
-        headers['CF-Access-Client-Id'] = env.CF_ACCESS_CLIENT_ID;
-        headers['CF-Access-Client-Secret'] = env.CF_ACCESS_CLIENT_SECRET;
+      const events = await queryRelay(relay, {
+        kinds: [34235, 34236],
+        '#d': [dTag],
+        limit
+      }, env, { collectAll: true });
+      if (events.length > 0) {
+        return events;
       }
-
-      ws = new WebSocket(relayUrl, { headers });
-      let foundEvent = null;
-
-      ws.addEventListener('open', () => {
-        // Query directly by #d tag (the SHA256 hash) - much faster than fetching all events
-        const subscriptionId = Math.random().toString(36).substring(7);
-        const reqMessage = JSON.stringify([
-          'REQ',
-          subscriptionId,
-          {
-            kinds: [34236],
-            '#d': [sha256],
-            limit: 1
-          }
-        ]);
-
-        console.log(`[NOSTR] Querying ${relayUrl} by #d tag for SHA256: ${sha256.substring(0, 16)}...`);
-        ws.send(reqMessage);
-      });
-
-      ws.addEventListener('message', (msg) => {
-        try {
-          const data = JSON.parse(msg.data);
-
-          // Check if this is an EVENT message
-          if (data[0] === 'EVENT' && !foundEvent) {
-            const event = data[2];
-            console.log(`[NOSTR] Found event for SHA256: ${sha256.substring(0, 16)}...`);
-            foundEvent = event;
-            clearTimeout(timeout);
-            ws.close();
-            resolve(event);
-          }
-
-          // Check if this is an EOSE (end of stored events)
-          if (data[0] === 'EOSE') {
-            clearTimeout(timeout);
-            ws.close();
-            if (!foundEvent) {
-              console.log(`[NOSTR] No event found for SHA256: ${sha256.substring(0, 16)}...`);
-              resolve(null);
-            }
-          }
-        } catch (err) {
-          console.error('[NOSTR] Failed to parse message:', err);
-        }
-      });
-
-      ws.addEventListener('error', (err) => {
-        clearTimeout(timeout);
-        reject(err);
-      });
-
-      ws.addEventListener('close', () => {
-        clearTimeout(timeout);
-        if (!foundEvent) {
-          resolve(null);
-        }
-      });
-
     } catch (error) {
-      clearTimeout(timeout);
-      reject(error);
+      console.error(`[NOSTR] Failed to fetch versions from ${relay}:`, error);
     }
-  });
+  }
+
+  return [];
 }
 
 /**

--- a/src/nostr/relay-client.test.mjs
+++ b/src/nostr/relay-client.test.mjs
@@ -1,8 +1,14 @@
 // This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
 // If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import { describe, it, expect } from 'vitest';
-import { parseVideoEventMetadata, isOriginalVine } from './relay-client.mjs';
+import { afterEach, describe, it, expect } from 'vitest';
+import { fetchNostrVideoEventsByDTag, parseVideoEventMetadata, isOriginalVine } from './relay-client.mjs';
+
+const OriginalWebSocket = globalThis.WebSocket;
+
+afterEach(() => {
+  globalThis.WebSocket = OriginalWebSocket;
+});
 
 describe('parseVideoEventMetadata', () => {
   it('extracts title from title tag', () => {
@@ -152,5 +158,56 @@ describe('isOriginalVine', () => {
 
   it('returns false for empty object with no vine indicators', () => {
     expect(isOriginalVine({ client: 'some-other-client', platform: 'youtube' })).toBe(false);
+  });
+});
+
+describe('fetchNostrVideoEventsByDTag', () => {
+  it('returns all matching event versions for the d-tag', async () => {
+    const sha256 = 'a'.repeat(64);
+    const versionA = { id: 'b'.repeat(64), kind: 34236, tags: [['d', sha256]] };
+    const versionB = { id: 'c'.repeat(64), kind: 34236, tags: [['d', sha256]] };
+
+    class FakeWebSocket {
+      constructor() {
+        this.listeners = {};
+        this.readyState = 0;
+        queueMicrotask(() => {
+          this.readyState = 1;
+          this.emit('open');
+        });
+      }
+
+      addEventListener(type, handler) {
+        if (!this.listeners[type]) {
+          this.listeners[type] = [];
+        }
+        this.listeners[type].push(handler);
+      }
+
+      send(message) {
+        const [, subscriptionId] = JSON.parse(message);
+        queueMicrotask(() => {
+          this.emit('message', { data: JSON.stringify(['EVENT', subscriptionId, versionA]) });
+          this.emit('message', { data: JSON.stringify(['EVENT', subscriptionId, versionB]) });
+          this.emit('message', { data: JSON.stringify(['EOSE', subscriptionId]) });
+        });
+      }
+
+      close() {
+        this.readyState = 3;
+        queueMicrotask(() => this.emit('close'));
+      }
+
+      emit(type, event = {}) {
+        for (const handler of this.listeners[type] || []) {
+          handler(event);
+        }
+      }
+    }
+
+    globalThis.WebSocket = FakeWebSocket;
+
+    const events = await fetchNostrVideoEventsByDTag(sha256);
+    expect(events).toEqual([versionA, versionB]);
   });
 });

--- a/src/uploader-enforcement.test.mjs
+++ b/src/uploader-enforcement.test.mjs
@@ -312,4 +312,95 @@ describe('admin uploader enforcement routes', () => {
       globalThis.fetch = originalFetch;
     }
   });
+
+  it('deletes all relay event versions when sha256 is provided', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalWebSocket = globalThis.WebSocket;
+    const secondEventId = 'd'.repeat(64);
+    const fetchCalls = [];
+
+    class FakeWebSocket {
+      constructor() {
+        this.listeners = {};
+        this.readyState = 0;
+        queueMicrotask(() => {
+          this.readyState = 1;
+          this.emit('open');
+        });
+      }
+
+      addEventListener(type, handler) {
+        if (!this.listeners[type]) {
+          this.listeners[type] = [];
+        }
+        this.listeners[type].push(handler);
+      }
+
+      send(message) {
+        const [, subscriptionId] = JSON.parse(message);
+        queueMicrotask(() => {
+          this.emit('message', {
+            data: JSON.stringify(['EVENT', subscriptionId, { id: EVENT_ID, kind: 34236, tags: [['d', SHA256]] }])
+          });
+          this.emit('message', {
+            data: JSON.stringify(['EVENT', subscriptionId, { id: secondEventId, kind: 34236, tags: [['d', SHA256]] }])
+          });
+          this.emit('message', { data: JSON.stringify(['EOSE', subscriptionId]) });
+        });
+      }
+
+      close() {
+        this.readyState = 3;
+        queueMicrotask(() => this.emit('close'));
+      }
+
+      emit(type, event = {}) {
+        for (const handler of this.listeners[type] || []) {
+          handler(event);
+        }
+      }
+    }
+
+    globalThis.WebSocket = FakeWebSocket;
+    globalThis.fetch = async (input, init) => {
+      fetchCalls.push({ input: String(input), init });
+      return new Response(JSON.stringify({ success: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    };
+
+    try {
+      const response = await worker.fetch(
+        new Request(`https://moderation.admin.divine.video/admin/api/event/${EVENT_ID}/delete`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Cf-Access-Authenticated-User-Email': 'mod@divine.video'
+          },
+          body: JSON.stringify({
+            reason: 'Delete all versions',
+            sha256: SHA256
+          })
+        }),
+        createEnv({
+          RELAY_ADMIN_URL: 'https://relay.admin.divine.video'
+        })
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toMatchObject({
+        success: true,
+        relayResult: {
+          deletedCount: 2,
+          attemptedCount: 2
+        }
+      });
+      expect(fetchCalls).toHaveLength(2);
+      expect(fetchCalls.map((call) => JSON.parse(call.init.body).eventId)).toEqual([EVENT_ID, secondEventId]);
+    } finally {
+      globalThis.fetch = originalFetch;
+      globalThis.WebSocket = originalWebSocket;
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- delete every addressable event version for a video sha instead of only one event id
- send the lookup card sha256 through the delete-event admin action so relay deletion can fan out across all versions
- add relay lookup and delete regression tests for multi-version videos

## Testing
- npx vitest run src/nostr/relay-client.test.mjs src/uploader-enforcement.test.mjs
- node --check src/index.mjs
- npm run lint
- npm test