### PR TITLE
fix: return 502 when Blossom notification fails on moderate endpoints

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1454,13 +1454,6 @@ export default {
       // Notify Blossom of the moderation decision.
       const blossomResult = await notifyBlossom(sha256, action, env);
 
-      // For PERMANENT_BAN: also delete the event from the relay (funnelcake).
-      // This is critical for externally-hosted content where Blossom can't enforce the ban.
-      let relayDeleteResult = null;
-      if (action === 'PERMANENT_BAN') {
-        relayDeleteResult = await deleteEventFromRelayBySha256(sha256, env, 'admin-moderate');
-      }
-
       if (!blossomResult.success && !blossomResult.skipped) {
         console.warn(`[ADMIN] Blossom notification failed: ${blossomResult.error}`);
         return new Response(JSON.stringify({
@@ -1474,6 +1467,13 @@ export default {
           status: 502,
           headers: { 'Content-Type': 'application/json' }
         });
+      }
+
+      // For PERMANENT_BAN: also delete the event from the relay (funnelcake),
+      // but only after Blossom confirms enforcement to avoid partial moderation.
+      let relayDeleteResult = null;
+      if (action === 'PERMANENT_BAN') {
+        relayDeleteResult = await deleteEventFromRelayBySha256(sha256, env, 'admin-moderate');
       }
 
       // Publish kind 1984 (NIP-56) report for non-SAFE actions so human moderation

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -840,6 +840,200 @@ describe('notifyBlossom integration via admin moderate endpoint', () => {
       globalThis.fetch = origFetch;
     }
   });
+
+  it('returns 502 when Blossom webhook fails for /admin/api/moderate', async () => {
+    const sha256 = 'b'.repeat(64);
+    const kvStore = new Map();
+    const env = {
+      ALLOW_DEV_ACCESS: 'true',
+      BLOSSOM_WEBHOOK_URL: 'https://mock-blossom.test/admin/moderate',
+      BLOSSOM_WEBHOOK_SECRET: 'test-webhook-secret',
+      BLOSSOM_DB: createDbMock({
+        moderationResults: new Map([[sha256, {
+          sha256,
+          action: 'REVIEW',
+          provider: 'hiveai',
+          scores: JSON.stringify({}),
+          categories: JSON.stringify([]),
+          moderated_at: '2026-03-12T00:00:00.000Z',
+          reviewed_by: null,
+          reviewed_at: null
+        }]])
+      }),
+      MODERATION_KV: {
+        store: kvStore,
+        async get(key) { return kvStore.get(key) ?? null; },
+        async put(key, value) { kvStore.set(key, value); },
+        async delete(key) { kvStore.delete(key); },
+        async list() { return { keys: [], list_complete: true, cursor: null }; }
+      },
+      MODERATION_QUEUE: { async send() {} },
+    };
+
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = async (url, init) => {
+      if (url === 'https://mock-blossom.test/admin/moderate') {
+        return new Response('Service Unavailable', { status: 503 });
+      }
+      return origFetch(url, init);
+    };
+
+    try {
+      const response = await worker.fetch(
+        new Request(`https://moderation.admin.divine.video/admin/api/moderate/${sha256}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ action: 'AGE_RESTRICTED', reason: 'test age restrict' })
+        }),
+        env
+      );
+
+      expect(response.status).toBe(502);
+      const data = await response.json();
+      expect(data.success).toBe(false);
+      expect(data.blossom_notified).toBe(false);
+      expect(data.action).toBe('AGE_RESTRICTED');
+      expect(data.previousAction).toBe('REVIEW');
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  it('does not delete relay events when Blossom webhook fails for /admin/api/moderate', async () => {
+    const sha256 = 'c'.repeat(64);
+    const kvStore = new Map();
+    let relayAdminCalls = 0;
+    let relaySocketConstructed = 0;
+    const env = {
+      ALLOW_DEV_ACCESS: 'true',
+      BLOSSOM_WEBHOOK_URL: 'https://mock-blossom.test/admin/moderate',
+      BLOSSOM_WEBHOOK_SECRET: 'test-webhook-secret',
+      RELAY_ADMIN_URL: 'https://relay-admin.test',
+      BLOSSOM_DB: createDbMock({
+        moderationResults: new Map([[sha256, {
+          sha256,
+          action: 'REVIEW',
+          provider: 'hiveai',
+          scores: JSON.stringify({}),
+          categories: JSON.stringify([]),
+          moderated_at: '2026-03-12T00:00:00.000Z',
+          reviewed_by: null,
+          reviewed_at: null
+        }]])
+      }),
+      MODERATION_KV: {
+        store: kvStore,
+        async get(key) { return kvStore.get(key) ?? null; },
+        async put(key, value) { kvStore.set(key, value); },
+        async delete(key) { kvStore.delete(key); },
+        async list() { return { keys: [], list_complete: true, cursor: null }; }
+      },
+      MODERATION_QUEUE: { async send() {} },
+    };
+
+    const origFetch = globalThis.fetch;
+    const OrigWebSocket = globalThis.WebSocket;
+    globalThis.fetch = async (url, init) => {
+      if (url === 'https://mock-blossom.test/admin/moderate') {
+        return new Response('Service Unavailable', { status: 503 });
+      }
+      if (typeof url === 'string' && url.startsWith('https://relay-admin.test')) {
+        relayAdminCalls += 1;
+        return new Response(JSON.stringify({ success: true }), { status: 200 });
+      }
+      return origFetch(url, init);
+    };
+    globalThis.WebSocket = class {
+      constructor() {
+        relaySocketConstructed += 1;
+      }
+      addEventListener() {}
+      close() {}
+      send() {}
+    };
+
+    try {
+      const response = await worker.fetch(
+        new Request(`https://moderation.admin.divine.video/admin/api/moderate/${sha256}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ action: 'PERMANENT_BAN', reason: 'test ban' })
+        }),
+        env
+      );
+
+      expect(response.status).toBe(502);
+      expect(relayAdminCalls).toBe(0);
+      expect(relaySocketConstructed).toBe(0);
+    } finally {
+      globalThis.fetch = origFetch;
+      globalThis.WebSocket = OrigWebSocket;
+    }
+  });
+
+  it('returns 502 when Blossom webhook fails for /api/v1/quarantine', async () => {
+    const sha256 = 'd'.repeat(64);
+    const kvStore = new Map();
+    const env = {
+      ALLOW_DEV_ACCESS: 'true',
+      SERVICE_API_TOKEN: 'test-service-token',
+      BLOSSOM_WEBHOOK_URL: 'https://mock-blossom.test/admin/moderate',
+      BLOSSOM_WEBHOOK_SECRET: 'test-webhook-secret',
+      BLOSSOM_DB: createDbMock({
+        moderationResults: new Map([[sha256, {
+          sha256,
+          action: 'REVIEW',
+          provider: 'hiveai',
+          scores: JSON.stringify({}),
+          categories: JSON.stringify([]),
+          moderated_at: '2026-03-12T00:00:00.000Z',
+          reviewed_by: null,
+          reviewed_at: null
+        }]])
+      }),
+      MODERATION_KV: {
+        store: kvStore,
+        async get(key) { return kvStore.get(key) ?? null; },
+        async put(key, value) { kvStore.set(key, value); },
+        async delete(key) { kvStore.delete(key); },
+        async list() { return { keys: [], list_complete: true, cursor: null }; }
+      },
+      MODERATION_QUEUE: { async send() {} },
+    };
+
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = async (url, init) => {
+      if (url === 'https://mock-blossom.test/admin/moderate') {
+        return new Response('Service Unavailable', { status: 503 });
+      }
+      return origFetch(url, init);
+    };
+
+    try {
+      const response = await worker.fetch(
+        new Request(`https://moderation-api.divine.video/api/v1/quarantine/${sha256}`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': 'Bearer test-service-token',
+          },
+          body: JSON.stringify({
+            quarantine: true,
+            reason: 'test quarantine',
+          }),
+        }),
+        env
+      );
+
+      expect(response.status).toBe(502);
+      const data = await response.json();
+      expect(data.success).toBe(false);
+      expect(data.blossom_notified).toBe(false);
+      expect(data.action).toBe('QUARANTINE');
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
 });
 
 describe('DM exclusion for QUARANTINE via admin moderate', () => {


### PR DESCRIPTION
## Summary
- `/api/v1/moderate`, `/admin/api/moderate`, and `/api/v1/quarantine` returned 200 even when the Blossom webhook failed, hiding enforcement failures from callers
- Now returns 502 with `blossom_notified: false` when the media server doesn't confirm, while still recording the moderation decision in D1
- Early return also prevents downstream side effects (DMs to creators, kind 1984 reports, reporter notifications) from firing for actions that didn't land on the media server
- CRON and pipeline paths intentionally stay as log-and-continue (no caller to return to, downstream side effects still need to fire)

## Context

Found while investigating Aleysha's age-restrict test in production. The relay admin showed "Remove Restriction" (success state) but the video was still live. Root cause: moderation-service told relay-manager the action succeeded even though Blossom never got the message.

Companion fix on divine-relay-manager PR #38 adds a verification step with a 1-second delay.

Rabble's divine-blossom #43 (merged Mar 27) already enforces Banned and Restricted checks on HLS content endpoints, so once the action reaches Blossom, age-restricted content is properly gated on all serving paths.

## Test plan
- [x] Unit tests: 502 on Blossom failure, 200 on success (both via `/api/v1/moderate`)
- [x] Existing Blossom integration tests still pass (534 total)
- [x] Local curl verification: wrangler dev with unreachable Blossom returns 502, mock Blossom returns 200
- [ ] Staging: deploy and test age-restrict flow end-to-end with relay-manager