### PR TITLE
fix: fall back to transcoded 720p MP4 for non-browser video formats

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -2019,21 +2019,44 @@ export default {
       const cdnUrl = `https://${env.CDN_DOMAIN}/${sha256}`;
       const adminBypassUrl = `https://${env.CDN_DOMAIN}/admin/api/blob/${sha256}/content`;
 
+      const BROWSER_PLAYABLE_TYPES = new Set(['video/mp4', 'video/webm', 'video/ogg']);
+
       try {
         // CDN fetch (unauthenticated) — works for SAFE/unmoderated content
         const cdnResponse = await fetch(cdnUrl);
         if (cdnResponse.ok) {
-          console.log(`[ADMIN] Serving video from CDN: ${sha256}`);
-          return new Response(cdnResponse.body, {
-            headers: {
-              'Content-Type': cdnResponse.headers.get('Content-Type') || 'video/mp4',
-              'Cache-Control': 'private, no-store',
-              'X-Admin-Proxy': 'cdn'
-            }
-          });
+          const contentType = cdnResponse.headers.get('Content-Type') || 'video/mp4';
+
+          // If the format is browser-playable, serve directly
+          if (BROWSER_PLAYABLE_TYPES.has(contentType)) {
+            console.log(`[ADMIN] Serving video from CDN: ${sha256}`);
+            return new Response(cdnResponse.body, {
+              headers: {
+                'Content-Type': contentType,
+                'Cache-Control': 'private, no-store',
+                'X-Admin-Proxy': 'cdn'
+              }
+            });
+          }
+
+          // Non-browser format (e.g. video/3gpp, video/x-matroska) — try transcoded 720p MP4 from Blossom
+          console.log(`[ADMIN] CDN returned non-playable ${contentType}, trying transcoded 720p for ${sha256}`);
+          const transcodeUrl = `https://${env.CDN_DOMAIN}/${sha256}/720p.mp4`;
+          const transcodeResponse = await fetch(transcodeUrl);
+          if (transcodeResponse.ok) {
+            console.log(`[ADMIN] Serving transcoded 720p MP4 for ${sha256}`);
+            return new Response(transcodeResponse.body, {
+              headers: {
+                'Content-Type': transcodeResponse.headers.get('Content-Type') || 'video/mp4',
+                'Cache-Control': 'private, no-store',
+                'X-Admin-Proxy': 'cdn-transcode'
+              }
+            });
+          }
+          console.warn(`[ADMIN] Transcoded 720p not available (${transcodeResponse.status}) for ${sha256}`);
         }
 
-        // CDN returned non-200 (banned/restricted content returns 404)
+        // CDN returned non-200 or non-playable with no transcode available
         // Fall back to admin bypass endpoint which serves regardless of moderation status
         if (env.BLOSSOM_WEBHOOK_SECRET) {
           console.log(`[ADMIN] CDN returned ${cdnResponse.status}, trying admin bypass for ${sha256}`);

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -56,6 +56,7 @@ function createEnv(overrides = {}) {
     MODERATION_QUEUE: {
       async send() {}
     },
+    CDN_DOMAIN: 'media.divine.video',
     ...overrides
   };
 }
@@ -538,7 +539,7 @@ This is a test`;
         new Request(`https://moderation.admin.divine.video/admin/api/transcript/${SHA256}`, {
           headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
         }),
-        createEnv({ CDN_DOMAIN: 'media.divine.video' })
+        createEnv()
       );
 
       expect(response.status).toBe(200);
@@ -576,12 +577,149 @@ Hello world`;
         new Request(`https://moderation.admin.divine.video/admin/transcript/${SHA256}.vtt`, {
           headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
         }),
