### PR TITLE
fix: skip Hive AI detection for legacy vines

### DIFF
--- a/src/moderation/pipeline.mjs
+++ b/src/moderation/pipeline.mjs
@@ -13,6 +13,63 @@ import { extractTopics } from '../classification/topic-extractor.mjs';
 
 const ORIGINAL_VINE_SUPPRESSED_CATEGORIES = new Set(['ai_generated', 'deepfake']);
 const DOWNSTREAM_SIGNAL_THRESHOLD = 0.5;
+const ARCHIVE_ORIGINAL_VINE_SOURCES = new Set(['archive-export', 'incident-backfill', 'sha-list']);
+
+function parseOptionalString(value) {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function parseOptionalInteger(value) {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.trunc(value);
+  }
+
+  if (typeof value === 'string' && value.trim().length > 0) {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  return null;
+}
+
+function buildQueueMetadataNostrContext(metadata) {
+  if (!metadata || typeof metadata !== 'object') {
+    return null;
+  }
+
+  const source = parseOptionalString(metadata.source);
+  const publishedAt = parseOptionalInteger(metadata.publishedAt ?? metadata.published_at);
+  const context = {
+    title: parseOptionalString(metadata.title),
+    author: parseOptionalString(metadata.author),
+    platform: parseOptionalString(metadata.platform),
+    client: parseOptionalString(metadata.client),
+    loops: parseOptionalInteger(metadata.loops),
+    likes: parseOptionalInteger(metadata.likes),
+    comments: parseOptionalInteger(metadata.comments),
+    url: parseOptionalString(metadata.videoUrl ?? metadata.url),
+    sourceUrl: parseOptionalString(metadata.sourceUrl ?? metadata.source_url ?? metadata.r),
+    publishedAt: ARCHIVE_ORIGINAL_VINE_SOURCES.has(source) ? publishedAt : null,
+    archivedAt: parseOptionalString(metadata.archivedAt ?? metadata.archived_at),
+    importedAt: parseOptionalInteger(metadata.importedAt ?? metadata.imported_at),
+    vineHashId: parseOptionalString(metadata.vineHashId ?? metadata.vine_hash_id ?? metadata.vine_id),
+    vineUserId: parseOptionalString(metadata.vineUserId ?? metadata.vine_user_id),
+    content: parseOptionalString(metadata.content),
+    eventId: parseOptionalString(metadata.eventId ?? metadata.event_id),
+    createdAt: parseOptionalInteger(metadata.createdAt ?? metadata.created_at)
+  };
+
+  if (
+    context.platform === 'vine'
+    || (context.client && /vine-(archive-importer|archaeologist)/.test(context.client))
+    || context.vineHashId
+    || (context.sourceUrl && context.sourceUrl.includes('vine.co'))
+  ) {
+    context.publishedAt = publishedAt;
+  }
+
+  return Object.values(context).some((value) => value !== null) ? context : null;
+}
 
 function applyOriginalVineEnforcementOverride(classification) {
   return {
@@ -166,16 +223,20 @@ export async function moderateVideo(videoData, env, fetchFn = fetch) {
   }
 
   // Step 1: Determine video URL - prefer metadata.videoUrl if provided (e.g., from relay-poller)
-  let nostrContext = null;
-  let videoUrl = metadata?.videoUrl || `https://${env.CDN_DOMAIN}/${sha256}`; // Default: blossom content-addressed URL
-  let nostrEventId = metadata?.eventId || null;
+  const queueNostrContext = buildQueueMetadataNostrContext(metadata);
+  let nostrContext = queueNostrContext;
+  let videoUrl = metadata?.videoUrl || queueNostrContext?.url || `https://${env.CDN_DOMAIN}/${sha256}`; // Default: blossom content-addressed URL
+  let nostrEventId = queueNostrContext?.eventId || metadata?.eventId || metadata?.event_id || null;
 
   // Always attempt to resolve Nostr context so policy decisions can use archive metadata
   try {
     const relays = env.NOSTR_RELAY_URL ? [env.NOSTR_RELAY_URL] : ['wss://relay.divine.video'];
     const event = await fetchNostrEventBySha256(sha256, relays);
     if (event) {
-      nostrContext = parseVideoEventMetadata(event);
+      const relayNostrContext = parseVideoEventMetadata(event);
+      nostrContext = queueNostrContext
+        ? { ...queueNostrContext, ...relayNostrContext }
+        : relayNostrContext;
       nostrEventId = event.id;
       console.log(`[MODERATION] Found Nostr context for ${sha256}:`, nostrContext);
 

--- a/src/moderation/pipeline.test.mjs
+++ b/src/moderation/pipeline.test.mjs
@@ -48,6 +48,44 @@ function createNostrLookupWebSocket(event) {
   };
 }
 
+function createEmptyNostrLookupWebSocket() {
+  return class FakeWebSocket {
+    constructor() {
+      this.listeners = {};
+      this.readyState = 0;
+      queueMicrotask(() => {
+        this.readyState = 1;
+        this.emit('open');
+      });
+    }
+
+    addEventListener(type, handler) {
+      if (!this.listeners[type]) {
+        this.listeners[type] = [];
+      }
+      this.listeners[type].push(handler);
+    }
+
+    send(message) {
+      const [, subscriptionId] = JSON.parse(message);
+      queueMicrotask(() => {
+        this.emit('message', { data: JSON.stringify(['EOSE', subscriptionId]) });
+      });
+    }
+
+    close() {
+      this.readyState = 3;
+      queueMicrotask(() => this.emit('close'));
+    }
+
+    emit(type, payload = {}) {
+      for (const handler of this.listeners[type] || []) {
+        handler(payload);
+      }
+    }
+  };
+}
+
 afterEach(() => {
   globalThis.WebSocket = OriginalWebSocket;
 });
@@ -301,6 +339,65 @@ describe('Moderation Pipeline', () => {
     expect(result.scores.ai_generated).toBe(0.96);
     expect(result.downstreamSignals?.scores?.ai_generated ?? 0).toBe(0);
     expect(result.downstreamSignals?.hasSignals).toBe(false);
+  });
+
+  it('skips Hive AI detection when legacy queue metadata already identifies an original Vine', async () => {
+    const sha256 = 'k'.repeat(64);
+    globalThis.WebSocket = createEmptyNostrLookupWebSocket();
+
+    const hiveAuthCalls = [];
+    const mockFetch = vi.fn(async (url, options = {}) => {
+      if (typeof url === 'string' && url.endsWith('.vtt')) {
+        return {
+          ok: false,
+          status: 404,
+          text: async () => ''
+        };
+      }
+
+      if (typeof url === 'string' && url.includes('api.thehive.ai')) {
+        hiveAuthCalls.push(options.headers?.authorization || null);
+        return {
+          ok: true,
+          json: async () => ({
+            status: [{
+              response: {
+                output: [{
+                  time: 0,
+                  classes: [
+                    { class: 'general_nsfw', score: 0.05 },
+                    { class: 'ai_generated', score: 0.96 }
+                  ]
+                }]
+              }
+            }]
+          })
+        };
+      }
+
+      throw new Error(`Unexpected fetch call: ${String(url)}`);
+    });
+
+    const env = {
+      CDN_DOMAIN: 'cdn.divine.video',
+      HIVE_MODERATION_API_KEY: 'mod-key',
+      HIVE_AI_DETECTION_API_KEY: 'ai-key'
+    };
+
+    const result = await moderateVideo({
+      sha256,
+      uploadedAt: Date.now(),
+      metadata: {
+        source: 'archive-export',
+        videoUrl: 'https://archive.example.com/original-vine.mp4',
+        platform: 'vine',
+        source_url: 'https://vine.co/v/abc123',
+        published_at: 1389756506
+      }
+    }, env, mockFetch);
+
+    expect(hiveAuthCalls).toEqual(['token mod-key']);
+    expect(result.policyContext?.originalVine).toBe(true);
   });
 
   it('keeps downstream moderation signals for original vines when non-AI scores are high', async () => {


### PR DESCRIPTION
## Summary
- normalize legacy queue metadata into a Nostr-like context before original-Vine policy checks
- merge explicit queue metadata with relay metadata so archive imports still skip Hive AI detection when relay lookup misses
- add a regression test proving archive Vine metadata only calls the Hive moderation model, not the AI detection model

## Test Plan
- [x] npm test -- src/moderation/pipeline.test.mjs -t "legacy queue metadata already identifies an original Vine"
- [x] npm test -- src/moderation/pipeline.test.mjs src/moderation/pipeline-classification.test.mjs src/nostr/relay-client.test.mjs
- [x] npm test
