### PR TITLE
feat: show uploader identity and Nostr event on dashboard cards

### DIFF
--- a/docs/superpowers/plans/2026-04-13-dashboard-uploader-identity-plan.md
+++ b/docs/superpowers/plans/2026-04-13-dashboard-uploader-identity-plan.md
@@ -1,0 +1,96 @@
+# Dashboard Uploader Identity + Nostr Event Link Plan
+
+Date: 2026-04-13
+Branch: `worktree-agent-ab0dbde8`
+
+## Problem
+
+`src/admin/dashboard.html` renders video moderation cards and a focused
+lookup result without any uploader identity: no display name, no avatar,
+no truncated pubkey, no outbound link to the Nostr event or profile.
+The sibling Quick Review page (`src/admin/swipe-review.html`) already
+shows this. We need to port the equivalent identity rendering to the
+dashboard so moderators can see who uploaded content they are reviewing
+and jump to the original Nostr event.
+
+## Scope (this agent)
+
+- Identity header at the top of each `createVideoCard` and
+  `createTriageCard` output.
+- Raw Nostr event JSON detail pane (collapsible, copy button) in the
+  focused lookup view.
+- Wider two-column lookup grid so the card and the detail pane fit
+  side-by-side.
+
+Explicitly **out of scope** (owned by another agent):
+
+- Uploader stats / history.
+- Any change to `createUploaderEnforcementPanel` behavior.
+
+## Design
+
+### Shared module: `src/admin/event-meta.mjs`
+
+Export:
+
+- `escapeHtml(value)` — plain-string HTML entity escape (no DOM; works
+  in workerd and browser).
+- `buildDivineVideoUrl(video)` — first non-empty of
+  `video.divineUrl`, `divine.video/video/<eventId>`.
+- `buildProfileUrl(pubkey)` — `divine.video/profile/<pubkey>` or null.
+- `truncatePubkey(pubkey)` — `abcdef12…90ab` style short form.
+- `pickAuthorName(video)` — best display name from nostrContext.
+- `createEventMetaHTML(video)` — returns identity block HTML
+  (avatar initial, author name, truncated pubkey, outbound links,
+  published-at).
+
+### Dashboard wiring
+
+- Add `<script type="module">` import (inline script re-defines it as a
+  non-module copy to keep the single-HTML-file shape — or switch the
+  main script tag to `type="module"`). Simpler: inline the same helpers
+  into `dashboard.html` AND import them from `event-meta.mjs` in the
+  vitest tests.
+- Call `createEventMetaHTML(video)` at the top of `createVideoCard`
+  and `createTriageCard` video-info section.
+- For the focused lookup, after rendering the card put a second child
+  into `.lookup-result-grid` containing:
+  - Identity summary (duplicate of `createEventMetaHTML`).
+  - Collapsible raw Nostr event JSON viewer (pretty-printed, copy button).
+- Change `.lookup-result-grid` template-columns to
+  `minmax(420px, 1fr) minmax(400px, 1.2fr)` with a media query fallback
+  to a single column on narrow viewports.
+
+### Backend
+
+`/admin/api/video/:sha256` already returns `nostrContext`, `eventId`,
+`uploaded_by`, `divineUrl`. No code change required; we will add an
+integration test that asserts these keys.
+
+## Tests (TDD)
+
+1. `src/admin/event-meta.test.mjs`
+   - `escapeHtml` escapes `<`, `>`, `&`, `"`, `'`.
+   - `buildDivineVideoUrl` prefers explicit `divineUrl`, then eventId.
+   - `buildProfileUrl` returns null for missing pubkey.
+   - `truncatePubkey` handles short strings and normal 64-hex.
+   - `createEventMetaHTML` returns HTML containing author name, short
+     pubkey, profile link, divine-video link, "Unknown" fallback when
+     empty.
+
+2. `src/index.test.mjs` (extend): a new test asserting the lookup
+   response for an untriaged video includes `nostrContext`, `eventId`,
+   `uploaded_by`, `divineUrl` keys (even if null). The existing
+   moderated-row test already verifies these — we add the assertion for
+   the webhook/UNTRIAGED branch.
+
+## Implementation steps
+
+1. Create `event-meta.mjs` and its tests. Confirm red.
+2. Make tests pass.
+3. Port helpers into `dashboard.html` (inline script copy) and add
+   identity block to both card builders.
+4. Extend `.lookup-result-grid` CSS to two columns and render the
+   detail pane next to the focused card.
+5. `npm test`.
+6. Commit on worktree branch (no PR).