-        createEnv({ CDN_DOMAIN: 'media.divine.video' })
+        createEnv()
       );
 
       expect(response.status).toBe(200);
       expect(response.headers.get('Content-Type')).toBe('text/vtt; charset=utf-8');
       await expect(response.text()).resolves.toBe(vttText);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+describe('admin video proxy format fallback', () => {
+  it('serves video directly when CDN returns browser-playable format', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (url) => {
+      if (String(url) === `https://media.divine.video/${SHA256}`) {
+        return new Response('mp4-bytes', {
+          status: 200,
+          headers: { 'Content-Type': 'video/mp4' }
+        });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    };
+
+    try {
+      const response = await worker.fetch(
+        new Request(`https://moderation.admin.divine.video/admin/video/${SHA256}.mp4`, {
+          headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
+        }),
+        createEnv()
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('Content-Type')).toBe('video/mp4');
+      expect(response.headers.get('X-Admin-Proxy')).toBe('cdn');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('falls back to transcoded 720p MP4 when CDN returns video/3gpp', async () => {
+    const originalFetch = globalThis.fetch;
+    const fetchedUrls = [];
+    globalThis.fetch = async (url, init) => {
+      fetchedUrls.push(String(url));
+      if (String(url) === `https://media.divine.video/${SHA256}`) {
+        return new Response('3gpp-bytes', {
+          status: 200,
+          headers: { 'Content-Type': 'video/3gpp' }
+        });
+      }
+      if (String(url) === `https://media.divine.video/${SHA256}/720p.mp4`) {
+        return new Response('transcoded-mp4-bytes', {
+          status: 200,
+          headers: { 'Content-Type': 'video/mp4' }
+        });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    };
+
+    try {
+      const response = await worker.fetch(
+        new Request(`https://moderation.admin.divine.video/admin/video/${SHA256}.mp4`, {
+          headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
+        }),
+        createEnv()
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('Content-Type')).toBe('video/mp4');
+      expect(response.headers.get('X-Admin-Proxy')).toBe('cdn-transcode');
+      expect(fetchedUrls).toContain(`https://media.divine.video/${SHA256}/720p.mp4`);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('falls back to admin bypass when transcode also unavailable', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (url, init) => {
+      if (String(url) === `https://media.divine.video/${SHA256}`) {
+        return new Response('3gpp-bytes', {
+          status: 200,
+          headers: { 'Content-Type': 'video/3gpp' }
+        });
+      }
+      if (String(url) === `https://media.divine.video/${SHA256}/720p.mp4`) {
+        return new Response('not found', { status: 404 });
+      }
+      if (String(url) === `https://media.divine.video/admin/api/blob/${SHA256}/content`) {
+        return new Response('bypass-bytes', {
+          status: 200,
+          headers: { 'Content-Type': 'video/mp4' }
+        });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    };
+
+    try {
+      const response = await worker.fetch(
+        new Request(`https://moderation.admin.divine.video/admin/video/${SHA256}.mp4`, {
+          headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
+        }),
+        createEnv({ BLOSSOM_WEBHOOK_SECRET: 'test-secret' })
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('X-Admin-Proxy')).toBe('blossom-admin');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('falls back to transcoded MP4 for video/x-matroska (MKV)', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (url) => {
+      if (String(url) === `https://media.divine.video/${SHA256}`) {
+        return new Response('mkv-bytes', {
+          status: 200,
+          headers: { 'Content-Type': 'video/x-matroska' }
+        });
+      }
+      if (String(url) === `https://media.divine.video/${SHA256}/720p.mp4`) {
+        return new Response('transcoded-mp4-bytes', {
+          status: 200,
+          headers: { 'Content-Type': 'video/mp4' }
+        });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    };
+
+    try {
+      const response = await worker.fetch(
+        new Request(`https://moderation.admin.divine.video/admin/video/${SHA256}.mp4`, {
+          headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
+        }),
+        createEnv()
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('Content-Type')).toBe('video/mp4');
+      expect(response.headers.get('X-Admin-Proxy')).toBe('cdn-transcode');
     } finally {
       globalThis.fetch = originalFetch;
     }


### PR DESCRIPTION
## Summary
- When the admin video proxy gets a non-browser-playable Content-Type from the CDN (e.g. `video/3gpp`, `video/x-matroska`), it now tries the Blossom transcoded `/{sha256}/720p.mp4` variant before falling back to the admin bypass endpoint
- Fixes broken video playback in the swipe review UI for videos uploaded in mobile formats
- Adds 4 tests covering: direct playback, 3gpp fallback, bypass when transcode unavailable, MKV fallback

## Fallback chain
1. CDN direct → serve if browser-playable (`video/mp4`, `video/webm`, `video/ogg`)
2. CDN returns non-playable format → try `/{sha256}/720p.mp4` transcoded version
3. Transcode unavailable → admin bypass endpoint (existing fallback)
4. All fail → 404

## Test plan
- [x] Existing video proxy behavior unchanged for MP4 content
- [x] `video/3gpp` triggers fallback to transcoded 720p MP4
- [x] `video/x-matroska` triggers fallback to transcoded 720p MP4
- [x] When transcode is also unavailable, falls through to admin bypass
- [x] Full test suite passes (2727 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)