### PR TITLE
Use FunnelCake REST for admin metadata lookups

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -228,8 +228,16 @@ function parseOptionalInteger(value) {
     return null;
   }
 
-  const parsed = Number.parseInt(value, 10);
-  return Number.isFinite(parsed) ? parsed : null;
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+
+  if (typeof value === 'string' && /^\d+$/.test(value)) {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  return value;
 }
 
 function buildStoredNostrContext(row, uploadedBy = null, options = {}) {

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -206,10 +206,65 @@ function buildFunnelcakeVideoLookup(eventResponse, identifier) {
       content: metadata.content || event.content || null,
       pubkey: event.pubkey ? `${event.pubkey.substring(0, 16)}...` : null,
       eventId: event.id,
-      platform: metadata.platform || null
+      platform: metadata.platform || null,
+      loops: metadata.loops ?? null,
+      likes: metadata.likes ?? null,
+      comments: metadata.comments ?? null,
+      url: metadata.url || videoUrl || null,
+      sourceUrl: metadata.sourceUrl || null,
+      publishedAt: metadata.publishedAt ?? null,
+      archivedAt: metadata.archivedAt ?? null,
+      importedAt: metadata.importedAt ?? null,
+      vineHashId: metadata.vineHashId || null,
+      vineUserId: metadata.vineUserId || null,
+      createdAt: metadata.createdAt || event.created_at || null
     },
     divineUrl: `https://divine.video/video/${encodeURIComponent(stableId)}`
   };
