### PR TITLE
feat: use relay api context in admin review lookup

### DIFF
--- a/docs/superpowers/plans/2026-04-14-relay-first-admin-review-context-plan.md
+++ b/docs/superpowers/plans/2026-04-14-relay-first-admin-review-context-plan.md
@@ -1,0 +1,204 @@
+# Relay-First Admin Review Context Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Quick Review and admin video lookup use `api.divine.video` as the primary source of post and publisher context, with admin/D1 only as fallback for deleted or missing content.
+
+**Architecture:** Add relay-first enrichment helpers in `src/index.mjs` that resolve video context from relay REST using stable identifiers, normalize the response into the admin payload shape, and merge it ahead of local fallback metadata. Keep moderation state local, but stop using thin local rows and raw websocket lookups as the default post-context source.
+
+**Tech Stack:** Cloudflare Worker, fetch-based REST integration, D1 fallback queries, vanilla HTML/JS admin UI, Vitest
+
+---
+
+## File Map
+
+- Modify: `src/index.mjs`
+  - Add relay-first admin review context fetch helpers.
+  - Update admin lookup shaping to prefer relay/API context over D1.
+  - Keep D1/admin fallback for deleted or unreachable content.
+- Modify: `src/index.test.mjs`
+  - Add regression coverage for relay-first admin lookup and fallback behavior.
+- Modify: `src/admin/swipe-review.html`
+  - Only if needed to consume new response fields or adjust merge order.
+
+## Chunk 1: Relay-First Lookup Helpers
+
+### Task 1: Add a failing admin lookup test for relay-first context
+
+**Files:**
+- Test: `src/index.test.mjs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add a test for `GET /admin/api/video/{identifier}` where:
+- D1 has a moderated row
+- relay/API returns rich post context
+
+Assert the response prefers relay/API values for:
+- title
+- content
+- event id / stable link
+- author name
+- publisher context
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/index.test.mjs -t "Admin video lookup"`
+Expected: FAIL because current lookup still depends on local rows and websocket enrichment.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/index.mjs`:
+- add a relay/API fetch helper for single-video admin context
+- normalize the relay response into the admin lookup payload shape
+- merge relay fields before local fallback fields
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/index.test.mjs -t "Admin video lookup"`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/index.mjs src/index.test.mjs
+git commit -m "feat: use relay context for admin video lookup"
+```
+
+### Task 2: Add a failing fallback test for deleted or missing relay content
+
+**Files:**
+- Test: `src/index.test.mjs`
+- Modify: `src/index.mjs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add a test where relay/API returns `404` or an upstream error while D1 contains fallback metadata.
+
+Assert the admin lookup still returns:
+- moderation state
+- stored title/author/link fields
+- uploader pubkey when available
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/index.test.mjs -t "Admin video lookup"`
+Expected: FAIL because the current merge path is not explicitly relay-first with local fallback semantics.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Update the lookup helpers so:
+- relay/API is attempted first
+- `404` and transport failures fall back to local admin/D1 metadata
+- deleted/missing content still yields a useful moderation payload
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/index.test.mjs -t "Admin video lookup"`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/index.mjs src/index.test.mjs
+git commit -m "fix: fall back to admin metadata when relay lookup misses"
+```
+
+## Chunk 2: Publisher Hydration
+
+### Task 3: Add a failing test for publisher context preference
+
+**Files:**
+- Test: `src/index.test.mjs`
+- Modify: `src/index.mjs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add a test where relay/API returns richer publisher information than the local row.
+
+Assert the admin lookup prefers relay/API publisher fields over:
+- `Unknown publisher`
+- truncated or missing author info
+- empty profile context
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/index.test.mjs -t "Admin video lookup"`
+Expected: FAIL because current publisher enrichment is built around the local row plus websocket profile lookup.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Update the enrichment path to use relay/API publisher context first and only use local placeholders when upstream data is missing.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/index.test.mjs -t "Admin video lookup"`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/index.mjs src/index.test.mjs
+git commit -m "feat: prefer relay publisher context in admin review"
+```
+
+## Chunk 3: Quick Review Merge Safety
+
+### Task 4: Add a failing UI merge test if the client still clobbers good data
+
+**Files:**
+- Modify: `src/admin/swipe-review.html`
+- Test: `src/index.test.mjs`
+
+- [ ] **Step 1: Write the failing test**
+
+If the page merge logic can overwrite good relay/API fields with sparse local values, add a targeted HTML/behavior test for that merge order.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/index.test.mjs`
+Expected: FAIL if client merge order is still wrong.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Adjust the review page merge helper so:
+- relay/API-enriched fields win
+- local fallback only fills gaps
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/index.test.mjs`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/admin/swipe-review.html src/index.test.mjs
+git commit -m "fix: preserve relay context in quick review merge"
+```
+
+## Chunk 4: Verification
+
+### Task 5: Run verification
+
+**Files:**
+- Modify: `src/index.mjs`
+- Modify: `src/index.test.mjs`
+- Modify: `src/admin/swipe-review.html` (if touched)
+
+- [ ] **Step 1: Run focused verification**
+
+Run: `npm test -- src/index.test.mjs -t "Admin video lookup|Quick review HTML"`
+Expected: PASS
+
+- [ ] **Step 2: Run full file verification**
+
+Run: `npm test -- src/index.test.mjs`
+Expected: PASS
+
+- [ ] **Step 3: Commit final integration changes**
+
+```bash
+git add src/index.mjs src/index.test.mjs src/admin/swipe-review.html docs/superpowers/specs/2026-04-14-relay-first-admin-review-context-design.md docs/superpowers/plans/2026-04-14-relay-first-admin-review-context-plan.md
+git commit -m "feat: use relay-first context in admin review"
+```

