### PR TITLE
feat: expand quick review metadata context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ old_files/
 .test-nsec
 old_files/
 cost-projections-internal.md
+.worktrees/

--- a/docs/superpowers/plans/2026-04-02-quick-review-metadata-plan.md
+++ b/docs/superpowers/plans/2026-04-02-quick-review-metadata-plan.md
@@ -1,0 +1,225 @@
+# Quick Review Metadata-First Card Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the quick review card show full publisher, post, timeline, and technical metadata by default so moderators can decide without opening another page.
+
+**Architecture:** Extend the quick review queue API to return persisted post metadata on first load, then refactor the card renderer in `src/admin/swipe-review.html` into a wider metadata-first layout that merges queue payload fields with async lookup enrichment. Keep existing async enrichment for missing or deeper lookup data, but make the initial card materially complete before any follow-up fetch resolves.
+
+**Tech Stack:** Cloudflare Worker, D1, vanilla HTML/CSS/JS, Vitest
+
+---
+
+## File Map
+
+- Modify: `src/index.mjs`
+  - Extend `/admin/api/videos` rows and JSON shaping to include persisted metadata fields needed by the quick review card.
+  - Extend admin lookup helpers so richer Nostr metadata is preserved in the card enrichment payload.
+- Modify: `src/admin/swipe-review.html`
+  - Refactor the card layout, rendering helpers, and metadata formatting for the metadata-first review card.
+- Modify: `src/index.test.mjs`
+  - Add failing coverage for quick review API metadata fields and enriched admin lookup payload behavior.
+
+## Chunk 1: API Payload And Lookup Enrichment
+
+### Task 1: Add a failing queue payload test
+
+**Files:**
+- Test: `src/index.test.mjs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add an admin quick review API test that seeds a `moderation_results` row with:
+- `title`
+- `author`
+- `event_id`
+- `content_url`
+- `published_at`
+
+Assert `GET /admin/api/videos?action=FLAGGED&limit=100` returns those fields in `body.videos[0]`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/index.test.mjs`
+Expected: FAIL because `/admin/api/videos` does not currently select/return the persisted metadata fields.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Update the `/admin/api/videos` SQL query and JSON shaping in `src/index.mjs` to include:
+- `title`
+- `author`
+- `event_id`
+- `content_url`
+- `published_at`
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/index.test.mjs`
+Expected: PASS for the new quick review API test.
+
+- [ ] **Step 5: Commit**
+
+Run:
+```bash
+git add src/index.mjs src/index.test.mjs
+git commit -m "feat: expose quick review metadata fields"
+```
+
+### Task 2: Add a failing lookup enrichment test
+
+**Files:**
+- Test: `src/index.test.mjs`
+- Modify: `src/index.mjs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add or extend an admin video lookup test to verify the response can carry rich `nostrContext` fields used by the card:
+- `content`
+- `sourceUrl`
+- `platform`
+- `client`
+- `loops`
+- `likes`
+- `comments`
+- `publishedAt`
+- `archivedAt`
+- `importedAt`
+- `vineHashId`
+- `vineUserId`
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/index.test.mjs`
+Expected: FAIL because the current moderation-row-backed lookup response does not preserve enough stored metadata for the card.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Update lookup shaping in `src/index.mjs` so admin lookup responses preserve stored metadata and merge richer event metadata when available without dropping persisted values.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/index.test.mjs`
+Expected: PASS for the new/updated lookup enrichment assertions.
+
+- [ ] **Step 5: Commit**
+
+Run:
+```bash
+git add src/index.mjs src/index.test.mjs
+git commit -m "feat: preserve rich admin lookup metadata"
+```
+
+## Chunk 2: Metadata-First Review Card
+
+### Task 3: Add a failing card-render test
+
+**Files:**
+- Test: `src/index.test.mjs`
+- Modify: `src/admin/swipe-review.html`
+
+- [ ] **Step 1: Write the failing test**
+
+Add an HTML response test for `/admin/review` that asserts the quick review page contains the new renderer markers/helper names for:
+- publisher identity section
+- timeline section
+- metadata grid
+- full-content/post block
+
+This test should be structural rather than screenshot-based.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/index.test.mjs`
+Expected: FAIL because the current HTML does not include the new metadata-first structure.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Refactor `src/admin/swipe-review.html` to:
+- widen the card and add a desktop two-column layout
+- render all visible metadata sections by default
+- show labeled timestamps for `Published`, `Received`, `Moderated`, and `Reviewed`
+- show full pubkey, post text, title, links, IDs, and technical metadata
+- keep classifier, transcript, scores, and actions visible below the post context
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/index.test.mjs`
+Expected: PASS for the new HTML structure assertions.
+
+- [ ] **Step 5: Commit**
+
+Run:
+```bash
+git add src/admin/swipe-review.html src/index.test.mjs
+git commit -m "feat: redesign quick review card around metadata"
+```
+
+### Task 4: Verify merged payload behavior end to end
+
+**Files:**
+- Modify: `src/admin/swipe-review.html`
+- Test: `src/index.test.mjs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add a targeted test that verifies queue metadata and lookup enrichment can coexist without clobbering the visible fields the card depends on.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/index.test.mjs`
+Expected: FAIL if the merge logic still favors sparse async lookup data over richer persisted queue fields.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Adjust the client-side merge/render helpers in `src/admin/swipe-review.html` so:
+- queue payload fields render immediately
+- async lookup fills missing values and richer metadata
+- existing values are not overwritten by emptier lookup fields
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/index.test.mjs`
+Expected: PASS for the merge/fallback assertions.
+
+- [ ] **Step 5: Commit**
+
+Run:
+```bash
+git add src/admin/swipe-review.html src/index.test.mjs
+git commit -m "fix: preserve quick review metadata during enrichment"
+```
+
+## Chunk 3: Verification
+
+### Task 5: Run targeted and full verification
+
+**Files:**
+- Modify: `src/index.mjs`
+- Modify: `src/admin/swipe-review.html`
+- Test: `src/index.test.mjs`
+
+- [ ] **Step 1: Run targeted tests**
+
+Run: `npm test -- src/index.test.mjs`
+Expected: PASS
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `npm test`
+Expected: PASS
+
+- [ ] **Step 3: Review the rendered quick review HTML for obvious regressions**
+
+Check:
+- card width and responsive layout classes
+- no hidden/collapsed metadata sections
+- action buttons still present
+- sanitization helpers still wrap user-provided strings
+
+- [ ] **Step 4: Commit final integration changes**
+
+Run:
+```bash
+git add src/index.mjs src/admin/swipe-review.html src/index.test.mjs
+git commit -m "feat: show full quick review context by default"
+```

--- a/docs/superpowers/specs/2026-04-02-quick-review-metadata-design.md
+++ b/docs/superpowers/specs/2026-04-02-quick-review-metadata-design.md
@@ -1,0 +1,149 @@
+# Quick Review Metadata-First Card
+
+**Date:** 2026-04-02
+**Status:** Approved
+**Scope:** divine-moderation-service quick review UI and supporting admin API payloads
+
+## Problem
+
+The quick review card does not show enough post context to make moderation decisions quickly or confidently.
+
+Current problems:
+- The card emphasizes AI scores before publisher identity and post context.
+- The top timestamp is effectively moderation time, which can be confused with publish time.
+- Persisted metadata such as `author`, `title`, `event_id`, `content_url`, and `published_at` is not surfaced in the quick review queue payload.
+- Extra metadata only appears opportunistically after an async lookup, so the card feels incomplete and inconsistent.
+
+## User Intent
+
+The moderator wants the card to answer these questions immediately, without collapsing anything:
+- Who published this?
+- When was it published?
+- What did they say?
+- What metadata exists for the video and event?
+
+The moderator explicitly requested that all available context be visible by default.
+
+## Design
+
+Rebuild the quick review card as a metadata-first review surface.
+
+### Layout
+
+- Increase the maximum card width on desktop to support a two-column layout.
+- Desktop layout:
+  - Left column: video player
+  - Right column: full metadata and review context
+- Mobile layout:
+  - Same sections in the same order
+  - Stacked vertically with no hidden details
+
+### Information Hierarchy
+
+Show the following sections in this order:
+
+1. Publisher identity
+2. Post body and content metadata
+3. Timeline
+4. Technical identifiers and source metadata
+5. Classifier summary
+6. Transcript
+7. Moderation scores and provider details
+8. Review actions
+
+### Publisher Identity
+
+Show all available publisher identity fields at the top:
+- `author` / display name
+- uploader pubkey in full
+- Divine profile link when a pubkey is known
+- avatar initial fallback
+
+If `author` is missing, fall back to uploader/pubkey-based labeling rather than leaving the section vague.
+
+### Post Body And Content Metadata
+
+Show all available post-level context:
+- title
+- full post text / event content
+- Divine video link
+- content/CDN URL
+- original source URL when present
+
+Content text should be fully visible by default with normal wrapping, not hidden behind a disclosure.
+
+### Timeline
+
+Show all known timestamps together with clear labels:
+- `Published`
+- `Received`
+- `Moderated`
+- `Reviewed`
+
+Each timestamp should include absolute time and relative time when available.
+
+Do not use moderation time as the only visible time field.
+
+### Technical Identifiers And Source Metadata
+
+Show all known technical metadata in a readable key/value grid:
+- `event_id`
+- `sha256`
+- `provider`
+- `platform`
+- `client`
+- `loops`
+- `likes`
+- `comments`
+- `published_at`
+- `archived_at`
+- `imported_at`
+- `vine_hash_id`
+- `vine_user_id`
+
+Only omit fields that are truly absent.
+
+### API Changes
+
+The quick review queue payload should include the metadata already persisted in `moderation_results` so the first render is complete:
+- `title`
+- `author`
+- `event_id`
+- `content_url`
+- `published_at`
+
+The single-video admin lookup route should also preserve or expose:
+- `nostrContext.content`
+- `nostrContext.sourceUrl`
+- `nostrContext.platform`
+- `nostrContext.client`
+- `nostrContext.loops`
+- `nostrContext.likes`
+- `nostrContext.comments`
+- `nostrContext.publishedAt`
+- `nostrContext.archivedAt`
+- `nostrContext.importedAt`
+- `nostrContext.vineHashId`
+- `nostrContext.vineUserId`
+
+### Non-Goals
+
+- No collapsible details panel
+- No persistence of UI expansion state
+- No change to moderation actions or queue semantics
+- No redesign of dashboard pages outside quick review
+
+## Implementation Notes
+
+- Reuse persisted D1 metadata for fast first paint.
+- Keep the async `/admin/api/video/:identifier` enrichment path for deeper or missing lookup metadata.
+- Preserve existing escape/sanitization behavior for all user-sourced strings.
+- Maintain mobile usability even with fully expanded metadata.
+
+## Testing
+
+Add coverage for:
+- queue payload returning persisted metadata fields
+- card rendering of publisher, post body, labeled timestamps, and technical metadata
+- fallback behavior when some metadata is absent
+- mobile-safe rendering helpers where practical via unit-level assertions

--- a/src/admin/swipe-review.html
+++ b/src/admin/swipe-review.html
@@ -95,8 +95,8 @@
 
     .video-card-swipe {
       position: relative;
-      width: 90%;
-      max-width: 600px;
+      width: 96%;
+      max-width: 1100px;
       max-height: none;
       background: #1a1a1a;
       border: 2px solid #333;
@@ -179,6 +179,190 @@
 
     .video-info {
       padding: 20px;
+    }
+
+    .review-primary-layout {
+      display: grid;
+      grid-template-columns: minmax(0, 1.05fr) minmax(320px, 0.95fr);
+      gap: 18px;
+      align-items: start;
+    }
+
+    .review-secondary-layout {
+      margin-top: 18px;
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 12px;
+    }
+
+    .review-media-column,
+    .review-metadata-column {
+      min-width: 0;
+    }
+
+    .review-metadata-column {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .review-full-width {
+      grid-column: 1 / -1;
+    }
+
+    .metadata-section {
+      background: #101010;
+      border: 1px solid #2a2a2a;
+      border-radius: 10px;
+      padding: 14px;
+    }
+
+    .metadata-section-title {
+      font-size: 11px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #8a8a8a;
+      margin-bottom: 12px;
+    }
+
+    .publisher-card {
+      display: flex;
+      gap: 12px;
+      align-items: flex-start;
+    }
+
+    .publisher-avatar {
+      width: 44px;
+      height: 44px;
+      border-radius: 999px;
+      background: #222;
+      color: #f4f4f5;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 18px;
+      font-weight: 700;
+      flex-shrink: 0;
+    }
+
+    .publisher-name {
+      font-size: 18px;
+      font-weight: 700;
+      color: #fafafa;
+      line-height: 1.2;
+      word-break: break-word;
+    }
+
+    .publisher-subtitle {
+      margin-top: 4px;
+      font-size: 12px;
+      color: #8b8b8b;
+      line-height: 1.4;
+    }
+
+    .metadata-grid {
+      display: grid;
+      gap: 10px;
+    }
+
+    .metadata-grid.compact {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 10px 14px;
+    }
+
+    .metadata-row {
+      display: grid;
+      grid-template-columns: 110px minmax(0, 1fr);
+      gap: 10px;
+      align-items: start;
+    }
+
+    .metadata-key {
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: #7a7a7a;
+    }
+
+    .metadata-value {
+      font-size: 13px;
+      color: #e7e7e7;
+      line-height: 1.5;
+      word-break: break-word;
+    }
+
+    .metadata-value.monospace {
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 12px;
+      color: #d4d4d8;
+    }
+
+    .metadata-link {
+      color: #93c5fd;
+      text-decoration: none;
+    }
+
+    .metadata-link:hover {
+      text-decoration: underline;
+    }
+
+    .metadata-link-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: 12px;
+    }
+
+    .metadata-link-chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 6px 10px;
+      border: 1px solid #334155;
+      border-radius: 999px;
+      background: #111827;
+      color: #bfdbfe;
+      font-size: 12px;
+      text-decoration: none;
+    }
+
+    .metadata-link-chip:hover {
+      border-color: #60a5fa;
+      color: #dbeafe;
+    }
+
+    .post-title {
+      font-size: 20px;
+      font-weight: 700;
+      color: #fafafa;
+      line-height: 1.25;
+      word-break: break-word;
+    }
+
+    .post-body {
+      margin-top: 10px;
+      padding: 12px;
+      border-radius: 8px;
+      border: 1px solid #242424;
+      background: #0a0a0a;
+      font-size: 13px;
+      line-height: 1.6;
+      color: #d4d4d8;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+
+    .post-body.empty {
+      color: #71717a;
+      font-style: italic;
+    }
+
+    .section-stack {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
     }
 
     .video-hash {
@@ -472,6 +656,33 @@
       font-size: 12px;
       color: #71717a;
       line-height: 1.5;
+    }
+
+    @media (max-width: 900px) {
+      .video-card-swipe {
+        width: 100%;
+        border-left: 0;
+        border-right: 0;
+        border-radius: 0;
+      }
+
+      .review-primary-layout,
+      .review-secondary-layout {
+        grid-template-columns: minmax(0, 1fr);
+      }
+
+      .video-wrapper {
+        height: 44vh;
+      }
+
+      .metadata-grid.compact {
+        grid-template-columns: minmax(0, 1fr);
+      }
+
+      .metadata-row {
+        grid-template-columns: minmax(0, 1fr);
+        gap: 4px;
+      }
     }
 
     .keyboard-hints kbd {
@@ -799,12 +1010,9 @@
         fetchClassifierSummary(video.sha256).then(summary => {
           if (summary && currentIndex < reviewQueue.length && reviewQueue[currentIndex].sha256 === video.sha256) {
             video.classifierSummary = summary;
-            const existing = card.querySelector('.classifier-summary');
-            if (!existing) {
-              const hashEl = card.querySelector('.video-hash');
-              if (hashEl) {
-                hashEl.insertAdjacentHTML('afterend', createClassifierHTML(summary));
-              }
+            const classifierSlot = card.querySelector('.classifier-slot');
+            if (classifierSlot) {
+              classifierSlot.innerHTML = createClassifierHTML(summary);
             }
           }
         });
@@ -824,21 +1032,15 @@
       }
 
       // Async-load nostr context if not already present (for flagged videos from DB)
-      if (!video.nostrContext && !video._nostrContextFetched) {
+      if (!video._nostrContextFetched) {
         video._nostrContextFetched = true;
         fetchVideoContext(video.sha256).then(ctx => {
           if (ctx && currentIndex < reviewQueue.length && reviewQueue[currentIndex].sha256 === video.sha256) {
-            video.nostrContext = ctx.nostrContext || null;
-            video.eventId = video.eventId || ctx.eventId || null;
-            video.uploaded_by = video.uploaded_by || ctx.uploaded_by || null;
-            // Re-render the event meta section
-            const metaEl = card.querySelector('.event-meta');
-            const infoEl = card.querySelector('.video-info');
-            if (infoEl && !metaEl) {
-              const newMetaHTML = createEventMetaHTML(video);
-              if (newMetaHTML) {
-                infoEl.insertAdjacentHTML('afterbegin', newMetaHTML);
-              }
+            const merged = mergeVideoContext(video, ctx);
+            reviewQueue[currentIndex] = merged;
+            const metadataColumn = card.querySelector('.review-metadata-column');
+            if (metadataColumn) {
+              metadataColumn.innerHTML = createMetadataColumnHTML(merged);
             }
           }
         });
@@ -870,13 +1072,11 @@
       }
 
       // Preload nostr context
-      if (!next.nostrContext && !next._nostrContextFetched) {
+      if (!next._nostrContextFetched) {
         next._nostrContextFetched = true;
         fetchVideoContext(next.sha256).then(ctx => {
           if (ctx) {
-            next.nostrContext = ctx.nostrContext || null;
-            next.eventId = next.eventId || ctx.eventId || null;
-            next.uploaded_by = next.uploaded_by || ctx.uploaded_by || null;
+            reviewQueue[nextIdx] = mergeVideoContext(next, ctx);
           }
         });
       }
@@ -896,50 +1096,163 @@
         const resp = await fetch(`/admin/api/video/${sha256}`);
         if (!resp.ok) return null;
         const data = await resp.json();
-        const video = data.video || {};
-        return {
-          nostrContext: video.nostrContext || null,
-          eventId: video.eventId || null,
-          uploaded_by: video.uploaded_by || video.uploadedBy || null,
-          divineUrl: video.divineUrl || null
-        };
+        return data.video || null;
       } catch {
         return null;
       }
     }
 
-    function createEventMetaHTML(video) {
-      const nostrContext = video.nostrContext;
-      const authorName = nostrContext?.author || null;
-      const pubkey = nostrContext?.pubkey || video.uploaded_by || null;
-      const truncatedPubkey = pubkey ? (pubkey.length > 20 ? pubkey.substring(0, 16) + '...' : pubkey) : null;
-      const timestamp = video.moderated_at || video.receivedAt || null;
-      const timeAgo = timestamp ? formatTimeAgo(timestamp) : null;
-      const divineVideoUrl = video.eventId
-        ? `https://divine.video/video/${video.eventId}`
-        : `https://divine.video/video/${video.sha256}`;
-      const divineProfileUrl = pubkey ? `https://divine.video/profile/${pubkey}` : null;
-      const divineLinkLabel = video.eventId ? 'View on Divine' : pubkey ? 'View on Divine (may not be published)' : 'Not published to relay';
-      const hasDivineLink = video.eventId || pubkey;
+    function isPresent(value) {
+      return value !== null && value !== undefined && value !== '';
+    }
 
