### PR TITLE
Use FunnelCake REST for admin metadata lookups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ old_files/
 .test-nsec
 old_files/
 cost-projections-internal.md
+.worktrees/

--- a/docs/superpowers/specs/2026-04-08-nudity-enforcement-design.md
+++ b/docs/superpowers/specs/2026-04-08-nudity-enforcement-design.md
@@ -1,0 +1,204 @@
+# Nudity Enforcement Policy Design
+
+## Goal
+
+Stop auto-restricting or auto-removing benign nudity such as shirtless men, swimwear, beachwear, and non-sexual topless content, while still:
+
+- preserving moderation labels and downstream trust-and-safety signals
+- auto-warning sexually explicit content
+- continuing to auto-ban porn, full-frontal nudity, simulated sex, CSAM, and other already-banworthy categories
+
+## Problem
+
+The current pipeline collapses broad Hive.AI classes into the enforcement category `nudity`, then treats `nudity` as a direct moderation action category.
+
+That means benign classes such as:
+
+- `yes_male_nudity`
+- `yes_male_underwear`
+- `yes_male_swimwear`
+- generic suggestive / NSFW classes
+
+can currently become:
+
+- `REVIEW`
+- `QUARANTINE`
+- `AGE_RESTRICTED`
+
+Those actions are then forwarded to Blossom, where `QUARANTINE` maps to `RESTRICT` and `AGE_RESTRICTED` maps to restricted serving. The result is that content that should only be labeled can be hidden or restricted automatically.
+
+## Approved Policy
+
+### Benign nudity
+
+The following should remain serveable by default and should not auto-enforce:
+
+- nipples simply existing, regardless of gender, when the chest is not the focus
+- shirtless / topless but non-sexual content
+- swimwear
+- beach activities
+- breastfeeding
+
+This content may still emit moderation labels and downstream signals.
+
+### Sexual content
+
+Sexual content should receive warnings, meaning it should auto-map to `AGE_RESTRICTED`.
+
+Examples:
+
+- sexually suggestive behavior
+- tiny underwear presented sexually
+- twerking in a sexual context
+- grabbing breasts
+- setups for porn shoots
+- displays or setups of sex toys
+
+### Ban-grade explicit content
+
+The following should remain auto-ban eligible:
+
+- porn
+- full frontal nudity
+- simulated sex
+- naked flash mobs
+- anything sexual involving minors or people who appear underage
+
+## Design
+
+### 1. Separate label signals from enforcement signals
+
+The moderation pipeline currently uses one score bucket for both:
+
+- public / downstream labels
+- enforcement decisions
+
+That coupling is the root cause of the false positives.
+
+The fix is to preserve two conceptual layers:
+
+- broad label signals
+- narrower enforcement signals
+
+Broad label signals may include benign nudity classes. Enforcement signals must be limited to categories that actually justify automatic serving changes.
+
+### 2. Narrow Hive nudity normalization
+
+Hive moderation classes should no longer all collapse into enforcement-grade `nudity`.
+
+Instead:
+
+- benign male-coded classes like `yes_male_nudity`, `yes_male_underwear`, and `yes_male_swimwear` should contribute to label-only nudity context
+- generic classes like `general_suggestive` should not auto-enforce on their own
+- sexually explicit classes such as `yes_sexual_activity`, `yes_sexual_display`, and sex-toy related classes should map into an enforcement-grade `sexual` bucket
+- the strongest explicit / pornographic classes should map into an enforcement-grade `porn` bucket
+
+This keeps broad awareness while preventing benign content from being fed into the enforcement path.
+
+### 3. Remove broad `nudity` from automatic enforcement
+
+The classifier should stop treating broad `nudity` as a direct enforcement category.
+
+Instead:
+
+- `nudity` remains a label / downstream context category
+- `sexual` becomes `AGE_RESTRICTED`
+- `porn` becomes `PERMANENT_BAN`
+
+Existing non-nudity policy remains unchanged:
+
+- AI-generated: unchanged
+- deepfake: unchanged
+- self-harm: unchanged
+- hate / offensive: unchanged
+- gore: unchanged
+- violence, drugs, weapons, etc.: unchanged
+
+### 4. Preserve downstream moderation context
+
+Benign nudity should still be available for:
+
+- moderation labels
+- ClickHouse moderation label writes
+- downstream trust-and-safety context
+- audits and analytics
+
+This means a `SAFE` serving action can still carry meaningful moderation metadata.
+
+### 5. Do not change Blossom action mapping
+
+The issue is upstream policy classification, not Blossom transport.
+
+No Blossom changes are required. Once the classifier stops emitting enforcement actions for benign nudity, Blossom will stop restricting that content automatically.
+
+## Files Expected To Change
+
+### Core policy and provider mapping
+
+- `src/moderation/providers/hiveai/normalizer.mjs`
+- `src/moderation/classifier.mjs`
+- `src/moderation/pipeline.mjs`
+
+### Tests
+
+- `src/moderation/providers/hiveai/normalizer.test.mjs`
+- `src/moderation/classifier.test.mjs`
+- `src/moderation/pipeline.test.mjs`
+- optionally `src/moderation/downstream-publishing.test.mjs` if downstream semantics need stronger regression coverage
+
+## Testing Strategy
+
+Tests should prove all of the following:
+
+1. Benign male-coded nudity classes do not produce enforcement-grade actions.
+2. Benign topless / swimwear content stays `SAFE`.
+3. Benign topless / swimwear content still emits label/downstream moderation context.
+4. Sexual content auto-maps to `AGE_RESTRICTED`.
+5. Porn / simulated sex / strongest explicit content still auto-map to `PERMANENT_BAN`.
+6. Existing AI, self-harm, hate, gore, and unrelated moderation rules are not regressed.
+
+## Non-Goals
+
+- no Blossom webhook contract changes
+- no backfill / automatic undo of already-restricted historical items
+- no changes to human moderator override actions
+- no redesign of unrelated moderation categories
+
+## Risks
+
+### Under-enforcement risk
+
+If the benign-vs-sexual split is too permissive, explicit sexual content may stop warning correctly.
+
+Mitigation:
+
+- write explicit fixture tests for sexual activity, sexual display, and pornographic classes
+- keep explicit-content mappings narrow and test-driven
+
+### Label regression risk
+
+If benign nudity is removed entirely instead of separated, we lose useful trust-and-safety context.
+
+Mitigation:
+
+- preserve broad nudity in downstream / label paths
+- test for `SAFE` plus retained labels
+
+### Historical content risk
+
+Previously restricted items will remain restricted until separately reviewed or backfilled.
+
+Mitigation:
+
+- handle new policy first
+- treat historical cleanup as a separate follow-up project
+
+## Recommended Implementation Order
+
+1. Add failing tests for benign male-coded nudity staying serveable.
+2. Add failing tests for sexual content warning behavior.
+3. Add failing tests for porn / explicit content ban behavior.
+4. Narrow Hive class normalization to distinguish benign nudity from sexual / pornographic content.
+5. Update classifier enforcement rules to use `sexual` and `porn`, not broad `nudity`.
+6. Verify downstream label behavior still includes benign nudity signals.
+7. Run targeted and full moderation test suites.

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -181,10 +181,65 @@ function buildFunnelcakeVideoLookup(eventResponse, identifier) {
       content: metadata.content || event.content || null,
       pubkey: event.pubkey ? `${event.pubkey.substring(0, 16)}...` : null,
       eventId: event.id,
-      platform: metadata.platform || null
+      platform: metadata.platform || null,
+      loops: metadata.loops ?? null,
+      likes: metadata.likes ?? null,
+      comments: metadata.comments ?? null,
+      url: metadata.url || videoUrl || null,
+      sourceUrl: metadata.sourceUrl || null,
+      publishedAt: metadata.publishedAt ?? null,
+      archivedAt: metadata.archivedAt ?? null,
+      importedAt: metadata.importedAt ?? null,
+      vineHashId: metadata.vineHashId || null,
+      vineUserId: metadata.vineUserId || null,
+      createdAt: metadata.createdAt || event.created_at || null
     },
     divineUrl: `https://divine.video/video/${encodeURIComponent(stableId)}`
   };
