### PR TITLE
feat: rewrite moderation DM templates for clarity and content links

### DIFF
--- a/src/nostr/dm-sender.mjs
+++ b/src/nostr/dm-sender.mjs
@@ -31,20 +31,29 @@ const FOOTER_LINKS = 'divine.video/terms | about.divine.video/faqs/ | divine.vid
 
 const TEMPLATES = {
   PERMANENT_BAN: (reason, sha256) =>
-    `Your content was removed because it was found to ${reason}.\n\nIf you believe this was a mistake, you can reply to this message to appeal.\n\ndivine.video/video/${sha256}\n${FOOTER_LINKS}`,
+    `Your content was removed because it was found to ${reason}.\n\nIf you believe this was a mistake, you can reply to this message to appeal.\n\n${sha256 ? `divine.video/video/${sha256}\n` : ''}${FOOTER_LINKS}`,
 
   AGE_RESTRICTED: (reason, sha256) =>
-    `Your content has been age-restricted because it was found to ${reason}. It's still available, but only visible to viewers who have confirmed their age.\n\ndivine.video/video/${sha256}\n${FOOTER_LINKS}`,
+    `Your content has been age-restricted because it was found to ${reason}. It's still available, but only visible to viewers who have confirmed their age.\n\n${sha256 ? `divine.video/video/${sha256}\n` : ''}${FOOTER_LINKS}`,
 
   // QUARANTINE intentionally ignores reason — the message is generic per spec
   QUARANTINE: (_reason, sha256) =>
-    `Your content has been temporarily hidden while we review it. A moderator will take a look shortly. If you'd like to provide context, you can reply to this message.\n\ndivine.video/video/${sha256}\n${FOOTER_LINKS}`,
+    `Your content has been temporarily hidden while we review it. A moderator will take a look shortly. If you'd like to provide context, you can reply to this message.\n\n${sha256 ? `divine.video/video/${sha256}\n` : ''}${FOOTER_LINKS}`,
 
   REPORT_OUTCOME: (action) =>
     `Thank you for your report. After review, the reported content has been ${action}. We appreciate your help keeping the community safe.`,
 };
 
+// Per-action default reasons so AGE_RESTRICTED gets its own fallback text
+const DEFAULT_REASONS = {
+  PERMANENT_BAN: 'violate Divine\'s content policies',
+  AGE_RESTRICTED: 'contain material that may not be suitable for all audiences',
+  QUARANTINE: '', // QUARANTINE template ignores reason
+};
+
 // --- Category-Specific Templates ---
+// NOTE: `policy` URLs are retained for future use but intentionally not included
+// in DM text until those pages exist. See 2026-03-19-dm-alignment-design.md.
 
 const CATEGORY_TEMPLATES = {
   nudity: {
@@ -102,24 +111,19 @@ export function selectTemplate(action, reason, categories, sha256) {
     }
   }
 
-  // Per-action default reasons so AGE_RESTRICTED gets its own fallback text
-  const DEFAULT_REASONS = {
-    PERMANENT_BAN: 'violate Divine\'s content policies',
-    AGE_RESTRICTED: 'contain material that may not be suitable for all audiences',
-    QUARANTINE: '', // QUARANTINE template ignores reason
-  };
-
   // Category reason takes priority. Caller-provided reason is ignored because it may not
   // fit the "was found to {reason}" grammar (e.g., "Manual moderator action").
   // Per-action defaults provide grammatically correct fallbacks.
   const specificReason = categoryInfo?.reason || DEFAULT_REASONS[action] || 'violate Divine\'s content policies';
   const extra = categoryInfo?.extra || '';
-  const contentHash = sha256 || 'unknown';
 
   const template = TEMPLATES[action];
   if (!template) return null;
 
-  return template(specificReason, contentHash) + extra;
+  // When sha256 is missing, omit the content link rather than showing a broken URL
+  const body = sha256 ? template(specificReason, sha256) : template(specificReason, null);
+
+  return extra ? body.replace(`\n${FOOTER_LINKS}`, `${extra}\n\n${FOOTER_LINKS}`) : body;
 }
 
 /**
@@ -128,7 +132,7 @@ export function selectTemplate(action, reason, categories, sha256) {
  * @param {string} reason
  * @returns {string|null} Message text or null if action has no template
  */
