### PR TITLE
fix: forward Range headers through admin video proxy

### DIFF
--- a/docs/superpowers/plans/2026-04-13-admin-video-range-headers-plan.md
+++ b/docs/superpowers/plans/2026-04-13-admin-video-range-headers-plan.md
@@ -1,0 +1,57 @@
+# Admin video proxy: forward Range headers
+
+## Problem
+Videos render as a black 0:00 frame in the moderation admin dashboard. Browsers
+(Safari, Chrome) send `Range: bytes=0-` on `<video>` element playback and require
+`206 Partial Content` responses with `Content-Range` / `Accept-Ranges` headers. The
+admin proxy handler at `src/index.mjs` (`/admin/video/:sha256.mp4`) currently does
+not forward the `Range` header to any of its three upstream branches (CDN, transcoded
+720p CDN variant, admin bypass), and does not pass through `206` status or the
+accompanying range/length headers.
+
+PR #77 (commit `c2921f2`) partially fixed the admin-bypass branch only. The CDN
+and transcode branches remain broken for content that is served directly from CDN.
+
+## Scope
+- `src/index.mjs` — modify ONLY the three upstream `fetch(...)` calls inside the
+  `/admin/video/` handler and their corresponding `new Response(...)` headers.
+- `src/index.test.mjs` — add tests for range forwarding.
+
+Do not refactor the CDN / transcode / bypass branching. Do not touch other routes.
+
+## Changes
+
+### Request-side (forward to upstream)
+For each of the three upstream fetches, forward these request headers when present:
+- `Range`
+- `If-Range`
+- `If-None-Match`
+- `If-Modified-Since`
+
+Extract a small helper `buildRangeRequestInit(request, extraHeaders)` scoped to
+the handler (local const/function) so it can be reused by the CDN, transcode, and
+admin-bypass fetches without refactoring the branching.
+
+### Response-side (pass through to client)
+For each of the three upstream response paths, when upstream status is 200 OR 206:
+- Preserve upstream status (`status: upstream.status`).
+- Pass through `Content-Range`, `Accept-Ranges`, `Content-Length`, `ETag`,
+  `Last-Modified` when present.
+- Keep existing `X-Admin-Proxy` tag value and `Cache-Control: private, no-store`.
+- Still accept 206 as "ok" (the CDN branch currently uses `cdnResponse.ok` which
+  is true for 200-299, so 206 already matches — but tighten checks where needed).
+
+## Tests
+Add to `src/index.test.mjs` in a new `describe('admin video proxy range forwarding', ...)`:
+
+1. `forwards Range header to CDN and returns 206 with Content-Range` — CDN mock
+   asserts received `Range: bytes=0-1023`, responds 206 with `Content-Range`;
+   handler returns 206 with same headers and `X-Admin-Proxy: cdn`.
+2. `forwards Range header to admin bypass branch and returns 206` — CDN miss (404),
+   bypass mock asserts received Range + Authorization, responds 206; handler
+   returns 206 with `X-Admin-Proxy: blossom-admin`.
+3. `serves 200 when no Range header present` — existing behavior preserved.
+4. `returns 404 when both CDN and bypass miss` — existing 404 fallthrough preserved.
+
+## Verification
+- `npm test` — all 303+ tests pass (new tests included).

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -2096,36 +2096,61 @@ export default {
 
       const BROWSER_PLAYABLE_TYPES = new Set(['video/mp4', 'video/webm', 'video/ogg']);
 
+      // Forward range-related request headers to upstream so that <video>
+      // byte-range playback works end-to-end. Upstream 206 responses must be
+      // preserved along with Content-Range / Accept-Ranges / Content-Length
+      // so the browser player accepts the partial content.
+      const FORWARDED_RANGE_REQUEST_HEADERS = ['Range', 'If-Range', 'If-None-Match', 'If-Modified-Since'];
+      const buildUpstreamHeaders = (extraHeaders = {}) => {
+        const headers = { ...extraHeaders };
+        for (const name of FORWARDED_RANGE_REQUEST_HEADERS) {
+          const value = request.headers.get(name);
+          if (value) headers[name] = value;
+        }
+        return headers;
+      };
+      const passthroughResponseHeaders = (upstream, baseHeaders) => {
+        const headers = { ...baseHeaders };
+        const passthrough = ['Content-Range', 'Accept-Ranges', 'Content-Length', 'ETag', 'Last-Modified'];
+        for (const name of passthrough) {
+          const value = upstream.headers.get(name);
+          if (value) headers[name] = value;
+        }
+        return headers;
+      };
+
       try {
         // CDN fetch (unauthenticated) — works for SAFE/unmoderated content
-        const cdnResponse = await fetch(cdnUrl);
-        if (cdnResponse.ok) {
+        const cdnResponse = await fetch(cdnUrl, { headers: buildUpstreamHeaders() });
+        if (cdnResponse.ok || cdnResponse.status === 206) {
           const contentType = cdnResponse.headers.get('Content-Type') || 'video/mp4';
 
           // If the format is browser-playable, serve directly
           if (BROWSER_PLAYABLE_TYPES.has(contentType)) {
             console.log(`[ADMIN] Serving video from CDN: ${sha256}`);
             return new Response(cdnResponse.body, {
-              headers: {
+              status: cdnResponse.status,
+              headers: passthroughResponseHeaders(cdnResponse, {
                 'Content-Type': contentType,
                 'Cache-Control': 'private, no-store',
                 'X-Admin-Proxy': 'cdn'
-              }
+              })
             });
           }
 
           // Non-browser format (e.g. video/3gpp, video/x-matroska) — try transcoded 720p MP4 from Blossom
           console.log(`[ADMIN] CDN returned non-playable ${contentType}, trying transcoded 720p for ${sha256}`);
           const transcodeUrl = `https://${env.CDN_DOMAIN}/${sha256}/720p.mp4`;
-          const transcodeResponse = await fetch(transcodeUrl);
-          if (transcodeResponse.ok) {
+          const transcodeResponse = await fetch(transcodeUrl, { headers: buildUpstreamHeaders() });
+          if (transcodeResponse.ok || transcodeResponse.status === 206) {
             console.log(`[ADMIN] Serving transcoded 720p MP4 for ${sha256}`);
             return new Response(transcodeResponse.body, {
-              headers: {
+              status: transcodeResponse.status,
+              headers: passthroughResponseHeaders(transcodeResponse, {
                 'Content-Type': transcodeResponse.headers.get('Content-Type') || 'video/mp4',
                 'Cache-Control': 'private, no-store',
                 'X-Admin-Proxy': 'cdn-transcode'
-              }
+              })
             });
           }
           console.warn(`[ADMIN] Transcoded 720p not available (${transcodeResponse.status}) for ${sha256}`);
@@ -2135,27 +2160,21 @@ export default {
         // Fall back to admin bypass endpoint which serves regardless of moderation status
         if (env.BLOSSOM_WEBHOOK_SECRET) {
           console.log(`[ADMIN] CDN returned ${cdnResponse.status}, trying admin bypass for ${sha256}`);
-          const bypassHeaders = { 'Authorization': `Bearer ${env.BLOSSOM_WEBHOOK_SECRET}` };
-          const rangeHeader = request.headers.get('Range');
-          if (rangeHeader) bypassHeaders['Range'] = rangeHeader;
+          const bypassHeaders = buildUpstreamHeaders({
+            'Authorization': `Bearer ${env.BLOSSOM_WEBHOOK_SECRET}`
+          });
           const bypassResponse = await fetch(adminBypassUrl, { headers: bypassHeaders });
           if (bypassResponse.ok || bypassResponse.status === 206) {
             console.log(`[ADMIN] Serving video from admin bypass: ${sha256}`);
             const moderationStatus = bypassResponse.headers.get('X-Moderation-Status');
-            const contentRange = bypassResponse.headers.get('Content-Range');
-            const acceptRanges = bypassResponse.headers.get('Accept-Ranges');
-            const contentLength = bypassResponse.headers.get('Content-Length');
             return new Response(bypassResponse.body, {
               status: bypassResponse.status,
-              headers: {
+              headers: passthroughResponseHeaders(bypassResponse, {
                 'Content-Type': bypassResponse.headers.get('Content-Type') || 'video/mp4',
                 'Cache-Control': 'private, no-store',
                 'X-Admin-Proxy': 'blossom-admin',
                 ...(moderationStatus && { 'X-Moderation-Status': moderationStatus }),
-                ...(contentRange && { 'Content-Range': contentRange }),
-                ...(acceptRanges && { 'Accept-Ranges': acceptRanges }),
-                ...(contentLength && { 'Content-Length': contentLength }),
-              }
+              })
             });
           }
           console.error(`[ADMIN] Admin bypass returned ${bypassResponse.status} for ${sha256}`);

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -851,6 +851,155 @@ describe('admin video proxy format fallback', () => {
   });
 });
 
+describe('admin video proxy range forwarding', () => {
+  it('forwards Range header to CDN and returns 206 with Content-Range', async () => {
+    const originalFetch = globalThis.fetch;
+    let receivedInit = null;
+    globalThis.fetch = async (url, init) => {
+      if (String(url) === `https://media.divine.video/${SHA256}`) {
+        receivedInit = init;
+        return new Response('partial-bytes', {
+          status: 206,
+          headers: {
+            'Content-Type': 'video/mp4',
+            'Content-Range': 'bytes 0-1023/5000000',
+            'Accept-Ranges': 'bytes',
+            'Content-Length': '1024'
+          }
+        });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    };
+
+    try {
+      const response = await worker.fetch(
+        new Request(`https://moderation.admin.divine.video/admin/video/${SHA256}.mp4`, {
+          headers: {
+            'Cf-Access-Authenticated-User-Email': 'mod@divine.video',
+            'Range': 'bytes=0-1023'
+          }
+        }),
+        createEnv()
+      );
+
+      expect(response.status).toBe(206);
+      expect(response.headers.get('Content-Range')).toBe('bytes 0-1023/5000000');
+      expect(response.headers.get('Accept-Ranges')).toBe('bytes');
+      expect(response.headers.get('Content-Length')).toBe('1024');
+      expect(response.headers.get('X-Admin-Proxy')).toBe('cdn');
+
+      const upstreamHeaders = new Headers(receivedInit?.headers || {});
+      expect(upstreamHeaders.get('Range')).toBe('bytes=0-1023');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('forwards Range header to admin bypass branch and returns 206', async () => {
+    const originalFetch = globalThis.fetch;
+    let bypassInit = null;
+    globalThis.fetch = async (url, init) => {
+      if (String(url) === `https://media.divine.video/${SHA256}`) {
+        return new Response('nope', { status: 404 });
+      }
+      if (String(url) === `https://media.divine.video/admin/api/blob/${SHA256}/content`) {
+        bypassInit = init;
+        return new Response('partial-bytes', {
+          status: 206,
+          headers: {
+            'Content-Type': 'video/mp4',
+            'Content-Range': 'bytes 0-1023/5000000',
+            'Accept-Ranges': 'bytes',
+            'Content-Length': '1024'
+          }
+        });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    };
+
+    try {
+      const response = await worker.fetch(
+        new Request(`https://moderation.admin.divine.video/admin/video/${SHA256}.mp4`, {
+          headers: {
+            'Cf-Access-Authenticated-User-Email': 'mod@divine.video',
+            'Range': 'bytes=0-1023'
+          }
+        }),
+        createEnv({ BLOSSOM_WEBHOOK_SECRET: 'test-secret' })
+      );
+
+      expect(response.status).toBe(206);
+      expect(response.headers.get('Content-Range')).toBe('bytes 0-1023/5000000');
+      expect(response.headers.get('Accept-Ranges')).toBe('bytes');
+      expect(response.headers.get('Content-Length')).toBe('1024');
+      expect(response.headers.get('X-Admin-Proxy')).toBe('blossom-admin');
+
+      const upstreamHeaders = new Headers(bypassInit?.headers || {});
+      expect(upstreamHeaders.get('Range')).toBe('bytes=0-1023');
+      expect(upstreamHeaders.get('Authorization')).toBe('Bearer test-secret');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('serves 200 from CDN when no Range header is present', async () => {
+    const originalFetch = globalThis.fetch;
+    let receivedInit = null;
+    globalThis.fetch = async (url, init) => {
+      if (String(url) === `https://media.divine.video/${SHA256}`) {
+        receivedInit = init;
+        return new Response('full-bytes', {
+          status: 200,
+          headers: { 'Content-Type': 'video/mp4' }
+        });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    };
+
+    try {
+      const response = await worker.fetch(
+        new Request(`https://moderation.admin.divine.video/admin/video/${SHA256}.mp4`, {
+          headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
+        }),
+        createEnv()
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('X-Admin-Proxy')).toBe('cdn');
+      const upstreamHeaders = new Headers(receivedInit?.headers || {});
+      expect(upstreamHeaders.get('Range')).toBeNull();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('returns 404 when CDN and admin bypass both miss', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (url) => {
+      if (String(url) === `https://media.divine.video/${SHA256}`) {
+        return new Response('nope', { status: 404 });
+      }
+      if (String(url) === `https://media.divine.video/admin/api/blob/${SHA256}/content`) {
+        return new Response('nope', { status: 404 });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    };
+
+    try {
+      const response = await worker.fetch(
+        new Request(`https://moderation.admin.divine.video/admin/video/${SHA256}.mp4`, {
+          headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
+        }),
+        createEnv({ BLOSSOM_WEBHOOK_SECRET: 'test-secret' })
+      );
+
+      expect(response.status).toBe(404);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
 describe('notifyBlossom integration via admin moderate endpoint', () => {
   // Exercises the real notifyBlossom() code path through the admin API.
   // A mock fetch interceptor captures the webhook payload Blossom would receive.


### PR DESCRIPTION
## Summary
- Unifies all three upstream branches of `/admin/video/:sha256.mp4` (CDN, CDN transcode, admin bypass) through shared `buildUpstreamHeaders()` / `passthroughResponseHeaders()` helpers
- Forwards `Range`, `If-Range`, `If-None-Match`, `If-Modified-Since` to upstream
- Passes through `Content-Range`, `Accept-Ranges`, `Content-Length`, `ETag`, `Last-Modified` to browser
- Preserves upstream status code so `206 Partial Content` reaches the `<video>` element
- Fixes black 0:00 frames on every card in the admin dashboard (Safari/Chrome require byte-range support)

Supersedes PR #77 by extending Range support to the CDN and transcode branches, not just admin bypass.

## Test plan
- [x] 4 new tests in `src/index.test.mjs` covering Range forwarding on CDN and bypass branches, no-Range still works, 404 fall-through
- [x] `npm test` → 597/597 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)