+}
+
+function parseOptionalInteger(value) {
+  if (value === null || value === undefined || value === '') {
+    return null;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function buildStoredNostrContext(row, uploadedBy = null, options = {}) {
+  const { includePubkey = true } = options;
+  if (!row) {
+    return null;
+  }
+
+  const metadata = {
+    title: row.title || null,
+    author: row.author || null,
+    platform: null,
+    client: null,
+    loops: null,
+    likes: null,
+    comments: null,
+    url: row.content_url || null,
+    sourceUrl: null,
+    publishedAt: parseOptionalInteger(row.published_at),
+    archivedAt: null,
+    importedAt: null,
+    vineHashId: null,
+    vineUserId: null,
+    content: null,
+    eventId: row.event_id || null,
+    createdAt: null
+  };
+
+  const hasStoredMetadata = Object.values(metadata).some((value) => value !== null);
+
+  if (includePubkey && uploadedBy) {
+    metadata.pubkey = `${uploadedBy.substring(0, 16)}...`;
+  }
+
+  return hasStoredMetadata ? metadata : null;
 }
 
 async function fetchFunnelcakeLookupVideo(identifier) {
@@ -381,28 +436,16 @@ async function deleteEventFromRelayBySha256(sha256, env, source = 'unknown', rea
 
 async function fetchLookupNostrContext(hash, env) {
   try {
-    const event = await fetchNostrEventBySha256(hash, ['wss://relay.divine.video'], env);
-    if (!event) {
+    const video = await fetchFunnelcakeLookupVideo(hash);
+    if (!video) {
       return null;
     }
 
-    const metadata = parseVideoEventMetadata(event) || {};
-    const tags = event.tags || [];
-    const stableId = getEventTagValue(tags, 'd') || event.id || hash;
-
     return {
-      eventId: event.id,
-      uploadedBy: event.pubkey || null,
-      divineUrl: `https://divine.video/video/${encodeURIComponent(stableId)}`,
-      nostrContext: {
-        title: metadata.title || null,
-        author: metadata.author || null,
-        client: metadata.client || null,
-        content: metadata.content || event.content || null,
-        pubkey: event.pubkey ? `${event.pubkey.substring(0, 16)}...` : null,
-        eventId: event.id,
-        platform: metadata.platform || null
-      }
+      eventId: video.eventId || null,
+      uploadedBy: video.uploaded_by || video.uploadedBy || null,
+      divineUrl: video.divineUrl || null,
+      nostrContext: video.nostrContext || null
     };
   } catch (error) {
     console.error(`[ADMIN] Failed to fetch Nostr context for ${hash}:`, error.message);
@@ -459,7 +502,8 @@ async function getAdminLookupVideo(identifier, env, options = {}) {
   const cdnUrl = `https://${env.CDN_DOMAIN || 'media.divine.video'}/${hash}`;
   if (hash) {
     const moderatedRow = await env.BLOSSOM_DB.prepare(`
-      SELECT sha256, action, provider, scores, categories, moderated_at, reviewed_by, reviewed_at, review_notes, uploaded_by
+      SELECT sha256, action, provider, scores, categories, moderated_at, reviewed_by, reviewed_at, review_notes, uploaded_by,
+             title, author, event_id, content_url, published_at
       FROM moderation_results
       WHERE sha256 = ?
     `).bind(hash).first();
@@ -469,6 +513,9 @@ async function getAdminLookupVideo(identifier, env, options = {}) {
 
     if (moderatedRow || kvModeration) {
       const moderatedAt = kvModeration?.moderated_at || moderatedRow?.moderated_at || null;
+      const uploadedBy = moderatedRow?.uploaded_by || kvModeration?.uploadedBy || null;
+      const storedNostrContext = buildStoredNostrContext(moderatedRow, uploadedBy, { includePubkey: true });
+      const storedEventId = moderatedRow?.event_id || null;
       return enrichAdminLookupVideo({
         sha256: hash,
         action: kvModeration?.action || moderatedRow?.action || 'REVIEW',
@@ -479,14 +526,17 @@ async function getAdminLookupVideo(identifier, env, options = {}) {
         moderated_at: moderatedAt,
         reviewed_by: moderatedRow?.reviewed_by || kvModeration?.reviewedBy || kvModeration?.overriddenBy || null,
         reviewed_at: moderatedRow?.reviewed_at || null,
-        uploaded_by: moderatedRow?.uploaded_by || kvModeration?.uploadedBy || null,
+        uploaded_by: uploadedBy,
         reason: kvModeration?.reason || moderatedRow?.review_notes || null,
         manualOverride: Boolean(kvModeration?.manualOverride),
         overriddenAt: kvModeration?.overriddenAt || moderatedRow?.reviewed_at || null,
         previousAction: kvModeration?.previousAction || null,
         detailedCategories: parseMaybeJson(kvModeration?.detailedCategories, null),
         categoryVerifications: parseMaybeJson(kvModeration?.categoryVerifications, {}) || {},
-        cdnUrl: kvModeration?.cdnUrl || cdnUrl
+        cdnUrl: kvModeration?.cdnUrl || moderatedRow?.content_url || cdnUrl,
+        nostrContext: storedNostrContext,
+        eventId: storedEventId,
+        divineUrl: storedEventId ? `https://divine.video/video/${encodeURIComponent(storedEventId)}` : null
       }, env);
     }
 
@@ -506,21 +556,12 @@ async function getAdminLookupVideo(identifier, env, options = {}) {
       let divineUrl = null;
       let uploaderPubkey = null;
       try {
-        const event = await fetchNostrEventBySha256(hash, ['wss://relay.divine.video'], env);
-        if (event) {
-          const metadata = parseVideoEventMetadata(event);
-          const stableId = getEventTagValue(event.tags || [], 'd') || event.id || hash;
-          eventId = event.id;
-          divineUrl = `https://divine.video/video/${encodeURIComponent(stableId)}`;
-          uploaderPubkey = event.pubkey || null;
-          nostrContext = {
-            title: metadata?.title || null,
-            author: metadata?.author || null,
-            client: metadata?.client || null,
-            content: metadata?.content || event.content || null,
-            pubkey: event.pubkey ? `${event.pubkey.substring(0, 16)}...` : null,
-            eventId
-          };
+        const video = await fetchFunnelcakeLookupVideo(hash);
+        if (video) {
+          eventId = video.eventId || null;
+          divineUrl = video.divineUrl || null;
+          uploaderPubkey = video.uploaded_by || video.uploadedBy || null;
+          nostrContext = video.nostrContext || null;
         }
       } catch (error) {
         console.error(`[ADMIN] Failed to fetch Nostr context for ${hash}:`, error.message);
@@ -1066,17 +1107,16 @@ export default {
         // Fetch Nostr context in parallel for all unmoderated videos
         const nostrPromises = unmoderatedRows.map(async (row) => {
           try {
-            const event = await fetchNostrEventBySha256(row.sha256, ['wss://relay.divine.video'], env);
-            if (event) {
-              const metadata = parseVideoEventMetadata(event);
+            const video = await fetchFunnelcakeLookupVideo(row.sha256);
+            if (video) {
               return {
                 sha256: row.sha256,
-                eventId: event.id,
-                title: metadata?.title || null,
-                author: metadata?.author || null,
-                client: metadata?.client || null,
-                content: metadata?.content || event.content || null,
-                pubkey: event.pubkey || null
+                eventId: video.eventId || null,
+                title: video.nostrContext?.title || null,
+                author: video.nostrContext?.author || null,
+                client: video.nostrContext?.client || null,
+                content: video.nostrContext?.content || null,
+                pubkey: video.uploaded_by || video.uploadedBy || null
               };
             }
           } catch (e) {
@@ -1734,16 +1774,27 @@ export default {
       const sha256 = url.pathname.split('/')[4];
 
       try {
-        const event = await fetchNostrEventBySha256(sha256, ['wss://relay.divine.video'], env);
+        const storedRow = await env.BLOSSOM_DB.prepare(`
+          SELECT uploaded_by, title, author, event_id, content_url, published_at
+          FROM moderation_results
+          WHERE sha256 = ?
+        `).bind(sha256).first();
+        const storedMetadata = buildStoredNostrContext(storedRow, storedRow?.uploaded_by || null, { includePubkey: false });
 
-        if (!event) {
+        if (storedMetadata) {
+          return new Response(JSON.stringify({ found: true, metadata: storedMetadata }), {
+            headers: { 'Content-Type': 'application/json' }
+          });
+        }
+
+        const video = await fetchFunnelcakeLookupVideo(sha256);
+        if (!video?.nostrContext) {
           return new Response(JSON.stringify({ found: false }), {
             headers: { 'Content-Type': 'application/json' }
           });
         }
 
-        const metadata = parseVideoEventMetadata(event);
-
+        const { pubkey: _ignoredPubkey, ...metadata } = video.nostrContext;
         return new Response(JSON.stringify({ found: true, metadata }), {
           headers: { 'Content-Type': 'application/json' }
         });

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -312,6 +312,149 @@ describe('Admin video lookup', () => {
     });
   });
 
+  it('returns stored moderation metadata when relay context is unavailable', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (url) => {
+      throw new Error(`Unexpected fetch: ${url}`);
+    };
+
+    try {
+      const env = createEnv({
+        BLOSSOM_DB: createDbMock({
+          moderationResults: new Map([[SHA256, {
+            sha256: SHA256,
+            action: 'REVIEW',
+            provider: 'hiveai',
+            scores: JSON.stringify({ nudity: 0.4 }),
+            categories: JSON.stringify(['nudity']),
+            moderated_at: '2026-03-07T00:00:00.000Z',
+            reviewed_by: null,
+            reviewed_at: null,
+            uploaded_by: 'b'.repeat(64),
+            title: 'Stored title',
+            author: 'Stored author',
+            event_id: 'c'.repeat(64),
+            content_url: 'https://media.divine.video/content.mp4',
+            published_at: '1389756506'
+          }]])
+        })
+      });
+
+      const response = await worker.fetch(
+        new Request(`https://moderation.admin.divine.video/admin/api/video/${SHA256}`, {
+          headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
+        }),
+        env
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toMatchObject({
+        video: {
+          sha256: SHA256,
+          uploaded_by: 'b'.repeat(64),
+          eventId: 'c'.repeat(64),
+          divineUrl: `https://divine.video/video/${'c'.repeat(64)}`,
+          nostrContext: {
+            title: 'Stored title',
+            author: 'Stored author',
+            url: 'https://media.divine.video/content.mp4',
+            publishedAt: 1389756506,
+            eventId: 'c'.repeat(64),
+            pubkey: `${'b'.repeat(16)}...`
+          }
+        }
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('uses FunnelCake REST instead of WebSocket when moderated metadata is missing', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalWebSocket = globalThis.WebSocket;
+    const restCalls = [];
+
+    globalThis.WebSocket = class {
+      constructor() {
+        throw new Error('WebSocket should not be used for admin lookup metadata');
+      }
+    };
+
+    globalThis.fetch = async (url) => {
+      restCalls.push(String(url));
+      if (String(url) === `https://relay.divine.video/api/videos/${SHA256}`) {
+        return new Response(JSON.stringify({
+          event: {
+            id: 'd'.repeat(64),
+            pubkey: 'b'.repeat(64),
+            created_at: 1700000000,
+            kind: 34236,
+            tags: [
+              ['d', SHA256],
+              ['title', 'REST title'],
+              ['published_at', '1389756506'],
+              ['imeta', 'url https://media.divine.video/rest-content.mp4', `x ${SHA256}`]
+            ],
+            content: 'REST description',
+            sig: 'e'.repeat(128)
+          },
+          stats: {
+            author_name: 'REST author'
+          }
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    };
+
+    try {
+      const response = await worker.fetch(
+        new Request(`https://moderation.admin.divine.video/admin/api/video/${SHA256}`, {
+          headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
+        }),
+        createEnv({
+          BLOSSOM_DB: createDbMock({
+            moderationResults: new Map([[SHA256, {
+              sha256: SHA256,
+              action: 'REVIEW',
+              provider: 'hiveai',
+              scores: JSON.stringify({ nudity: 0.4 }),
+              categories: JSON.stringify(['nudity']),
+              moderated_at: '2026-03-07T00:00:00.000Z',
+              reviewed_by: null,
+              reviewed_at: null,
+              uploaded_by: 'b'.repeat(64)
+            }]])
+          })
+        })
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toMatchObject({
+        video: {
+          sha256: SHA256,
+          eventId: 'd'.repeat(64),
+          divineUrl: `https://divine.video/video/${SHA256}`,
+          nostrContext: {
+            title: 'REST title',
+            author: 'REST author',
+            url: 'https://media.divine.video/rest-content.mp4',
+            publishedAt: 1389756506,
+            content: 'REST description',
+            eventId: 'd'.repeat(64)
+          }
+        }
+      });
+      expect(restCalls).toEqual([`https://relay.divine.video/api/videos/${SHA256}`]);
+    } finally {
+      globalThis.fetch = originalFetch;
+      globalThis.WebSocket = originalWebSocket;
+    }
+  });
+
   it('returns an untriaged video by sha lookup', async () => {
     const env = createEnv({
       CDN_DOMAIN: 'media.divine.video',
@@ -509,6 +652,148 @@ describe('Admin video lookup', () => {
       });
     } finally {
       globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+describe('Admin nostr context lookup', () => {
+  it('returns stored moderation metadata when relay context is unavailable', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (url) => {
+      throw new Error(`Unexpected fetch: ${url}`);
+    };
+
+    try {
+      const response = await worker.fetch(
+        new Request(`https://moderation.admin.divine.video/admin/api/nostr-context/${SHA256}`, {
+          headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
+        }),
+        createEnv({
+          BLOSSOM_DB: createDbMock({
+            moderationResults: new Map([[SHA256, {
+              sha256: SHA256,
+              action: 'REVIEW',
+              provider: 'hiveai',
+              scores: JSON.stringify({ nudity: 0.4 }),
+              categories: JSON.stringify(['nudity']),
+              moderated_at: '2026-03-07T00:00:00.000Z',
+              reviewed_by: null,
+              reviewed_at: null,
+              uploaded_by: 'b'.repeat(64),
+              title: 'Stored title',
+              author: 'Stored author',
+              event_id: 'c'.repeat(64),
+              content_url: 'https://media.divine.video/content.mp4',
+              published_at: '1389756506'
+            }]])
+          })
+        })
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({
+        found: true,
+        metadata: {
+          title: 'Stored title',
+          author: 'Stored author',
+          platform: null,
+          client: null,
+          loops: null,
+          likes: null,
+          comments: null,
+          url: 'https://media.divine.video/content.mp4',
+          sourceUrl: null,
+          publishedAt: 1389756506,
+          archivedAt: null,
+          importedAt: null,
+          vineHashId: null,
+          vineUserId: null,
+          content: null,
+          eventId: 'c'.repeat(64),
+          createdAt: null
+        }
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('uses FunnelCake REST instead of WebSocket when stored metadata is unavailable', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalWebSocket = globalThis.WebSocket;
+    const restCalls = [];
+
+    globalThis.WebSocket = class {
+      constructor() {
+        throw new Error('WebSocket should not be used for admin nostr context');
+      }
+    };
+
+    globalThis.fetch = async (url) => {
+      restCalls.push(String(url));
+      if (String(url) === `https://relay.divine.video/api/videos/${SHA256}`) {
+        return new Response(JSON.stringify({
+          event: {
+            id: 'd'.repeat(64),
+            pubkey: 'b'.repeat(64),
+            created_at: 1700000000,
+            kind: 34236,
+            tags: [
+              ['d', SHA256],
+              ['title', 'REST title'],
+              ['published_at', '1389756506'],
+              ['imeta', 'url https://media.divine.video/rest-content.mp4', `x ${SHA256}`]
+            ],
+            content: 'REST description',
+            sig: 'e'.repeat(128)
+          },
+          stats: {
+            author_name: 'REST author'
+          }
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    };
+
+    try {
+      const response = await worker.fetch(
+        new Request(`https://moderation.admin.divine.video/admin/api/nostr-context/${SHA256}`, {
+          headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
+        }),
+        createEnv()
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({
+        found: true,
+        metadata: {
+          title: 'REST title',
+          author: 'REST author',
+          platform: null,
+          client: null,
+          loops: null,
+          likes: null,
+          comments: null,
+          url: 'https://media.divine.video/rest-content.mp4',
+          sourceUrl: null,
+          publishedAt: 1389756506,
+          archivedAt: null,
+          importedAt: null,
+          vineHashId: null,
+          vineUserId: null,
+          content: 'REST description',
+          eventId: 'd'.repeat(64),
+          createdAt: 1700000000
+        }
+      });
+      expect(restCalls).toEqual([`https://relay.divine.video/api/videos/${SHA256}`]);
+    } finally {
+      globalThis.fetch = originalFetch;
+      globalThis.WebSocket = originalWebSocket;
     }
   });
 });

--- a/src/moderation/pipeline.mjs
+++ b/src/moderation/pipeline.mjs
@@ -13,6 +13,63 @@ import { extractTopics } from '../classification/topic-extractor.mjs';
 
 const ORIGINAL_VINE_SUPPRESSED_CATEGORIES = new Set(['ai_generated', 'deepfake']);
 const DOWNSTREAM_SIGNAL_THRESHOLD = 0.5;
+const ARCHIVE_ORIGINAL_VINE_SOURCES = new Set(['archive-export', 'incident-backfill', 'sha-list']);
+
+function parseOptionalString(value) {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function parseOptionalInteger(value) {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.trunc(value);
+  }
+
+  if (typeof value === 'string' && value.trim().length > 0) {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  return null;
+}
+
+function buildQueueMetadataNostrContext(metadata) {
+  if (!metadata || typeof metadata !== 'object') {
+    return null;
+  }
+
+  const source = parseOptionalString(metadata.source);
+  const publishedAt = parseOptionalInteger(metadata.publishedAt ?? metadata.published_at);
+  const context = {
+    title: parseOptionalString(metadata.title),
+    author: parseOptionalString(metadata.author),
+    platform: parseOptionalString(metadata.platform),
+    client: parseOptionalString(metadata.client),
+    loops: parseOptionalInteger(metadata.loops),
+    likes: parseOptionalInteger(metadata.likes),
+    comments: parseOptionalInteger(metadata.comments),
+    url: parseOptionalString(metadata.videoUrl ?? metadata.url),
+    sourceUrl: parseOptionalString(metadata.sourceUrl ?? metadata.source_url ?? metadata.r),
+    publishedAt: ARCHIVE_ORIGINAL_VINE_SOURCES.has(source) ? publishedAt : null,
+    archivedAt: parseOptionalString(metadata.archivedAt ?? metadata.archived_at),
+    importedAt: parseOptionalInteger(metadata.importedAt ?? metadata.imported_at),
+    vineHashId: parseOptionalString(metadata.vineHashId ?? metadata.vine_hash_id ?? metadata.vine_id),
+    vineUserId: parseOptionalString(metadata.vineUserId ?? metadata.vine_user_id),
+    content: parseOptionalString(metadata.content),
+    eventId: parseOptionalString(metadata.eventId ?? metadata.event_id),
+    createdAt: parseOptionalInteger(metadata.createdAt ?? metadata.created_at)
+  };
+
+  if (
+    context.platform === 'vine'
+    || (context.client && /vine-(archive-importer|archaeologist)/.test(context.client))
+    || context.vineHashId
+    || (context.sourceUrl && context.sourceUrl.includes('vine.co'))
+  ) {
+    context.publishedAt = publishedAt;
+  }
+
+  return Object.values(context).some((value) => value !== null) ? context : null;
+}
 
 function applyOriginalVineEnforcementOverride(classification) {
   return {
@@ -166,16 +223,20 @@ export async function moderateVideo(videoData, env, fetchFn = fetch) {
   }
 
   // Step 1: Determine video URL - prefer metadata.videoUrl if provided (e.g., from relay-poller)
-  let nostrContext = null;
-  let videoUrl = metadata?.videoUrl || `https://${env.CDN_DOMAIN}/${sha256}`; // Default: blossom content-addressed URL
-  let nostrEventId = metadata?.eventId || null;
+  const queueNostrContext = buildQueueMetadataNostrContext(metadata);
+  let nostrContext = queueNostrContext;
+  let videoUrl = metadata?.videoUrl || queueNostrContext?.url || `https://${env.CDN_DOMAIN}/${sha256}`; // Default: blossom content-addressed URL
+  let nostrEventId = queueNostrContext?.eventId || metadata?.eventId || metadata?.event_id || null;
 
   // Always attempt to resolve Nostr context so policy decisions can use archive metadata
   try {
     const relays = env.NOSTR_RELAY_URL ? [env.NOSTR_RELAY_URL] : ['wss://relay.divine.video'];
     const event = await fetchNostrEventBySha256(sha256, relays);
     if (event) {
-      nostrContext = parseVideoEventMetadata(event);
+      const relayNostrContext = parseVideoEventMetadata(event);
+      nostrContext = queueNostrContext
+        ? { ...queueNostrContext, ...relayNostrContext }
+        : relayNostrContext;
       nostrEventId = event.id;
       console.log(`[MODERATION] Found Nostr context for ${sha256}:`, nostrContext);
 

--- a/src/moderation/pipeline.test.mjs
+++ b/src/moderation/pipeline.test.mjs
@@ -48,6 +48,44 @@ function createNostrLookupWebSocket(event) {
   };
 }
 
+function createEmptyNostrLookupWebSocket() {
+  return class FakeWebSocket {
+    constructor() {
+      this.listeners = {};
+      this.readyState = 0;
+      queueMicrotask(() => {
+        this.readyState = 1;
+        this.emit('open');
+      });
+    }
+
+    addEventListener(type, handler) {
+      if (!this.listeners[type]) {
+        this.listeners[type] = [];
+      }
+      this.listeners[type].push(handler);
+    }
+
+    send(message) {
+      const [, subscriptionId] = JSON.parse(message);
+      queueMicrotask(() => {
+        this.emit('message', { data: JSON.stringify(['EOSE', subscriptionId]) });
+      });
+    }
+
+    close() {
+      this.readyState = 3;
+      queueMicrotask(() => this.emit('close'));
+    }
+
+    emit(type, payload = {}) {
+      for (const handler of this.listeners[type] || []) {
+        handler(payload);
+      }
+    }
+  };
+}
+
 afterEach(() => {
   globalThis.WebSocket = OriginalWebSocket;
 });
@@ -301,6 +339,65 @@ describe('Moderation Pipeline', () => {
     expect(result.scores.ai_generated).toBe(0.96);
     expect(result.downstreamSignals?.scores?.ai_generated ?? 0).toBe(0);
     expect(result.downstreamSignals?.hasSignals).toBe(false);
+  });
+
+  it('skips Hive AI detection when legacy queue metadata already identifies an original Vine', async () => {
+    const sha256 = 'k'.repeat(64);
+    globalThis.WebSocket = createEmptyNostrLookupWebSocket();
+
+    const hiveAuthCalls = [];
+    const mockFetch = vi.fn(async (url, options = {}) => {
+      if (typeof url === 'string' && url.endsWith('.vtt')) {
+        return {
+          ok: false,
+          status: 404,
+          text: async () => ''
+        };
+      }
+
+      if (typeof url === 'string' && url.includes('api.thehive.ai')) {
+        hiveAuthCalls.push(options.headers?.authorization || null);
+        return {
+          ok: true,
+          json: async () => ({
+            status: [{
+              response: {
+                output: [{
+                  time: 0,
+                  classes: [
+                    { class: 'general_nsfw', score: 0.05 },
+                    { class: 'ai_generated', score: 0.96 }
+                  ]
+                }]
+              }
+            }]
+          })
+        };
+      }
+
+      throw new Error(`Unexpected fetch call: ${String(url)}`);
+    });
+
+    const env = {
+      CDN_DOMAIN: 'cdn.divine.video',
+      HIVE_MODERATION_API_KEY: 'mod-key',
+      HIVE_AI_DETECTION_API_KEY: 'ai-key'
+    };
+
+    const result = await moderateVideo({
+      sha256,
+      uploadedAt: Date.now(),
+      metadata: {
+        source: 'archive-export',
+        videoUrl: 'https://archive.example.com/original-vine.mp4',
+        platform: 'vine',
+        source_url: 'https://vine.co/v/abc123',
+        published_at: 1389756506
+      }
+    }, env, mockFetch);
+
+    expect(hiveAuthCalls).toEqual(['token mod-key']);
+    expect(result.policyContext?.originalVine).toBe(true);
   });
 
   it('keeps downstream moderation signals for original vines when non-AI scores are high', async () => {


### PR DESCRIPTION
## Summary
- switch admin metadata hydration from relay WebSocket lookups to FunnelCake REST `GET /api/videos/{id}`
- prefer stored `moderation_results` metadata for already-moderated content so admin review still has context when relay lookups miss
- add regression tests covering `/admin/api/video/:id` and `/admin/api/nostr-context/:sha256` so these paths fail if they try to use WebSocket again

## Test Plan
- [x] `npm test`
- [x] `npm test -- src/uploader-enforcement.test.mjs`
- [x] `npm test -- src/index.test.mjs`