--- a/docs/superpowers/specs/2026-04-14-relay-first-admin-review-context-design.md
+++ b/docs/superpowers/specs/2026-04-14-relay-first-admin-review-context-design.md
@@ -1,0 +1,94 @@
+# Relay-First Admin Review Context
+
+**Date:** 2026-04-14
+**Status:** Approved
+**Scope:** quick review and admin lookup context hydration in `divine-moderation-service`
+
+## Problem
+
+Quick Review usually shows weak post context because the admin worker relies on sparse local moderation rows and raw relay websocket lookups.
+
+Current problems:
+- `moderation_results` is not reliable enough to be the primary source of post context.
+- The admin APIs return thin review rows and then attempt best-effort enrichment later.
+- Raw websocket lookups are used for fields that the relay docs say should come from REST denormalized endpoints.
+- Profile misses are cached aggressively, so `Unknown publisher` persists even after transient lookup failures.
+
+## User Intent
+
+The moderator wants Quick Review to use the same fast, accurate post context source as the main product, not a neglected local snapshot.
+
+The explicit rule is:
+- use `api.divine.video` first
+- use admin/D1 only as fallback for deleted or missing content
+
+## Design
+
+Make relay REST the primary source of truth for admin review context.
+
+### Source Of Truth
+
+For non-deleted content:
+- post metadata comes from relay/API responses first
+- publisher metadata comes from relay/API responses first
+
+For deleted, missing, or unreachable relay content:
+- fall back to local admin/D1 metadata so moderation can still proceed
+
+### Resolution Order
+
+For a given review item:
+
+1. Load moderation state from the admin worker as today.
+2. Resolve post context from `api.divine.video` using the best available stable identifier.
+3. Merge relay fields over local placeholders.
+4. Use local admin/D1 metadata only for fields still missing or when relay says the content is gone.
+5. Use raw websocket relay lookups only as a last resort.
+
+### Identifier Strategy
+
+Use identifiers in this order:
+
+1. `event_id` from persisted moderation metadata
+2. stable video identifier / `d` tag when available
+3. relay/API lookup identifiers already returned by FunnelCake lookup
+4. media SHA only as a fallback path when no stable post identifier exists
+
+The goal is to stop treating media SHA as the primary external post identifier.
+
+### API Changes
+
+Introduce a server-side relay-first enrichment helper used by admin lookup endpoints.
+
+It should:
+- fetch single-video context from relay REST
+- fetch publisher profiles from relay/API bulk user endpoints when pubkeys are known
+- normalize the response into the existing admin review payload shape
+
+Admin endpoints should return:
+- moderation state from local admin data
+- post and publisher context from relay/API when available
+- local fallback data only when upstream data is unavailable
+
+### UI Behavior
+
+Quick Review should continue calling the admin worker, not the relay directly from the browser.
+
+That keeps:
+- auth simple
+- fallback logic centralized
+- payload shape stable for the existing UI
+
+### Non-Goals
+
+- No change to moderation decisions or playback routing
+- No attempt to fully repair or trust all legacy D1 rows
+- No new background sync from relay into D1
+
+## Testing
+
+Add coverage for:
+- relay-first enrichment when relay/API returns a complete post
+- fallback to local admin metadata when relay/API returns 404 or errors
+- publisher hydration preferring relay/API data over local placeholders
+- merge behavior that does not clobber good relay fields with sparse local data

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -51,6 +51,8 @@ const CATEGORY_TO_LABEL = {
 const ADMIN_HOSTNAME = 'moderation.admin.divine.video';
 const API_HOSTNAME = 'moderation-api.divine.video';
 const DEFAULT_RELAY_ADMIN_URL = 'https://relay.admin.divine.video';
+const DEFAULT_DIVINE_API_BASE_URL = 'https://api.divine.video';
+const DEFAULT_LEGACY_FUNNELCAKE_BASE_URL = 'https://relay.divine.video';
 const JSON_HEADERS = { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' };
 
 // ETags for admin HTML pages — computed once at module load, change only on deploy.
@@ -176,6 +178,37 @@ function hostMismatchResponse(requestId, hostname, pathname, expectedHost) {
   return jsonError(`Not found on ${hostname}. Use https://${expectedHost}${pathname}`, 404);
 }
 
+function isPresentValue(value) {
+  return value !== null && value !== undefined && value !== '';
+}
+
+function pickFirstPresentValue(...values) {
+  for (const value of values) {
+    if (isPresentValue(value)) {
+      return value;
+    }
+  }
+  return null;
+}
+
+function mergePresentFields(primary = {}, fallback = {}) {
+  const merged = { ...(fallback || {}) };
+  for (const [key, value] of Object.entries(primary || {})) {
+    if (isPresentValue(value)) {
+      merged[key] = value;
+    }
+  }
+  return Object.keys(merged).length > 0 ? merged : null;
+}
+
+function getDivineApiBaseUrl(env) {
+  return env.DIVINE_API_BASE_URL || DEFAULT_DIVINE_API_BASE_URL;
+}
+
+function getLegacyFunnelcakeBaseUrl(env) {
+  return env.FUNNELCAKE_API_BASE_URL || DEFAULT_LEGACY_FUNNELCAKE_BASE_URL;
+}
+
 function buildFunnelcakeVideoLookup(eventResponse, identifier) {
   if (!eventResponse?.event) {
     return null;
@@ -193,12 +226,17 @@ function buildFunnelcakeVideoLookup(eventResponse, identifier) {
 
   return {
     eventId: event.id,
+    event_id: event.id,
     stableId,
     lookupId: identifier,
     mediaSha,
     videoUrl,
+    content_url: videoUrl,
     thumbnailUrl,
     uploadedBy: event.pubkey || null,
+    author: metadata.author || stats.author_name || null,
+    title: metadata.title || null,
+    published_at: metadata.publishedAt || null,
     createdAt: event.created_at ? new Date(event.created_at * 1000).toISOString() : null,
     nostrContext: {
       title: metadata.title || null,
@@ -219,6 +257,10 @@ function buildFunnelcakeVideoLookup(eventResponse, identifier) {
       vineHashId: metadata.vineHashId || null,
       vineUserId: metadata.vineUserId || null,
       createdAt: metadata.createdAt || event.created_at || null
+    },
+    publisherProfile: {
+      display_name: stats.author_name || null,
+      picture: stats.author_avatar || null
     },
     divineUrl: `https://divine.video/video/${encodeURIComponent(stableId)}`
   };
@@ -276,22 +318,38 @@ function buildStoredNostrContext(row, uploadedBy = null, options = {}) {
   return hasStoredMetadata ? metadata : null;
 }
 
-async function fetchFunnelcakeLookupVideo(identifier) {
-  const response = await fetch(`https://relay.divine.video/api/videos/${encodeURIComponent(identifier)}`, {
-    headers: {
-      'Accept': 'application/json'
+async function fetchFunnelcakeLookupVideo(identifier, env) {
+  const bases = [getDivineApiBaseUrl(env), getLegacyFunnelcakeBaseUrl(env)];
+  let lastError = null;
+
+  for (const baseUrl of [...new Set(bases.filter(Boolean))]) {
+    try {
+      const response = await fetch(`${baseUrl}/api/videos/${encodeURIComponent(identifier)}`, {
+        headers: {
+          'Accept': 'application/json'
+        }
+      });
+
+      if (response.status === 404) {
+        continue;
+      }
+
+      if (!response.ok) {
+        lastError = new Error(`Funnelcake lookup failed with HTTP ${response.status}`);
+        continue;
+      }
+
+      return buildFunnelcakeVideoLookup(await response.json(), identifier);
+    } catch (error) {
+      lastError = error;
     }
-  });
-
-  if (response.status === 404) {
-    return null;
   }
 
-  if (!response.ok) {
-    throw new Error(`Funnelcake lookup failed with HTTP ${response.status}`);
+  if (lastError) {
+    throw lastError;
   }
 
-  return buildFunnelcakeVideoLookup(await response.json(), identifier);
+  return null;
 }
 
 function mergeLookupMetadata(baseVideo, funnelcakeVideo) {
@@ -301,16 +359,50 @@ function mergeLookupMetadata(baseVideo, funnelcakeVideo) {
 
   return {
     ...baseVideo,
-    cdnUrl: funnelcakeVideo.videoUrl || baseVideo.cdnUrl || null,
-    thumbnailUrl: baseVideo.thumbnailUrl || funnelcakeVideo.thumbnailUrl || null,
-    uploaded_by: baseVideo.uploaded_by || funnelcakeVideo.uploadedBy || null,
-    divineUrl: funnelcakeVideo.divineUrl || baseVideo.divineUrl,
-    lookupId: funnelcakeVideo.lookupId || baseVideo.lookupId,
-    nostrContext: {
-      ...(funnelcakeVideo.nostrContext || {}),
-      ...(baseVideo.nostrContext || {})
-    }
+    eventId: pickFirstPresentValue(funnelcakeVideo.eventId, funnelcakeVideo.event_id, baseVideo.eventId, baseVideo.event_id),
+    event_id: pickFirstPresentValue(funnelcakeVideo.event_id, funnelcakeVideo.eventId, baseVideo.event_id, baseVideo.eventId),
+    cdnUrl: pickFirstPresentValue(funnelcakeVideo.videoUrl, funnelcakeVideo.content_url, baseVideo.cdnUrl, baseVideo.content_url),
+    content_url: pickFirstPresentValue(funnelcakeVideo.content_url, funnelcakeVideo.videoUrl, baseVideo.content_url, baseVideo.cdnUrl),
+    thumbnailUrl: pickFirstPresentValue(funnelcakeVideo.thumbnailUrl, baseVideo.thumbnailUrl),
+    uploaded_by: pickFirstPresentValue(funnelcakeVideo.uploadedBy, funnelcakeVideo.uploaded_by, baseVideo.uploaded_by),
+    divineUrl: pickFirstPresentValue(funnelcakeVideo.divineUrl, baseVideo.divineUrl),
+    lookupId: pickFirstPresentValue(funnelcakeVideo.lookupId, baseVideo.lookupId),
+    title: pickFirstPresentValue(funnelcakeVideo.title, baseVideo.title, baseVideo.nostrContext?.title),
+    author: pickFirstPresentValue(funnelcakeVideo.author, baseVideo.author, baseVideo.nostrContext?.author),
+    published_at: pickFirstPresentValue(
+      funnelcakeVideo.published_at,
+      funnelcakeVideo.publishedAt,
+      funnelcakeVideo.nostrContext?.publishedAt,
+      baseVideo.published_at,
+      baseVideo.nostrContext?.publishedAt
+    ),
+    publisherProfile: mergePresentFields(funnelcakeVideo.publisherProfile, baseVideo.publisherProfile),
+    nostrContext: mergePresentFields(funnelcakeVideo.nostrContext || {}, baseVideo.nostrContext || {})
   };
+}
+
+async function fetchDivineApiUserProfiles(pubkeys, env) {
+  const uniquePubkeys = [...new Set((pubkeys || []).filter((pubkey) => typeof pubkey === 'string' && pubkey.length === 64))];
+  if (uniquePubkeys.length === 0) {
+    return {};
+  }
+
+  const response = await fetch(`${getDivineApiBaseUrl(env)}/api/users/bulk`, {
+    method: 'POST',
+    headers: {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ pubkeys: uniquePubkeys })
+  });
+
+  if (!response.ok) {
+    throw new Error(`User bulk lookup failed with HTTP ${response.status}`);
+  }
+
+  const data = await response.json();
+  const users = Array.isArray(data?.users) ? data.users : [];
+  return Object.fromEntries(users.map((user) => [user.pubkey, user.profile || null]));
 }
 
 function getRelayAdminUrl(env) {
@@ -495,7 +587,7 @@ async function deleteEventFromRelayBySha256(sha256, env, source = 'unknown', rea
 
 async function fetchLookupNostrContext(hash, env) {
   try {
-    const video = await fetchFunnelcakeLookupVideo(hash);
+    const video = await fetchFunnelcakeLookupVideo(hash, env);
     if (!video) {
       return null;
     }
@@ -512,13 +604,72 @@ async function fetchLookupNostrContext(hash, env) {
   }
 }
 
-async function enrichAdminLookupVideo(video, env) {
+function buildLookupCandidates(identifier, video) {
+  const candidates = [];
+  const seen = new Set();
+  const append = (value) => {
+    if (!isPresentValue(value)) {
+      return;
+    }
+    const normalized = String(value);
+    if (seen.has(normalized)) {
+      return;
+    }
+    seen.add(normalized);
+    candidates.push(normalized);
+  };
+
+  append(video?.eventId);
+  append(video?.event_id);
+  append(video?.lookupId);
+  append(identifier);
+  append(video?.sha256);
+
+  return candidates;
+}
+
+async function fetchRelayFirstAdminContext(identifier, video, env) {
+  const candidates = buildLookupCandidates(identifier, video);
+  for (const candidate of candidates) {
+    try {
+      const relayVideo = await fetchFunnelcakeLookupVideo(candidate, env);
+      if (!relayVideo) {
+        continue;
+      }
+
+      if (relayVideo.uploadedBy) {
+        try {
+          const profiles = await fetchDivineApiUserProfiles([relayVideo.uploadedBy], env);
+          relayVideo.publisherProfile = mergePresentFields(
+            profiles[relayVideo.uploadedBy] || {},
+            relayVideo.publisherProfile || {}
+          );
+        } catch (error) {
+          console.warn(`[ADMIN] Failed to fetch relay user profile for ${relayVideo.uploadedBy}: ${error.message}`);
+        }
+      }
+
+      return relayVideo;
+    } catch (error) {
+      console.warn(`[ADMIN] Relay-first lookup failed for ${candidate}: ${error.message}`);
+    }
+  }
+
+  return null;
+}
+
+async function enrichAdminLookupVideo(video, env, identifier = null) {
   if (!video) {
     return null;
   }
 
   let enriched = { ...video };
-  const needsNostrEnrichment = enriched.sha256 && (
+  const relayFirstContext = await fetchRelayFirstAdminContext(identifier, enriched, env);
+  if (relayFirstContext) {
+    enriched = mergeLookupMetadata(enriched, relayFirstContext);
+  }
+
+  const needsNostrEnrichment = !relayFirstContext && enriched.sha256 && (
     !enriched.eventId
     || !enriched.divineUrl
     || !enriched.nostrContext
@@ -536,14 +687,27 @@ async function enrichAdminLookupVideo(video, env) {
         ...enriched,
         eventId: enriched.eventId || nostrContext.eventId,
         divineUrl: enriched.divineUrl || nostrContext.divineUrl,
-        nostrContext: {
-          ...(nostrContext.nostrContext || {}),
-          ...(enriched.nostrContext || {})
-        },
+        nostrContext: mergePresentFields(enriched.nostrContext || {}, nostrContext.nostrContext || {}),
         uploaded_by: enriched.uploaded_by || nostrContext.uploadedBy || null
       };
     }
   }
+
+  enriched.title = pickFirstPresentValue(enriched.title, enriched.nostrContext?.title);
+  enriched.author = pickFirstPresentValue(enriched.author, enriched.nostrContext?.author);
+  enriched.content_url = pickFirstPresentValue(enriched.content_url, enriched.cdnUrl, enriched.nostrContext?.url);
+  enriched.published_at = pickFirstPresentValue(enriched.published_at, enriched.nostrContext?.publishedAt);
+  enriched.event_id = pickFirstPresentValue(enriched.event_id, enriched.eventId, enriched.nostrContext?.eventId);
+  enriched.eventId = pickFirstPresentValue(enriched.eventId, enriched.event_id, enriched.nostrContext?.eventId);
+  enriched.divineUrl = pickFirstPresentValue(enriched.divineUrl, enriched.eventId ? `https://divine.video/video/${encodeURIComponent(enriched.eventId)}` : null);
+
+  enriched.nostrContext = mergePresentFields(enriched.nostrContext || {}, {
+    title: enriched.title,
+    author: enriched.author,
+    url: enriched.content_url,
+    publishedAt: enriched.published_at,
+    eventId: enriched.eventId
+  });
 
   if (enriched.uploaded_by) {
     const uploaderEnforcement = await getUploaderEnforcement(env.BLOSSOM_DB, enriched.uploaded_by).catch(() => null);
@@ -667,8 +831,10 @@ async function getAdminLookupVideo(identifier, env, options = {}) {
     if (moderatedRow || kvModeration) {
       const moderatedAt = kvModeration?.moderated_at || moderatedRow?.moderated_at || null;
       const uploadedBy = moderatedRow?.uploaded_by || kvModeration?.uploadedBy || null;
-      const storedNostrContext = buildStoredNostrContext(moderatedRow, uploadedBy, { includePubkey: true });
-      const storedEventId = moderatedRow?.event_id || null;
+      const persistedNostrContext = buildStoredNostrContext(moderatedRow, uploadedBy, { includePubkey: true });
+      const eventId = moderatedRow?.event_id || null;
+      const persistedContentUrl = moderatedRow?.content_url || null;
+      const persistedPublishedAt = moderatedRow?.published_at || null;
       return enrichAdminLookupVideo({
         sha256: hash,
         action: kvModeration?.action || moderatedRow?.action || 'REVIEW',
@@ -686,11 +852,16 @@ async function getAdminLookupVideo(identifier, env, options = {}) {
         previousAction: kvModeration?.previousAction || null,
         detailedCategories: parseMaybeJson(kvModeration?.detailedCategories, null),
         categoryVerifications: parseMaybeJson(kvModeration?.categoryVerifications, {}) || {},
-        cdnUrl: kvModeration?.cdnUrl || moderatedRow?.content_url || cdnUrl,
-        nostrContext: storedNostrContext,
-        eventId: storedEventId,
-        divineUrl: storedEventId ? `https://divine.video/video/${encodeURIComponent(storedEventId)}` : null
-      }, env);
+        cdnUrl: kvModeration?.cdnUrl || persistedContentUrl || cdnUrl,
+        title: moderatedRow?.title || null,
+        author: moderatedRow?.author || null,
+        content_url: persistedContentUrl,
+        published_at: persistedPublishedAt,
+        event_id: eventId,
+        eventId,
+        divineUrl: eventId ? `https://divine.video/video/${encodeURIComponent(eventId)}` : null,
+        nostrContext: persistedNostrContext
+      }, env, identifier);
     }
 
     const untriagedRow = await env.BLOSSOM_DB.prepare(`
@@ -709,7 +880,7 @@ async function getAdminLookupVideo(identifier, env, options = {}) {
       let divineUrl = null;
       let uploaderPubkey = null;
       try {
-        const video = await fetchFunnelcakeLookupVideo(hash);
+        const video = await fetchFunnelcakeLookupVideo(hash, env);
         if (video) {
           eventId = video.eventId || null;
           divineUrl = video.divineUrl || null;
@@ -733,7 +904,7 @@ async function getAdminLookupVideo(identifier, env, options = {}) {
         eventId,
         divineUrl,
         uploaded_by: uploaderPubkey
-      }, env);
+      }, env, identifier);
     }
   }
 
@@ -741,7 +912,7 @@ async function getAdminLookupVideo(identifier, env, options = {}) {
     return null;
   }
 
-  const funnelcakeVideo = await fetchFunnelcakeLookupVideo(identifier);
+  const funnelcakeVideo = await fetchFunnelcakeLookupVideo(identifier, env);
   if (!funnelcakeVideo) {
     return null;
   }
@@ -751,7 +922,7 @@ async function getAdminLookupVideo(identifier, env, options = {}) {
       allowFunnelcakeFallback: false
     });
     if (resolvedByMediaSha) {
-      return enrichAdminLookupVideo(mergeLookupMetadata(resolvedByMediaSha, funnelcakeVideo), env);
+      return enrichAdminLookupVideo(mergeLookupMetadata(resolvedByMediaSha, funnelcakeVideo), env, identifier);
     }
   }
 
@@ -770,7 +941,7 @@ async function getAdminLookupVideo(identifier, env, options = {}) {
     divineUrl: funnelcakeVideo.divineUrl,
     lookupId: funnelcakeVideo.lookupId,
     eventId: funnelcakeVideo.eventId
-  }, env);
+  }, env, identifier);
 }
 
 async function handleLegacyScan(request, env) {
@@ -1257,7 +1428,7 @@ export default {
         // Fetch Nostr context in parallel for all unmoderated videos
         const nostrPromises = unmoderatedRows.map(async (row) => {
           try {
-            const video = await fetchFunnelcakeLookupVideo(row.sha256);
+            const video = await fetchFunnelcakeLookupVideo(row.sha256, env);
             if (video) {
               return {
                 sha256: row.sha256,
@@ -1937,7 +2108,7 @@ export default {
           });
         }
 
-        const video = await fetchFunnelcakeLookupVideo(sha256);
+        const video = await fetchFunnelcakeLookupVideo(sha256, env);
         if (!video?.nostrContext) {
           return new Response(JSON.stringify({ found: false }), {
             headers: { 'Content-Type': 'application/json' }

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -1085,6 +1085,10 @@ describe('Admin nostr context lookup', () => {
 
     globalThis.fetch = async (url) => {
       restCalls.push(String(url));
+      if (String(url) === `https://api.divine.video/api/videos/${SHA256}`) {
+        return new Response('not found', { status: 404 });
+      }
+
       if (String(url) === `https://relay.divine.video/api/videos/${SHA256}`) {
         return new Response(JSON.stringify({
           event: {
@@ -1144,7 +1148,10 @@ describe('Admin nostr context lookup', () => {
           createdAt: 1700000000
         }
       });
-      expect(restCalls).toEqual([`https://relay.divine.video/api/videos/${SHA256}`]);
+      expect(restCalls).toEqual([
+        `https://api.divine.video/api/videos/${SHA256}`,
+        `https://relay.divine.video/api/videos/${SHA256}`
+      ]);
     } finally {
       globalThis.fetch = originalFetch;
       globalThis.WebSocket = originalWebSocket;

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -469,7 +469,7 @@ describe('Admin video lookup', () => {
 
     globalThis.fetch = async (url) => {
       restCalls.push(String(url));
-      if (String(url) === `https://relay.divine.video/api/videos/${SHA256}`) {
+      if (String(url) === `https://api.divine.video/api/videos/${SHA256}`) {
         return new Response(JSON.stringify({
           event: {
             id: 'd'.repeat(64),
@@ -488,6 +488,22 @@ describe('Admin video lookup', () => {
           stats: {
             author_name: 'REST author'
           }
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }
+
+      if (String(url) === 'https://api.divine.video/api/users/bulk') {
+        return new Response(JSON.stringify({
+          users: [{
+            pubkey: 'b'.repeat(64),
+            profile: {
+              display_name: 'REST display name',
+              picture: 'https://cdn.divine.video/rest-avatar.jpg'
+            }
+          }],
+          missing: []
         }), {
           status: 200,
           headers: { 'Content-Type': 'application/json' }
@@ -523,8 +539,13 @@ describe('Admin video lookup', () => {
       await expect(response.json()).resolves.toMatchObject({
         video: {
           sha256: SHA256,
+          uploaded_by: 'b'.repeat(64),
           eventId: 'd'.repeat(64),
           divineUrl: `https://divine.video/video/${SHA256}`,
+          publisherProfile: {
+            display_name: 'REST display name',
+            picture: 'https://cdn.divine.video/rest-avatar.jpg'
+          },
           nostrContext: {
             title: 'REST title',
             author: 'REST author',
@@ -535,10 +556,179 @@ describe('Admin video lookup', () => {
           }
         }
       });
-      expect(restCalls).toEqual([`https://relay.divine.video/api/videos/${SHA256}`]);
+      expect(restCalls).toEqual([
+        `https://api.divine.video/api/videos/${SHA256}`,
+        'https://api.divine.video/api/users/bulk'
+      ]);
     } finally {
       globalThis.fetch = originalFetch;
       globalThis.WebSocket = originalWebSocket;
+    }
+  });
+
+  it('prefers api.divine.video context over stored metadata for moderated videos', async () => {
+    const eventId = '1'.repeat(64);
+    const uploaderPubkey = '9'.repeat(64);
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (url) => {
+      if (String(url) === `https://api.divine.video/api/videos/${eventId}`) {
+        return new Response(JSON.stringify({
+          event: {
+            id: eventId,
+            pubkey: uploaderPubkey,
+            created_at: 1773503656,
+            kind: 34236,
+            tags: [
+              ['d', 'relay-stable-id'],
+              ['title', 'Relay title'],
+              ['client', 'divine-web'],
+              ['platform', 'vine'],
+              ['published_at', '1773503656'],
+              ['imeta', `url https://cdn.divine.video/${SHA256}.mp4`, `x ${SHA256}`, 'image https://cdn.divine.video/thumb.jpg']
+            ],
+            content: 'Relay description',
+            sig: 'd'.repeat(128)
+          },
+          stats: {
+            author_name: 'Relay Author',
+            author_avatar: 'https://cdn.divine.video/avatar.jpg'
+          }
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }
+
+      if (String(url) === 'https://api.divine.video/api/users/bulk') {
+        return new Response(JSON.stringify({
+          users: [{
+            pubkey: uploaderPubkey,
+            profile: {
+              display_name: 'Relay Display Name',
+              picture: 'https://cdn.divine.video/avatar.jpg',
+              nip05: 'relay@example.com'
+            }
+          }],
+          missing: []
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    };
+
+    try {
+      const response = await worker.fetch(
+        new Request(`https://moderation.admin.divine.video/admin/api/video/${SHA256}`, {
+          headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
+        }),
+        createEnv({
+          BLOSSOM_DB: createDbMock({
+            moderationResults: new Map([[SHA256, {
+              sha256: SHA256,
+              action: 'REVIEW',
+              provider: 'hiveai',
+              scores: JSON.stringify({ nudity: 0.82 }),
+              categories: JSON.stringify(['nudity']),
+              moderated_at: '2026-03-07T00:00:00.000Z',
+              reviewed_by: null,
+              reviewed_at: null,
+              review_notes: 'legacy note',
+              uploaded_by: 'f'.repeat(64),
+              title: 'Stored title',
+              author: 'Stored author',
+              event_id: eventId,
+              content_url: 'https://media.divine.video/stored.mp4',
+              published_at: '2026-03-06T00:00:00.000Z'
+            }]])
+          })
+        })
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toMatchObject({
+        video: {
+          sha256: SHA256,
+          uploaded_by: uploaderPubkey,
+          eventId,
+          divineUrl: 'https://divine.video/video/relay-stable-id',
+          title: 'Relay title',
+          author: 'Relay Author',
+          content_url: `https://cdn.divine.video/${SHA256}.mp4`,
+          nostrContext: {
+            title: 'Relay title',
+            author: 'Relay Author',
+            content: 'Relay description',
+            client: 'divine-web',
+            platform: 'vine',
+            url: `https://cdn.divine.video/${SHA256}.mp4`
+          }
+        }
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('falls back to stored admin metadata when api.divine.video lookup misses', async () => {
+    const eventId = '2'.repeat(64);
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (url) => {
+      if (String(url) === `https://api.divine.video/api/videos/${eventId}`) {
+        return new Response('not found', { status: 404 });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    };
+
+    try {
+      const response = await worker.fetch(
+        new Request(`https://moderation.admin.divine.video/admin/api/video/${SHA256}`, {
+          headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
+        }),
+        createEnv({
+          BLOSSOM_DB: createDbMock({
+            moderationResults: new Map([[SHA256, {
+              sha256: SHA256,
+              action: 'REVIEW',
+              provider: 'hiveai',
+              scores: JSON.stringify({ nudity: 0.82 }),
+              categories: JSON.stringify(['nudity']),
+              moderated_at: '2026-03-07T00:00:00.000Z',
+              reviewed_by: null,
+              reviewed_at: null,
+              review_notes: 'legacy note',
+              uploaded_by: 'f'.repeat(64),
+              title: 'Stored title',
+              author: 'Stored author',
+              event_id: eventId,
+              content_url: 'https://media.divine.video/stored.mp4',
+              published_at: '2026-03-06T00:00:00.000Z'
+            }]])
+          })
+        })
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toMatchObject({
+        video: {
+          sha256: SHA256,
+          uploaded_by: 'f'.repeat(64),
+          eventId,
+          title: 'Stored title',
+          author: 'Stored author',
+          content_url: 'https://media.divine.video/stored.mp4',
+          nostrContext: {
+            title: 'Stored title',
+            author: 'Stored author',
+            url: 'https://media.divine.video/stored.mp4',
+            publishedAt: '2026-03-06T00:00:00.000Z'
+          }
+        }
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
     }
   });
 


### PR DESCRIPTION
## Summary
- use `api.divine.video` as the primary source for admin review post context and only fall back to local admin metadata when upstream misses
- merge relay/API metadata ahead of stored D1 placeholders for moderated lookups, including title, author, content URL, publish time, and stable Divine links
- add regression coverage for relay-first lookup and local fallback behavior in admin video lookup

## Test Plan
- [x] npm test -- src/index.test.mjs -t "Admin video lookup"
- [x] npm test -- src/index.test.mjs
