### PR TITLE
fix: forward Range header in admin video proxy for age-restricted content

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -2135,18 +2135,26 @@ export default {
         // Fall back to admin bypass endpoint which serves regardless of moderation status
         if (env.BLOSSOM_WEBHOOK_SECRET) {
           console.log(`[ADMIN] CDN returned ${cdnResponse.status}, trying admin bypass for ${sha256}`);
-          const bypassResponse = await fetch(adminBypassUrl, {
-            headers: { 'Authorization': `Bearer ${env.BLOSSOM_WEBHOOK_SECRET}` }
-          });
-          if (bypassResponse.ok) {
+          const bypassHeaders = { 'Authorization': `Bearer ${env.BLOSSOM_WEBHOOK_SECRET}` };
+          const rangeHeader = request.headers.get('Range');
+          if (rangeHeader) bypassHeaders['Range'] = rangeHeader;
+          const bypassResponse = await fetch(adminBypassUrl, { headers: bypassHeaders });
+          if (bypassResponse.ok || bypassResponse.status === 206) {
             console.log(`[ADMIN] Serving video from admin bypass: ${sha256}`);
             const moderationStatus = bypassResponse.headers.get('X-Moderation-Status');
+            const contentRange = bypassResponse.headers.get('Content-Range');
+            const acceptRanges = bypassResponse.headers.get('Accept-Ranges');
+            const contentLength = bypassResponse.headers.get('Content-Length');
             return new Response(bypassResponse.body, {
+              status: bypassResponse.status,
               headers: {
                 'Content-Type': bypassResponse.headers.get('Content-Type') || 'video/mp4',
                 'Cache-Control': 'private, no-store',
                 'X-Admin-Proxy': 'blossom-admin',
-                ...(moderationStatus && { 'X-Moderation-Status': moderationStatus })
+                ...(moderationStatus && { 'X-Moderation-Status': moderationStatus }),
+                ...(contentRange && { 'Content-Range': contentRange }),
+                ...(acceptRanges && { 'Accept-Ranges': acceptRanges }),
+                ...(contentLength && { 'Content-Length': contentLength }),
               }
             });
           }


### PR DESCRIPTION
## Summary

Age-restricted videos were showing black in the moderation dashboard.

**Root cause:** PERMANENT_BAN content plays fine via Tier 1 (CDN still has cached content from when it was Active). AGE_RESTRICTED content falls through to Tier 3 (admin bypass via `BLOSSOM_WEBHOOK_SECRET`), which was fetching from Blossom without forwarding the browser's `Range` header. The browser sends `Range: bytes=0-` to start playback and expects a `206 Partial Content` response — receiving a full `200 OK` instead causes the video player to black out.

## Changes

Single change in the Tier 3 fetch in `/admin/video/` proxy (`src/index.mjs`):

- Forward `Range` header from the incoming browser request to Blossom
- Pass back `Content-Range`, `Accept-Ranges`, and `Content-Length` from Blossom's response
- Preserve response status (`206` vs `200`) so the browser video player handles it correctly

No HTML changes, no new endpoints. Matches the pattern already used in divine-relay-manager's media proxy.

## Testing

592 tests passing. Needs manual verification against a live age-restricted video in the dashboard.