-      if (!authorName && !pubkey && !timestamp) return '';
+    function pickFirstPresent(...values) {
+      for (const value of values) {
+        if (isPresent(value)) return value;
+      }
+      return null;
+    }
+
+    function mergeFields(existing = {}, incoming = {}) {
+      const merged = { ...(existing || {}) };
+      for (const [key, value] of Object.entries(incoming || {})) {
+        if (!isPresent(merged[key]) && isPresent(value)) {
+          merged[key] = value;
+        }
+      }
+      return Object.keys(merged).length > 0 ? merged : null;
+    }
+
+    function mergeVideoContext(video, context) {
+      if (!context) return video;
+
+      const merged = { ...video };
+      merged.nostrContext = mergeFields(video.nostrContext || {}, context.nostrContext || {});
+      merged.uploaded_by = pickFirstPresent(video.uploaded_by, context.uploaded_by, context.uploadedBy);
+      merged.eventId = pickFirstPresent(video.eventId, video.event_id, context.eventId, context.event_id, merged.nostrContext?.eventId);
+      merged.event_id = pickFirstPresent(video.event_id, video.eventId, context.event_id, context.eventId, merged.nostrContext?.eventId);
+      merged.divineUrl = pickFirstPresent(video.divineUrl, context.divineUrl, merged.eventId ? `https://divine.video/video/${merged.eventId}` : null);
+      merged.title = pickFirstPresent(video.title, context.title, merged.nostrContext?.title);
+      merged.author = pickFirstPresent(video.author, context.author, merged.nostrContext?.author);
+      merged.content_url = pickFirstPresent(video.content_url, context.content_url, context.contentUrl, merged.nostrContext?.url, video.cdnUrl);
+      merged.published_at = pickFirstPresent(video.published_at, context.published_at, context.publishedAt, merged.nostrContext?.publishedAt);
+
+      merged.nostrContext = mergeFields(merged.nostrContext || {}, {
+        title: merged.title,
+        author: merged.author,
+        url: merged.content_url,
+        publishedAt: merged.published_at
+      });
+
+      return Object.assign(video, merged);
+    }
+
+    function buildDivineVideoUrl(video) {
+      return pickFirstPresent(
+        video.divineUrl,
+        video.eventId ? `https://divine.video/video/${video.eventId}` : null,
+        video.event_id ? `https://divine.video/video/${video.event_id}` : null
+      );
+    }
+
+    function buildProfileUrl(pubkey) {
+      return pubkey ? `https://divine.video/profile/${pubkey}` : null;
+    }
+
+    function createMetadataField(label, value, options = {}) {
+      const resolvedValue = isPresent(value) ? value : (options.fallback ?? null);
+      if (!isPresent(resolvedValue)) return '';
+
+      const valueHtml = options.href
+        ? `<a class="metadata-link" href="${escapeHtml(options.href)}" target="_blank" rel="noopener noreferrer">${escapeHtml(String(resolvedValue))}</a>`
+        : escapeHtml(String(resolvedValue));
+      const valueClass = options.monospace ? 'metadata-value monospace' : 'metadata-value';
 
       return `
-        <div class="event-meta">
-          <div class="event-meta-avatar">${authorName ? authorName.charAt(0).toUpperCase() : '?'}</div>
-          <div class="event-meta-details">
-            ${authorName ? `<div class="event-meta-author">${divineProfileUrl ? `<a href="${escapeHtml(divineProfileUrl)}" target="_blank" style="color: inherit; text-decoration: none;">${escapeHtml(authorName)}</a>` : escapeHtml(authorName)}</div>` : ''}
-            ${truncatedPubkey ? `<div class="event-meta-pubkey">${divineProfileUrl ? `<a href="${escapeHtml(divineProfileUrl)}" target="_blank" style="color: inherit; text-decoration: underline dotted;">${escapeHtml(truncatedPubkey)}</a>` : escapeHtml(truncatedPubkey)}</div>` : ''}
-            ${timeAgo ? `<div class="event-meta-time">${escapeHtml(timeAgo)}</div>` : ''}
-            <div class="event-meta-links">
-              ${hasDivineLink
-                ? `<a href="${escapeHtml(divineVideoUrl)}" target="_blank">${divineLinkLabel}</a>`
-                : `<span style="color: #666; font-style: italic;">${divineLinkLabel}</span>`}
-              ${nostrContext?.url ? `<a href="${escapeHtml(nostrContext.url)}" target="_blank">CDN</a>` : ''}
-            </div>
-          </div>
+        <div class="metadata-row">
+          <div class="metadata-key">${escapeHtml(label)}</div>
+          <div class="${valueClass}">${valueHtml}</div>
         </div>
       `;
+    }
+
+    function createMetadataSection(title, innerHtml, extraClass = '') {
+      return `
+        <section class="metadata-section ${extraClass}">
+          <div class="metadata-section-title">${escapeHtml(title)}</div>
+          ${innerHtml}
+        </section>
+      `;
+    }
+
+    function createMetadataColumnHTML(video) {
+      const nostrContext = video.nostrContext || {};
+      const authorName = pickFirstPresent(video.author, nostrContext.author, 'Unknown publisher');
+      const pubkey = pickFirstPresent(video.uploaded_by, nostrContext.pubkey);
+      const profileUrl = buildProfileUrl(pubkey);
+      const eventId = pickFirstPresent(video.eventId, video.event_id, nostrContext.eventId);
+      const divineVideoUrl = buildDivineVideoUrl(video);
+      const contentUrl = pickFirstPresent(video.content_url, nostrContext.url, video.cdnUrl);
+      const sourceUrl = pickFirstPresent(nostrContext.sourceUrl);
+      const title = pickFirstPresent(video.title, nostrContext.title);
+      const postBody = pickFirstPresent(nostrContext.content);
+      const publishedAt = pickFirstPresent(video.published_at, nostrContext.publishedAt);
+
+      const publisherSection = createMetadataSection('Publisher', `
+        <div class="publisher-card">
+          <div class="publisher-avatar">${escapeHtml((authorName || '?').charAt(0).toUpperCase())}</div>
+          <div class="section-stack" style="min-width: 0;">
+            <div class="publisher-name">${profileUrl ? `<a class="metadata-link" href="${escapeHtml(profileUrl)}" target="_blank" rel="noopener noreferrer">${escapeHtml(authorName)}</a>` : escapeHtml(authorName)}</div>
+            <div class="publisher-subtitle">Who published this</div>
+          </div>
+        </div>
+        <div class="metadata-grid" style="margin-top: 12px;">
+          ${createMetadataField('Pubkey', pubkey, { monospace: true, fallback: 'Not available' })}
+          ${profileUrl ? createMetadataField('Profile', 'Open profile', { href: profileUrl }) : createMetadataField('Profile', null, { fallback: 'Not available' })}
+        </div>
+      `);
+
+      const postSection = createMetadataSection('Post Context', `
+        ${title ? `<div class="post-title">${escapeHtml(title)}</div>` : '<div class="post-title">Untitled post</div>'}
+        <div class="post-body ${postBody ? '' : 'empty'}">${postBody ? escapeHtml(postBody) : 'No post text available from stored metadata or relay lookup.'}</div>
+        <div class="metadata-link-list">
+          ${divineVideoUrl ? `<a class="metadata-link-chip" href="${escapeHtml(divineVideoUrl)}" target="_blank" rel="noopener noreferrer">Open Divine Post</a>` : ''}
+          ${contentUrl ? `<a class="metadata-link-chip" href="${escapeHtml(contentUrl)}" target="_blank" rel="noopener noreferrer">Open Content URL</a>` : ''}
+          ${sourceUrl ? `<a class="metadata-link-chip" href="${escapeHtml(sourceUrl)}" target="_blank" rel="noopener noreferrer">Open Source URL</a>` : ''}
+        </div>
+      `);
+
+      const timelineSection = createMetadataSection('Timeline', `
+        <div class="metadata-grid">
+          ${createMetadataField('Published', formatTimestampDetail(publishedAt), { fallback: 'Not available' })}
+          ${createMetadataField('Received', formatTimestampDetail(video.receivedAt), { fallback: 'Not available' })}
+          ${createMetadataField('Moderated', formatTimestampDetail(video.moderated_at), { fallback: 'Not available' })}
+          ${createMetadataField('Reviewed', formatTimestampDetail(video.reviewed_at), { fallback: 'Not available' })}
+        </div>
+      `);
+
+      const technicalFields = [
+        createMetadataField('Event ID', eventId, { monospace: true }),
+        createMetadataField('SHA256', video.sha256, { monospace: true }),
+        createMetadataField('Provider', video.provider, { fallback: 'Not available' }),
+        createMetadataField('Platform', nostrContext.platform),
+        createMetadataField('Client', nostrContext.client),
+        createMetadataField('Loops', nostrContext.loops),
+        createMetadataField('Likes', nostrContext.likes),
+        createMetadataField('Comments', nostrContext.comments),
+        createMetadataField('Archived At', formatTimestampDetail(nostrContext.archivedAt)),
+        createMetadataField('Imported At', formatTimestampDetail(nostrContext.importedAt)),
+        createMetadataField('Vine Hash ID', nostrContext.vineHashId, { monospace: true }),
+        createMetadataField('Vine User ID', nostrContext.vineUserId, { monospace: true })
+      ].filter(Boolean).join('');
+
+      const technicalSection = createMetadataSection('Technical Metadata', `
+        <div class="metadata-grid compact">
+          ${technicalFields || createMetadataField('Metadata', null, { fallback: 'No additional metadata available' })}
+        </div>
+      `);
+
+      return publisherSection + postSection + timelineSection + technicalSection;
     }
 
     async function fetchClassifierSummary(sha256) {
@@ -1072,10 +1385,9 @@
     }
 
     function createVideoCard(video) {
-      const { sha256, scores, nostrContext, provider, detailedCategories, isUntriaged, classifierSummary, uploaded_by, moderated_at, receivedAt, eventId } = video;
+      const { sha256, scores, detailedCategories, isUntriaged, classifierSummary } = video;
       const videoUrl = '/admin/video/' + sha256 + '.mp4';
 
-      // Get top scores (empty for untriaged)
       const scoreEntries = Object.entries(scores || {})
         .filter(([, value]) => typeof value === 'number' && value > 0)
         .sort(([, a], [, b]) => b - a)
@@ -1094,77 +1406,27 @@
         `;
       }).join('');
 
-      // Classifier summary (VLM description + topics)
       const classifierHTML = createClassifierHTML(classifierSummary);
       const transcriptHTML = video.transcriptData
         ? createTranscriptHTML(video.transcriptData)
         : '<div class="transcript-panel-empty">Loading transcript…</div>';
 
-      // Provider info with AI source detection
-      let providerHTML = '';
-      if (provider) {
-        providerHTML = `<div style="font-size: 11px; color: #666; margin-top: 8px;">Provider: ${provider}</div>`;
-      }
-
-      // AI source detection details
       let aiSourceHTML = '';
       if (scores.ai_generated && scores.ai_generated > 0 && detailedCategories?.ai_generated) {
         const aiDetails = detailedCategories.ai_generated;
         if (aiDetails.detectedSource) {
           const sourceName = aiDetails.detectedSource.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
           aiSourceHTML = `
-            <div style="background: #1a1a1a; padding: 8px; border-radius: 4px; margin-top: 8px; font-size: 12px;">
-              <div style="color: #f59e0b; font-weight: 600;">🤖 AI Source: ${sourceName}</div>
-              <div style="color: #888; font-size: 11px; margin-top: 4px;">
-                Confidence: ${(aiDetails.sourceConfidence * 100).toFixed(0)}%
-                • ${aiDetails.framesDetected}/${aiDetails.totalFrames} frames
+            <div class="section-stack">
+              <div style="font-size: 14px; font-weight: 700; color: #fbbf24;">${escapeHtml(sourceName)}</div>
+              <div style="font-size: 12px; color: #a1a1aa;">
+                Confidence ${(aiDetails.sourceConfidence * 100).toFixed(0)}% · ${aiDetails.framesDetected}/${aiDetails.totalFrames} frames
               </div>
             </div>
           `;
         }
       }
 
-      // Event metadata: who posted it, when, links
-      const authorName = nostrContext?.author || null;
-      const pubkey = nostrContext?.pubkey || uploaded_by || null;
-      const truncatedPubkey = pubkey ? (pubkey.length > 20 ? pubkey.substring(0, 16) + '...' : pubkey) : null;
-      const timestamp = moderated_at || receivedAt || null;
-      const timeAgo = timestamp ? formatTimeAgo(timestamp) : null;
-      const title = nostrContext?.title || null;
-      const divineVideoUrl = eventId
-        ? `https://divine.video/video/${eventId}`
-        : `https://divine.video/video/${sha256}`;
-      const divineProfileUrl = pubkey ? `https://divine.video/profile/${pubkey}` : null;
-      const divineLinkLabel = eventId ? 'View on Divine' : pubkey ? 'View on Divine (may not be published)' : 'Not published to relay';
-      const hasDivineLink = eventId || pubkey;
-
-      const eventMetaHTML = (authorName || pubkey || timestamp) ? `
-        <div class="event-meta">
-          <div class="event-meta-avatar">${authorName ? authorName.charAt(0).toUpperCase() : '?'}</div>
-          <div class="event-meta-details">
-            ${authorName ? `<div class="event-meta-author">${divineProfileUrl ? `<a href="${escapeHtml(divineProfileUrl)}" target="_blank" style="color: inherit; text-decoration: none;">${escapeHtml(authorName)}</a>` : escapeHtml(authorName)}</div>` : ''}
-            ${truncatedPubkey ? `<div class="event-meta-pubkey">${divineProfileUrl ? `<a href="${escapeHtml(divineProfileUrl)}" target="_blank" style="color: inherit; text-decoration: underline dotted;">${escapeHtml(truncatedPubkey)}</a>` : escapeHtml(truncatedPubkey)}</div>` : ''}
-            ${timeAgo ? `<div class="event-meta-time">${escapeHtml(timeAgo)}</div>` : ''}
-            <div class="event-meta-links">
-              ${hasDivineLink
-                ? `<a href="${escapeHtml(divineVideoUrl)}" target="_blank">${divineLinkLabel}</a>`
-                : `<span style="color: #666; font-style: italic;">${divineLinkLabel}</span>`}
-              ${nostrContext?.url ? `<a href="${escapeHtml(nostrContext.url)}" target="_blank">CDN</a>` : ''}
-            </div>
-          </div>
-        </div>
-      ` : '';
-
-      const nostrStatsHTML = (nostrContext && (nostrContext.loops || nostrContext.likes)) ? `
-        <div class="nostr-meta">
-          <div class="nostr-stats">
-            ${nostrContext.loops ? `<span>🔁 ${formatNumber(nostrContext.loops)}</span>` : ''}
-            ${nostrContext.likes ? `<span>❤️ ${formatNumber(nostrContext.likes)}</span>` : ''}
-          </div>
-        </div>
-      ` : '';
-
-      // Banner for untriaged videos
       const untriagedBanner = isUntriaged ? `
         <div style="background: linear-gradient(135deg, #8b5cf6, #6366f1); padding: 12px; text-align: center;">
           <div style="font-weight: 600; color: white; font-size: 14px;">📦 NEW - Not Yet Moderated</div>
@@ -1180,33 +1442,47 @@
 
           ${untriagedBanner}
 
-          <div class="video-wrapper">
-            <video src="${videoUrl}" controls loop preload="auto"></video>
-          </div>
-
           <div class="video-info">
-            ${eventMetaHTML}
+            <div class="review-primary-layout">
+              <div class="review-media-column">
+                <div class="video-wrapper">
+                  <video src="${videoUrl}" controls loop preload="auto"></video>
+                </div>
+              </div>
 
-            ${title ? `<div class="nostr-title" style="margin-bottom: 10px;">${escapeHtml(title)}</div>` : ''}
-
-            <div class="video-hash" style="display: flex; align-items: center; gap: 8px;">
-              ${sha256}
-              <button onclick="copyPermalink('${sha256}', this)" style="background: none; border: 1px solid #555; color: #aaa; padding: 2px 8px; border-radius: 4px; cursor: pointer; font-size: 11px;">📋 Link</button>
+              <div class="review-metadata-column">
+                ${createMetadataColumnHTML(video)}
+              </div>
             </div>
 
-            ${classifierHTML}
-
-            <div class="transcript-panel">${transcriptHTML}</div>
-
-            ${scoreEntries.length > 0 ? `
-              <div class="scores-grid">
-                ${scoresHTML}
+            <div class="review-secondary-layout">
+              <div class="classifier-slot">
+                ${classifierHTML}
               </div>
-            ` : (isUntriaged ? '<div style="color: #888; font-size: 13px; margin-bottom: 10px;">No moderation scores yet - will be analyzed after queuing</div>' : '')}
 
-            ${providerHTML}
-            ${aiSourceHTML}
-            ${nostrStatsHTML}
+              <div class="transcript-panel">${transcriptHTML}</div>
+
+              ${scoreEntries.length > 0 ? `
+                <div class="metadata-section">
+                  <div class="metadata-section-title">Moderation Scores</div>
+                  <div class="scores-grid">
+                    ${scoresHTML}
+                  </div>
+                </div>
+              ` : (isUntriaged ? `
+                <div class="metadata-section">
+                  <div class="metadata-section-title">Moderation Scores</div>
+                  <div style="color: #888; font-size: 13px;">No moderation scores yet. This will be analyzed after queuing.</div>
+                </div>
+              ` : '')}
+
+              ${aiSourceHTML ? `
+                <div class="metadata-section">
+                  <div class="metadata-section-title">AI Source</div>
+                  ${aiSourceHTML}
+                </div>
+              ` : ''}
+            </div>
 
             <div class="action-buttons">
               <button class="action-btn ban" onclick="handleAction('${sha256}', 'PERMANENT_BAN')">
@@ -1492,8 +1768,22 @@
       }, 300);
     }
 
+    function normalizeTimestampValue(timestamp) {
+      if (!isPresent(timestamp)) return null;
+      if (timestamp instanceof Date) return timestamp;
+      if (typeof timestamp === 'number') {
+        return new Date(timestamp < 1e12 ? timestamp * 1000 : timestamp);
+      }
+      if (typeof timestamp === 'string' && /^\d+$/.test(timestamp)) {
+        const parsed = Number(timestamp);
+        return new Date(parsed < 1e12 ? parsed * 1000 : parsed);
+      }
+      return new Date(timestamp);
+    }
+
     function formatTimeAgo(timestamp) {
-      const date = new Date(timestamp);
+      const date = normalizeTimestampValue(timestamp);
+      if (!date || Number.isNaN(date.getTime())) return 'Not available';
       const now = new Date();
       const diffMs = now - date;
       const diffSec = Math.floor(diffMs / 1000);
@@ -1514,6 +1804,10 @@
       });
 
       return `${relative} · ${absolute}`;
+    }
+
+    function formatTimestampDetail(timestamp) {
+      return formatTimeAgo(timestamp);
     }
 
     function formatCategoryName(key) {

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -401,7 +401,18 @@ async function fetchLookupNostrContext(hash, env) {
         content: metadata.content || event.content || null,
         pubkey: event.pubkey ? `${event.pubkey.substring(0, 16)}...` : null,
         eventId: event.id,
-        platform: metadata.platform || null
+        platform: metadata.platform || null,
+        url: metadata.url || null,
+        sourceUrl: metadata.sourceUrl || null,
+        loops: metadata.loops ?? null,
+        likes: metadata.likes ?? null,
+        comments: metadata.comments ?? null,
+        publishedAt: metadata.publishedAt || null,
+        archivedAt: metadata.archivedAt || null,
+        importedAt: metadata.importedAt || null,
+        vineHashId: metadata.vineHashId || null,
+        vineUserId: metadata.vineUserId || null,
+        createdAt: metadata.createdAt || null
       }
     };
   } catch (error) {
@@ -416,8 +427,18 @@ async function enrichAdminLookupVideo(video, env) {
   }
 
   let enriched = { ...video };
+  const needsNostrEnrichment = enriched.sha256 && (
+    !enriched.eventId
+    || !enriched.divineUrl
+    || !enriched.nostrContext
+    || !enriched.nostrContext.content
+    || !enriched.nostrContext.sourceUrl
+    || !enriched.nostrContext.platform
+    || !enriched.nostrContext.client
+    || !enriched.nostrContext.publishedAt
+  );
 
-  if (enriched.sha256 && (!enriched.eventId || !enriched.divineUrl || !enriched.nostrContext)) {
+  if (needsNostrEnrichment) {
     const nostrContext = await fetchLookupNostrContext(enriched.sha256, env);
     if (nostrContext) {
       enriched = {
@@ -459,7 +480,7 @@ async function getAdminLookupVideo(identifier, env, options = {}) {
   const cdnUrl = `https://${env.CDN_DOMAIN || 'media.divine.video'}/${hash}`;
   if (hash) {
     const moderatedRow = await env.BLOSSOM_DB.prepare(`
-      SELECT sha256, action, provider, scores, categories, moderated_at, reviewed_by, reviewed_at, review_notes, uploaded_by
+      SELECT sha256, action, provider, scores, categories, moderated_at, reviewed_by, reviewed_at, review_notes, uploaded_by, title, author, event_id, content_url, published_at
       FROM moderation_results
       WHERE sha256 = ?
     `).bind(hash).first();
@@ -469,6 +490,20 @@ async function getAdminLookupVideo(identifier, env, options = {}) {
 
     if (moderatedRow || kvModeration) {
       const moderatedAt = kvModeration?.moderated_at || moderatedRow?.moderated_at || null;
+      const eventId = moderatedRow?.event_id || null;
+      const persistedPublishedAt = moderatedRow?.published_at || null;
+      const persistedContentUrl = moderatedRow?.content_url || null;
+      const persistedNostrContext = (
+        moderatedRow?.title
+        || moderatedRow?.author
+        || persistedContentUrl
+        || persistedPublishedAt
+      ) ? {
+        title: moderatedRow?.title || null,
+        author: moderatedRow?.author || null,
+        url: persistedContentUrl,
+        publishedAt: persistedPublishedAt
+      } : null;
       return enrichAdminLookupVideo({
         sha256: hash,
         action: kvModeration?.action || moderatedRow?.action || 'REVIEW',
@@ -486,7 +521,10 @@ async function getAdminLookupVideo(identifier, env, options = {}) {
         previousAction: kvModeration?.previousAction || null,
         detailedCategories: parseMaybeJson(kvModeration?.detailedCategories, null),
         categoryVerifications: parseMaybeJson(kvModeration?.categoryVerifications, {}) || {},
-        cdnUrl: kvModeration?.cdnUrl || cdnUrl
+        cdnUrl: kvModeration?.cdnUrl || persistedContentUrl || cdnUrl,
+        eventId,
+        divineUrl: eventId ? `https://divine.video/video/${encodeURIComponent(eventId)}` : null,
+        nostrContext: persistedNostrContext
       }, env);
     }
 
@@ -519,7 +557,19 @@ async function getAdminLookupVideo(identifier, env, options = {}) {
             client: metadata?.client || null,
             content: metadata?.content || event.content || null,
             pubkey: event.pubkey ? `${event.pubkey.substring(0, 16)}...` : null,
-            eventId
+            eventId,
+            platform: metadata?.platform || null,
+            url: metadata?.url || null,
+            sourceUrl: metadata?.sourceUrl || null,
+            loops: metadata?.loops ?? null,
+            likes: metadata?.likes ?? null,
+            comments: metadata?.comments ?? null,
+            publishedAt: metadata?.publishedAt || null,
+            archivedAt: metadata?.archivedAt || null,
+            importedAt: metadata?.importedAt || null,
+            vineHashId: metadata?.vineHashId || null,
+            vineUserId: metadata?.vineUserId || null,
+            createdAt: metadata?.createdAt || null
           };
         }
       } catch (error) {
@@ -879,7 +929,7 @@ export default {
 
       // Query D1 with pagination
       const query = `
-        SELECT sha256, action, provider, scores, categories, moderated_at, reviewed_by, reviewed_at, uploaded_by
+        SELECT sha256, action, provider, scores, categories, moderated_at, reviewed_by, reviewed_at, uploaded_by, title, author, event_id, content_url, published_at
         FROM moderation_results
         ${whereClause}
         ORDER BY moderated_at ${orderDirection}
@@ -902,7 +952,12 @@ export default {
         moderated_at: row.moderated_at,
         reviewed_by: row.reviewed_by,
         reviewed_at: row.reviewed_at,
-        uploaded_by: row.uploaded_by || null
+        uploaded_by: row.uploaded_by || null,
+        title: row.title || null,
+        author: row.author || null,
+        event_id: row.event_id || null,
+        content_url: row.content_url || null,
+        published_at: row.published_at || null
       }));
 
       // Classifier summaries fetched client-side via /admin/api/classifier/{sha256}

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -32,6 +32,38 @@ function createDbMock({ moderationResults = new Map(), webhookEvents = new Map()
           return null;
         },
         async all() {
+          if (sql.includes('FROM moderation_results')) {
+            let results = Array.from(moderationResults.values());
+
+            if (sql.includes("reviewed_by IS NULL")) {
+              results = results.filter((row) => row.reviewed_by == null);
+            }
+
+            if (sql.includes("action IN ('REVIEW', 'AGE_RESTRICTED', 'PERMANENT_BAN')")) {
+              const allowed = new Set(['REVIEW', 'AGE_RESTRICTED', 'PERMANENT_BAN']);
+              results = results.filter((row) => allowed.has(row.action));
+            }
+
+            if (sql.includes("action IN ('AGE_RESTRICTED', 'PERMANENT_BAN')")) {
+              const allowed = new Set(['AGE_RESTRICTED', 'PERMANENT_BAN']);
+              results = results.filter((row) => allowed.has(row.action));
+            }
+
+            if (sql.includes('moderated_at >= ?')) {
+              const since = bindings[0];
+              results = results.filter((row) => row.moderated_at >= since);
+            }
+
+            const limit = bindings[bindings.length - 2];
+            const offset = bindings[bindings.length - 1];
+            results = results
+              .sort((a, b) => a.moderated_at.localeCompare(b.moderated_at))
+              .reverse()
+              .slice(offset, offset + limit);
+
+            return { results };
+          }
+
           return { results: [] };
         }
       };
@@ -252,6 +284,48 @@ describe('HTTP hostname routing', () => {
 });
 
 describe('Admin video lookup', () => {
+  it('returns quick review queue rows with persisted metadata fields', async () => {
+    const env = createEnv({
+      BLOSSOM_DB: createDbMock({
+        moderationResults: new Map([[SHA256, {
+          sha256: SHA256,
+          action: 'REVIEW',
+          provider: 'hiveai',
+          scores: JSON.stringify({ ai_generated: 0.9 }),
+          categories: JSON.stringify(['ai_generated']),
+          moderated_at: '2026-03-11T00:00:00.000Z',
+          reviewed_by: null,
+          reviewed_at: null,
+          uploaded_by: 'f'.repeat(64),
+          title: 'Airport dance',
+          author: 'Creator Name',
+          event_id: 'e'.repeat(64),
+          content_url: 'https://media.divine.video/airport-dance.mp4',
+          published_at: '2026-03-10T12:00:00.000Z'
+        }]])
+      })
+    });
+
+    const response = await worker.fetch(
+      new Request('https://moderation.admin.divine.video/admin/api/videos?action=FLAGGED&limit=100', {
+        headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
+      }),
+      env
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      videos: [{
+        sha256: SHA256,
+        title: 'Airport dance',
+        author: 'Creator Name',
+        event_id: 'e'.repeat(64),
+        content_url: 'https://media.divine.video/airport-dance.mp4',
+        published_at: '2026-03-10T12:00:00.000Z'
+      }]
+    });
+  });
+
   it('returns a moderated video and merges KV override fields', async () => {
     const env = createEnv({
       BLOSSOM_DB: createDbMock({
@@ -265,7 +339,12 @@ describe('Admin video lookup', () => {
           reviewed_by: 'admin',
           reviewed_at: '2026-03-07T01:00:00.000Z',
           review_notes: 'legacy note',
-          uploaded_by: 'npub123'
+          uploaded_by: 'npub123',
+          title: 'Stored title',
+          author: 'Stored author',
+          event_id: '1'.repeat(64),
+          content_url: 'https://media.divine.video/stored.mp4',
+          published_at: '2026-03-06T00:00:00.000Z'
         }]])
       }),
       MODERATION_KV: {
@@ -307,7 +386,15 @@ describe('Admin video lookup', () => {
         reason: 'Manual override',
         scores: {
           nudity: 0.91
-        }
+        },
+        nostrContext: {
+          title: 'Stored title',
+          author: 'Stored author',
+          url: 'https://media.divine.video/stored.mp4',
+          publishedAt: '2026-03-06T00:00:00.000Z'
+        },
+        eventId: '1'.repeat(64),
+        divineUrl: `https://divine.video/video/${'1'.repeat(64)}`
       }
     });
   });