-export function getMessageForAction(action, reason = 'violate Divine\'s content policies', sha256 = 'unknown') {
+export function getMessageForAction(action, reason = 'violate Divine\'s content policies', sha256 = null) {
   const template = TEMPLATES[action];
   return template ? template(reason, sha256) : null;
 }

--- a/src/nostr/dm-sender.test.mjs
+++ b/src/nostr/dm-sender.test.mjs
@@ -60,6 +60,7 @@ describe('DM Sender - Message Templates', () => {
   it('should use default reason when none provided', () => {
     const message = getMessageForAction('PERMANENT_BAN');
     expect(message).toContain('content policies');
+    expect(message).not.toContain('divine.video/video/');
   });
 
   it('should produce correct report outcome message', () => {
@@ -276,7 +277,7 @@ describe('DM Sender - selectTemplate (Category-Specific)', () => {
     expect(msg).not.toContain('https://divine.video/policies#sexual-content');
   });
 
-  it('should include crisis resources for self_harm category', () => {
+  it('should include crisis resources for self_harm category before footer', () => {
     const msg = selectTemplate('PERMANENT_BAN', null, '{"self_harm": 0.8}', 'abc123');
 
     expect(msg).toContain('self-harm');
@@ -284,6 +285,10 @@ describe('DM Sender - selectTemplate (Category-Specific)', () => {
     expect(msg).toContain('suicide.org/international-suicide-hotlines.html');
     expect(msg).toContain('988');
     expect(msg).not.toContain('https://divine.video/policies#self-harm');
+    // Crisis resources should appear before footer links
+    const crisisIdx = msg.indexOf('helpguide.org');
+    const footerIdx = msg.indexOf('divine.video/terms');
+    expect(crisisIdx).toBeLessThan(footerIdx);
   });
 
   it('should ignore caller-provided reason for QUARANTINE (intentional)', () => {
@@ -369,7 +374,8 @@ describe('DM Sender - selectTemplate (Category-Specific)', () => {
   it('should handle missing sha256 gracefully', () => {
     const msg = selectTemplate('PERMANENT_BAN', null, null, null);
 
-    expect(msg).toContain('divine.video/video/unknown');
+    expect(msg).not.toContain('divine.video/video/');
     expect(msg).toContain('content policies');
+    expect(msg).toContain('divine.video/terms');
   });
 });


### PR DESCRIPTION
## Summary

- Rewrites all moderation DM templates: softer tone, "your content" instead of "your video", clearer language throughout
- Adds `divine.video/video/{sha256}` content link and standard footer links (`about.divine.video/faqs/` | `divine.video/support`) to every template
- Removes category-specific policy URLs from message text until those pages exist (data retained in `CATEGORY_TEMPLATES` for future use)
- Adds per-action default reasons so AGE_RESTRICTED gets its own generic fallback ("contain material that may not be suitable for all audiences")
- QUARANTINE template intentionally ignores caller-provided reason (generic message per spec)
- `selectTemplate()` gains `sha256` parameter (already available at all call sites, no caller changes needed)

## Context

Phase 1 of the DM alignment spec (`support-trust-safety/docs/superpowers/specs/2026-03-19-dm-alignment-design.md`). Addresses #109.

Template text needs editorial review from Aleysha and Charlie before merge.

## Test Plan

- [x] All 520 tests passing (29 files)
- [x] All 3 `sendModerationDM` call sites verified -- sha256 already passed as param 2
- [x] New tests for: per-action default reasons, AGE_RESTRICTED fallback, QUARANTINE ignoring reason, self_harm + AGE_RESTRICTED, missing sha256 graceful fallback
- [x] Aleysha/Charlie review template text
- [ ] Deploy to staging and verify DM content on a test moderation action