### PR TITLE
chore: remove redundant catch wrappers around notifyReporters

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1519,7 +1519,7 @@ export default {
 
       // Notify reporters who filed reports on this content (non-blocking)
       const { notifyReporters } = await import('./nostr/dm-sender.mjs');
-      notifyReporters(sha256, action, env, '[ADMIN]').catch(() => {});
+      notifyReporters(sha256, action, env, '[ADMIN]');
 
       // Notify ATProto labeler of manual override
       notifyAtprotoLabeler({ sha256, action, scores: updated.scores || {}, reviewed_by: 'admin' }, env).catch(err => {
@@ -3620,7 +3620,7 @@ async function runMigration() {
 
                   // Notify reporters
                   const { notifyReporters: notifyCronReporters } = await import('./nostr/dm-sender.mjs');
-                  notifyCronReporters(sha256, 'PERMANENT_BAN', env, '[CRON]').catch(() => {});
+                  notifyCronReporters(sha256, 'PERMANENT_BAN', env, '[CRON]');
 
                   // Mark escalation complete so cron doesn't retry
                   const rdCached = await env.MODERATION_KV.get(`rd:${sha256}`);
@@ -3729,7 +3729,7 @@ async function handleModerationResult(result, env) {
 
   // Notify reporters who filed reports on this content (non-blocking)
   const { notifyReporters: notifyReportersOfOutcome } = await import('./nostr/dm-sender.mjs');
-  notifyReportersOfOutcome(sha256, action, env, '[MODERATION]').catch(() => {});
+  notifyReportersOfOutcome(sha256, action, env, '[MODERATION]');
 
   // Write normalized moderation labels to ClickHouse
   try {


### PR DESCRIPTION
Replaces #62 (auto-closed when I squash-merged #61 with --delete-branch -- GitHub deleted the base branch #62 was targeting and auto-closed it). I should have retargeted #62 to main before merging #61. Lesson learned, won't happen again.

Same code Liz already approved on #62, same branch, just rebased onto main now that #61 is merged.

## Summary

- `notifyReporters` catches internally and never throws
- Call sites in `index.mjs` still wrap it in `.catch(() => {})` -- redundant and obscures failure behavior
- Removes 3 empty catch wrappers, keeps internal logging intact

Closes #60