@@ -510,6 +597,44 @@ describe('Admin video lookup', () => {
     } finally {
       globalThis.fetch = originalFetch;
     }
+  });
+});
+
+describe('Quick review HTML', () => {
+  it('serves metadata-first quick review sections', async () => {
+    const response = await worker.fetch(
+      new Request('https://moderation.admin.divine.video/admin/review', {
+        headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
+      }),
+      createEnv()
+    );
+
+    expect(response.status).toBe(200);
+    const html = await response.text();
+    expect(html).toContain('review-primary-layout');
+    expect(html).toContain('Publisher');
+    expect(html).toContain('Post Context');
+    expect(html).toContain('Timeline');
+    expect(html).toContain('Technical Metadata');
+  });
+
+  it('includes labeled timestamps and full-context field wiring', async () => {
+    const response = await worker.fetch(
+      new Request('https://moderation.admin.divine.video/admin/review', {
+        headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
+      }),
+      createEnv()
+    );
+
+    expect(response.status).toBe(200);
+    const html = await response.text();
+    expect(html).toContain('Published');
+    expect(html).toContain('Received');
+    expect(html).toContain('Moderated');
+    expect(html).toContain('Reviewed');
+    expect(html).toContain('published_at');
+    expect(html).toContain('content_url');
+    expect(html).toContain('event_id');
   });
 });
 


### PR DESCRIPTION
## Summary
- widen the quick review card and make publisher, post, timeline, and technical metadata visible by default
- expose persisted moderation metadata in the quick review queue payload and preserve richer admin lookup context for card enrichment
- add coverage for the new queue payload fields and metadata-first quick review HTML structure

## Test Plan
- [x] npm test