--- a/src/admin/dashboard.html
+++ b/src/admin/dashboard.html
@@ -137,8 +137,199 @@
 
     .lookup-result-grid {
       display: grid;
-      grid-template-columns: minmax(300px, 420px);
+      grid-template-columns: minmax(420px, 1fr) minmax(400px, 1.2fr);
       gap: 20px;
+      align-items: start;
+    }
+
+    @media (max-width: 1100px) {
+      .lookup-result-grid {
+        grid-template-columns: minmax(320px, 1fr);
+      }
+    }
+
+    .lookup-detail-pane {
+      background: #141b27;
+      border: 1px solid #1f2a3a;
+      border-radius: 10px;
+      padding: 16px;
+      color: #cbd5e1;
+      font-size: 12px;
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+    }
+
+    .lookup-detail-pane h3 {
+      margin: 0;
+      font-size: 11px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #94a3b8;
+    }
+
+    .lookup-detail-section {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .lookup-detail-row {
+      display: flex;
+      align-items: flex-start;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+
+    .lookup-detail-row .k {
+      color: #64748b;
+      min-width: 80px;
+    }
+
+    .lookup-detail-row .v {
+      color: #e2e8f0;
+      word-break: break-all;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    }
+
+    .lookup-detail-row a {
+      color: #8b5cf6;
+      text-decoration: none;
+    }
+
+    .lookup-detail-row a:hover {
+      text-decoration: underline;
+    }
+
+    .nostr-event-json {
+      background: #0b1220;
+      border: 1px solid #1f2a3a;
+      border-radius: 8px;
+      padding: 10px;
+      color: #cbd5e1;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 11px;
+      line-height: 1.5;
+      max-height: 360px;
+      overflow: auto;
+      white-space: pre-wrap;
+      word-break: break-word;
+      margin: 0;
+    }
+
+    .nostr-event-toolbar {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .nostr-event-toolbar button {
+      background: #1f2a3a;
+      color: #cbd5e1;
+      border: 1px solid #334155;
+      border-radius: 5px;
+      padding: 4px 10px;
+      font-size: 11px;
+      cursor: pointer;
+    }
+
+    .nostr-event-toolbar button:hover {
+      background: #27324a;
+    }
+
+    /* Uploader identity block shown at top of each card */
+    .event-meta {
+      display: flex;
+      gap: 10px;
+      align-items: flex-start;
+      padding: 8px 10px;
+      background: #141b27;
+      border: 1px solid #1f2a3a;
+      border-radius: 8px;
+      margin-bottom: 10px;
+    }
+
+    .event-meta-avatar {
+      width: 34px;
+      height: 34px;
+      flex-shrink: 0;
+      border-radius: 50%;
+      background: linear-gradient(135deg, #8b5cf6, #6366f1);
+      color: #fff;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-weight: 700;
+      font-size: 14px;
+    }
+
+    .event-meta-body {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+      min-width: 0;
+      flex: 1;
+    }
+
+    .event-meta-name {
+      color: #e2e8f0;
+      font-size: 13px;
+      font-weight: 600;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .event-meta-pubkey-row {
+      font-size: 11px;
+      color: #94a3b8;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    }
+
+    .event-meta-pubkey.empty {
+      color: #64748b;
+      font-style: italic;
+    }
+
+    .event-meta-event-id,
+    .event-meta-published {
+      font-size: 11px;
+      color: #94a3b8;
+    }
+
+    .event-meta-event-id code {
+      font-size: 10px;
+      color: #cbd5e1;
+    }
+
+    .event-meta-label {
+      color: #64748b;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      font-size: 9px;
+      margin-right: 4px;
+    }
+
+    .event-meta-links {
+      display: flex;
+      gap: 8px;
+      margin-top: 4px;
+    }
+
+    .event-meta-link {
+      color: #8b5cf6;
+      font-size: 11px;
+      text-decoration: none;
+      border: 1px solid #334155;
+      border-radius: 4px;
+      padding: 2px 8px;
+      background: #0b1220;
+    }
+
+    .event-meta-link:hover {
+      background: #1f2a3a;
+      text-decoration: none;
     }
 
     .control-group {
@@ -2190,9 +2381,11 @@
         ? { ...video, showDirectActions: true, showTranscriptTools: true }
         : { ...video, showTranscriptTools: true };
 
-      result.innerHTML = video.status === 'UNTRIAGED'
+      const cardHtml = video.status === 'UNTRIAGED'
         ? createTriageCard(renderVideo)
         : createVideoCard(renderVideo);
+      const detailPaneHtml = createLookupDetailPaneHTML(renderVideo);
+      result.innerHTML = cardHtml + detailPaneHtml;
 
       section.style.display = 'block';
       meta.textContent = `${video.sha256.substring(0, 16)}...${video.status === 'UNTRIAGED' ? ' · needs triage' : ` · ${video.action}`}`;
@@ -2485,6 +2678,7 @@
           '</div>' +
         '</div>' +
         '<div class="video-info">' +
+          createEventMetaHTML(video) +
           '<div style="font-size: 11px; color: #666; margin-bottom: 6px; font-family: monospace;">' +
             '<span title="' + sha256 + '">' + sha256.substring(0, 16) + '...</span> ' +
             '<button onclick="copyToClipboard(\'' + copyVideoUrl + '\'); event.stopPropagation();" style="background: #333; color: #888; border: none; padding: 2px 6px; border-radius: 3px; cursor: pointer; font-size: 10px;" title="Copy video URL">📋 URL</button> ' +
@@ -3036,6 +3230,203 @@
       return div.innerHTML;
     }
 
+    // --- Uploader identity helpers (mirror of src/admin/event-meta.mjs) ---
+    // Unit-tested via event-meta.test.mjs; duplicated here because
+    // dashboard.html is a single served HTML file without a build step.
+    function eventMetaFirstPresent() {
+      for (let i = 0; i < arguments.length; i++) {
+        const v = arguments[i];
+        if (v === null || v === undefined) continue;
+        if (typeof v === 'string' && v.trim() === '') continue;
+        return v;
+      }
+      return null;
+    }
+
+    function buildDivineVideoUrl(video) {
+      if (!video) return null;
+      if (video.divineUrl) return video.divineUrl;
+      const eid = eventMetaFirstPresent(video.eventId, video.event_id, video.nostrContext && video.nostrContext.eventId);
+      return eid ? 'https://divine.video/video/' + eid : null;
+    }
+
+    function buildProfileUrl(pubkey) {
+      if (!pubkey) return null;
+      const str = String(pubkey).trim();
+      if (!str) return null;
+      return 'https://divine.video/profile/' + str;
+    }
+
+    function truncatePubkey(pubkey) {
+      if (!pubkey) return '';
+      const str = String(pubkey);
+      if (str.length <= 16) return str;
+      return str.slice(0, 8) + '...' + str.slice(-8);
+    }
+
+    function pickAuthorName(video) {
+      if (!video) return 'Unknown publisher';
+      const ctx = video.nostrContext || {};
+      return eventMetaFirstPresent(video.author, ctx.author, ctx.displayName) || 'Unknown publisher';
+    }
+
+    function pickUploaderPubkey(video) {
+      if (!video) return null;
+      const ctx = video.nostrContext || {};
+      const raw = eventMetaFirstPresent(video.uploaded_by, video.uploadedBy, ctx.pubkey);
+      return raw ? String(raw) : null;
+    }
+
+    function isFullHexPubkey(pubkey) {
+      return typeof pubkey === 'string' && /^[0-9a-f]{64}$/i.test(pubkey);
+    }
+
+    function formatEventMetaTimestamp(value) {
+      if (value === null || value === undefined || value === '') return null;
+      let date;
+      if (typeof value === 'number') {
+        date = new Date(value < 1e12 ? value * 1000 : value);
+      } else {
+        date = new Date(value);
+      }
+      if (Number.isNaN(date.getTime())) return null;
+      return date.toISOString().replace('T', ' ').replace(/:\d{2}\.\d{3}Z$/, 'Z');
+    }
+
+    /**
+     * Renders the uploader identity block shown at the top of every
+     * moderation card (avatar, author, pubkey, profile + Nostr event link).
+     */
+    function createEventMetaHTML(video) {
+      video = video || {};
+      const authorName = pickAuthorName(video);
+      const pubkey = pickUploaderPubkey(video);
+      const profileUrl = isFullHexPubkey(pubkey) ? buildProfileUrl(pubkey) : null;
+      const divineUrl = buildDivineVideoUrl(video);
+      const eventId = eventMetaFirstPresent(video.eventId, video.event_id, video.nostrContext && video.nostrContext.eventId);
+      const publishedAt = formatEventMetaTimestamp(
+        eventMetaFirstPresent(video.published_at, video.publishedAt, video.nostrContext && video.nostrContext.publishedAt)
+      );
+      const avatarChar = (authorName || '?').trim().charAt(0).toUpperCase() || '?';
+
+      const pubkeyLine = pubkey
+        ? '<span class="event-meta-pubkey" title="' + escapeHtml(pubkey) + '" onclick="copyToClipboard(\'' + escapeHtml(pubkey) + '\')" style="cursor:pointer">' + escapeHtml(truncatePubkey(pubkey)) + '</span>'
+        : '<span class="event-meta-pubkey empty">No pubkey</span>';
+
+      const links = [];
+      if (profileUrl) {
+        links.push('<a class="event-meta-link" href="' + escapeHtml(profileUrl) + '" target="_blank" rel="noopener noreferrer" onclick="event.stopPropagation()">Profile</a>');
+      }
+      if (divineUrl) {
+        links.push('<a class="event-meta-link" href="' + escapeHtml(divineUrl) + '" target="_blank" rel="noopener noreferrer" onclick="event.stopPropagation()">Nostr event</a>');
+      }
+
+      const linksHtml = links.length ? '<div class="event-meta-links">' + links.join('') + '</div>' : '';
+      const publishedHtml = publishedAt
+        ? '<div class="event-meta-published"><span class="event-meta-label">Published</span>' + escapeHtml(publishedAt) + '</div>'
+        : '';
+      const eventIdHtml = eventId
+        ? '<div class="event-meta-event-id"><span class="event-meta-label">Event</span><code>' + escapeHtml(truncatePubkey(eventId)) + '</code></div>'
+        : '';
+
+      return (
+        '<div class="event-meta">' +
+          '<div class="event-meta-avatar" aria-hidden="true">' + escapeHtml(avatarChar) + '</div>' +
+          '<div class="event-meta-body">' +
+            '<div class="event-meta-name">' + escapeHtml(authorName) + '</div>' +
+            '<div class="event-meta-pubkey-row">' + pubkeyLine + '</div>' +
+            eventIdHtml +
+            publishedHtml +
+            linksHtml +
+          '</div>' +
+        '</div>'
+      );
+    }
+
+    /**
+     * Renders the lookup detail pane shown to the right of the focused
+     * card: a pretty-printed, copyable Nostr event JSON view plus
+     * quick identity links.
+     */
+    function createLookupDetailPaneHTML(video) {
+      video = video || {};
+      const nostrContext = video.nostrContext || {};
+      const pubkey = pickUploaderPubkey(video);
+      const divineUrl = buildDivineVideoUrl(video);
+      const profileUrl = isFullHexPubkey(pubkey) ? buildProfileUrl(pubkey) : null;
+      const eventId = eventMetaFirstPresent(video.eventId, video.event_id, nostrContext.eventId);
+      const eventPayload = {
+        eventId: eventId || null,
+        pubkey: pubkey || null,
+        divineUrl: divineUrl || null,
+        profileUrl: profileUrl || null,
+        sha256: video.sha256 || null,
+        title: eventMetaFirstPresent(video.title, nostrContext.title),
+        author: pickAuthorName(video),
+        content: nostrContext.content || null,
+        url: eventMetaFirstPresent(video.content_url, nostrContext.url, video.cdnUrl),
+        sourceUrl: nostrContext.sourceUrl || null,
+        publishedAt: eventMetaFirstPresent(video.published_at, video.publishedAt, nostrContext.publishedAt),
+        platform: nostrContext.platform || null,
+        client: nostrContext.client || null,
+        loops: nostrContext.loops ?? null,
+        likes: nostrContext.likes ?? null,
+        comments: nostrContext.comments ?? null,
+        archivedAt: nostrContext.archivedAt || null,
+        importedAt: nostrContext.importedAt || null,
+        vineHashId: nostrContext.vineHashId || null,
+        vineUserId: nostrContext.vineUserId || null
+      };
+      const jsonText = JSON.stringify(eventPayload, null, 2);
+
+      const rows = [];
+      if (eventId) {
+        rows.push('<div class="lookup-detail-row"><span class="k">Event</span><span class="v">' + escapeHtml(eventId) + '</span></div>');
+      }
+      if (pubkey) {
+        rows.push('<div class="lookup-detail-row"><span class="k">Pubkey</span><span class="v">' + escapeHtml(pubkey) + '</span></div>');
+      }
+      const linkChips = [];
+      if (divineUrl) {
+        linkChips.push('<a class="event-meta-link" href="' + escapeHtml(divineUrl) + '" target="_blank" rel="noopener noreferrer">Open Nostr event</a>');
+      }
+      if (profileUrl) {
+        linkChips.push('<a class="event-meta-link" href="' + escapeHtml(profileUrl) + '" target="_blank" rel="noopener noreferrer">Open profile</a>');
+      }
+      const linksRow = linkChips.length
+        ? '<div class="lookup-detail-row">' + linkChips.join('') + '</div>'
+        : '';
+
+      return (
+        '<aside class="lookup-detail-pane" data-sha256="' + escapeHtml(video.sha256 || '') + '">' +
+          '<div class="lookup-detail-section">' +
+            '<h3>Uploader Identity</h3>' +
+            createEventMetaHTML(video) +
+            rows.join('') +
+            linksRow +
+          '</div>' +
+          '<div class="lookup-detail-section">' +
+            '<div class="nostr-event-toolbar">' +
+              '<h3>Nostr Event</h3>' +
+              '<button type="button" onclick="copyNostrEventJson(this)" data-json=\'' + escapeHtml(jsonText) + '\'>Copy JSON</button>' +
+            '</div>' +
+            '<details open>' +
+              '<summary style="cursor:pointer;color:#94a3b8;font-size:11px;">Toggle raw event JSON</summary>' +
+              '<pre class="nostr-event-json">' + escapeHtml(jsonText) + '</pre>' +
+            '</details>' +
+          '</div>' +
+        '</aside>'
+      );
+    }
+
+    function copyNostrEventJson(button) {
+      const json = button.getAttribute('data-json') || '';
+      copyToClipboard(json);
+      const orig = button.textContent;
+      button.textContent = 'Copied!';
+      setTimeout(() => { button.textContent = orig; }, 1200);
+    }
+
     function createVideoCard(video) {
       const { sha256, cdnUrl, action, scores, reason, processedAt, detailedCategories, provider, manualOverride, overriddenAt, previousAction, showTranscriptTools } = video;
 
@@ -3147,6 +3538,7 @@
             </div>
           </div>
           <div class="video-info">
+            ${createEventMetaHTML(video)}
             <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
               <div style="display: flex; align-items: center; gap: 4px;">
                 <div class="video-hash" title="Click to copy full hash" onclick="copyToClipboard('${sha256}')" style="margin-bottom: 0;">${sha256.substring(0, 16)}...</div>

--- a/src/admin/event-meta.mjs
+++ b/src/admin/event-meta.mjs
@@ -1,0 +1,142 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Shared helpers that render uploader identity + Nostr event
+// ABOUTME: links for the admin dashboard and Quick Review pages.
+
+const HTML_ESCAPES = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;',
+};
+
+export function escapeHtml(value) {
+  if (value === null || value === undefined) return '';
+  return String(value).replace(/[&<>"']/g, (ch) => HTML_ESCAPES[ch]);
+}
+
+function firstPresent(...values) {
+  for (const v of values) {
+    if (v === null || v === undefined) continue;
+    if (typeof v === 'string' && v.trim() === '') continue;
+    return v;
+  }
+  return null;
+}
+
+export function buildDivineVideoUrl(video) {
+  if (!video) return null;
+  const direct = firstPresent(video.divineUrl);
+  if (direct) return direct;
+  const eid = firstPresent(video.eventId, video.event_id, video?.nostrContext?.eventId);
+  return eid ? `https://divine.video/video/${eid}` : null;
+}
+
+export function buildProfileUrl(pubkey) {
+  if (!pubkey) return null;
+  const str = String(pubkey).trim();
+  if (!str) return null;
+  return `https://divine.video/profile/${str}`;
+}
+
+export function truncatePubkey(pubkey) {
+  if (!pubkey) return '';
+  const str = String(pubkey);
+  if (str.length <= 16) return str;
+  return `${str.slice(0, 8)}...${str.slice(-8)}`;
+}
+
+export function pickAuthorName(video) {
+  if (!video) return 'Unknown publisher';
+  const ctx = video.nostrContext || {};
+  return firstPresent(video.author, ctx.author, ctx.displayName) || 'Unknown publisher';
+}
+
+function pickPubkey(video) {
+  if (!video) return null;
+  const ctx = video.nostrContext || {};
+  const raw = firstPresent(video.uploaded_by, video.uploadedBy, ctx.pubkey);
+  if (!raw) return null;
+  const str = String(raw);
+  // The swipe-review API occasionally stores a pre-truncated pubkey like
+  // "aabbccdd...". We keep the raw value for display but don't use it to
+  // build a profile link (which needs a full 64-hex pubkey).
+  return str;
+}
+
+function isFullHexPubkey(pubkey) {
+  return typeof pubkey === 'string' && /^[0-9a-f]{64}$/i.test(pubkey);
+}
+
+function formatTimestamp(value) {
+  if (value === null || value === undefined || value === '') return null;
+  let date;
+  if (typeof value === 'number') {
+    // Seconds vs. milliseconds heuristic (Nostr published_at is seconds)
+    date = new Date(value < 1e12 ? value * 1000 : value);
+  } else {
+    date = new Date(value);
+  }
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toISOString().replace('T', ' ').replace(/:\d{2}\.\d{3}Z$/, 'Z');
+}
+
+/**
+ * Renders the uploader identity block: avatar initial, author name,
+ * truncated pubkey (copyable via data attribute), profile link, and
+ * Nostr event link. Used at the top of moderation cards.
+ */
+export function createEventMetaHTML(video = {}) {
+  const authorName = pickAuthorName(video);
+  const pubkey = pickPubkey(video);
+  const profileUrl = isFullHexPubkey(pubkey) ? buildProfileUrl(pubkey) : null;
+  const divineUrl = buildDivineVideoUrl(video);
+  const eventId = firstPresent(video.eventId, video.event_id, video?.nostrContext?.eventId);
+  const publishedAt = formatTimestamp(
+    firstPresent(video.published_at, video.publishedAt, video?.nostrContext?.publishedAt)
+  );
+  const avatarChar = (authorName || '?').trim().charAt(0).toUpperCase() || '?';
+
+  const pubkeyLine = pubkey
+    ? `<span class="event-meta-pubkey" title="${escapeHtml(pubkey)}" data-pubkey="${escapeHtml(pubkey)}">${escapeHtml(truncatePubkey(pubkey))}</span>`
+    : '<span class="event-meta-pubkey empty">No pubkey</span>';
+
+  const links = [];
+  if (profileUrl) {
+    links.push(
+      `<a class="event-meta-link" href="${escapeHtml(profileUrl)}" target="_blank" rel="noopener noreferrer">Profile</a>`
+    );
+  }
+  if (divineUrl) {
+    links.push(
+      `<a class="event-meta-link" href="${escapeHtml(divineUrl)}" target="_blank" rel="noopener noreferrer">Nostr event</a>`
+    );
+  }
+
+  const linksHtml = links.length
+    ? `<div class="event-meta-links">${links.join('')}</div>`
+    : '';
+
+  const publishedHtml = publishedAt
+    ? `<div class="event-meta-published"><span class="event-meta-label">Published</span> ${escapeHtml(publishedAt)}</div>`
+    : '';
+
+  const eventIdHtml = eventId
+    ? `<div class="event-meta-event-id"><span class="event-meta-label">Event</span> <code>${escapeHtml(truncatePubkey(eventId))}</code></div>`
+    : '';
+
+  return `
+    <div class="event-meta">
+      <div class="event-meta-avatar" aria-hidden="true">${escapeHtml(avatarChar)}</div>
+      <div class="event-meta-body">
+        <div class="event-meta-name">${escapeHtml(authorName)}</div>
+        <div class="event-meta-pubkey-row">${pubkeyLine}</div>
+        ${eventIdHtml}
+        ${publishedHtml}
+        ${linksHtml}
+      </div>
+    </div>
+  `;
+}

--- a/src/admin/event-meta.test.mjs
+++ b/src/admin/event-meta.test.mjs
@@ -1,0 +1,136 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Tests for the shared uploader-identity helpers used by the
+// ABOUTME: admin dashboard and Quick Review to render Nostr event meta.
+
+import { describe, it, expect } from 'vitest';
+import {
+  escapeHtml,
+  buildDivineVideoUrl,
+  buildProfileUrl,
+  truncatePubkey,
+  pickAuthorName,
+  createEventMetaHTML,
+} from './event-meta.mjs';
+
+const PUBKEY = 'a'.repeat(64);
+const EVENT_ID = '1'.repeat(64);
+
+describe('escapeHtml', () => {
+  it('escapes angle brackets, ampersands and quotes', () => {
+    expect(escapeHtml('<a href="x">&"\'</a>')).toBe(
+      '&lt;a href=&quot;x&quot;&gt;&amp;&quot;&#39;&lt;/a&gt;'
+    );
+  });
+
+  it('coerces null/undefined to empty string', () => {
+    expect(escapeHtml(null)).toBe('');
+    expect(escapeHtml(undefined)).toBe('');
+  });
+});
+
+describe('buildDivineVideoUrl', () => {
+  it('prefers an explicit divineUrl', () => {
+    expect(
+      buildDivineVideoUrl({
+        divineUrl: 'https://divine.video/video/stable-id',
+        eventId: EVENT_ID,
+      })
+    ).toBe('https://divine.video/video/stable-id');
+  });
+
+  it('falls back to eventId', () => {
+    expect(buildDivineVideoUrl({ eventId: EVENT_ID })).toBe(
+      `https://divine.video/video/${EVENT_ID}`
+    );
+  });
+
+  it('returns null when no identifier is present', () => {
+    expect(buildDivineVideoUrl({})).toBeNull();
+  });
+});
+
+describe('buildProfileUrl', () => {
+  it('returns a profile url for a pubkey', () => {
+    expect(buildProfileUrl(PUBKEY)).toBe(`https://divine.video/profile/${PUBKEY}`);
+  });
+
+  it('returns null when pubkey missing', () => {
+    expect(buildProfileUrl(null)).toBeNull();
+    expect(buildProfileUrl('')).toBeNull();
+  });
+});
+
+describe('truncatePubkey', () => {
+  it('shortens a 64-char hex pubkey', () => {
+    const result = truncatePubkey(PUBKEY);
+    expect(result.length).toBeLessThan(PUBKEY.length);
+    expect(result).toMatch(/\.\.\./);
+    expect(result.startsWith('aaaaaaaa')).toBe(true);
+    expect(result.endsWith('aaaaaaaa')).toBe(true);
+  });
+
+  it('returns short strings unchanged', () => {
+    expect(truncatePubkey('abc')).toBe('abc');
+  });
+
+  it('handles nullish values', () => {
+    expect(truncatePubkey(null)).toBe('');
+    expect(truncatePubkey(undefined)).toBe('');
+  });
+});
+
+describe('pickAuthorName', () => {
+  it('returns the top-level author first', () => {
+    expect(pickAuthorName({ author: 'Top', nostrContext: { author: 'Nested' } })).toBe('Top');
+  });
+
+  it('falls back to nostrContext.author', () => {
+    expect(pickAuthorName({ nostrContext: { author: 'Nested' } })).toBe('Nested');
+  });
+
+  it('returns "Unknown publisher" when no name is available', () => {
+    expect(pickAuthorName({})).toBe('Unknown publisher');
+  });
+});
+
+describe('createEventMetaHTML', () => {
+  it('renders author name, truncated pubkey, and outbound links', () => {
+    const html = createEventMetaHTML({
+      author: 'Alice',
+      uploaded_by: PUBKEY,
+      eventId: EVENT_ID,
+      divineUrl: `https://divine.video/video/${EVENT_ID}`,
+      nostrContext: { publishedAt: 1_700_000_000 },
+    });
+
+    expect(html).toContain('Alice');
+    expect(html).toContain('aaaaaaaa');
+    expect(html).toContain(`https://divine.video/profile/${PUBKEY}`);
+    expect(html).toContain(`https://divine.video/video/${EVENT_ID}`);
+    expect(html).toMatch(/event-meta/);
+  });
+
+  it('escapes hostile author names', () => {
+    const html = createEventMetaHTML({ author: '<script>alert(1)</script>' });
+    expect(html).not.toContain('<script>alert(1)</script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+
+  it('renders a fallback when identity is missing', () => {
+    const html = createEventMetaHTML({});
+    expect(html).toContain('Unknown publisher');
+    // Should NOT render a broken profile link
+    expect(html).not.toContain('divine.video/profile/null');
+    expect(html).not.toContain('divine.video/profile/undefined');
+  });
+
+  it('includes a profile link when only nostrContext.pubkey is present', () => {
+    const html = createEventMetaHTML({
+      nostrContext: { pubkey: PUBKEY, author: 'Bob' },
+    });
+    expect(html).toContain(`https://divine.video/profile/${PUBKEY}`);
+    expect(html).toContain('Bob');
+  });
+});

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -577,6 +577,45 @@ describe('Admin video lookup', () => {
     });
   });
 
+  it('includes uploader identity keys (nostrContext, eventId, uploaded_by, divineUrl) for moderated rows', async () => {
+    const env = createEnv({
+      BLOSSOM_DB: createDbMock({
+        moderationResults: new Map([[SHA256, {
+          sha256: SHA256,
+          action: 'REVIEW',
+          provider: 'hiveai',
+          scores: JSON.stringify({ nudity: 0.2 }),
+          categories: JSON.stringify([]),
+          moderated_at: '2026-04-01T00:00:00.000Z',
+          uploaded_by: 'c'.repeat(64),
+          title: 'Clip title',
+          author: 'Alice',
+          event_id: '2'.repeat(64),
+          content_url: 'https://media.divine.video/clip.mp4',
+          published_at: '2026-04-01T00:00:00.000Z'
+        }]])
+      })
+    });
+
+    const response = await worker.fetch(
+      new Request(`https://moderation.admin.divine.video/admin/api/video/${SHA256}`, {
+        headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
+      }),
+      env
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.video).toHaveProperty('nostrContext');
+    expect(body.video).toHaveProperty('eventId');
+    expect(body.video).toHaveProperty('uploaded_by');
+    expect(body.video).toHaveProperty('divineUrl');
+    expect(body.video.uploaded_by).toBe('c'.repeat(64));
+    expect(body.video.eventId).toBe('2'.repeat(64));
+    expect(body.video.divineUrl).toBe(`https://divine.video/video/${'2'.repeat(64)}`);
+    expect(body.video.nostrContext).toMatchObject({ title: 'Clip title', author: 'Alice' });
+  });
+
   it('returns 404 when the lookup identifier is unknown', async () => {
     const originalFetch = globalThis.fetch;
     globalThis.fetch = async () => new Response('not found', { status: 404 });


### PR DESCRIPTION
## Summary
- New shared `src/admin/event-meta.mjs` (avatar, author, truncated pubkey, Profile/Nostr event links, published-at) — ported from `swipe-review.html` so dashboard cards match Quick Review
- Identity block rendered at the top of both `createVideoCard` and `createTriageCard`
- `.lookup-result-grid` widened to a responsive 2-column layout (`minmax(420px, 1fr) minmax(400px, 1.2fr)`) with a <1100px fallback
- New detail pane alongside the focused lookup: identity rows + collapsible pretty-printed Nostr event JSON with Copy button
- `/admin/api/video/:sha256` already returned `nostrContext` / `eventId` / `uploaded_by` — added a test to lock that contract

Fixes the reviewer-context gap where moderators couldn't see who posted a video or link out to the original event.

## Test plan
- [x] 17 new unit tests in `src/admin/event-meta.test.mjs` (escaping, URL builders, truncation, author fallback, XSS-safe rendering)
- [x] New contract test on `/admin/api/video/:sha256` uploader identity keys
- [x] `npm test` → 611/611 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)