### PR TITLE
fix: add ETag cache validation to admin HTML pages

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -52,6 +52,32 @@ const ADMIN_HOSTNAME = 'moderation.admin.divine.video';
 const API_HOSTNAME = 'moderation-api.divine.video';
 const DEFAULT_RELAY_ADMIN_URL = 'https://relay.admin.divine.video';
 const JSON_HEADERS = { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' };
+
+// ETags for admin HTML pages — computed once at module load, change only on deploy.
+// Allows browsers to cache the HTML but revalidate on every request (304 if unchanged).
+const HTML_ETAGS = {
+  dashboard: `"${hashCode(dashboardHTML)}"`,
+  review: `"${hashCode(swipeReviewHTML)}"`,
+  messages: `"${hashCode(messagesHTML)}"`,
+};
+
+function hashCode(str) {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) - hash + str.charCodeAt(i)) | 0;
+  }
+  return hash.toString(36);
+}
+
+function serveHTML(html, etag, request) {
+  if (request.headers.get('If-None-Match') === etag) {
+    return new Response(null, { status: 304, headers: { 'ETag': etag } });
+  }
+  return new Response(html, {
+    headers: { 'Content-Type': 'text/html', 'Cache-Control': 'no-cache', 'ETag': etag }
+  });
+}
+
 const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]']);
 
 /**
@@ -811,9 +837,7 @@ export default {
         return authError;
       }
 
-      return new Response(dashboardHTML, {
-        headers: { 'Content-Type': 'text/html' }
-      });
+      return serveHTML(dashboardHTML, HTML_ETAGS.dashboard, request);
     }
 
     if (url.pathname === '/admin/review') {
@@ -823,18 +847,14 @@ export default {
         return authError;
       }
 
-      return new Response(swipeReviewHTML, {
-        headers: { 'Content-Type': 'text/html' }
-      });
+      return serveHTML(swipeReviewHTML, HTML_ETAGS.review, request);
     }
 
     if (url.pathname === '/admin/messages') {
       const authError = await requireAuth(request, env);
       if (authError) return authError;
 
-      return new Response(messagesHTML, {
-        headers: { 'Content-Type': 'text/html' }
-      });
+      return serveHTML(messagesHTML, HTML_ETAGS.messages, request);
     }
 
     if (url.pathname === '/admin/api/videos') {


### PR DESCRIPTION
## Summary

- Admin HTML pages (dashboard, swipe review, messages) were served without cache headers, so browsers could run stale JavaScript from cached or still-open tabs after a deploy
- API responses already had `Cache-Control: no-store` via `JSON_HEADERS`, but the HTML pages did not
- Adds ETag-based validation: `Cache-Control: no-cache` + `ETag` computed from HTML content at module load
- Browsers cache locally but revalidate every request. 304 if unchanged (saves bandwidth), full response after deploy
- ETags update automatically on deploy -- no manual version bumping needed

## Context

Through direct testing and inspection of persisted data, we confirmed that moderation decisions are saving correctly after recent fixes (PRs #72, #73). We isolated a remaining gap: browsers serving stale frontend code from cached or open tabs would not pick up deploys that included fixes and improvements, making it appear that decisions weren't persisting even after the underlying issue was resolved.

## Test plan

- [x] 588/588 tests pass
- [x] Verified only three `new Response(html, ...)` calls changed
- [x] No changes to API endpoints, D1 writes, or any other functionality