### PR TITLE
fix: add Cache-Control no-store to admin API responses

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -49,7 +49,7 @@ const CATEGORY_TO_LABEL = {
 const ADMIN_HOSTNAME = 'moderation.admin.divine.video';
 const API_HOSTNAME = 'moderation-api.divine.video';
 const DEFAULT_RELAY_ADMIN_URL = 'https://relay.admin.divine.video';
-const JSON_HEADERS = { 'Content-Type': 'application/json' };
+const JSON_HEADERS = { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' };
 const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]']);
 
 /**
@@ -841,7 +841,7 @@ export default {
         hasMore,
         nextOffset: hasMore ? offset + limit : null
       }), {
-        headers: { 'Content-Type': 'application/json' }
+        headers: JSON_HEADERS
       });
     }
 
@@ -1024,7 +1024,7 @@ export default {
           limit,
           hasMore: offset + limit < (countResult?.total || 0)
         }), {
-          headers: { 'Content-Type': 'application/json' }
+          headers: JSON_HEADERS
         });
       } catch (error) {
         console.error('[ADMIN] Failed to fetch untriaged videos:', error);


### PR DESCRIPTION
## Summary

Mobile browsers cache GET responses for `/admin/api/videos` and `/admin/api/untriaged`. When a moderator reviews content in Quick Review, navigates away, and returns, the browser serves the cached queue instead of re-fetching. The server correctly filters out reviewed content (`reviewed_by IS NULL`), but the browser never re-asks.

Reported by Aleysha: moderated ~50 videos on mobile, went to dashboard and back, same videos reappeared.

## Changes

- Added `Cache-Control: no-store` to the shared `JSON_HEADERS` constant, which applies to all admin API JSON responses (including error responses, transcript lookups, and any endpoint using `jsonError()`/`jsonResponse()`)
- Replaced inline headers at `/admin/api/videos` and `/admin/api/untriaged` with `JSON_HEADERS` to deduplicate

The broader scope is intentional — caching is equally undesirable for all dynamic admin API responses.

## Verification

- Confirmed production responses have no Cache-Control header (curl)
- 530/530 tests passing