### PR TITLE
fix: set reviewed_by on /api/v1/moderate so relay-manager bans don't pollute the AI flagged queue

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -2881,24 +2881,31 @@ async function runMigration() {
           });
         }
 
-        // Update or insert moderation result
+        // Update or insert moderation result.
+        // reviewed_by is set to the source because /api/v1/moderate is called by human
+        // operators (relay-manager UI, external tools) — not by the AI pipeline.
+        // Without this, relay-manager bans land in the AI Flagged human-review queue.
+        const reviewedBy = source || 'external-api';
+        const now = new Date().toISOString();
         await env.BLOSSOM_DB.prepare(`
-          INSERT INTO moderation_results (sha256, action, provider, scores, categories, moderated_at)
-          VALUES (?, ?, ?, ?, ?, ?)
+          INSERT INTO moderation_results (sha256, action, provider, scores, categories, moderated_at, reviewed_by, reviewed_at)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?)
           ON CONFLICT(sha256) DO UPDATE SET
             action = excluded.action,
             provider = excluded.provider,
             review_notes = ?,
-            reviewed_at = ?
+            reviewed_by = excluded.reviewed_by,
+            reviewed_at = excluded.reviewed_at
         `).bind(
           sha256,
           action.toUpperCase(),
-          source || 'external-api',
+          reviewedBy,
           JSON.stringify({}),
           JSON.stringify([reason || action.toLowerCase()]),
-          new Date().toISOString(),
-          reason || null,
-          new Date().toISOString()
+          now,
+          reviewedBy,
+          now,
+          reason || null
         ).run();
 
         console.log(`[API] Moderation updated: ${sha256} -> ${action} by ${source || 'external-api'} (auth: ${authSource})`);

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -1051,6 +1051,68 @@ describe('notifyBlossom integration via admin moderate endpoint', () => {
     }
   });
 
+  it('sets reviewed_by to source on /api/v1/moderate', async () => {
+    const kvStore = new Map();
+    let capturedSql = null;
+    let capturedBindings = null;
+    const env = {
+      ALLOW_DEV_ACCESS: 'true',
+      SERVICE_API_TOKEN: 'test-service-token',
+      BLOSSOM_WEBHOOK_URL: 'https://mock-blossom.test/admin/moderate',
+      BLOSSOM_WEBHOOK_SECRET: 'test-webhook-secret',
+      BLOSSOM_DB: {
+        prepare(sql) {
+          let bindings = [];
+          return {
+            bind(...args) { bindings = args; return this; },
+            async run() {
+              capturedSql = sql;
+              capturedBindings = bindings;
+              return { success: true };
+            },
+            async first() { return null; },
+            async all() { return { results: [] }; },
+          };
+        },
+        async batch() { return []; },
+      },
+      MODERATION_KV: {
+        store: kvStore,
+        async get(key) { return kvStore.get(key) ?? null; },
+        async put(key, value) { kvStore.set(key, value); },
+        async delete(key) { kvStore.delete(key); },
+        async list() { return { keys: [], list_complete: true, cursor: null }; }
+      },
+      MODERATION_QUEUE: { async send() {} },
+    };
+
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = async (url) => {
+      if (url === 'https://mock-blossom.test/admin/moderate') {
+        return new Response(JSON.stringify({ success: true }), { status: 200 });
+      }
+      return origFetch(url);
+    };
+
+    try {
+      const response = await worker.fetch(
+        new Request('https://moderation-api.divine.video/api/v1/moderate', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer test-service-token' },
+          body: JSON.stringify({ sha256: 'abc123', action: 'PERMANENT_BAN', source: 'relay-manager' }),
+        }),
+        env
+      );
+
+      expect(response.status).toBe(200);
+      expect(capturedSql).toContain('reviewed_by');
+      // reviewed_by binding should be 'relay-manager' (same as source)
+      expect(capturedBindings).toContain('relay-manager');
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
   it('returns 200 when Blossom webhook succeeds for /api/v1/moderate', async () => {
     const kvStore = new Map();
     const env = {


### PR DESCRIPTION
## Summary

When a moderator bans content in relay-manager, that decision should be final — it should not reappear in Aleysha's review queue, and AI should not re-process it. Both depend on \`reviewed_by\` being set in moderation-service's D1.

- \`/api/v1/moderate\` was writing the D1 record but leaving \`reviewed_by = NULL\`, so relay-manager bans were enforced in Blossom but kept surfacing in the human review queue as if no one had looked at them.
- The review queue filter is \`reviewed_by IS NULL\`. Set it, the item is gone. The AI pipeline dedup check also skips any sha256 with an existing D1 record.
- Root cause surfaced when Matt's March 24 routing fix (\`fa1f6ec\`) made relay-manager bans actually reach moderation-service for the first time. Before that they were silently 404ing.

## Changes

- \`INSERT\` and \`ON CONFLICT\` in \`/api/v1/moderate\` now set \`reviewed_by = source\` and \`reviewed_at\`
- Added test asserting \`reviewed_by\` is written with the caller's source value

## Backfill

59 existing relay-manager entries updated directly in production D1:
\`\`\`sql
UPDATE moderation_results
SET reviewed_by = 'relay-manager', reviewed_at = moderated_at
WHERE provider = 'relay-manager' AND reviewed_by IS NULL
\`\`\`