### PR TITLE
fix: preserve byte-range streaming in admin video proxy

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -2089,36 +2089,61 @@ export default {
 
       const BROWSER_PLAYABLE_TYPES = new Set(['video/mp4', 'video/webm', 'video/ogg']);
 
+      // Forward range-related request headers to upstream so that <video>
+      // byte-range playback works end-to-end. Upstream 206 responses must be
+      // preserved along with Content-Range / Accept-Ranges / Content-Length
+      // so the browser player accepts the partial content.
+      const FORWARDED_RANGE_REQUEST_HEADERS = ['Range', 'If-Range', 'If-None-Match', 'If-Modified-Since'];
+      const buildUpstreamHeaders = (extraHeaders = {}) => {
+        const headers = { ...extraHeaders };
+        for (const name of FORWARDED_RANGE_REQUEST_HEADERS) {
+          const value = request.headers.get(name);
+          if (value) headers[name] = value;
+        }
+        return headers;
+      };
+      const passthroughResponseHeaders = (upstream, baseHeaders) => {
+        const headers = { ...baseHeaders };
+        const passthrough = ['Content-Range', 'Accept-Ranges', 'Content-Length', 'ETag', 'Last-Modified'];
+        for (const name of passthrough) {
+          const value = upstream.headers.get(name);
+          if (value) headers[name] = value;
+        }
+        return headers;
+      };
+
       try {
         // CDN fetch (unauthenticated) — works for SAFE/unmoderated content
-        const cdnResponse = await fetch(cdnUrl);
-        if (cdnResponse.ok) {
+        const cdnResponse = await fetch(cdnUrl, { headers: buildUpstreamHeaders() });
+        if (cdnResponse.ok || cdnResponse.status === 206) {
           const contentType = cdnResponse.headers.get('Content-Type') || 'video/mp4';
 
           // If the format is browser-playable, serve directly
           if (BROWSER_PLAYABLE_TYPES.has(contentType)) {
             console.log(`[ADMIN] Serving video from CDN: ${sha256}`);
             return new Response(cdnResponse.body, {
-              headers: {
+              status: cdnResponse.status,
+              headers: passthroughResponseHeaders(cdnResponse, {
                 'Content-Type': contentType,
                 'Cache-Control': 'private, no-store',
                 'X-Admin-Proxy': 'cdn'
-              }
+              })
             });
           }
 
           // Non-browser format (e.g. video/3gpp, video/x-matroska) — try transcoded 720p MP4 from Blossom
           console.log(`[ADMIN] CDN returned non-playable ${contentType}, trying transcoded 720p for ${sha256}`);
           const transcodeUrl = `https://${env.CDN_DOMAIN}/${sha256}/720p.mp4`;
-          const transcodeResponse = await fetch(transcodeUrl);
-          if (transcodeResponse.ok) {
+          const transcodeResponse = await fetch(transcodeUrl, { headers: buildUpstreamHeaders() });
+          if (transcodeResponse.ok || transcodeResponse.status === 206) {
             console.log(`[ADMIN] Serving transcoded 720p MP4 for ${sha256}`);
             return new Response(transcodeResponse.body, {
-              headers: {
+              status: transcodeResponse.status,
+              headers: passthroughResponseHeaders(transcodeResponse, {
                 'Content-Type': transcodeResponse.headers.get('Content-Type') || 'video/mp4',
                 'Cache-Control': 'private, no-store',
                 'X-Admin-Proxy': 'cdn-transcode'
-              }
+              })
             });
           }
           console.warn(`[ADMIN] Transcoded 720p not available (${transcodeResponse.status}) for ${sha256}`);
@@ -2128,27 +2153,21 @@ export default {
         // Fall back to admin bypass endpoint which serves regardless of moderation status
         if (env.BLOSSOM_WEBHOOK_SECRET) {
           console.log(`[ADMIN] CDN returned ${cdnResponse.status}, trying admin bypass for ${sha256}`);
-          const bypassHeaders = { 'Authorization': `Bearer ${env.BLOSSOM_WEBHOOK_SECRET}` };
-          const rangeHeader = request.headers.get('Range');
-          if (rangeHeader) bypassHeaders['Range'] = rangeHeader;
+          const bypassHeaders = buildUpstreamHeaders({
+            'Authorization': `Bearer ${env.BLOSSOM_WEBHOOK_SECRET}`
+          });
           const bypassResponse = await fetch(adminBypassUrl, { headers: bypassHeaders });
           if (bypassResponse.ok || bypassResponse.status === 206) {
             console.log(`[ADMIN] Serving video from admin bypass: ${sha256}`);
             const moderationStatus = bypassResponse.headers.get('X-Moderation-Status');
-            const contentRange = bypassResponse.headers.get('Content-Range');
-            const acceptRanges = bypassResponse.headers.get('Accept-Ranges');
-            const contentLength = bypassResponse.headers.get('Content-Length');
             return new Response(bypassResponse.body, {
               status: bypassResponse.status,
-              headers: {
+              headers: passthroughResponseHeaders(bypassResponse, {
                 'Content-Type': bypassResponse.headers.get('Content-Type') || 'video/mp4',
                 'Cache-Control': 'private, no-store',
                 'X-Admin-Proxy': 'blossom-admin',
                 ...(moderationStatus && { 'X-Moderation-Status': moderationStatus }),
-                ...(contentRange && { 'Content-Range': contentRange }),
-                ...(acceptRanges && { 'Accept-Ranges': acceptRanges }),
-                ...(contentLength && { 'Content-Length': contentLength }),
-              }
+              })
             });
           }
           console.error(`[ADMIN] Admin bypass returned ${bypassResponse.status} for ${sha256}`);

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -851,6 +851,155 @@ describe('admin video proxy format fallback', () => {
   });
 });
 
+describe('admin video proxy range forwarding', () => {
+  it('forwards Range header to CDN and returns 206 with Content-Range', async () => {
+    const originalFetch = globalThis.fetch;
+    let receivedInit = null;
+    globalThis.fetch = async (url, init) => {
+      if (String(url) === `https://media.divine.video/${SHA256}`) {
+        receivedInit = init;
+        return new Response('partial-bytes', {
+          status: 206,
+          headers: {
+            'Content-Type': 'video/mp4',
+            'Content-Range': 'bytes 0-1023/5000000',
+            'Accept-Ranges': 'bytes',
+            'Content-Length': '1024'
+          }
+        });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    };
+
+    try {
+      const response = await worker.fetch(
+        new Request(`https://moderation.admin.divine.video/admin/video/${SHA256}.mp4`, {
+          headers: {
+            'Cf-Access-Authenticated-User-Email': 'mod@divine.video',
+            'Range': 'bytes=0-1023'
+          }
+        }),
+        createEnv()
+      );
+
+      expect(response.status).toBe(206);
+      expect(response.headers.get('Content-Range')).toBe('bytes 0-1023/5000000');
+      expect(response.headers.get('Accept-Ranges')).toBe('bytes');
+      expect(response.headers.get('Content-Length')).toBe('1024');
+      expect(response.headers.get('X-Admin-Proxy')).toBe('cdn');
+
+      const upstreamHeaders = new Headers(receivedInit?.headers || {});
+      expect(upstreamHeaders.get('Range')).toBe('bytes=0-1023');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('forwards Range header to admin bypass branch and returns 206', async () => {
+    const originalFetch = globalThis.fetch;
+    let bypassInit = null;
+    globalThis.fetch = async (url, init) => {
+      if (String(url) === `https://media.divine.video/${SHA256}`) {
+        return new Response('nope', { status: 404 });
+      }
+      if (String(url) === `https://media.divine.video/admin/api/blob/${SHA256}/content`) {
+        bypassInit = init;
+        return new Response('partial-bytes', {
+          status: 206,
+          headers: {
+            'Content-Type': 'video/mp4',
+            'Content-Range': 'bytes 0-1023/5000000',
+            'Accept-Ranges': 'bytes',
+            'Content-Length': '1024'
+          }
+        });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    };
+
+    try {
+      const response = await worker.fetch(
+        new Request(`https://moderation.admin.divine.video/admin/video/${SHA256}.mp4`, {
+          headers: {
+            'Cf-Access-Authenticated-User-Email': 'mod@divine.video',
+            'Range': 'bytes=0-1023'
+          }
+        }),
+        createEnv({ BLOSSOM_WEBHOOK_SECRET: 'test-secret' })
+      );
+
+      expect(response.status).toBe(206);
+      expect(response.headers.get('Content-Range')).toBe('bytes 0-1023/5000000');
+      expect(response.headers.get('Accept-Ranges')).toBe('bytes');
+      expect(response.headers.get('Content-Length')).toBe('1024');
+      expect(response.headers.get('X-Admin-Proxy')).toBe('blossom-admin');
+
+      const upstreamHeaders = new Headers(bypassInit?.headers || {});
+      expect(upstreamHeaders.get('Range')).toBe('bytes=0-1023');
+      expect(upstreamHeaders.get('Authorization')).toBe('Bearer test-secret');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('serves 200 from CDN when no Range header is present', async () => {
+    const originalFetch = globalThis.fetch;
+    let receivedInit = null;
+    globalThis.fetch = async (url, init) => {
+      if (String(url) === `https://media.divine.video/${SHA256}`) {
+        receivedInit = init;
+        return new Response('full-bytes', {
+          status: 200,
+          headers: { 'Content-Type': 'video/mp4' }
+        });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    };
+
+    try {
+      const response = await worker.fetch(
+        new Request(`https://moderation.admin.divine.video/admin/video/${SHA256}.mp4`, {
+          headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
+        }),
+        createEnv()
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('X-Admin-Proxy')).toBe('cdn');
+      const upstreamHeaders = new Headers(receivedInit?.headers || {});
+      expect(upstreamHeaders.get('Range')).toBeNull();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('returns 404 when CDN and admin bypass both miss', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (url) => {
+      if (String(url) === `https://media.divine.video/${SHA256}`) {
+        return new Response('nope', { status: 404 });
+      }
+      if (String(url) === `https://media.divine.video/admin/api/blob/${SHA256}/content`) {
+        return new Response('nope', { status: 404 });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    };
+
+    try {
+      const response = await worker.fetch(
+        new Request(`https://moderation.admin.divine.video/admin/video/${SHA256}.mp4`, {
+          headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
+        }),
+        createEnv({ BLOSSOM_WEBHOOK_SECRET: 'test-secret' })
+      );
+
+      expect(response.status).toBe(404);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
 describe('notifyBlossom integration via admin moderate endpoint', () => {
   // Exercises the real notifyBlossom() code path through the admin API.
   // A mock fetch interceptor captures the webhook payload Blossom would receive.


### PR DESCRIPTION
## Summary
- forward range-related request headers through `/admin/video/:sha.mp4`
- preserve upstream streaming response status and headers for CDN, transcode, and Blossom admin bypass paths
- add regression coverage for 206 partial-content playback and existing admin playback fallbacks

## Test Plan
- [x] npm test -- src/index.test.mjs -t "admin video proxy range forwarding|admin video proxy format fallback"
