### PR TITLE
fix: restore code clobbered by stale branch merge

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1523,7 +1523,7 @@ export default {
 
       // Notify reporters who filed reports on this content (non-blocking)
       const { notifyReporters } = await import('./nostr/dm-sender.mjs');
-      notifyReporters(sha256, action, env, '[ADMIN]');
+      notifyReporters(sha256, action, env, '[ADMIN]').catch(() => {});
       // Notify ATProto labeler of manual override
       notifyAtprotoLabeler({ sha256, action, scores: updated.scores || {}, reviewed_by: 'admin' }, env).catch(err => {
         console.error('[ADMIN] ATProto labeler notification failed:', err.message);
@@ -3649,7 +3649,7 @@ async function runMigration() {
 
                   // Notify reporters
                   const { notifyReporters: notifyCronReporters } = await import('./nostr/dm-sender.mjs');
-                  notifyCronReporters(sha256, 'PERMANENT_BAN', env, '[CRON]');
+                  notifyCronReporters(sha256, 'PERMANENT_BAN', env, '[CRON]').catch(() => {});
 
                   // Mark escalation complete so cron doesn't retry
                   const rdCached = await env.MODERATION_KV.get(`rd:${sha256}`);
@@ -3750,7 +3750,7 @@ async function handleModerationResult(result, env) {
 
   // Notify reporters who filed reports on this content (non-blocking)
   const { notifyReporters: notifyReportersOfOutcome } = await import('./nostr/dm-sender.mjs');
-  notifyReportersOfOutcome(sha256, action, env, '[MODERATION]');
+  notifyReportersOfOutcome(sha256, action, env, '[MODERATION]').catch(() => {});
 
   // Write normalized moderation labels to ClickHouse
   try {

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -9,6 +9,7 @@ import { moderateVideo, classifyVideoOnly } from './moderation/pipeline.mjs';
 import { publishToFaro, publishToContentRelay, publishLabelEvent } from './nostr/publisher.mjs';
 import { requireAuth, getAuthenticatedUser } from './admin/auth.mjs';
 import { verifyZeroTrustJWT } from './admin/zerotrust.mjs';
+import { getConfiguredBearerTokens, authenticateApiRequest, apiUnauthorizedResponse, authSourceFromVerification, verifyLegacyBearerAuth } from './auth-api.mjs';
 import { fetchNostrEventBySha256, fetchNostrVideoEventsByDTag, parseVideoEventMetadata } from './nostr/relay-client.mjs';
 import { pollRelayForVideos, getLastPollTimestamp, setLastPollTimestamp, getPollingStatus } from './nostr/relay-poller.mjs';
 import { getPublicKey } from 'nostr-tools/pure';
@@ -22,8 +23,11 @@ import { initUploaderEnforcementTable, getUploaderEnforcement, setUploaderEnforc
 import { formatForStorage, formatForGorse, formatForFunnelcake } from './classification/pipeline.mjs';
 import { topicsToLabels, topicsToWeightedFeatures } from './classification/topic-extractor.mjs';
 import { getKVThresholds, setKVThresholds, DEFAULT_THRESHOLDS } from './moderation/classifier.mjs';
+import { isValidSha256, isValidLookupIdentifier, isValidPubkey, parseMaybeJson, getEventTagValue, parseImetaParams, extractShaFromUrl, extractMediaShaFromEvent } from './validation.mjs';
 import { parseVttText } from './moderation/text-classifier.mjs';
 import { notifyAtprotoLabeler } from './atproto/label-webhook.mjs';
+import { buildDownstreamPublishContext } from './moderation/downstream-publishing.mjs';
+import { runClassicVineRollback } from './moderation/classic-vine-rollback.mjs';
 /**
  * NIP-32 label mapping for content categories
  * Maps internal category names to NIP-32/NIP-56 compatible labels
@@ -47,7 +51,7 @@ const CATEGORY_TO_LABEL = {
 const ADMIN_HOSTNAME = 'moderation.admin.divine.video';
 const API_HOSTNAME = 'moderation-api.divine.video';
 const DEFAULT_RELAY_ADMIN_URL = 'https://relay.admin.divine.video';
-const JSON_HEADERS = { 'Content-Type': 'application/json' };
+const JSON_HEADERS = { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' };
 const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]']);
 
 /**
@@ -141,151 +145,9 @@ function corsResponse(response) {
   });
 }
 
-function getConfiguredBearerTokens(env) {
-  return [env.SERVICE_API_TOKEN, env.API_BEARER_TOKEN, env.MODERATION_API_KEY]
-    .filter((value, index, all) => typeof value === 'string' && value.length > 0 && all.indexOf(value) === index);
-}
-
 function hostMismatchResponse(requestId, hostname, pathname, expectedHost) {
   console.log(`[${requestId}] Rejected ${pathname} on ${hostname}; expected ${expectedHost}`);
   return jsonError(`Not found on ${hostname}. Use https://${expectedHost}${pathname}`, 404);
-}
-
-async function authenticateApiRequest(request, env) {
-  if (env.ALLOW_DEV_ACCESS === 'true') {
-    return { valid: true, email: 'dev@localhost', isServiceToken: false };
-  }
-
-  const authHeader = request.headers.get('Authorization');
-  const bearerToken = authHeader && authHeader.startsWith('Bearer ') ? authHeader.slice(7) : null;
-  const configuredTokens = getConfiguredBearerTokens(env);
-  if (bearerToken && configuredTokens.includes(bearerToken)) {
-    return { valid: true, email: 'service@internal', isServiceToken: true };
-  }
-
-  const jwtToken = request.headers.get('cf-access-jwt-assertion');
-  if (jwtToken) {
-    try {
-      return await verifyZeroTrustJWT(jwtToken, env);
-    } catch (error) {
-      return { valid: false, error: error.message };
-    }
-  }
-
-  if (configuredTokens.length === 0) {
-    return { valid: false, error: 'No bearer token configured (SERVICE_API_TOKEN/API_BEARER_TOKEN/MODERATION_API_KEY)' };
-  }
-
-  return { valid: false, error: 'Missing bearer token or Cloudflare Access JWT' };
-}
-
-function apiUnauthorizedResponse(verification) {
-  return jsonError(`Unauthorized - ${verification.error}`, 401);
-}
-
-function authSourceFromVerification(verification) {
-  return verification.email
-    ? `user:${verification.email}`
-    : `service-token:${verification.payload?.sub || 'unknown'}`;
-}
-
-function verifyLegacyBearerAuth(request, env) {
-  const configuredTokens = getConfiguredBearerTokens(env);
-  if (configuredTokens.length === 0) {
-    console.error('[AUTH] No legacy bearer token configured');
-    return jsonResponse(500, { error: 'Server misconfigured — no auth token set' });
-  }
-
-  const authHeader = request.headers.get('Authorization');
-  if (!authHeader || !authHeader.startsWith('Bearer ')) {
-    return jsonResponse(401, { error: 'Missing Authorization: Bearer <token>' });
-  }
-
-  const token = authHeader.slice(7);
-  if (!configuredTokens.includes(token)) {
-    return jsonResponse(403, { error: 'Invalid token' });
-  }
-
-  return null;
-}
-
-function isValidSha256(value) {
-  return typeof value === 'string' && /^[0-9a-f]{64}$/i.test(value);
-}
-
-function isValidLookupIdentifier(value) {
-  return typeof value === 'string' && value.length > 0 && value.length <= 255;
-}
-
-function isValidPubkey(value) {
-  return isValidSha256(value);
-}
-
-function parseMaybeJson(value, fallback) {
-  if (value == null) {
-    return fallback;
-  }
-
-  if (typeof value === 'string') {
-    try {
-      return JSON.parse(value);
-    } catch {
-      return fallback;
-    }
-  }
-
-  return value;
-}
-
-function getEventTagValue(tags, key) {
-  return tags?.find((tag) => tag[0] === key)?.[1] || null;
-}
-
-function parseImetaParams(tags) {
-  const imetaTag = tags?.find((tag) => tag[0] === 'imeta');
-  if (!imetaTag) {
-    return {};
-  }
-
-  const params = {};
-  for (let i = 1; i < imetaTag.length; i++) {
-    const entry = imetaTag[i];
-    if (!entry || typeof entry !== 'string') {
-      continue;
-    }
-
-    const separatorIndex = entry.indexOf(' ');
-    if (separatorIndex === -1) {
-      continue;
-    }
-
-    const key = entry.slice(0, separatorIndex);
-    const value = entry.slice(separatorIndex + 1).trim();
-    if (key && value) {
-      params[key] = value;
-    }
-  }
-
-  return params;
-}
-
-function extractShaFromUrl(url) {
-  if (typeof url !== 'string') {
-    return null;
-  }
-
-  const match = url.match(/[0-9a-f]{64}/i);
-  return match ? match[0].toLowerCase() : null;
-}
-
-function extractMediaShaFromEvent(event) {
-  const tags = event?.tags || [];
-  const imeta = parseImetaParams(tags);
-  return extractShaFromUrl(imeta.x)
-    || extractShaFromUrl(getEventTagValue(tags, 'x'))
-    || extractShaFromUrl(imeta.url)
-    || extractShaFromUrl(getEventTagValue(tags, 'url'))
-    || null;
 }
 
 function buildFunnelcakeVideoLookup(eventResponse, identifier) {
@@ -350,7 +212,7 @@ function mergeLookupMetadata(baseVideo, funnelcakeVideo) {
 
   return {
     ...baseVideo,
-    cdnUrl: baseVideo.cdnUrl || funnelcakeVideo.videoUrl || baseVideo.cdnUrl,
+    cdnUrl: funnelcakeVideo.videoUrl || baseVideo.cdnUrl || null,
     thumbnailUrl: baseVideo.thumbnailUrl || funnelcakeVideo.thumbnailUrl || null,
     uploaded_by: baseVideo.uploaded_by || funnelcakeVideo.uploadedBy || null,
     divineUrl: funnelcakeVideo.divineUrl || baseVideo.divineUrl,
@@ -379,9 +241,6 @@ function getRelayAdminHeaders(env) {
   return headers;
 }
 
-function getNostrLookupRelays(env) {
-  return env.NOSTR_RELAY_URL ? [env.NOSTR_RELAY_URL] : ['wss://relay.divine.video'];
-}
 
 function getTranscriptSourceUrl(sha256, env) {
   return `https://${env.CDN_DOMAIN || 'media.divine.video'}/${sha256}.vtt`;
@@ -436,63 +295,88 @@ async function callRelayAdminAction(env, payload) {
   return data;
 }
 
-/**
- * Look up the Nostr event for a SHA256 and delete it from the relay.
- * Used to enforce PERMANENT_BAN on content that may be hosted externally.
- */
-async function deleteEventFromRelayBySha256(sha256, env, source = 'unknown') {
-  try {
-    const event = await fetchNostrEventBySha256(sha256, getNostrLookupRelays(env), env);
-    if (!event?.id) {
-      console.log(`[RELAY-ENFORCE] ${sha256} - No relay event found, skipping delete`);
-      return { success: false, reason: 'no_event_found' };
-    }
-
-    const result = await callRelayAdminAction(env, {
-      action: 'delete_event',
-      eventId: event.id,
-      reason: `PERMANENT_BAN enforcement (${source})`
-    });
-    console.log(`[RELAY-ENFORCE] ${sha256} - Deleted event ${event.id} from relay`);
-    return { success: true, eventId: event.id, result };
-  } catch (error) {
-    console.error(`[RELAY-ENFORCE] ${sha256} - Failed to delete from relay:`, error.message);
-    return { success: false, error: error.message };
-  }
-}
-
-async function deleteRelayEventVersions(eventId, sha256, env, reason) {
-  const fallbackEventId = isValidSha256(eventId) ? eventId : null;
-  const events = await fetchNostrVideoEventsByDTag(sha256, getNostrLookupRelays(env), env);
-  const uniqueEventIds = [...new Set([
-    ...events.map((event) => event?.id).filter(isValidSha256),
-    fallbackEventId
-  ].filter(Boolean))];
+async function deleteRelayEventIds(eventIds, env, reason) {
+  const uniqueEventIds = [...new Set(
+    (eventIds || []).filter((eventId) => typeof eventId === 'string' && isValidSha256(eventId))
+  )];
 
   if (uniqueEventIds.length === 0) {
     return {
       success: false,
-      attemptedCount: 0,
+      reason: 'no_event_found',
+      eventId: null,
+      eventIds: [],
       deletedCount: 0,
-      deletedEventIds: [],
-      reason: 'no_event_found'
+      attemptedCount: 0,
+      failures: []
     };
   }
 
-  for (const id of uniqueEventIds) {
-    await callRelayAdminAction(env, {
-      action: 'delete_event',
-      eventId: id,
-      reason
-    });
+  const deletedEventIds = [];
+  const failures = [];
+
+  for (const eventId of uniqueEventIds) {
+    try {
+      await callRelayAdminAction(env, {
+        action: 'delete_event',
+        eventId,
+        reason
+      });
+      deletedEventIds.push(eventId);
+    } catch (error) {
+      failures.push({
+        eventId,
+        error: error instanceof Error ? error.message : String(error)
+      });
+    }
   }
 
   return {
-    success: true,
+    success: failures.length === 0,
+    eventId: deletedEventIds[0] || uniqueEventIds[0],
+    eventIds: deletedEventIds,
+    deletedCount: deletedEventIds.length,
     attemptedCount: uniqueEventIds.length,
-    deletedCount: uniqueEventIds.length,
-    deletedEventIds: uniqueEventIds
+    failures
   };
+}
+
+/**
+ * Look up all Nostr event versions for a SHA256 d-tag and delete them from the relay.
+ * Used to enforce PERMANENT_BAN on content that may be hosted externally.
+ */
+async function deleteEventFromRelayBySha256(sha256, env, source = 'unknown', reasonOverride = null) {
+  try {
+    const events = await fetchNostrVideoEventsByDTag(sha256, ['wss://relay.divine.video'], env, { limit: 50 });
+    const fallbackEvent = events.length === 0
+      ? await fetchNostrEventBySha256(sha256, ['wss://relay.divine.video'], env)
+      : null;
+    const eventIds = events.length > 0
+      ? events.map((event) => event?.id)
+      : [fallbackEvent?.id];
+
+    if (eventIds.filter(Boolean).length === 0) {
+      console.log(`[RELAY-ENFORCE] ${sha256} - No relay events found for d-tag, skipping delete`);
+      return { success: false, reason: 'no_event_found' };
+    }
+
+    const result = await deleteRelayEventIds(
+      eventIds,
+      env,
+      reasonOverride || `PERMANENT_BAN enforcement (${source})`
+    );
+
+    if (result.success) {
+      console.log(`[RELAY-ENFORCE] ${sha256} - Deleted ${result.deletedCount}/${result.attemptedCount} relay event version(s)`);
+    } else {
+      console.warn(`[RELAY-ENFORCE] ${sha256} - Partial relay delete ${result.deletedCount}/${result.attemptedCount}`, result.failures);
+    }
+
+    return result;
+  } catch (error) {
+    console.error(`[RELAY-ENFORCE] ${sha256} - Failed to delete from relay:`, error.message);
+    return { success: false, error: error.message };
+  }
 }
 
 async function fetchLookupNostrContext(hash, env) {
@@ -602,7 +486,7 @@ async function getAdminLookupVideo(identifier, env, options = {}) {
         previousAction: kvModeration?.previousAction || null,
         detailedCategories: parseMaybeJson(kvModeration?.detailedCategories, null),
         categoryVerifications: parseMaybeJson(kvModeration?.categoryVerifications, {}) || {},
-        cdnUrl
+        cdnUrl: kvModeration?.cdnUrl || cdnUrl
       }, env);
     }
 
@@ -968,24 +852,37 @@ export default {
       console.log(`[${requestId}] Fetching videos: filter=${actionFilter}, limit=${limit}, offset=${offset}`);
 
       // Build SQL query based on filter
-      let whereClause = '';
+      let conditions = [];
       const params = [];
 
       if (actionFilter === 'FLAGGED') {
-        whereClause = "WHERE action IN ('REVIEW', 'AGE_RESTRICTED', 'PERMANENT_BAN') AND reviewed_by IS NULL";
+        conditions.push("action IN ('REVIEW', 'AGE_RESTRICTED', 'PERMANENT_BAN') AND reviewed_by IS NULL");
       } else if (actionFilter === 'QUARANTINE') {
-        whereClause = "WHERE action IN ('AGE_RESTRICTED', 'PERMANENT_BAN') AND reviewed_by IS NULL";
+        conditions.push("action IN ('AGE_RESTRICTED', 'PERMANENT_BAN') AND reviewed_by IS NULL");
       } else if (actionFilter !== 'all') {
-        whereClause = 'WHERE action = ?';
+        conditions.push('action = ?');
         params.push(actionFilter.toUpperCase());
       }
+
+      // Date filter — exclude old test content from review queues
+      const sinceParam = url.searchParams.get('since');
+      if (sinceParam) {
+        conditions.push('moderated_at >= ?');
+        params.push(sinceParam);
+      }
+
+      const whereClause = conditions.length > 0 ? 'WHERE ' + conditions.join(' AND ') : '';
+
+      // Sort order — 'oldest' fetches from the back of the queue
+      const sortParam = url.searchParams.get('sort');
+      const orderDirection = sortParam === 'oldest' ? 'ASC' : 'DESC';
 
       // Query D1 with pagination
       const query = `
         SELECT sha256, action, provider, scores, categories, moderated_at, reviewed_by, reviewed_at, uploaded_by
         FROM moderation_results
         ${whereClause}
-        ORDER BY moderated_at DESC
+        ORDER BY moderated_at ${orderDirection}
         LIMIT ? OFFSET ?
       `;
       params.push(limit + 1, offset); // Fetch one extra to check if more exist
@@ -1019,7 +916,7 @@ export default {
         hasMore,
         nextOffset: hasMore ? offset + limit : null
       }), {
-        headers: { 'Content-Type': 'application/json' }
+        headers: JSON_HEADERS
       });
     }
 
@@ -1034,7 +931,7 @@ export default {
 
       try {
         // All stats from D1 - fast SQL queries instead of KV iteration
-        const [totalResult, moderationStats] = await Promise.all([
+        const [totalResult, moderationStats, pendingStats] = await Promise.all([
           // Total videos (excluding deleted/error)
           env.BLOSSOM_DB.prepare(`
             SELECT COUNT(DISTINCT sha256) as total
@@ -1042,19 +939,28 @@ export default {
             WHERE sha256 IS NOT NULL
               AND status_name NOT IN ('error', 'deleted')
           `).first(),
-          // Moderation breakdown by action
+          // Moderation breakdown by action (all, for "Total Moderated" and "Safe" cards)
           env.BLOSSOM_DB.prepare(`
             SELECT
               action,
               COUNT(*) as count
             FROM moderation_results
             GROUP BY action
+          `).all(),
+          // Pending review breakdown (unreviewed, for "AI Flagged" and queue counts)
+          env.BLOSSOM_DB.prepare(`
+            SELECT
+              action,
+              COUNT(*) as count
+            FROM moderation_results
+            WHERE reviewed_by IS NULL
+            GROUP BY action
           `).all()
         ]);
 
         const totalInD1 = totalResult?.total || 0;
 
-        // Parse moderation stats
+        // Parse total moderation stats
         let totalModerated = 0;
         let safeCount = 0;
         let reviewCount = 0;
@@ -1072,21 +978,45 @@ export default {
           }
         }
 
+        // Parse pending review stats (items not yet reviewed by a human)
+        let pendingReviewCount = 0;
+        let pendingQuarantineCount = 0;
+        let pendingAgeRestrictedCount = 0;
+        let pendingPermanentBanCount = 0;
+
+        for (const row of (pendingStats?.results || [])) {
+          const count = row.count || 0;
+          switch (row.action) {
+            case 'REVIEW': pendingReviewCount = count; break;
+            case 'QUARANTINE': pendingQuarantineCount = count; break;
+            case 'AGE_RESTRICTED': pendingAgeRestrictedCount = count; break;
+            case 'PERMANENT_BAN': pendingPermanentBanCount = count; break;
+          }
+        }
+
+        const pendingFlagged = pendingReviewCount + pendingQuarantineCount + pendingAgeRestrictedCount + pendingPermanentBanCount;
         const untriaged = Math.max(0, totalInD1 - totalModerated);
 
-        console.log(`[${requestId}] Stats: total=${totalInD1}, moderated=${totalModerated}, untriaged=${untriaged}, safe=${safeCount}, review=${reviewCount} in ${Date.now() - startTime}ms`);
+        console.log(`[${requestId}] Stats: total=${totalInD1}, moderated=${totalModerated}, untriaged=${untriaged}, pendingFlagged=${pendingFlagged} in ${Date.now() - startTime}ms`);
         return new Response(JSON.stringify({
           totalInD1,
           totalModerated,
           untriaged,
+          pendingFlagged,
           breakdown: {
             safe: safeCount,
             review: reviewCount,
             ageRestricted: ageRestrictedCount,
             permanentBan: permanentBanCount
+          },
+          pending: {
+            review: pendingReviewCount,
+            quarantine: pendingQuarantineCount,
+            ageRestricted: pendingAgeRestrictedCount,
+            permanentBan: pendingPermanentBanCount
           }
         }), {
-          headers: { 'Content-Type': 'application/json' }
+          headers: JSON_HEADERS
         });
       } catch (error) {
         console.error(`[${requestId}] Failed to get stats:`, error);
@@ -1202,7 +1132,7 @@ export default {
           limit,
           hasMore: offset + limit < (countResult?.total || 0)
         }), {
-          headers: { 'Content-Type': 'application/json' }
+          headers: JSON_HEADERS
         });
       } catch (error) {
         console.error('[ADMIN] Failed to fetch untriaged videos:', error);
@@ -1321,12 +1251,20 @@ export default {
       const moderatorEmail = getAuthenticatedUser(request) || 'admin';
       const reason = body.reason || `Deleted by moderator ${moderatorEmail}`;
       const relayResult = isValidSha256(body.sha256)
-        ? await deleteRelayEventVersions(eventId, body.sha256, env, reason)
-        : await callRelayAdminAction(env, {
-          action: 'delete_event',
+        ? await deleteEventFromRelayBySha256(body.sha256, env, 'admin-delete-event', reason)
+        : await deleteRelayEventIds([eventId], env, reason);
+
+      if (!relayResult.success) {
+        return new Response(JSON.stringify({
+          success: false,
           eventId,
-          reason
+          relayResult,
+          error: relayResult.error || relayResult.reason || 'Failed to delete relay event'
+        }), {
+          status: 502,
+          headers: { 'Content-Type': 'application/json' }
         });
+      }
 
       return new Response(JSON.stringify({
         success: true,
@@ -1465,7 +1403,12 @@ export default {
           reviewed_by = excluded.reviewed_by,
           reviewed_at = excluded.reviewed_at,
           review_notes = excluded.review_notes,
-          uploaded_by = COALESCE(moderation_results.uploaded_by, excluded.uploaded_by)
+          uploaded_by = COALESCE(moderation_results.uploaded_by, excluded.uploaded_by),
+          title = COALESCE(moderation_results.title, excluded.title),
+          author = COALESCE(moderation_results.author, excluded.author),
+          event_id = COALESCE(moderation_results.event_id, excluded.event_id),
+          content_url = COALESCE(moderation_results.content_url, excluded.content_url),
+          published_at = COALESCE(moderation_results.published_at, excluded.published_at)
       `).bind(
         sha256,
         action,
@@ -1514,15 +1457,16 @@ export default {
       // Notify Blossom of the moderation decision.
       const blossomResult = await notifyBlossom(sha256, action, env);
 
-      // For PERMANENT_BAN: also delete the event from the relay (funnelcake).
-      // This is critical for externally-hosted content where Blossom can't enforce the ban.
+      if (!blossomResult.success && !blossomResult.skipped) {
+        console.warn(`[ADMIN] Blossom notification failed: ${blossomResult.error}`);
+        return blossomFailureResponse(sha256, action, blossomResult.error);
+      }
+
+      // For PERMANENT_BAN: also delete the event from the relay (funnelcake),
+      // but only after Blossom confirms enforcement to avoid partial moderation.
       let relayDeleteResult = null;
       if (action === 'PERMANENT_BAN') {
         relayDeleteResult = await deleteEventFromRelayBySha256(sha256, env, 'admin-moderate');
-      }
-
-      if (!blossomResult.success && !blossomResult.skipped) {
-        console.warn(`[ADMIN] Blossom notification failed: ${blossomResult.error}`);
       }
 
       // Publish kind 1984 (NIP-56) report for non-SAFE actions so human moderation
@@ -1564,11 +1508,11 @@ export default {
         try {
           // Look up uploaded_by from D1
           const uploaderRow = await env.BLOSSOM_DB.prepare(
-            'SELECT uploaded_by, categories FROM moderation_results WHERE sha256 = ?'
+            'SELECT uploaded_by, categories, title, published_at FROM moderation_results WHERE sha256 = ?'
           ).bind(sha256).first();
           if (uploaderRow?.uploaded_by) {
             const { sendModerationDM } = await import('./nostr/dm-sender.mjs');
-            await sendModerationDM(uploaderRow.uploaded_by, sha256, action, reason || 'Manual moderator action', env, null, uploaderRow?.categories);
+            await sendModerationDM(uploaderRow.uploaded_by, sha256, action, reason || 'Manual moderator action', env, null, { categories: uploaderRow?.categories, title: uploaderRow?.title, publishedAt: uploaderRow?.published_at });
             dmSent = true;
             console.log(`[ADMIN] DM sent to creator ${uploaderRow.uploaded_by.substring(0, 16)}...`);
           }
@@ -1577,6 +1521,9 @@ export default {
         }
       }
 
+      // Notify reporters who filed reports on this content (non-blocking)
+      const { notifyReporters } = await import('./nostr/dm-sender.mjs');
+      notifyReporters(sha256, action, env, '[ADMIN]');
       // Notify ATProto labeler of manual override
       notifyAtprotoLabeler({ sha256, action, scores: updated.scores || {}, reviewed_by: 'admin' }, env).catch(err => {
         console.error('[ADMIN] ATProto labeler notification failed:', err.message);
@@ -2640,6 +2587,22 @@ async function runMigration() {
       return new Response(JSON.stringify(result), { headers: { 'Content-Type': 'application/json' } });
     }
 
+    if (url.pathname === '/admin/api/classic-vines/rollback' && request.method === 'POST') {
+      const authError = await requireAuth(request, env);
+      if (authError) return authError;
+
+      try {
+        const body = await request.json();
+        const result = await runClassicVineRollback(body, env, {
+          notifyBlossom: (sha256, action) => notifyBlossom(sha256, action, env)
+        });
+        return jsonResponse(200, result);
+      } catch (error) {
+        console.error('[CLASSIC-VINES] Rollback error:', error);
+        return jsonResponse(error.status || 500, { error: error.message });
+      }
+    }
+
     // API: Submit a user report for a piece of content (NIP-56)
     // Auth: Bearer token or Cloudflare Access JWT
     if (url.pathname === '/api/v1/scan' && request.method === 'POST') {
@@ -2712,6 +2675,80 @@ async function runMigration() {
       }
     }
 
+    // API: Send DM notification only (no Blossom/D1 moderation side effects)
+    // Used by relay-manager to notify users after NIP-86 moderation actions
+    // Auth: Bearer token or Cloudflare Access JWT
+    if (url.pathname === '/api/v1/notify' && request.method === 'POST') {
+      const verification = await authenticateApiRequest(request, env);
+      if (!verification.valid) {
+        console.log(`[API] Authentication failed for /api/v1/notify: ${verification.error}`);
+        return apiUnauthorizedResponse(verification);
+      }
+
+      try {
+        const body = await request.json();
+        const { recipientPubkey, action, reason, sha256, eventId } = body;
+
+        if (!isValidPubkey(recipientPubkey)) {
+          return new Response(JSON.stringify({ error: 'Valid recipientPubkey (64-char hex) required' }), {
+            status: 400,
+            headers: { 'Content-Type': 'application/json' }
+          });
+        }
+
+        if (!action || typeof action !== 'string') {
+          return new Response(JSON.stringify({ error: 'action required' }), {
+            status: 400,
+            headers: { 'Content-Type': 'application/json' }
+          });
+        }
+
+        const validNotifyActions = ['PERMANENT_BAN', 'AGE_RESTRICTED', 'QUARANTINE', 'ACCOUNT_SUSPENDED', 'REPORT_OUTCOME_ACTION', 'REPORT_OUTCOME_NO_ACTION'];
+        if (!validNotifyActions.includes(action)) {
+          return new Response(JSON.stringify({
+            error: `Invalid action. Must be one of: ${validNotifyActions.join(', ')}`
+          }), {
+            status: 400,
+            headers: { 'Content-Type': 'application/json' }
+          });
+        }
+
+        if (!env.NOSTR_PRIVATE_KEY) {
+          console.warn('[API] /api/v1/notify called but NOSTR_PRIVATE_KEY not configured');
+          return new Response(JSON.stringify({ success: true, dm_sent: false, reason: 'DM sending not configured' }), {
+            headers: { 'Content-Type': 'application/json' }
+          });
+        }
+
+        const { sendModerationDM } = await import('./nostr/dm-sender.mjs');
+        const dmResult = await sendModerationDM(
+          recipientPubkey,
+          sha256 || null,
+          action,
+          reason || null,
+          env,
+          null
+        );
+
+        const authSource = authSourceFromVerification(verification);
+        console.log(`[API] /api/v1/notify: action=${action} recipient=${recipientPubkey.substring(0, 16)}... dm_sent=${dmResult.sent} (auth: ${authSource})${eventId ? ` eventId=${eventId}` : ''}`);
+
+        return new Response(JSON.stringify({
+          success: true,
+          dm_sent: dmResult.sent,
+          reason: dmResult.reason || null
+        }), {
+          headers: { 'Content-Type': 'application/json' }
+        });
+      } catch (error) {
+        console.error('[API] Error in /api/v1/notify:', error);
+        return new Response(JSON.stringify({ error: error.message }), {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }
+    }
+
     // API: Update moderation status (for external services)
     // Auth: Bearer token or Cloudflare Access JWT
     if (url.pathname === '/api/v1/moderate' && request.method === 'POST') {
@@ -2769,10 +2806,13 @@ async function runMigration() {
         console.log(`[API] Moderation updated: ${sha256} -> ${action} by ${source || 'external-api'} (auth: ${authSource})`);
 
         // Notify divine-blossom of the moderation decision
-        // This is fire-and-forget - we don't fail the request if blossom notification fails
         const blossomResult = await notifyBlossom(sha256, action.toUpperCase(), env);
+
+        // If Blossom notification failed (and wasn't skipped), return 502.
+        // The D1 record is written but enforcement didn't land.
         if (!blossomResult.success && !blossomResult.skipped) {
           console.warn(`[API] Blossom notification failed but moderation was recorded: ${blossomResult.error}`);
+          return blossomFailureResponse(sha256, action.toUpperCase(), blossomResult.error);
         }
 
         return new Response(JSON.stringify({
@@ -3009,6 +3049,13 @@ async function runMigration() {
 
         // Notify Blossom (relay notification removed — see comment in admin moderate handler)
         const blossomResult = await notifyBlossom(sha256, newAction, env);
+
+        // If Blossom notification failed (and wasn't skipped), return 502.
+        // The D1/KV records are written but enforcement didn't land.
+        if (!blossomResult.success && !blossomResult.skipped) {
+          console.warn(`[API] Blossom notification failed for quarantine ${sha256}: ${blossomResult.error}`);
+          return blossomFailureResponse(sha256, newAction, blossomResult.error);
+        }
 
         console.log(`[API] Quarantine updated: ${sha256} -> ${newAction} by ${authSource}`);
 
@@ -3315,8 +3362,9 @@ async function runMigration() {
         // Store result in D1
         await env.BLOSSOM_DB.prepare(`
           INSERT OR REPLACE INTO moderation_results
-          (sha256, action, provider, scores, categories, raw_response, moderated_at, uploaded_by)
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+          (sha256, action, provider, scores, categories, raw_response, moderated_at, uploaded_by,
+           title, author, event_id, content_url, published_at)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         `).bind(
           sha256,
           result.action,
@@ -3325,7 +3373,12 @@ async function runMigration() {
           JSON.stringify(result.categories || []),
           JSON.stringify(result.rawResponse || {}),
           new Date().toISOString(),
-          result.uploadedBy || null
+          result.uploadedBy || null,
+          result.nostrContext?.title || null,
+          result.nostrContext?.author || null,
+          result.nostrEventId || null,
+          result.nostrContext?.url || result.cdnUrl || null,
+          result.nostrContext?.publishedAt || null
         ).run();
         console.log(`[MODERATION] Step 7: D1 write successful`);
 
@@ -3584,12 +3637,19 @@ async function runMigration() {
                   if (uploadedBy && env.NOSTR_PRIVATE_KEY) {
                     try {
                       const { sendModerationDM } = await import('./nostr/dm-sender.mjs');
-                      await sendModerationDM(uploadedBy, sha256, 'PERMANENT_BAN', moderation.reason, env);
+                      const metaRow = await env.BLOSSOM_DB.prepare(
+                        'SELECT title, published_at FROM moderation_results WHERE sha256 = ?'
+                      ).bind(sha256).first();
+                      await sendModerationDM(uploadedBy, sha256, 'PERMANENT_BAN', moderation.reason, env, null, { title: metaRow?.title, publishedAt: metaRow?.published_at });
                       console.log(`[CRON] DM sent to creator for auto-escalated ${sha256}`);
                     } catch (dmErr) {
                       console.error(`[CRON] DM failed for ${sha256}:`, dmErr.message);
                     }
                   }
+
+                  // Notify reporters
+                  const { notifyReporters: notifyCronReporters } = await import('./nostr/dm-sender.mjs');
+                  notifyCronReporters(sha256, 'PERMANENT_BAN', env, '[CRON]');
 
                   // Mark escalation complete so cron doesn't retry
                   const rdCached = await env.MODERATION_KV.get(`rd:${sha256}`);
@@ -3634,29 +3694,21 @@ async function runMigration() {
  */
 async function handleModerationResult(result, env) {
   const { sha256, action, scores, reason, flaggedFrames, severity, cdnUrl, uploadedBy } = result;
+  const downstreamContext = buildDownstreamPublishContext(result);
 
   console.log(`[MODERATION] handleModerationResult called for ${sha256} with action ${action}`);
 
   // Publish Nostr notifications for flagged content
-  if (action !== 'SAFE') {
+  if (downstreamContext.publishReport) {
     try {
-      const reportData = {
-        type: action.toLowerCase().replace('_', '-'),
-        sha256,
-        cdnUrl,
-        category: result.category,
-        scores,
-        reason,
-        severity,
-        frames: flaggedFrames
-      };
+      const reportData = downstreamContext.reportData;
       await publishToFaro(reportData, env);
-      console.log(`[MODERATION] ${sha256} - Nostr ${action} event published to Faro`);
+      console.log(`[MODERATION] ${sha256} - Nostr ${reportData.type} event published to Faro`);
 
       // Also publish to content relay so it can stop serving flagged events
       try {
         await publishToContentRelay(reportData, env);
-        console.log(`[MODERATION] ${sha256} - Nostr ${action} event published to content relay`);
+        console.log(`[MODERATION] ${sha256} - Nostr ${reportData.type} event published to content relay`);
       } catch (relayError) {
         console.error(`[MODERATION] ${sha256} - Content relay publish failed:`, relayError);
       }
@@ -3689,17 +3741,21 @@ async function handleModerationResult(result, env) {
   if (['PERMANENT_BAN', 'AGE_RESTRICTED'].includes(action) && uploadedBy && env.NOSTR_PRIVATE_KEY) {
     try {
       const { sendModerationDM } = await import('./nostr/dm-sender.mjs');
-      await sendModerationDM(uploadedBy, sha256, action, reason, env, null, result.categories);
+      await sendModerationDM(uploadedBy, sha256, action, reason, env, null, { categories: result.categories, title: result.nostrContext?.title, publishedAt: result.nostrContext?.publishedAt });
       console.log(`[MODERATION] ${sha256} - DM notification sent to creator ${uploadedBy.substring(0, 16)}...`);
     } catch (dmErr) {
       console.error(`[MODERATION] ${sha256} - DM notification failed:`, dmErr.message);
     }
   }
 
+  // Notify reporters who filed reports on this content (non-blocking)
+  const { notifyReporters: notifyReportersOfOutcome } = await import('./nostr/dm-sender.mjs');
+  notifyReportersOfOutcome(sha256, action, env, '[MODERATION]');
+
   // Write normalized moderation labels to ClickHouse
   try {
     const { writeModerationLabels } = await import('./moderation/label-writer.mjs');
-    await writeModerationLabels(sha256, result, env, {
+    await writeModerationLabels(sha256, downstreamContext.labelResult, env, {
       sourceId: result.provider || 'divine-hive',
       sourceOwner: 'divine',
       sourceType: 'machine-labeler',
@@ -3710,11 +3766,28 @@ async function handleModerationResult(result, env) {
   }
 
   // Notify ATProto labeler service (fire-and-forget)
-  notifyAtprotoLabeler({ sha256, action, scores, reviewed_by: result.reviewed_by }, env).catch(err => {
+  notifyAtprotoLabeler({ ...downstreamContext.labelResult, sha256, action, reviewed_by: result.reviewed_by }, env).catch(err => {
     console.error('[MODERATION] ATProto labeler notification failed:', err.message);
   });
 
   console.log(`[MODERATION] handleModerationResult finished for ${sha256}`);
+}
+
+/**
+ * Build a 502 response for when Blossom notification fails.
+ * Used by /admin/api/moderate, /api/v1/moderate, and /api/v1/quarantine.
+ */
+function blossomFailureResponse(sha256, action, blossomError) {
+  return new Response(JSON.stringify({
+    success: false,
+    sha256,
+    action,
+    blossom_notified: false,
+    error: `Moderation recorded but media server did not confirm: ${blossomError}`,
+  }), {
+    status: 502,
+    headers: { 'Content-Type': 'application/json' }
+  });
 }
 
 /**

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -92,27 +92,11 @@ describe('HTTP hostname routing', () => {
     );
 
     expect(response.status).toBe(200);
-    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
     await expect(response.json()).resolves.toMatchObject({
       sha256: SHA256,
       moderated: true,
       action: 'SAFE',
       status: 'safe'
-    });
-  });
-
-  it('returns CORS headers for unknown public moderation status on moderation-api host', async () => {
-    const response = await worker.fetch(
-      new Request(`https://moderation-api.divine.video/check-result/${SHA256}`),
-      createEnv()
-    );
-
-    expect(response.status).toBe(200);
-    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
-    await expect(response.json()).resolves.toMatchObject({
-      sha256: SHA256,
-      status: 'unknown',
-      moderated: false
     });
   });
 
@@ -288,6 +272,7 @@ describe('Admin video lookup', () => {
           if (key === `moderation:${SHA256}`) {
             return JSON.stringify({
               action: 'AGE_RESTRICTED',
+              cdnUrl: `https://blossom.primal.net/${SHA256}.mp4`,
               scores: { nudity: 0.91, ai_generated: 0.2 },
               manualOverride: true,
               previousAction: 'REVIEW',
@@ -315,6 +300,7 @@ describe('Admin video lookup', () => {
       video: {
         sha256: SHA256,
         action: 'AGE_RESTRICTED',
+        cdnUrl: `https://blossom.primal.net/${SHA256}.mp4`,
         manualOverride: true,
         previousAction: 'REVIEW',
         reason: 'Manual override',
@@ -416,6 +402,78 @@ describe('Admin video lookup', () => {
     }
   });
 
+  it('preserves imported source URLs when a stable-id lookup resolves to an already moderated media hash', async () => {
+    const mediaSha = 'b'.repeat(64);
+    const stableId = 'video-imported-stable-id';
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (url) => {
+      if (String(url) === `https://relay.divine.video/api/videos/${stableId}`) {
+        return new Response(JSON.stringify({
+          event: {
+            id: SHA256,
+            pubkey: 'c'.repeat(64),
+            created_at: 1773503656,
+            kind: 34235,
+            tags: [
+              ['d', stableId],
+              ['title', 'Imported archive video'],
+              ['client', 'Plebs'],
+              ['imeta', `url https://blossom.primal.net/${mediaSha}.mp4`, `x ${mediaSha}`, 'image https://blossom.primal.net/thumb.png']
+            ],
+            content: 'archive description',
+            sig: 'd'.repeat(128)
+          },
+          stats: {
+            author_name: 'Archive User'
+          }
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    };
+
+    try {
+      const response = await worker.fetch(
+        new Request(`https://moderation.admin.divine.video/admin/api/video/${stableId}`, {
+          headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
+        }),
+        createEnv({
+          BLOSSOM_DB: createDbMock({
+            moderationResults: new Map([[mediaSha, {
+              sha256: mediaSha,
+              action: 'PERMANENT_BAN',
+              provider: 'manual',
+              scores: JSON.stringify({ ai_generated: 0.92 }),
+              categories: JSON.stringify(['ai_generated']),
+              moderated_at: '2026-03-17T00:00:00.000Z',
+              reviewed_by: 'admin',
+              reviewed_at: '2026-03-17T00:10:00.000Z',
+              review_notes: 'Imported moderation',
+              uploaded_by: 'c'.repeat(64)
+            }]])
+          })
+        })
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toMatchObject({
+        video: {
+          sha256: mediaSha,
+          action: 'PERMANENT_BAN',
+          cdnUrl: `https://blossom.primal.net/${mediaSha}.mp4`,
+          thumbnailUrl: 'https://blossom.primal.net/thumb.png',
+          divineUrl: `https://divine.video/video/${stableId}`,
+          lookupId: stableId
+        }
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it('rejects oversized admin lookup identifiers', async () => {
     const identifier = 'x'.repeat(256);
     const response = await worker.fetch(
@@ -448,6 +506,82 @@ describe('Admin video lookup', () => {
         error: 'Video not found',
         identifier: SHA256
       });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+describe('Admin transcript access', () => {
+  it('returns parsed transcript text for admin transcript lookup', async () => {
+    const vttText = `WEBVTT
+
+00:00:00.000 --> 00:00:02.000
+Hello world
+
+00:00:02.000 --> 00:00:04.000
+This is a test`;
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (url) => {
+      if (String(url) === `https://media.divine.video/${SHA256}.vtt`) {
+        return new Response(vttText, {
+          status: 200,
+          headers: { 'Content-Type': 'text/vtt' }
+        });
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    };
+
+    try {
+      const response = await worker.fetch(
+        new Request(`https://moderation.admin.divine.video/admin/api/transcript/${SHA256}`, {
+          headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
+        }),
+        createEnv({ CDN_DOMAIN: 'media.divine.video' })
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({
+        sha256: SHA256,
+        found: true,
+        subtitleUrl: `/admin/transcript/${SHA256}.vtt`,
+        sourceUrl: `https://media.divine.video/${SHA256}.vtt`,
+        transcriptText: 'Hello world This is a test'
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('proxies raw VTT content through the admin transcript route', async () => {
+    const vttText = `WEBVTT
+
+00:00:00.000 --> 00:00:02.000
+Hello world`;
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (url) => {
+      if (String(url) === `https://media.divine.video/${SHA256}.vtt`) {
+        return new Response(vttText, {
+          status: 200,
+          headers: { 'Content-Type': 'text/vtt' }
+        });
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    };
+
+    try {
+      const response = await worker.fetch(
+        new Request(`https://moderation.admin.divine.video/admin/transcript/${SHA256}.vtt`, {
+          headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
+        }),
+        createEnv({ CDN_DOMAIN: 'media.divine.video' })
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('Content-Type')).toBe('text/vtt; charset=utf-8');
+      await expect(response.text()).resolves.toBe(vttText);
     } finally {
       globalThis.fetch = originalFetch;
     }
@@ -595,6 +729,695 @@ describe('notifyBlossom integration via admin moderate endpoint', () => {
 
       expect(response.status).toBe(200);
       expect(blossom.captured).toHaveLength(0);
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  it('returns 502 when Blossom webhook fails for /api/v1/moderate', async () => {
+    const kvStore = new Map();
+    const env = {
+      ALLOW_DEV_ACCESS: 'true',
+      SERVICE_API_TOKEN: 'test-service-token',
+      BLOSSOM_WEBHOOK_URL: 'https://mock-blossom.test/admin/moderate',
+      BLOSSOM_WEBHOOK_SECRET: 'test-webhook-secret',
+      BLOSSOM_DB: createDbMock({ moderationResults: new Map() }),
+      MODERATION_KV: {
+        store: kvStore,
+        async get(key) { return kvStore.get(key) ?? null; },
+        async put(key, value) { kvStore.set(key, value); },
+        async delete(key) { kvStore.delete(key); },
+        async list() { return { keys: [], list_complete: true, cursor: null }; }
+      },
+      MODERATION_QUEUE: { async send() {} },
+    };
+
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = async (url, init) => {
+      if (url === 'https://mock-blossom.test/admin/moderate') {
+        return new Response('Service Unavailable', { status: 503 });
+      }
+      return origFetch(url, init);
+    };
+
+    try {
+      const response = await worker.fetch(
+        new Request('https://moderation-api.divine.video/api/v1/moderate', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': 'Bearer test-service-token',
+          },
+          body: JSON.stringify({
+            sha256: 'abc123',
+            action: 'AGE_RESTRICTED',
+            reason: 'test age restrict',
+            source: 'relay-manager',
+          }),
+        }),
+        env
+      );
+
+      expect(response.status).toBe(502);
+      const data = await response.json();
+      expect(data.success).toBe(false);
+      expect(data.blossom_notified).toBe(false);
+      expect(data.action).toBe('AGE_RESTRICTED');
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  it('returns 200 when Blossom webhook succeeds for /api/v1/moderate', async () => {
+    const kvStore = new Map();
+    const env = {
+      ALLOW_DEV_ACCESS: 'true',
+      SERVICE_API_TOKEN: 'test-service-token',
+      BLOSSOM_WEBHOOK_URL: 'https://mock-blossom.test/admin/moderate',
+      BLOSSOM_WEBHOOK_SECRET: 'test-webhook-secret',
+      BLOSSOM_DB: createDbMock({ moderationResults: new Map() }),
+      MODERATION_KV: {
+        store: kvStore,
+        async get(key) { return kvStore.get(key) ?? null; },
+        async put(key, value) { kvStore.set(key, value); },
+        async delete(key) { kvStore.delete(key); },
+        async list() { return { keys: [], list_complete: true, cursor: null }; }
+      },
+      MODERATION_QUEUE: { async send() {} },
+    };
+
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = async (url, init) => {
+      if (url === 'https://mock-blossom.test/admin/moderate') {
+        return new Response(JSON.stringify({ success: true }), { status: 200 });
+      }
+      return origFetch(url, init);
+    };
+
+    try {
+      const response = await worker.fetch(
+        new Request('https://moderation-api.divine.video/api/v1/moderate', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': 'Bearer test-service-token',
+          },
+          body: JSON.stringify({
+            sha256: 'abc123',
+            action: 'AGE_RESTRICTED',
+            reason: 'test',
+            source: 'relay-manager',
+          }),
+        }),
+        env
+      );
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.success).toBe(true);
+      expect(data.blossom_notified).toBe(true);
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  it('returns 502 when Blossom webhook fails for /admin/api/moderate', async () => {
+    const sha256 = 'b'.repeat(64);
+    const kvStore = new Map();
+    const env = {
+      ALLOW_DEV_ACCESS: 'true',
+      BLOSSOM_WEBHOOK_URL: 'https://mock-blossom.test/admin/moderate',
+      BLOSSOM_WEBHOOK_SECRET: 'test-webhook-secret',
+      BLOSSOM_DB: createDbMock({
+        moderationResults: new Map([[sha256, {
+          sha256,
+          action: 'REVIEW',
+          provider: 'hiveai',
+          scores: JSON.stringify({}),
+          categories: JSON.stringify([]),
+          moderated_at: '2026-03-12T00:00:00.000Z',
+          reviewed_by: null,
+          reviewed_at: null
+        }]])
+      }),
+      MODERATION_KV: {
+        store: kvStore,
+        async get(key) { return kvStore.get(key) ?? null; },
+        async put(key, value) { kvStore.set(key, value); },
+        async delete(key) { kvStore.delete(key); },
+        async list() { return { keys: [], list_complete: true, cursor: null }; }
+      },
+      MODERATION_QUEUE: { async send() {} },
+    };
+
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = async (url, init) => {
+      if (url === 'https://mock-blossom.test/admin/moderate') {
+        return new Response('Service Unavailable', { status: 503 });
+      }
+      return origFetch(url, init);
+    };
+
+    try {
+      const response = await worker.fetch(
+        new Request(`https://moderation.admin.divine.video/admin/api/moderate/${sha256}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ action: 'AGE_RESTRICTED', reason: 'test age restrict' })
+        }),
+        env
+      );
+
+      expect(response.status).toBe(502);
+      const data = await response.json();
+      expect(data.success).toBe(false);
+      expect(data.blossom_notified).toBe(false);
+      expect(data.action).toBe('AGE_RESTRICTED');
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  it('does not delete relay events when Blossom webhook fails for /admin/api/moderate', async () => {
+    const sha256 = 'c'.repeat(64);
+    const kvStore = new Map();
+    let relayAdminCalls = 0;
+    let relaySocketConstructed = 0;
+    const env = {
+      ALLOW_DEV_ACCESS: 'true',
+      BLOSSOM_WEBHOOK_URL: 'https://mock-blossom.test/admin/moderate',
+      BLOSSOM_WEBHOOK_SECRET: 'test-webhook-secret',
+      RELAY_ADMIN_URL: 'https://relay-admin.test',
+      BLOSSOM_DB: createDbMock({
+        moderationResults: new Map([[sha256, {
+          sha256,
+          action: 'REVIEW',
+          provider: 'hiveai',
+          scores: JSON.stringify({}),
+          categories: JSON.stringify([]),
+          moderated_at: '2026-03-12T00:00:00.000Z',
+          reviewed_by: null,
+          reviewed_at: null
+        }]])
+      }),
+      MODERATION_KV: {
+        store: kvStore,
+        async get(key) { return kvStore.get(key) ?? null; },
+        async put(key, value) { kvStore.set(key, value); },
+        async delete(key) { kvStore.delete(key); },
+        async list() { return { keys: [], list_complete: true, cursor: null }; }
+      },
+      MODERATION_QUEUE: { async send() {} },
+    };
+
+    const origFetch = globalThis.fetch;
+    const OrigWebSocket = globalThis.WebSocket;
+    globalThis.fetch = async (url, init) => {
+      if (url === 'https://mock-blossom.test/admin/moderate') {
+        return new Response('Service Unavailable', { status: 503 });
+      }
+      if (typeof url === 'string' && url.startsWith('https://relay-admin.test')) {
+        relayAdminCalls += 1;
+        return new Response(JSON.stringify({ success: true }), { status: 200 });
+      }
+      return origFetch(url, init);
+    };
+    globalThis.WebSocket = class {
+      constructor() {
+        relaySocketConstructed += 1;
+      }
+      addEventListener() {}
+      close() {}
+      send() {}
+    };
+
+    try {
+      const response = await worker.fetch(
+        new Request(`https://moderation.admin.divine.video/admin/api/moderate/${sha256}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ action: 'PERMANENT_BAN', reason: 'test ban' })
+        }),
+        env
+      );
+
+      expect(response.status).toBe(502);
+      expect(relayAdminCalls).toBe(0);
+      expect(relaySocketConstructed).toBe(0);
+    } finally {
+      globalThis.fetch = origFetch;
+      globalThis.WebSocket = OrigWebSocket;
+    }
+  });
+
+  it('returns 502 when Blossom webhook fails for /api/v1/quarantine', async () => {
+    const sha256 = 'd'.repeat(64);
+    const kvStore = new Map();
+    const env = {
+      ALLOW_DEV_ACCESS: 'true',
+      SERVICE_API_TOKEN: 'test-service-token',
+      BLOSSOM_WEBHOOK_URL: 'https://mock-blossom.test/admin/moderate',
+      BLOSSOM_WEBHOOK_SECRET: 'test-webhook-secret',
+      BLOSSOM_DB: createDbMock({
+        moderationResults: new Map([[sha256, {
+          sha256,
+          action: 'REVIEW',
+          provider: 'hiveai',
+          scores: JSON.stringify({}),
+          categories: JSON.stringify([]),
+          moderated_at: '2026-03-12T00:00:00.000Z',
+          reviewed_by: null,
+          reviewed_at: null
+        }]])
+      }),
+      MODERATION_KV: {
+        store: kvStore,
+        async get(key) { return kvStore.get(key) ?? null; },
+        async put(key, value) { kvStore.set(key, value); },
+        async delete(key) { kvStore.delete(key); },
+        async list() { return { keys: [], list_complete: true, cursor: null }; }
+      },
+      MODERATION_QUEUE: { async send() {} },
+    };
+
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = async (url, init) => {
+      if (url === 'https://mock-blossom.test/admin/moderate') {
+        return new Response('Service Unavailable', { status: 503 });
+      }
+      return origFetch(url, init);
+    };
+
+    try {
+      const response = await worker.fetch(
+        new Request(`https://moderation-api.divine.video/api/v1/quarantine/${sha256}`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': 'Bearer test-service-token',
+          },
+          body: JSON.stringify({
+            quarantine: true,
+            reason: 'test quarantine',
+          }),
+        }),
+        env
+      );
+
+      expect(response.status).toBe(502);
+      const data = await response.json();
+      expect(data.success).toBe(false);
+      expect(data.blossom_notified).toBe(false);
+      expect(data.action).toBe('QUARANTINE');
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+});
+
+describe('classic vine rollback admin endpoint', () => {
+  function createRollbackDb(rowBySha = new Map(), writes = []) {
+    return {
+      prepare(sql) {
+        let bindings = [];
+
+        return {
+          bind(...args) {
+            bindings = args;
+            return this;
+          },
+          async run() {
+            writes.push({ sql, bindings });
+            return { success: true };
+          },
+          async first() {
+            if (sql.includes('FROM moderation_results') && sql.includes('WHERE sha256 = ?')) {
+              return rowBySha.get(bindings[0]) ?? null;
+            }
+            return null;
+          },
+          async all() {
+            return { results: [] };
+          }
+        };
+      },
+      async batch() {
+        return [];
+      }
+    };
+  }
+
+  function createRollbackEnv({ rows = new Map(), kvStore = new Map(), blossomPayloads = [], dbWrites = [] } = {}) {
+    return {
+      ALLOW_DEV_ACCESS: 'true',
+      SERVICE_API_TOKEN: 'test-service-token',
+      BLOSSOM_WEBHOOK_URL: 'https://mock-blossom.test/classic-vines/rollback',
+      BLOSSOM_WEBHOOK_SECRET: 'test-webhook-secret',
+      BLOSSOM_DB: createRollbackDb(rows, dbWrites),
+      MODERATION_KV: {
+        store: kvStore,
+        async get(key) { return kvStore.get(key) ?? null; },
+        async put(key, value) { kvStore.set(key, value); },
+        async delete(key) { kvStore.delete(key); },
+        async list() { return { keys: [], list_complete: true, cursor: null }; }
+      },
+      MODERATION_QUEUE: { async send() {} },
+      __fetchInterceptor: (url, init) => {
+        if (url === 'https://mock-blossom.test/classic-vines/rollback') {
+          blossomPayloads.push(JSON.parse(init.body));
+          return new Response(JSON.stringify({ success: true }), { status: 200 });
+        }
+        return null;
+      }
+    };
+  }
+
+  it('previews classic vine rollback candidates without mutating enforcement state', async () => {
+    const env = createRollbackEnv({
+      rows: new Map([[SHA256, {
+        sha256: SHA256,
+        action: 'PERMANENT_BAN',
+        provider: 'hiveai',
+        scores: JSON.stringify({ ai_generated: 0.97 }),
+        categories: JSON.stringify(['ai_generated']),
+        moderated_at: '2026-03-12T00:00:00.000Z'
+      }]])
+    });
+
+    const response = await worker.fetch(
+      new Request('https://moderation.admin.divine.video/admin/api/classic-vines/rollback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          mode: 'preview',
+          source: 'sha-list',
+          videos: [{
+            sha256: SHA256,
+            nostrContext: {
+              platform: 'vine',
+              sourceUrl: 'https://vine.co/v/abc123',
+              publishedAt: 1389756506
+            }
+          }]
+        })
+      }),
+      env
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      mode: 'preview',
+      processed: 1,
+      restored: 0,
+      skipped: 0,
+      failed: 0,
+      candidates: [{
+        sha256: SHA256,
+        would_restore: true,
+        reason: 'confirmed-classic-vine'
+      }]
+    });
+  });
+
+  it('restores enforcement for confirmed classic vines without calling moderation providers', async () => {
+    const kvStore = new Map([
+      [`review:${SHA256}`, JSON.stringify({ action: 'REVIEW' })],
+      [`quarantine:${SHA256}`, JSON.stringify({ action: 'QUARANTINE' })],
+      [`age-restricted:${SHA256}`, JSON.stringify({ action: 'AGE_RESTRICTED' })],
+      [`permanent-ban:${SHA256}`, JSON.stringify({ action: 'PERMANENT_BAN' })],
+    ]);
+    const blossomPayloads = [];
+    const providerRequests = [];
+    const env = createRollbackEnv({
+      rows: new Map([[SHA256, {
+        sha256: SHA256,
+        action: 'PERMANENT_BAN',
+        provider: 'hiveai',
+        scores: JSON.stringify({ ai_generated: 0.97 }),
+        categories: JSON.stringify(['ai_generated']),
+        moderated_at: '2026-03-12T00:00:00.000Z'
+      }]]),
+      kvStore,
+      blossomPayloads
+    });
+
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = async (url, init) => {
+      const intercepted = env.__fetchInterceptor(url, init);
+      if (intercepted) return intercepted;
+      providerRequests.push(String(url));
+      return new Response('{}', { status: 404 });
+    };
+
+    try {
+      const response = await worker.fetch(
+        new Request('https://moderation.admin.divine.video/admin/api/classic-vines/rollback', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            mode: 'execute',
+            source: 'sha-list',
+            videos: [{
+              sha256: SHA256,
+              nostrContext: {
+                platform: 'vine',
+                sourceUrl: 'https://vine.co/v/abc123',
+                publishedAt: 1389756506
+              }
+            }]
+          })
+        }),
+        env
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toMatchObject({
+        mode: 'execute',
+        processed: 1,
+        restored: 1,
+        skipped: 0,
+        failed: 0,
+        candidates: [{
+          sha256: SHA256,
+          restored: true,
+          reason: 'confirmed-classic-vine'
+        }]
+      });
+      expect(blossomPayloads).toHaveLength(1);
+      expect(blossomPayloads[0].action).toBe('SAFE');
+      expect(providerRequests).toEqual([]);
+      expect(kvStore.has(`review:${SHA256}`)).toBe(false);
+      expect(kvStore.has(`quarantine:${SHA256}`)).toBe(false);
+      expect(kvStore.has(`age-restricted:${SHA256}`)).toBe(false);
+      expect(kvStore.has(`permanent-ban:${SHA256}`)).toBe(false);
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  it('returns a cursor for unfinished classic vine rollback batches', async () => {
+    const blossomPayloads = [];
+    const env = createRollbackEnv({
+      rows: new Map([
+        [SHA256, {
+          sha256: SHA256,
+          action: 'PERMANENT_BAN',
+          provider: 'hiveai',
+          scores: JSON.stringify({ ai_generated: 0.97 }),
+          categories: JSON.stringify(['ai_generated']),
+          moderated_at: '2026-03-12T00:00:00.000Z'
+        }],
+        ['b'.repeat(64), {
+          sha256: 'b'.repeat(64),
+          action: 'PERMANENT_BAN',
+          provider: 'hiveai',
+          scores: JSON.stringify({ ai_generated: 0.96 }),
+          categories: JSON.stringify(['ai_generated']),
+          moderated_at: '2026-03-12T00:00:00.000Z'
+        }]
+      ]),
+      blossomPayloads
+    });
+
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = async (url, init) => {
+      const intercepted = env.__fetchInterceptor(url, init);
+      if (intercepted) return intercepted;
+      return new Response('{}', { status: 404 });
+    };
+
+    try {
+      const response = await worker.fetch(
+        new Request('https://moderation.admin.divine.video/admin/api/classic-vines/rollback', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            mode: 'execute',
+            source: 'sha-list',
+            limit: 1,
+            videos: [
+              {
+                sha256: SHA256,
+                nostrContext: {
+                  platform: 'vine',
+                  sourceUrl: 'https://vine.co/v/abc123',
+                  publishedAt: 1389756506
+                }
+              },
+              {
+                sha256: 'b'.repeat(64),
+                nostrContext: {
+                  vineHashId: 'second-vine',
+                  publishedAt: 1390000000
+                }
+              }
+            ]
+          })
+        }),
+        env
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toMatchObject({
+        mode: 'execute',
+        processed: 1,
+        restored: 1,
+        next_cursor: '1'
+      });
+      expect(blossomPayloads).toHaveLength(1);
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  it('treats already-SAFE rows as skipped without rewriting D1', async () => {
+    const dbWrites = [];
+    const blossomPayloads = [];
+    const env = createRollbackEnv({
+      rows: new Map([[SHA256, {
+        sha256: SHA256,
+        action: 'SAFE',
+        provider: 'classic-vine-rollback',
+        scores: JSON.stringify({}),
+        categories: JSON.stringify([]),
+        moderated_at: '2026-03-12T00:00:00.000Z'
+      }]]),
+      blossomPayloads,
+      dbWrites
+    });
+
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = async (url, init) => {
+      const intercepted = env.__fetchInterceptor(url, init);
+      if (intercepted) return intercepted;
+      return new Response('{}', { status: 404 });
+    };
+
+    try {
+      const response = await worker.fetch(
+        new Request('https://moderation.admin.divine.video/admin/api/classic-vines/rollback', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            mode: 'execute',
+            source: 'sha-list',
+            videos: [{
+              sha256: SHA256,
+              nostrContext: {
+                platform: 'vine',
+                sourceUrl: 'https://vine.co/v/abc123',
+                publishedAt: 1389756506
+              }
+            }]
+          })
+        }),
+        env
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toMatchObject({
+        mode: 'execute',
+        processed: 1,
+        restored: 0,
+        skipped: 1,
+        failed: 0,
+        candidates: [{
+          sha256: SHA256,
+          reason: 'already-safe',
+          already_safe: true,
+          restored: false
+        }]
+      });
+      expect(dbWrites.filter(({ sql }) => sql.includes('INSERT INTO moderation_results'))).toHaveLength(0);
+      expect(blossomPayloads).toHaveLength(0);
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  it('reports Blossom failures instead of claiming rollback success', async () => {
+    const kvStore = new Map([
+      [`permanent-ban:${SHA256}`, JSON.stringify({ action: 'PERMANENT_BAN' })],
+    ]);
+    const dbWrites = [];
+    const env = createRollbackEnv({
+      rows: new Map([[SHA256, {
+        sha256: SHA256,
+        action: 'PERMANENT_BAN',
+        provider: 'hiveai',
+        scores: JSON.stringify({ ai_generated: 0.97 }),
+        categories: JSON.stringify(['ai_generated']),
+        moderated_at: '2026-03-12T00:00:00.000Z'
+      }]]),
+      kvStore,
+      dbWrites
+    });
+
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = async (url, init) => {
+      if (url === 'https://mock-blossom.test/classic-vines/rollback') {
+        return new Response('Service Unavailable', { status: 503 });
+      }
+      return new Response('{}', { status: 404 });
+    };
+
+    try {
+      const response = await worker.fetch(
+        new Request('https://moderation.admin.divine.video/admin/api/classic-vines/rollback', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            mode: 'execute',
+            source: 'sha-list',
+            videos: [{
+              sha256: SHA256,
+              nostrContext: {
+                platform: 'vine',
+                sourceUrl: 'https://vine.co/v/abc123',
+                publishedAt: 1389756506
+              }
+            }]
+          })
+        }),
+        env
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toMatchObject({
+        mode: 'execute',
+        processed: 1,
+        restored: 0,
+        skipped: 0,
+        failed: 1,
+        candidates: [{
+          sha256: SHA256,
+          reason: 'blossom-notification-failed',
+          blossom_notified: false,
+          restored: false
+        }]
+      });
+      expect(dbWrites.filter(({ sql }) => sql.includes('INSERT INTO moderation_results'))).toHaveLength(1);
+      expect(kvStore.has(`permanent-ban:${SHA256}`)).toBe(false);
     } finally {
       globalThis.fetch = origFetch;
     }
@@ -1057,5 +1880,496 @@ describe('RD auto-escalation cron integration', () => {
     } finally {
       globalThis.fetch = origFetch;
     }
+  });
+});
+
+describe('POST /admin/api/moderate/:sha256', () => {
+  it('rejects unauthenticated requests', async () => {
+    const sha = 'f'.repeat(64);
+    const response = await worker.fetch(
+      new Request(`https://moderation.admin.divine.video/admin/api/moderate/${sha}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'SAFE', reason: 'test' })
+      }),
+      createEnv({ ALLOW_DEV_ACCESS: 'false' })
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it('rejects invalid action', async () => {
+    const sha = 'e'.repeat(64);
+    const kvStore = new Map();
+    const env = createEnv({
+      ALLOW_DEV_ACCESS: 'true',
+      MODERATION_KV: {
+        store: kvStore,
+        async get(key) { return kvStore.get(key) ?? null; },
+        async put(key, value) { kvStore.set(key, value); },
+        async delete(key) { kvStore.delete(key); },
+        async list() { return { keys: [], list_complete: true, cursor: null }; }
+      }
+    });
+
+    const response = await worker.fetch(
+      new Request(`https://moderation.admin.divine.video/admin/api/moderate/${sha}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'INVALID_ACTION', reason: 'test' })
+      }),
+      env
+    );
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toContain('Invalid action');
+  });
+
+  it('creates manual override for new sha256', async () => {
+    const sha = 'd'.repeat(64);
+    const kvStore = new Map();
+    const env = createEnv({
+      ALLOW_DEV_ACCESS: 'true',
+      MODERATION_KV: {
+        store: kvStore,
+        async get(key) { return kvStore.get(key) ?? null; },
+        async put(key, value) { kvStore.set(key, value); },
+        async delete(key) { kvStore.delete(key); },
+        async list() { return { keys: [], list_complete: true, cursor: null }; }
+      }
+    });
+
+    const response = await worker.fetch(
+      new Request(`https://moderation.admin.divine.video/admin/api/moderate/${sha}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'SAFE', reason: 'Looks fine' })
+      }),
+      env
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(body.action).toBe('SAFE');
+  });
+
+  it('records previousAction on override', async () => {
+    const sha = 'c'.repeat(64);
+    const kvStore = new Map();
+    const env = createEnv({
+      ALLOW_DEV_ACCESS: 'true',
+      BLOSSOM_DB: createDbMock({
+        moderationResults: new Map([[sha, {
+          sha256: sha,
+          action: 'AGE_RESTRICTED',
+          provider: 'hiveai',
+          scores: JSON.stringify({ nudity: 0.85 }),
+          categories: JSON.stringify(['nudity']),
+          moderated_at: '2026-03-07T00:00:00.000Z',
+          reviewed_by: null,
+          reviewed_at: null
+        }]])
+      }),
+      MODERATION_KV: {
+        store: kvStore,
+        async get(key) { return kvStore.get(key) ?? null; },
+        async put(key, value) { kvStore.set(key, value); },
+        async delete(key) { kvStore.delete(key); },
+        async list() { return { keys: [], list_complete: true, cursor: null }; }
+      }
+    });
+
+    // First moderate as AGE_RESTRICTED
+    await worker.fetch(
+      new Request(`https://moderation.admin.divine.video/admin/api/moderate/${sha}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'AGE_RESTRICTED', reason: 'Contains nudity' })
+      }),
+      env
+    );
+
+    // Then override as SAFE
+    const response = await worker.fetch(
+      new Request(`https://moderation.admin.divine.video/admin/api/moderate/${sha}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'SAFE', reason: 'Actually fine' })
+      }),
+      env
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.previousAction).toBe('AGE_RESTRICTED');
+  });
+});
+
+describe('POST /admin/api/verify-category/:sha256', () => {
+  function createVerifyEnv(sha256, moderationResult, overrides = {}) {
+    const kvStore = new Map();
+    return {
+      ALLOW_DEV_ACCESS: 'true',
+      SERVICE_API_TOKEN: 'test-service-token',
+      BLOSSOM_DB: createDbMock({
+        moderationResults: moderationResult
+          ? new Map([[sha256, moderationResult]])
+          : new Map()
+      }),
+      MODERATION_KV: {
+        store: kvStore,
+        async get(key) { return kvStore.get(key) ?? null; },
+        async put(key, value) { kvStore.set(key, value); },
+        async delete(key) { kvStore.delete(key); },
+        async list() { return { keys: [], list_complete: true, cursor: null }; }
+      },
+      MODERATION_QUEUE: { async send() {} },
+      ...overrides
+    };
+  }
+
+  async function seedModeration(sha256, env, action, scores = {}) {
+    const response = await worker.fetch(
+      new Request(`https://moderation.admin.divine.video/admin/api/moderate/${sha256}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action, reason: 'seed for test', scores })
+      }),
+      env
+    );
+    expect(response.status).toBe(200);
+  }
+
+  it('rejects invalid category', async () => {
+    const sha = '1'.repeat(64);
+    const env = createVerifyEnv(sha, {
+      sha256: sha,
+      action: 'REVIEW',
+      provider: 'hiveai',
+      scores: JSON.stringify({ nudity: 0.5 }),
+      categories: JSON.stringify(['nudity']),
+      moderated_at: '2026-03-07T00:00:00.000Z',
+      reviewed_by: null,
+      reviewed_at: null
+    });
+
+    // First create a moderation result in KV
+    await seedModeration(sha, env, 'REVIEW');
+
+    const response = await worker.fetch(
+      new Request(`https://moderation.admin.divine.video/admin/api/verify-category/${sha}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ category: 'INVALID_CAT', status: 'confirmed' })
+      }),
+      env
+    );
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toContain('Invalid category');
+  });
+
+  it('rejects invalid status', async () => {
+    const sha = '2'.repeat(64);
+    const env = createVerifyEnv(sha, {
+      sha256: sha,
+      action: 'REVIEW',
+      provider: 'hiveai',
+      scores: JSON.stringify({ nudity: 0.5 }),
+      categories: JSON.stringify(['nudity']),
+      moderated_at: '2026-03-07T00:00:00.000Z',
+      reviewed_by: null,
+      reviewed_at: null
+    });
+
+    await seedModeration(sha, env, 'REVIEW');
+
+    const response = await worker.fetch(
+      new Request(`https://moderation.admin.divine.video/admin/api/verify-category/${sha}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ category: 'nudity', status: 'maybe' })
+      }),
+      env
+    );
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toContain('Status must be');
+  });
+
+  it('returns 404 for non-existent sha256', async () => {
+    const sha = '3'.repeat(64);
+    const env = createVerifyEnv(sha, null);
+
+    const response = await worker.fetch(
+      new Request(`https://moderation.admin.divine.video/admin/api/verify-category/${sha}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ category: 'nudity', status: 'confirmed' })
+      }),
+      env
+    );
+
+    expect(response.status).toBe(404);
+    const body = await response.json();
+    expect(body.error).toContain('not found');
+  });
+
+  it('stores category verification', async () => {
+    const sha = '4'.repeat(64);
+    const env = createVerifyEnv(sha, {
+      sha256: sha,
+      action: 'AGE_RESTRICTED',
+      provider: 'hiveai',
+      scores: JSON.stringify({ nudity: 0.9 }),
+      categories: JSON.stringify(['nudity']),
+      moderated_at: '2026-03-07T00:00:00.000Z',
+      reviewed_by: null,
+      reviewed_at: null
+    });
+
+    // Seed moderation result with scores in KV
+    await seedModeration(sha, env, 'AGE_RESTRICTED', { nudity: 0.9 });
+
+    const response = await worker.fetch(
+      new Request(`https://moderation.admin.divine.video/admin/api/verify-category/${sha}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ category: 'nudity', status: 'confirmed' })
+      }),
+      env
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(body.categoryVerifications.nudity).toBe('confirmed');
+  });
+
+  it('auto-approves when all major flags rejected', async () => {
+    const sha = '5'.repeat(64);
+    const env = createVerifyEnv(sha, {
+      sha256: sha,
+      action: 'AGE_RESTRICTED',
+      provider: 'hiveai',
+      scores: JSON.stringify({ nudity: 0.9 }),
+      categories: JSON.stringify(['nudity']),
+      moderated_at: '2026-03-07T00:00:00.000Z',
+      reviewed_by: null,
+      reviewed_at: null
+    });
+
+    // Seed moderation result with nudity score in KV
+    await seedModeration(sha, env, 'AGE_RESTRICTED', { nudity: 0.9 });
+
+    const response = await worker.fetch(
+      new Request(`https://moderation.admin.divine.video/admin/api/verify-category/${sha}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ category: 'nudity', status: 'rejected' })
+      }),
+      env
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.autoApproved).toBe(true);
+    expect(body.newAction).toBe('SAFE');
+  });
+});
+
+describe('POST /api/v1/scan (legacy)', () => {
+  it('rejects request without bearer token', async () => {
+    const response = await worker.fetch(
+      new Request('https://moderation-api.divine.video/api/v1/scan', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sha256: SHA256 })
+      }),
+      createEnv()
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it('rejects invalid sha256', async () => {
+    const env = createEnv({
+      MODERATION_API_KEY: 'legacy-token'
+    });
+
+    const response = await worker.fetch(
+      new Request('https://moderation-api.divine.video/api/v1/scan', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer legacy-token'
+        },
+        body: JSON.stringify({ sha256: 'not-a-hash' })
+      }),
+      env
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: 'sha256 required (64 hex characters)'
+    });
+  });
+});
+
+describe('POST /api/v1/batch-scan (legacy)', () => {
+  it('rejects empty videos array', async () => {
+    const env = createEnv({
+      MODERATION_API_KEY: 'legacy-token'
+    });
+
+    const response = await worker.fetch(
+      new Request('https://moderation-api.divine.video/api/v1/batch-scan', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer legacy-token'
+        },
+        body: JSON.stringify({ videos: [] })
+      }),
+      env
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: 'videos array required'
+    });
+  });
+
+  it('rejects batch over 100 videos', async () => {
+    const env = createEnv({
+      MODERATION_API_KEY: 'legacy-token'
+    });
+
+    const videos = Array.from({ length: 101 }, () => ({
+      sha256: SHA256
+    }));
+
+    const response = await worker.fetch(
+      new Request('https://moderation-api.divine.video/api/v1/batch-scan', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer legacy-token'
+        },
+        body: JSON.stringify({ videos })
+      }),
+      env
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: 'Maximum 100 videos per batch'
+    });
+  });
+});
+
+describe('POST /api/v1/notify', () => {
+  const VALID_PUBKEY = 'ab'.repeat(32);
+
+  it('rejects unauthorized request', async () => {
+    const env = createEnv({ ALLOW_DEV_ACCESS: 'false' });
+
+    const response = await worker.fetch(
+      new Request('https://moderation-api.divine.video/api/v1/notify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ recipientPubkey: VALID_PUBKEY, action: 'PERMANENT_BAN' })
+      }),
+      env
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it('rejects invalid pubkey', async () => {
+    const env = createEnv({ ALLOW_DEV_ACCESS: 'true' });
+
+    const response = await worker.fetch(
+      new Request('https://moderation-api.divine.video/api/v1/notify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ recipientPubkey: 'not-a-valid-hex-pubkey', action: 'PERMANENT_BAN' })
+      }),
+      env
+    );
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toContain('recipientPubkey');
+  });
+
+  it('rejects invalid action', async () => {
+    const env = createEnv({ ALLOW_DEV_ACCESS: 'true' });
+
+    const response = await worker.fetch(
+      new Request('https://moderation-api.divine.video/api/v1/notify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ recipientPubkey: VALID_PUBKEY, action: 'INVALID_ACTION' })
+      }),
+      env
+    );
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toContain('Invalid action');
+    expect(body.error).toContain('PERMANENT_BAN');
+  });
+
+  it('returns success with dm_sent false when NOSTR_PRIVATE_KEY not configured', async () => {
+    const env = createEnv({
+      ALLOW_DEV_ACCESS: 'true',
+      NOSTR_PRIVATE_KEY: undefined
+    });
+
+    const response = await worker.fetch(
+      new Request('https://moderation-api.divine.video/api/v1/notify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ recipientPubkey: VALID_PUBKEY, action: 'PERMANENT_BAN' })
+      }),
+      env
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(body.dm_sent).toBe(false);
+    expect(body.reason).toContain('not configured');
+  });
+
+  it('sends DM for valid request with NOSTR_PRIVATE_KEY configured', async () => {
+    const env = createEnv({
+      ALLOW_DEV_ACCESS: 'true',
+      NOSTR_PRIVATE_KEY: 'deadbeef'.repeat(8)
+    });
+
+    // sendModerationDM will attempt WebSocket connections to relays.
+    // Mock fetch/WebSocket to prevent real connections. The DM sender
+    // catches all errors internally and returns { sent: false, reason }.
+    const response = await worker.fetch(
+      new Request('https://moderation-api.divine.video/api/v1/notify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ recipientPubkey: VALID_PUBKEY, action: 'PERMANENT_BAN', reason: 'test' })
+      }),
+      env
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    // dm_sent may be true or false depending on relay connectivity,
+    // but the endpoint should not error
+    expect(typeof body.dm_sent).toBe('boolean');
   });
 });


### PR DESCRIPTION
## Summary

- Merge `1bdb009` resolved conflicts using the stale `quick-review-ux-improvements` branch, which silently dropped features that had been merged to main between its fork point and the merge
- This PR restores all clobbered code and preserves the legitimate post-merge additions (ATProto labeler, CORS on public status, transcript proxy, inbound-labels stubs)
- **Most code restored here was previously approved and merged via PRs #47, #48, #49, #52, #53, #54, #57, #61, #63, #64, #67, #69**

**Restored:**
- `pendingFlagged` + `pending` breakdown in `/admin/api/stats` (dashboard "AI Flagged" count was showing 0)
- `/api/v1/notify` endpoint (DM-only notifications used by relay-manager)
- `notifyReporters` calls in admin moderate, handleModerationResult, and cron paths
- `blossomFailureResponse` helper + 502 returns on Blossom notification failures
- Classic vine rollback endpoint
- Metadata fields (`title`, `author`, `event_id`, `content_url`, `published_at`) in D1 UPSERT
- Enriched `sendModerationDM` options (categories object, title, publishedAt)
- `Cache-Control: no-store` on admin JSON responses
- Sort parameter (`oldest`/`newest`) on untriaged list
- `buildDownstreamPublishContext` import
- ~791 lines of tests covering the above

**New improvements beyond restoration:**
- `blossomFailureResponse` shared helper consolidating three inline 502 responses (PR #57 review)
- Blossom failure check moved before relay delete in admin handler to prevent partial enforcement (PR #57 review)
- 502 tests added for all three moderate endpoints (PR #57 review)
- Already-SAFE skip in classic vine rollback to avoid unnecessary Blossom webhooks (PR #63 review)
- Blossom failure handling in classic vine rollback (PR #63 review)
- CORS wrapping on `/check-result/` responses
- `deleteRelayEventIds` refactored with per-event error tracking
- `deleteEventFromRelayBySha256` now fetches all d-tag versions
- Admin delete-event route returns 502 on relay failure

## Test plan

- [x] 584/584 tests passing locally (34 test files)
- [x] Lint clean (85 modules + 4 HTML files)
- [x] Verified restored index.mjs differs from last known-good commit (97d9b63) only by the CORS fix (4 lines)
- [x] Verified index.test.mjs matches 97d9b63 exactly
- [x] CI passes
- [x] Deploy to production and verify dashboard "AI Flagged" count is non-zero