### PR TITLE
fix: guard sendModerationDM against null options argument

### DIFF
--- a/src/nostr/dm-sender.mjs
+++ b/src/nostr/dm-sender.mjs
@@ -536,7 +536,7 @@ function publishToSingleRelay(event, relayUrl, env) {
  * @returns {Promise<{ sent: boolean, reason?: string }>}
  */
 export async function sendModerationDM(recipientPubkey, sha256, action, reason, env, ctx, options = {}) {
-  const { categories = null, title = null, publishedAt = null } = options;
+  const { categories = null, title = null, publishedAt = null } = options || {};
   try {
     // Validate inputs
     if (!recipientPubkey || typeof recipientPubkey !== 'string') {

--- a/src/nostr/dm-sender.test.mjs
+++ b/src/nostr/dm-sender.test.mjs
@@ -309,6 +309,17 @@ describe('DM Sender - Error Handling', () => {
     expect(result.sent).toBe(false);
   });
 
+  it('should not throw when options is explicitly null', async () => {
+    const env = {};
+    const ctx = { waitUntil: vi.fn() };
+
+    const result = await sendModerationDM('b'.repeat(64), 'c'.repeat(64), 'PERMANENT_BAN', 'test', env, ctx, null);
+    expect(result).toBeDefined();
+    expect(result.sent).toBe(false);
+    // Should fail gracefully (no keys configured) rather than TypeError on null destructuring
+    expect(result.reason).toContain('NOSTR_PRIVATE_KEY');
+  });
+
   it('should not throw when relay connection fails', async () => {
     const mockKV = {
       get: vi.fn().mockResolvedValue(null),


### PR DESCRIPTION
## Merge order

**Merge after #47** (reporter notifications), which introduces the options object signature this PR hardens.

## Summary

- `sendModerationDM(..., options = {})` defaults safely when omitted, but throws TypeError when explicit `null` is passed (destructuring `null` fails)
- Normalizes with `options || {}` before destructuring
- Adds a focused test for the null case

Closes #59