+}
+
+function parseOptionalInteger(value) {
+  if (value === null || value === undefined || value === '') {
+    return null;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function buildStoredNostrContext(row, uploadedBy = null, options = {}) {
+  const { includePubkey = true } = options;
+  if (!row) {
+    return null;
+  }
+
+  const metadata = {
+    title: row.title || null,
+    author: row.author || null,
+    platform: null,
+    client: null,
+    loops: null,
+    likes: null,
+    comments: null,
+    url: row.content_url || null,
+    sourceUrl: null,
+    publishedAt: parseOptionalInteger(row.published_at),
+    archivedAt: null,
+    importedAt: null,
+    vineHashId: null,
+    vineUserId: null,
+    content: null,
+    eventId: row.event_id || null,
+    createdAt: null
+  };
+
+  const hasStoredMetadata = Object.values(metadata).some((value) => value !== null);
+
+  if (includePubkey && uploadedBy) {
+    metadata.pubkey = `${uploadedBy.substring(0, 16)}...`;
+  }
+
+  return hasStoredMetadata ? metadata : null;
 }
 
 async function fetchFunnelcakeLookupVideo(identifier) {
@@ -406,39 +461,16 @@ async function deleteEventFromRelayBySha256(sha256, env, source = 'unknown', rea
 
 async function fetchLookupNostrContext(hash, env) {
   try {
-    const event = await fetchNostrEventBySha256(hash, ['wss://relay.divine.video'], env);
-    if (!event) {
+    const video = await fetchFunnelcakeLookupVideo(hash);
+    if (!video) {
       return null;
     }
 
-    const metadata = parseVideoEventMetadata(event) || {};
-    const tags = event.tags || [];
-    const stableId = getEventTagValue(tags, 'd') || event.id || hash;
-
     return {
-      eventId: event.id,
-      uploadedBy: event.pubkey || null,
-      divineUrl: `https://divine.video/video/${encodeURIComponent(stableId)}`,
-      nostrContext: {
-        title: metadata.title || null,
-        author: metadata.author || null,
-        client: metadata.client || null,
-        content: metadata.content || event.content || null,
-        pubkey: event.pubkey ? `${event.pubkey.substring(0, 16)}...` : null,
-        eventId: event.id,
-        platform: metadata.platform || null,
-        url: metadata.url || null,
-        sourceUrl: metadata.sourceUrl || null,
-        loops: metadata.loops ?? null,
-        likes: metadata.likes ?? null,
-        comments: metadata.comments ?? null,
-        publishedAt: metadata.publishedAt || null,
-        archivedAt: metadata.archivedAt || null,
-        importedAt: metadata.importedAt || null,
-        vineHashId: metadata.vineHashId || null,
-        vineUserId: metadata.vineUserId || null,
-        createdAt: metadata.createdAt || null
-      }
+      eventId: video.eventId || null,
+      uploadedBy: video.uploaded_by || video.uploadedBy || null,
+      divineUrl: video.divineUrl || null,
+      nostrContext: video.nostrContext || null
     };
   } catch (error) {
     console.error(`[ADMIN] Failed to fetch Nostr context for ${hash}:`, error.message);
@@ -501,7 +533,8 @@ async function getAdminLookupVideo(identifier, env, options = {}) {
   const cdnUrl = `https://${env.CDN_DOMAIN || 'media.divine.video'}/${hash}`;
   if (hash) {
     const moderatedRow = await env.BLOSSOM_DB.prepare(`
-      SELECT sha256, action, provider, scores, categories, moderated_at, reviewed_by, reviewed_at, review_notes, uploaded_by, title, author, event_id, content_url, published_at
+      SELECT sha256, action, provider, scores, categories, moderated_at, reviewed_by, reviewed_at, review_notes, uploaded_by,
+             title, author, event_id, content_url, published_at
       FROM moderation_results
       WHERE sha256 = ?
     `).bind(hash).first();
@@ -511,20 +544,9 @@ async function getAdminLookupVideo(identifier, env, options = {}) {
 
     if (moderatedRow || kvModeration) {
       const moderatedAt = kvModeration?.moderated_at || moderatedRow?.moderated_at || null;
-      const eventId = moderatedRow?.event_id || null;
-      const persistedPublishedAt = moderatedRow?.published_at || null;
-      const persistedContentUrl = moderatedRow?.content_url || null;
-      const persistedNostrContext = (
-        moderatedRow?.title
-        || moderatedRow?.author
-        || persistedContentUrl
-        || persistedPublishedAt
-      ) ? {
-        title: moderatedRow?.title || null,
-        author: moderatedRow?.author || null,
-        url: persistedContentUrl,
-        publishedAt: persistedPublishedAt
-      } : null;
+      const uploadedBy = moderatedRow?.uploaded_by || kvModeration?.uploadedBy || null;
+      const storedNostrContext = buildStoredNostrContext(moderatedRow, uploadedBy, { includePubkey: true });
+      const storedEventId = moderatedRow?.event_id || null;
       return enrichAdminLookupVideo({
         sha256: hash,
         action: kvModeration?.action || moderatedRow?.action || 'REVIEW',
@@ -535,17 +557,17 @@ async function getAdminLookupVideo(identifier, env, options = {}) {
         moderated_at: moderatedAt,
         reviewed_by: moderatedRow?.reviewed_by || kvModeration?.reviewedBy || kvModeration?.overriddenBy || null,
         reviewed_at: moderatedRow?.reviewed_at || null,
-        uploaded_by: moderatedRow?.uploaded_by || kvModeration?.uploadedBy || null,
+        uploaded_by: uploadedBy,
         reason: kvModeration?.reason || moderatedRow?.review_notes || null,
         manualOverride: Boolean(kvModeration?.manualOverride),
         overriddenAt: kvModeration?.overriddenAt || moderatedRow?.reviewed_at || null,
         previousAction: kvModeration?.previousAction || null,
         detailedCategories: parseMaybeJson(kvModeration?.detailedCategories, null),
         categoryVerifications: parseMaybeJson(kvModeration?.categoryVerifications, {}) || {},
-        cdnUrl: kvModeration?.cdnUrl || persistedContentUrl || cdnUrl,
-        eventId,
-        divineUrl: eventId ? `https://divine.video/video/${encodeURIComponent(eventId)}` : null,
-        nostrContext: persistedNostrContext
+        cdnUrl: kvModeration?.cdnUrl || moderatedRow?.content_url || cdnUrl,
+        nostrContext: storedNostrContext,
+        eventId: storedEventId,
+        divineUrl: storedEventId ? `https://divine.video/video/${encodeURIComponent(storedEventId)}` : null
       }, env);
     }
 
@@ -565,33 +587,12 @@ async function getAdminLookupVideo(identifier, env, options = {}) {
       let divineUrl = null;
       let uploaderPubkey = null;
       try {
-        const event = await fetchNostrEventBySha256(hash, ['wss://relay.divine.video'], env);
-        if (event) {
-          const metadata = parseVideoEventMetadata(event);
-          const stableId = getEventTagValue(event.tags || [], 'd') || event.id || hash;
-          eventId = event.id;
-          divineUrl = `https://divine.video/video/${encodeURIComponent(stableId)}`;
-          uploaderPubkey = event.pubkey || null;
-          nostrContext = {
-            title: metadata?.title || null,
-            author: metadata?.author || null,
-            client: metadata?.client || null,
-            content: metadata?.content || event.content || null,
-            pubkey: event.pubkey ? `${event.pubkey.substring(0, 16)}...` : null,
-            eventId,
-            platform: metadata?.platform || null,
-            url: metadata?.url || null,
-            sourceUrl: metadata?.sourceUrl || null,
-            loops: metadata?.loops ?? null,
-            likes: metadata?.likes ?? null,
-            comments: metadata?.comments ?? null,
-            publishedAt: metadata?.publishedAt || null,
-            archivedAt: metadata?.archivedAt || null,
-            importedAt: metadata?.importedAt || null,
-            vineHashId: metadata?.vineHashId || null,
-            vineUserId: metadata?.vineUserId || null,
-            createdAt: metadata?.createdAt || null
-          };
+        const video = await fetchFunnelcakeLookupVideo(hash);
+        if (video) {
+          eventId = video.eventId || null;
+          divineUrl = video.divineUrl || null;
+          uploaderPubkey = video.uploaded_by || video.uploadedBy || null;
+          nostrContext = video.nostrContext || null;
         }
       } catch (error) {
         console.error(`[ADMIN] Failed to fetch Nostr context for ${hash}:`, error.message);
@@ -1134,17 +1135,16 @@ export default {
         // Fetch Nostr context in parallel for all unmoderated videos
         const nostrPromises = unmoderatedRows.map(async (row) => {
           try {
-            const event = await fetchNostrEventBySha256(row.sha256, ['wss://relay.divine.video'], env);
-            if (event) {
-              const metadata = parseVideoEventMetadata(event);
+            const video = await fetchFunnelcakeLookupVideo(row.sha256);
+            if (video) {
               return {
                 sha256: row.sha256,
-                eventId: event.id,
-                title: metadata?.title || null,
-                author: metadata?.author || null,
-                client: metadata?.client || null,
-                content: metadata?.content || event.content || null,
-                pubkey: event.pubkey || null
+                eventId: video.eventId || null,
+                title: video.nostrContext?.title || null,
+                author: video.nostrContext?.author || null,
+                client: video.nostrContext?.client || null,
+                content: video.nostrContext?.content || null,
+                pubkey: video.uploaded_by || video.uploadedBy || null
               };
             }
           } catch (e) {
@@ -1802,16 +1802,27 @@ export default {
       const sha256 = url.pathname.split('/')[4];
 
       try {
-        const event = await fetchNostrEventBySha256(sha256, ['wss://relay.divine.video'], env);
+        const storedRow = await env.BLOSSOM_DB.prepare(`
+          SELECT uploaded_by, title, author, event_id, content_url, published_at
+          FROM moderation_results
+          WHERE sha256 = ?
+        `).bind(sha256).first();
+        const storedMetadata = buildStoredNostrContext(storedRow, storedRow?.uploaded_by || null, { includePubkey: false });
 
-        if (!event) {
+        if (storedMetadata) {
+          return new Response(JSON.stringify({ found: true, metadata: storedMetadata }), {
+            headers: { 'Content-Type': 'application/json' }
+          });
+        }
+
+        const video = await fetchFunnelcakeLookupVideo(sha256);
+        if (!video?.nostrContext) {
           return new Response(JSON.stringify({ found: false }), {
             headers: { 'Content-Type': 'application/json' }
           });
         }
 
-        const metadata = parseVideoEventMetadata(event);
-
+        const { pubkey: _ignoredPubkey, ...metadata } = video.nostrContext;
         return new Response(JSON.stringify({ found: true, metadata }), {
           headers: { 'Content-Type': 'application/json' }
         });

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -399,6 +399,149 @@ describe('Admin video lookup', () => {
     });
   });
 
+  it('returns stored moderation metadata when relay context is unavailable', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (url) => {
+      throw new Error(`Unexpected fetch: ${url}`);
+    };
+
+    try {
+      const env = createEnv({
+        BLOSSOM_DB: createDbMock({
+          moderationResults: new Map([[SHA256, {
+            sha256: SHA256,
+            action: 'REVIEW',
+            provider: 'hiveai',
+            scores: JSON.stringify({ nudity: 0.4 }),
+            categories: JSON.stringify(['nudity']),
+            moderated_at: '2026-03-07T00:00:00.000Z',
+            reviewed_by: null,
+            reviewed_at: null,
+            uploaded_by: 'b'.repeat(64),
+            title: 'Stored title',
+            author: 'Stored author',
+            event_id: 'c'.repeat(64),
+            content_url: 'https://media.divine.video/content.mp4',
+            published_at: '1389756506'
+          }]])
+        })
+      });
+
+      const response = await worker.fetch(
+        new Request(`https://moderation.admin.divine.video/admin/api/video/${SHA256}`, {
+          headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
+        }),
+        env
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toMatchObject({
+        video: {
+          sha256: SHA256,
+          uploaded_by: 'b'.repeat(64),
+          eventId: 'c'.repeat(64),
+          divineUrl: `https://divine.video/video/${'c'.repeat(64)}`,
+          nostrContext: {
+            title: 'Stored title',
+            author: 'Stored author',
+            url: 'https://media.divine.video/content.mp4',
+            publishedAt: 1389756506,
+            eventId: 'c'.repeat(64),
+            pubkey: `${'b'.repeat(16)}...`
+          }
+        }
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('uses FunnelCake REST instead of WebSocket when moderated metadata is missing', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalWebSocket = globalThis.WebSocket;
+    const restCalls = [];
+
+    globalThis.WebSocket = class {
+      constructor() {
+        throw new Error('WebSocket should not be used for admin lookup metadata');
+      }
+    };
+
+    globalThis.fetch = async (url) => {
+      restCalls.push(String(url));
+      if (String(url) === `https://relay.divine.video/api/videos/${SHA256}`) {
+        return new Response(JSON.stringify({
+          event: {
+            id: 'd'.repeat(64),
+            pubkey: 'b'.repeat(64),
+            created_at: 1700000000,
+            kind: 34236,
+            tags: [
+              ['d', SHA256],
+              ['title', 'REST title'],
+              ['published_at', '1389756506'],
+              ['imeta', 'url https://media.divine.video/rest-content.mp4', `x ${SHA256}`]
+            ],
+            content: 'REST description',
+            sig: 'e'.repeat(128)
+          },
+          stats: {
+            author_name: 'REST author'
+          }
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    };
+
+    try {
+      const response = await worker.fetch(
+        new Request(`https://moderation.admin.divine.video/admin/api/video/${SHA256}`, {
+          headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
+        }),
+        createEnv({
+          BLOSSOM_DB: createDbMock({
+            moderationResults: new Map([[SHA256, {
+              sha256: SHA256,
+              action: 'REVIEW',
+              provider: 'hiveai',
+              scores: JSON.stringify({ nudity: 0.4 }),
+              categories: JSON.stringify(['nudity']),
+              moderated_at: '2026-03-07T00:00:00.000Z',
+              reviewed_by: null,
+              reviewed_at: null,
+              uploaded_by: 'b'.repeat(64)
+            }]])
+          })
+        })
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toMatchObject({
+        video: {
+          sha256: SHA256,
+          eventId: 'd'.repeat(64),
+          divineUrl: `https://divine.video/video/${SHA256}`,
+          nostrContext: {
+            title: 'REST title',
+            author: 'REST author',
+            url: 'https://media.divine.video/rest-content.mp4',
+            publishedAt: 1389756506,
+            content: 'REST description',
+            eventId: 'd'.repeat(64)
+          }
+        }
+      });
+      expect(restCalls).toEqual([`https://relay.divine.video/api/videos/${SHA256}`]);
+    } finally {
+      globalThis.fetch = originalFetch;
+      globalThis.WebSocket = originalWebSocket;
+    }
+  });
+
   it('returns an untriaged video by sha lookup', async () => {
     const env = createEnv({
       CDN_DOMAIN: 'media.divine.video',
@@ -635,6 +778,148 @@ describe('Quick review HTML', () => {
     expect(html).toContain('published_at');
     expect(html).toContain('content_url');
     expect(html).toContain('event_id');
+  });
+});
+
+describe('Admin nostr context lookup', () => {
+  it('returns stored moderation metadata when relay context is unavailable', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (url) => {
+      throw new Error(`Unexpected fetch: ${url}`);
+    };
+
+    try {
+      const response = await worker.fetch(
+        new Request(`https://moderation.admin.divine.video/admin/api/nostr-context/${SHA256}`, {
+          headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
+        }),
+        createEnv({
+          BLOSSOM_DB: createDbMock({
+            moderationResults: new Map([[SHA256, {
+              sha256: SHA256,
+              action: 'REVIEW',
+              provider: 'hiveai',
+              scores: JSON.stringify({ nudity: 0.4 }),
+              categories: JSON.stringify(['nudity']),
+              moderated_at: '2026-03-07T00:00:00.000Z',
+              reviewed_by: null,
+              reviewed_at: null,
+              uploaded_by: 'b'.repeat(64),
+              title: 'Stored title',
+              author: 'Stored author',
+              event_id: 'c'.repeat(64),
+              content_url: 'https://media.divine.video/content.mp4',
+              published_at: '1389756506'
+            }]])
+          })
+        })
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({
+        found: true,
+        metadata: {
+          title: 'Stored title',
+          author: 'Stored author',
+          platform: null,
+          client: null,
+          loops: null,
+          likes: null,
+          comments: null,
+          url: 'https://media.divine.video/content.mp4',
+          sourceUrl: null,
+          publishedAt: 1389756506,
+          archivedAt: null,
+          importedAt: null,
+          vineHashId: null,
+          vineUserId: null,
+          content: null,
+          eventId: 'c'.repeat(64),
+          createdAt: null
+        }
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('uses FunnelCake REST instead of WebSocket when stored metadata is unavailable', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalWebSocket = globalThis.WebSocket;
+    const restCalls = [];
+
+    globalThis.WebSocket = class {
+      constructor() {
+        throw new Error('WebSocket should not be used for admin nostr context');
+      }
+    };
+
+    globalThis.fetch = async (url) => {
+      restCalls.push(String(url));
+      if (String(url) === `https://relay.divine.video/api/videos/${SHA256}`) {
+        return new Response(JSON.stringify({
+          event: {
+            id: 'd'.repeat(64),
+            pubkey: 'b'.repeat(64),
+            created_at: 1700000000,
+            kind: 34236,
+            tags: [
+              ['d', SHA256],
+              ['title', 'REST title'],
+              ['published_at', '1389756506'],
+              ['imeta', 'url https://media.divine.video/rest-content.mp4', `x ${SHA256}`]
+            ],
+            content: 'REST description',
+            sig: 'e'.repeat(128)
+          },
+          stats: {
+            author_name: 'REST author'
+          }
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    };
+
+    try {
+      const response = await worker.fetch(
+        new Request(`https://moderation.admin.divine.video/admin/api/nostr-context/${SHA256}`, {
+          headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
+        }),
+        createEnv()
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({
+        found: true,
+        metadata: {
+          title: 'REST title',
+          author: 'REST author',
+          platform: null,
+          client: null,
+          loops: null,
+          likes: null,
+          comments: null,
+          url: 'https://media.divine.video/rest-content.mp4',
+          sourceUrl: null,
+          publishedAt: 1389756506,
+          archivedAt: null,
+          importedAt: null,
+          vineHashId: null,
+          vineUserId: null,
+          content: 'REST description',
+          eventId: 'd'.repeat(64),
+          createdAt: 1700000000
+        }
+      });
+      expect(restCalls).toEqual([`https://relay.divine.video/api/videos/${SHA256}`]);
+    } finally {
+      globalThis.fetch = originalFetch;
+      globalThis.WebSocket = originalWebSocket;
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- switch admin metadata hydration from relay WebSocket lookups to FunnelCake REST `GET /api/videos/{id}`
- prefer stored `moderation_results` metadata for already-moderated content so admin review still has context when relay lookups miss
- preserve stored `published_at` values from D1 whether they are ISO strings or unix-second strings
- add regression tests covering `/admin/api/video/:id` and `/admin/api/nostr-context/:sha256` so these paths fail if they try to use WebSocket again

## Test Plan
- [x] `npm test`
- [x] `npm test -- src/index.test.mjs -t "returns a moderated video and merges KV override fields|returns stored moderation metadata when relay context is unavailable|uses FunnelCake REST instead of WebSocket"`
