### PR TITLE
feat: per-video delete end-to-end enforcement

### DIFF
--- a/docs/superpowers/plans/2026-04-16-per-video-delete-enforcement-plan.md
+++ b/docs/superpowers/plans/2026-04-16-per-video-delete-enforcement-plan.md
@@ -1,0 +1,2019 @@
+# Per-Video Delete End-to-End Enforcement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the divine-moderation-service side of per-video creator-initiated deletes: a race-safe processing pipeline with a NIP-98 synchronous endpoint for divine-mobile's fast path and a 1-minute cron for non-Divine client coverage, writing to a D1 audit table and calling Blossom's new `DELETE` action.
+
+**Architecture:** Sync endpoint and cron both invoke a shared `processKind5` function that claims a D1 row via INSERT-OR-IGNORE, fetches the target event from Funnelcake (with read-after-write retry), extracts sha256, calls Blossom, records terminal state. State taxonomy distinguishes `failed:transient:*` (cron-retryable) from `failed:permanent:*`.
+
+**Tech Stack:** Cloudflare Workers, D1, KV, nostr-tools (for NIP-98 signature verification), vitest for tests.
+
+**Scope of this plan:** divine-moderation-service only (PR #92). Sibling work streams are:
+- **divine-blossom:** new `DELETE` action + cascade + `ENABLE_PHYSICAL_DELETE` flag + tombstone verification. Has its own plan when that work is picked up.
+- **divine-mobile:** polling + UI state machine. Its own plan, sibling of #3101.
+- **support-trust-safety:** one-line vocab doc update. Trivial; handled inline when Blossom PR lands.
+
+**Spec:** `docs/superpowers/specs/2026-04-16-per-video-delete-enforcement-design.md` on this branch.
+
+---
+
+## File Structure
+
+**New files:**
+
+- `migrations/006-creator-deletions.sql` — D1 schema for the audit table
+- `src/creator-delete/nip98.mjs` — NIP-98 Authorization header validation
+- `src/creator-delete/nip98.test.mjs`
+- `src/creator-delete/d1.mjs` — D1 helpers (claim, read-state, update-status)
+- `src/creator-delete/d1.test.mjs`
+- `src/creator-delete/process.mjs` — `processKind5` shared function
+- `src/creator-delete/process.test.mjs`
+- `src/creator-delete/rate-limit.mjs` — Per-pubkey + per-IP rate limiting via KV counters
+- `src/creator-delete/rate-limit.test.mjs`
+- `src/creator-delete/sync-endpoint.mjs` — `POST /api/delete/{kind5_id}` handler
+- `src/creator-delete/sync-endpoint.test.mjs`
+- `src/creator-delete/status-endpoint.mjs` — `GET /api/delete-status/{kind5_id}` handler
+- `src/creator-delete/status-endpoint.test.mjs`
+- `src/creator-delete/cron.mjs` — Scheduled work for kind 5 polling + transient retry
+- `src/creator-delete/cron.test.mjs`
+
+**Files to modify:**
+
+- `wrangler.toml` — Add a `* * * * *` cron entry alongside existing `*/5 * * * *`; verify existing `BLOSSOM_WEBHOOK_SECRET`, `BLOSSOM_ADMIN_URL`, `MODERATION_KV`, `BLOSSOM_DB` bindings are sufficient.
+- `src/index.mjs` — Register two routes on `moderation-api.divine.video`; dispatch new cron in the existing `scheduled(event, env, ctx)` handler based on `event.cron`.
+
+Each file has one clear responsibility. `process.mjs` is the hub; endpoints and cron orchestrate around it. Tests are colocated with source (existing repo pattern).
+
+---
+
+## Staging Preflight
+
+Complete these BEFORE starting implementation. Failures here can redirect the design.
+
+- [ ] **Funnelcake kind 5 queryability.** Open a WebSocket to `wss://relay.staging.divine.video`, send `["REQ","test",{"kinds":[5],"limit":5}]`, confirm events are returned (or that a recent kind 5 is visible). If kind 5s are treated as ephemeral and dropped, the cron strategy does not work and the design needs revision. Record result.
+
+    Command helper:
+    ```bash
+    wscat -c wss://relay.staging.divine.video
+    # after connect:
+    ["REQ","preflight",{"kinds":[5],"limit":5}]
+    ```
+
+- [ ] **Blossom webhook secret present in staging.** Confirm staging Blossom's `blossom_secrets` Fastly Secret Store has `webhook_secret` populated (same value moderation-service uses).
+
+    ```bash
+    # On staging Blossom:
+    fastly secret-store-entry list --store-id=<staging-store-id>
+    # Look for webhook_secret
+    ```
+
+- [ ] **Staging Blossom has PR #33 (or equivalent) deployed.** Confirms `Deleted` status is checked on HLS HEAD and subtitle-by-hash routes. Test: flip a staging blob to `Deleted` via `/admin/api/moderate` with action `BAN` (as a proxy since `DELETE` isn't wired yet), confirm the blob 404s on `/<sha256>`, `/<sha256>.jpg`, `/<sha256>.vtt`.
+
+- [ ] **D1 binding writable from staging.** Confirm the existing `BLOSSOM_DB` binding has write access from staging worker context.
+
+    ```bash
+    npx wrangler d1 execute blossom-webhook-events --env staging --command "SELECT name FROM sqlite_master WHERE type='table'"
+    ```
+
+- [ ] **NIP-98 verification path works end-to-end.** Sign a test NIP-98 header locally, send a request with it, confirm `nostr-tools` signature verification in the Worker accepts it. No existing code to reference; this is a first-principles check using `nostr-tools/pure` and `nostr-tools/nip98` helpers.
+
+If any preflight check fails, stop and address before writing implementation code.
+
+---
+
+## Task 1: D1 migration for creator_deletions
+
+**Files:**
+- Create: `migrations/006-creator-deletions.sql`
+
+- [ ] **Step 1: Write the migration SQL**
+
+    Create `migrations/006-creator-deletions.sql` with:
+
+    ```sql
+    -- Audit table for creator-initiated deletions (kind 5 events from Funnelcake).
+    -- Composite PRIMARY KEY ensures idempotency across concurrent invocations
+    -- (sync endpoint + cron colliding on the same kind 5).
+    --
+    -- status taxonomy:
+    --   accepted                              - claimed by a worker, in-progress
+    --   success                               - terminal success
+    --   failed:transient:{subcategory}        - retryable by cron (retry_count < 5)
+    --   failed:permanent:{subcategory}        - terminal, manual intervention required
+
+    CREATE TABLE IF NOT EXISTS creator_deletions (
+      kind5_id TEXT NOT NULL,
+      target_event_id TEXT NOT NULL,
+      creator_pubkey TEXT NOT NULL,
+      blob_sha256 TEXT,
+      status TEXT NOT NULL,
+      accepted_at TEXT NOT NULL,
+      completed_at TEXT,
+      retry_count INTEGER NOT NULL DEFAULT 0,
+      last_error TEXT,
+      PRIMARY KEY (kind5_id, target_event_id)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_creator_deletions_target ON creator_deletions(target_event_id);
+    CREATE INDEX IF NOT EXISTS idx_creator_deletions_creator ON creator_deletions(creator_pubkey);
+    CREATE INDEX IF NOT EXISTS idx_creator_deletions_sha256 ON creator_deletions(blob_sha256);
+    CREATE INDEX IF NOT EXISTS idx_creator_deletions_status ON creator_deletions(status);
+    ```
+
+- [ ] **Step 2: Apply migration to staging**
+
+    ```bash
+    npx wrangler d1 execute blossom-webhook-events --env staging --file migrations/006-creator-deletions.sql
+    ```
+
+    Expected: success, table created.
+
+- [ ] **Step 3: Verify table structure on staging**
+
+    ```bash
+    npx wrangler d1 execute blossom-webhook-events --env staging --command ".schema creator_deletions"
+    ```
+
+    Expected: output matches the CREATE TABLE statement.
+
+- [ ] **Step 4: Commit**
+
+    ```bash
+    git add migrations/006-creator-deletions.sql
+    git commit -m "feat: add creator_deletions audit table migration"
+    ```
+
+---
+
+## Task 2: NIP-98 validation module
+
+Validates an incoming NIP-98 Authorization header: base64-decoded kind 27235 event with `["u", url]` and `["method", method]` tags, `created_at` within ±60s, valid signature.
+
+**Files:**
+- Create: `src/creator-delete/nip98.mjs`
+- Create: `src/creator-delete/nip98.test.mjs`
+
+- [ ] **Step 1: Write the first failing test — valid NIP-98 header**
+
+    Create `src/creator-delete/nip98.test.mjs`:
+
+    ```javascript
+    import { describe, it, expect, beforeEach } from 'vitest';
+    import { generateSecretKey, getPublicKey, finalizeEvent } from 'nostr-tools/pure';
+    import { bytesToHex } from '@noble/hashes/utils';
+    import { validateNip98Header } from './nip98.mjs';
+
+    describe('validateNip98Header', () => {
+      let sk, pk;
+
+      beforeEach(() => {
+        sk = generateSecretKey();
+        pk = getPublicKey(sk);
+      });
+
+      function signNip98(url, method, skOverride) {
+        const event = finalizeEvent({
+          kind: 27235,
+          created_at: Math.floor(Date.now() / 1000),
+          tags: [['u', url], ['method', method]],
+          content: ''
+        }, skOverride || sk);
+        const encoded = btoa(JSON.stringify(event));
+        return `Nostr ${encoded}`;
+      }
+
+      it('accepts a valid signature for matching url and method', async () => {
+        const header = signNip98('https://moderation-api.divine.video/api/delete/abc123', 'POST');
+        const result = await validateNip98Header(header, 'https://moderation-api.divine.video/api/delete/abc123', 'POST');
+        expect(result.valid).toBe(true);
+        expect(result.pubkey).toBe(pk);
+      });
+    });
+    ```
+
+- [ ] **Step 2: Run test — confirm it fails**
+
+    ```bash
+    npx vitest run src/creator-delete/nip98.test.mjs
+    ```
+
+    Expected: FAIL with `Cannot find module './nip98.mjs'` or equivalent.
+
+- [ ] **Step 3: Implement the validator**
+
+    Create `src/creator-delete/nip98.mjs`:
+
+    ```javascript
+    // ABOUTME: NIP-98 HTTP Authorization header validation for creator-delete endpoints.
+    // ABOUTME: Validates base64-encoded kind 27235 event with u, method tags, ±60s clock drift, signature.
+
+    import { verifyEvent } from 'nostr-tools/pure';
+
+    const CLOCK_DRIFT_SECONDS = 60;
+    const EXPECTED_KIND = 27235;
+
+    export async function validateNip98Header(authorizationHeader, expectedUrl, expectedMethod) {
+      if (!authorizationHeader || !authorizationHeader.startsWith('Nostr ')) {
+        return { valid: false, error: 'Missing or malformed Authorization header (expected "Nostr <base64>")' };
+      }
+
+      const encoded = authorizationHeader.slice('Nostr '.length).trim();
+
+      let event;
+      try {
+        const decoded = atob(encoded);
+        event = JSON.parse(decoded);
+      } catch (e) {
+        return { valid: false, error: `Invalid base64 or JSON in Authorization header: ${e.message}` };
+      }
+
+      if (event.kind !== EXPECTED_KIND) {
+        return { valid: false, error: `Expected kind ${EXPECTED_KIND}, got ${event.kind}` };
+      }
+
+      const now = Math.floor(Date.now() / 1000);
+      if (Math.abs(now - event.created_at) > CLOCK_DRIFT_SECONDS) {
+        return { valid: false, error: `created_at ${event.created_at} outside ±${CLOCK_DRIFT_SECONDS}s window (server now: ${now})` };
+      }
+
+      const uTag = event.tags.find(t => t[0] === 'u')?.[1];
+      const methodTag = event.tags.find(t => t[0] === 'method')?.[1];
+
+      if (uTag !== expectedUrl) {
+        return { valid: false, error: `u tag '${uTag}' does not match expected URL '${expectedUrl}'` };
+      }
+
+      if ((methodTag || '').toUpperCase() !== expectedMethod.toUpperCase()) {
+        return { valid: false, error: `method tag '${methodTag}' does not match expected method '${expectedMethod}'` };
+      }
+
+      if (!verifyEvent(event)) {
+        return { valid: false, error: 'Signature verification failed' };
+      }
+
+      return { valid: true, pubkey: event.pubkey };
+    }
+    ```
+
+- [ ] **Step 4: Run test — confirm happy path passes**
+
+    ```bash
+    npx vitest run src/creator-delete/nip98.test.mjs
+    ```
+
+    Expected: PASS.
+
+- [ ] **Step 5: Add failing tests for rejection paths**
+
+    Append to `src/creator-delete/nip98.test.mjs`:
+
+    ```javascript
+      it('rejects missing Authorization header', async () => {
+        const result = await validateNip98Header(undefined, 'https://x/y', 'POST');
+        expect(result.valid).toBe(false);
+        expect(result.error).toMatch(/Missing or malformed/);
+      });
+
+      it('rejects non-Nostr scheme', async () => {
+        const result = await validateNip98Header('Bearer abc', 'https://x/y', 'POST');
+        expect(result.valid).toBe(false);
+      });
+
+      it('rejects wrong kind', async () => {
+        const event = finalizeEvent({
+          kind: 1,
+          created_at: Math.floor(Date.now() / 1000),
+          tags: [['u', 'https://x/y'], ['method', 'POST']],
+          content: ''
+        }, sk);
+        const header = `Nostr ${btoa(JSON.stringify(event))}`;
+        const result = await validateNip98Header(header, 'https://x/y', 'POST');
+        expect(result.valid).toBe(false);
+        expect(result.error).toMatch(/Expected kind 27235/);
+      });
+
+      it('rejects expired created_at (outside ±60s)', async () => {
+        const event = finalizeEvent({
+          kind: 27235,
+          created_at: Math.floor(Date.now() / 1000) - 120,
+          tags: [['u', 'https://x/y'], ['method', 'POST']],
+          content: ''
+        }, sk);
+        const header = `Nostr ${btoa(JSON.stringify(event))}`;
+        const result = await validateNip98Header(header, 'https://x/y', 'POST');
+        expect(result.valid).toBe(false);
+        expect(result.error).toMatch(/outside/);
+      });
+
+      it('rejects mismatched url', async () => {
+        const header = signNip98('https://x/different', 'POST');
+        const result = await validateNip98Header(header, 'https://x/expected', 'POST');
+        expect(result.valid).toBe(false);
+        expect(result.error).toMatch(/u tag/);
+      });
+
+      it('rejects mismatched method', async () => {
+        const header = signNip98('https://x/y', 'GET');
+        const result = await validateNip98Header(header, 'https://x/y', 'POST');
+        expect(result.valid).toBe(false);
+        expect(result.error).toMatch(/method tag/);
+      });
+
+      it('rejects tampered signature', async () => {
+        const realEvent = finalizeEvent({
+          kind: 27235,
+          created_at: Math.floor(Date.now() / 1000),
+          tags: [['u', 'https://x/y'], ['method', 'POST']],
+          content: ''
+        }, sk);
+        realEvent.sig = realEvent.sig.slice(0, -4) + '0000';
+        const header = `Nostr ${btoa(JSON.stringify(realEvent))}`;
+        const result = await validateNip98Header(header, 'https://x/y', 'POST');
+        expect(result.valid).toBe(false);
+        expect(result.error).toMatch(/Signature/);
+      });
+    ```
+
+- [ ] **Step 6: Run tests — all should pass**
+
+    ```bash
+    npx vitest run src/creator-delete/nip98.test.mjs
+    ```
+
+    Expected: all tests PASS.
+
+- [ ] **Step 7: Commit**
+
+    ```bash
+    git add src/creator-delete/nip98.mjs src/creator-delete/nip98.test.mjs
+    git commit -m "feat: add NIP-98 Authorization header validator"
+    ```
+
+---
+
+## Task 3: D1 helpers for creator_deletions
+
+Race-safe claim-or-inspect logic that multiple concurrent invocations can call safely.
+
+**Files:**
+- Create: `src/creator-delete/d1.mjs`
+- Create: `src/creator-delete/d1.test.mjs`
+
+- [ ] **Step 1: Write failing test for `claimRow` happy path**
+
+    Create `src/creator-delete/d1.test.mjs`:
+
+    ```javascript
+    import { describe, it, expect, beforeEach } from 'vitest';
+    import { claimRow, readRow, updateToSuccess, updateToFailed } from './d1.mjs';
+
+    // Test helper: in-memory D1 fake with the same schema as creator_deletions.
+    function makeFakeD1() {
+      const rows = new Map(); // key: `${kind5_id}:${target_event_id}`
+      return {
+        rows,
+        prepare(sql) {
+          return {
+            _sql: sql,
+            _binds: [],
+            bind(...args) { this._binds = args; return this; },
+            async run() {
+              if (this._sql.startsWith('INSERT')) {
+                const [kind5_id, target_event_id, creator_pubkey, status, accepted_at] = this._binds;
+                const key = `${kind5_id}:${target_event_id}`;
+                if (rows.has(key)) {
+                  return { meta: { changes: 0, rows_written: 0 } };
+                }
+                rows.set(key, { kind5_id, target_event_id, creator_pubkey, status, accepted_at, retry_count: 0, last_error: null, blob_sha256: null, completed_at: null });
+                return { meta: { changes: 1, rows_written: 1 } };
+              }
+              if (this._sql.startsWith('UPDATE')) {
+                const target_key = `${this._binds[this._binds.length - 2]}:${this._binds[this._binds.length - 1]}`;
+                const existing = rows.get(target_key);
+                if (existing) {
+                  // Very simplified: we're just testing the wrappers, not SQL correctness.
+                  rows.set(target_key, { ...existing, _updated: true });
+                  return { meta: { changes: 1 } };
+                }
+                return { meta: { changes: 0 } };
+              }
+              return { meta: { changes: 0 } };
+            },
+            async first() {
+              if (this._sql.startsWith('SELECT')) {
+                const key = `${this._binds[0]}:${this._binds[1]}`;
+                return rows.get(key) || null;
+              }
+              return null;
+            }
+          };
+        }
+      };
+    }
+
+    describe('claimRow', () => {
+      let db;
+      beforeEach(() => { db = makeFakeD1(); });
+
+      it('claims a new row and returns claimed: true', async () => {
+        const now = new Date().toISOString();
+        const result = await claimRow(db, {
+          kind5_id: 'k1',
+          target_event_id: 't1',
+          creator_pubkey: 'pub1',
+          accepted_at: now
+        });
+        expect(result.claimed).toBe(true);
+        expect(result.existing).toBeNull();
+      });
+
+      it('does not claim when row already exists; returns existing', async () => {
+        const now = new Date().toISOString();
+        await claimRow(db, { kind5_id: 'k1', target_event_id: 't1', creator_pubkey: 'pub1', accepted_at: now });
+        const second = await claimRow(db, { kind5_id: 'k1', target_event_id: 't1', creator_pubkey: 'pub1', accepted_at: new Date().toISOString() });
+        expect(second.claimed).toBe(false);
+        expect(second.existing).toMatchObject({ kind5_id: 'k1', target_event_id: 't1', status: 'accepted' });
+      });
+    });
+    ```
+
+- [ ] **Step 2: Run — confirm it fails**
+
+    ```bash
+    npx vitest run src/creator-delete/d1.test.mjs
+    ```
+
+    Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `claimRow` and companion helpers**
+
+    Create `src/creator-delete/d1.mjs`:
+
+    ```javascript
+    // ABOUTME: Race-safe D1 helpers for creator_deletions audit table.
+    // ABOUTME: claimRow implements INSERT ... ON CONFLICT DO NOTHING then SELECT to read canonical state.
+
+    const MAX_RETRY_COUNT = 5;
+    const IN_PROGRESS_TIMEOUT_MS = 30_000;
+
+    /**
+     * Attempt to claim a row for processing. Returns { claimed, existing }.
+     * If claimed, this worker owns the row. If not, inspect existing.status and decide.
+     */
+    export async function claimRow(db, { kind5_id, target_event_id, creator_pubkey, accepted_at }) {
+      const insertResult = await db.prepare(
+        `INSERT INTO creator_deletions
+          (kind5_id, target_event_id, creator_pubkey, status, accepted_at)
+         VALUES (?, ?, ?, 'accepted', ?)
+         ON CONFLICT(kind5_id, target_event_id) DO NOTHING`
+      ).bind(kind5_id, target_event_id, creator_pubkey, accepted_at).run();
+
+      const inserted = insertResult.meta.changes === 1 || insertResult.meta.rows_written === 1;
+
+      if (inserted) {
+        return { claimed: true, existing: null };
+      }
+
+      const existing = await readRow(db, { kind5_id, target_event_id });
+      return { claimed: false, existing };
+    }
+
+    export async function readRow(db, { kind5_id, target_event_id }) {
+      return db.prepare(
+        `SELECT kind5_id, target_event_id, creator_pubkey, blob_sha256, status, accepted_at, completed_at, retry_count, last_error
+         FROM creator_deletions WHERE kind5_id = ? AND target_event_id = ?`
+      ).bind(kind5_id, target_event_id).first();
+    }
+
+    export async function readAllTargetsForKind5(db, { kind5_id }) {
+      const result = await db.prepare(
+        `SELECT kind5_id, target_event_id, creator_pubkey, blob_sha256, status, accepted_at, completed_at, retry_count, last_error
+         FROM creator_deletions WHERE kind5_id = ?`
+      ).bind(kind5_id).all();
+      return result.results || [];
+    }
+
+    export async function updateToSuccess(db, { kind5_id, target_event_id, blob_sha256, completed_at }) {
+      await db.prepare(
+        `UPDATE creator_deletions
+         SET status = 'success', blob_sha256 = ?, completed_at = ?, last_error = NULL
+         WHERE kind5_id = ? AND target_event_id = ?`
+      ).bind(blob_sha256, completed_at, kind5_id, target_event_id).run();
+    }
+
+    export async function updateToFailed(db, { kind5_id, target_event_id, status, last_error, increment_retry = false }) {
+      if (increment_retry) {
+        await db.prepare(
+          `UPDATE creator_deletions
+           SET status = ?, last_error = ?, retry_count = retry_count + 1
+           WHERE kind5_id = ? AND target_event_id = ?`
+        ).bind(status, last_error, kind5_id, target_event_id).run();
+      } else {
+        await db.prepare(
+          `UPDATE creator_deletions
+           SET status = ?, last_error = ?
+           WHERE kind5_id = ? AND target_event_id = ?`
+        ).bind(status, last_error, kind5_id, target_event_id).run();
+      }
+    }
+
+    /**
+     * Decide what to do with an existing row given the claim result.
+     * Returns one of: 'proceed' (caller should re-try processing), 'skip_success',
+     * 'skip_permanent_failure', 'skip_in_progress'.
+     */
+    export function decideAction(existing, { now = Date.now() } = {}) {
+      if (!existing) return 'proceed';
+      if (existing.status === 'success') return 'skip_success';
+      if (existing.status.startsWith('failed:permanent:')) return 'skip_permanent_failure';
+      if (existing.status === 'accepted') {
+        const acceptedMs = Date.parse(existing.accepted_at);
+        if (now - acceptedMs < IN_PROGRESS_TIMEOUT_MS) return 'skip_in_progress';
+        return 'proceed';
+      }
+      if (existing.status.startsWith('failed:transient:')) {
+        if (existing.retry_count < MAX_RETRY_COUNT) return 'proceed';
+        return 'skip_permanent_failure';
+      }
+      return 'proceed';
+    }
+
+    export { MAX_RETRY_COUNT, IN_PROGRESS_TIMEOUT_MS };
+    ```
+
+- [ ] **Step 4: Run — confirm happy path passes**
+
+    ```bash
+    npx vitest run src/creator-delete/d1.test.mjs
+    ```
+
+    Expected: PASS.
+
+- [ ] **Step 5: Add failing tests for `decideAction`**
+
+    Append to `src/creator-delete/d1.test.mjs`:
+
+    ```javascript
+    import { decideAction } from './d1.mjs';
+
+    describe('decideAction', () => {
+      it('proceed when no row exists', () => {
+        expect(decideAction(null)).toBe('proceed');
+      });
+
+      it('skip_success on terminal success', () => {
+        expect(decideAction({ status: 'success' })).toBe('skip_success');
+      });
+
+      it('skip_permanent_failure on permanent failure', () => {
+        expect(decideAction({ status: 'failed:permanent:blossom_400' })).toBe('skip_permanent_failure');
+      });
+
+      it('skip_in_progress when accepted and recent', () => {
+        const now = Date.now();
+        const existing = {
+          status: 'accepted',
+          accepted_at: new Date(now - 5_000).toISOString()
+        };
+        expect(decideAction(existing, { now })).toBe('skip_in_progress');
+      });
+
+      it('proceed when accepted but stale (>30s)', () => {
+        const now = Date.now();
+        const existing = {
+          status: 'accepted',
+          accepted_at: new Date(now - 60_000).toISOString()
+        };
+        expect(decideAction(existing, { now })).toBe('proceed');
+      });
+
+      it('proceed when failed:transient and retries remain', () => {
+        expect(decideAction({ status: 'failed:transient:blossom_5xx', retry_count: 2 })).toBe('proceed');
+      });
+
+      it('skip when failed:transient and retries exhausted', () => {
+        expect(decideAction({ status: 'failed:transient:blossom_5xx', retry_count: 5 })).toBe('skip_permanent_failure');
+      });
+    });
+    ```
+
+- [ ] **Step 6: Run — all tests pass**
+
+    ```bash
+    npx vitest run src/creator-delete/d1.test.mjs
+    ```
+
+    Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+    ```bash
+    git add src/creator-delete/d1.mjs src/creator-delete/d1.test.mjs
+    git commit -m "feat: add race-safe D1 helpers for creator_deletions"
+    ```
+
+---
+
+## Task 4: `processKind5` core function
+
+The shared function called by both the sync endpoint and the cron. Given a fetched kind 5 event, processes each target independently.
+
+**Files:**
+- Create: `src/creator-delete/process.mjs`
+- Create: `src/creator-delete/process.test.mjs`
+
+- [ ] **Step 1: Failing test — happy path with one target**
+
+    Create `src/creator-delete/process.test.mjs`:
+
+    ```javascript
+    import { describe, it, expect, vi, beforeEach } from 'vitest';
+    import { processKind5 } from './process.mjs';
+
+    describe('processKind5', () => {
+      let db, fetchTargetEvent, callBlossomDelete;
+
+      beforeEach(() => {
+        db = makeFakeD1();
+        fetchTargetEvent = vi.fn();
+        callBlossomDelete = vi.fn();
+      });
+
+      it('happy path: claim, fetch target, extract sha256, call Blossom, mark success', async () => {
+        const kind5 = {
+          id: 'k1',
+          pubkey: 'pub1',
+          tags: [['e', 't1']]
+        };
+        fetchTargetEvent.mockResolvedValueOnce({
+          id: 't1',
+          pubkey: 'pub1',
+          tags: [['imeta', 'url https://media.divine.video/abc.mp4', 'x abc']]
+        });
+        callBlossomDelete.mockResolvedValueOnce({ ok: true, status: 200 });
+
+        const result = await processKind5(kind5, {
+          db,
+          fetchTargetEvent,
+          callBlossomDelete
+        });
+
+        expect(result.targets).toEqual([{ target_event_id: 't1', status: 'success', blob_sha256: 'abc' }]);
+        expect(callBlossomDelete).toHaveBeenCalledWith('abc');
+      });
+    });
+
+    function makeFakeD1() { /* same helper as d1.test.mjs — copy or import */ }
+    ```
+
+    Before writing this test, extract `makeFakeD1` and `makeFakeKV` into `src/creator-delete/test-helpers.mjs` (exporting both) and update `d1.test.mjs` + `rate-limit.test.mjs` to import from it. Keeps the fakes DRY across the four test files that need them. This is a mechanical extraction — no new logic, just `mv` + update imports.
+
+- [ ] **Step 2: Run — confirm fail**
+
+    ```bash
+    npx vitest run src/creator-delete/process.test.mjs
+    ```
+
+    Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `processKind5`**
+
+    Create `src/creator-delete/process.mjs`:
+
+    ```javascript
+    // ABOUTME: Shared kind 5 processing function used by both sync endpoint and cron.
+    // ABOUTME: Race-safe via D1 INSERT-OR-IGNORE claim, handles multi-target kind 5 per NIP-09.
+
+    import { claimRow, readRow, updateToSuccess, updateToFailed, decideAction } from './d1.mjs';
+
+    /**
+     * Extract the main blob sha256 from a kind 34236 video event.
+     * Looks at imeta tags for x=<sha256> or parses url for the sha256 segment.
+     */
+    export function extractSha256(targetEvent) {
+      for (const tag of targetEvent.tags || []) {
+        if (tag[0] !== 'imeta') continue;
+        for (const part of tag.slice(1)) {
+          if (typeof part !== 'string') continue;
+          const xMatch = part.match(/^x\s+([a-f0-9]{64})$/i);
+          if (xMatch) return xMatch[1].toLowerCase();
+          const urlMatch = part.match(/^url\s+\S*\/([a-f0-9]{64})(?:\.\w+)?(?:\?|$)/i);
+          if (urlMatch) return urlMatch[1].toLowerCase();
+        }
+      }
+      return null;
+    }
+
+    /**
+     * Process a kind 5 event. Processes each e-tag target independently.
+     * Returns { targets: [{ target_event_id, status, blob_sha256?, last_error? }] }
+     */
+    export async function processKind5(kind5, { db, fetchTargetEvent, callBlossomDelete, now = () => Date.now() }) {
+      const targetIds = (kind5.tags || [])
+        .filter(t => t[0] === 'e' && t[1])
+        .map(t => t[1]);
+
+      const resultTargets = [];
+
+      for (const target_event_id of targetIds) {
+        const acceptedIso = new Date(now()).toISOString();
+        const claim = await claimRow(db, {
+          kind5_id: kind5.id,
+          target_event_id,
+          creator_pubkey: kind5.pubkey,
+          accepted_at: acceptedIso
+        });
+
+        const action = claim.claimed ? 'proceed' : decideAction(claim.existing, { now: now() });
+
+        if (action === 'skip_success') {
+          resultTargets.push({ target_event_id, status: 'success', blob_sha256: claim.existing.blob_sha256 });
+          continue;
+        }
+        if (action === 'skip_permanent_failure') {
+          resultTargets.push({ target_event_id, status: claim.existing.status, last_error: claim.existing.last_error });
+          continue;
+        }
+        if (action === 'skip_in_progress') {
+          resultTargets.push({ target_event_id, status: 'in_progress' });
+          continue;
+        }
+
+        // action === 'proceed'
+        const target = await fetchTargetEvent(target_event_id);
+        if (!target) {
+          await updateToFailed(db, {
+            kind5_id: kind5.id,
+            target_event_id,
+            status: 'failed:permanent:target_unresolved',
+            last_error: 'Target event not found on Funnelcake'
+          });
+          resultTargets.push({ target_event_id, status: 'failed:permanent:target_unresolved' });
+          continue;
+        }
+
+        const sha256 = extractSha256(target);
+        if (!sha256) {
+          await updateToFailed(db, {
+            kind5_id: kind5.id,
+            target_event_id,
+            status: 'failed:permanent:no_sha256',
+            last_error: 'No sha256 in target event imeta/url'
+          });
+          resultTargets.push({ target_event_id, status: 'failed:permanent:no_sha256' });
+          continue;
+        }
+
+        const blossomResult = await callBlossomDelete(sha256);
+        if (blossomResult.ok && blossomResult.status >= 200 && blossomResult.status < 300) {
+          await updateToSuccess(db, {
+            kind5_id: kind5.id,
+            target_event_id,
+            blob_sha256: sha256,
+            completed_at: new Date(now()).toISOString()
+          });
+          resultTargets.push({ target_event_id, status: 'success', blob_sha256: sha256 });
+          continue;
+        }
+
+        // Blossom returned non-2xx
+        const isTransient = blossomResult.status >= 500 || blossomResult.status === 429 || blossomResult.networkError;
+        const category = isTransient
+          ? (blossomResult.networkError ? 'failed:transient:network' : `failed:transient:blossom_${blossomResult.status === 429 ? '429' : '5xx'}`)
+          : `failed:permanent:blossom_${blossomResult.status}`;
+
+        await updateToFailed(db, {
+          kind5_id: kind5.id,
+          target_event_id,
+          status: category,
+          last_error: blossomResult.error || `Blossom returned ${blossomResult.status}`,
+          increment_retry: isTransient
+        });
+        resultTargets.push({ target_event_id, status: category, last_error: blossomResult.error, blob_sha256: sha256 });
+      }
+
+      return { targets: resultTargets };
+    }
+    ```
+
+- [ ] **Step 4: Run — happy path passes**
+
+    ```bash
+    npx vitest run src/creator-delete/process.test.mjs
+    ```
+
+    Expected: PASS.
+
+- [ ] **Step 5: Add failing tests for edge cases**
+
+    Append to `src/creator-delete/process.test.mjs`:
+
+    ```javascript
+      it('multi-target kind 5: processes each independently', async () => {
+        const kind5 = {
+          id: 'k1',
+          pubkey: 'pub1',
+          tags: [['e', 't1'], ['e', 't2']]
+        };
+        fetchTargetEvent
+          .mockResolvedValueOnce({ id: 't1', pubkey: 'pub1', tags: [['imeta', 'x aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa']] })
+          .mockResolvedValueOnce({ id: 't2', pubkey: 'pub1', tags: [['imeta', 'x bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb']] });
+        callBlossomDelete.mockResolvedValue({ ok: true, status: 200 });
+
+        const result = await processKind5(kind5, { db, fetchTargetEvent, callBlossomDelete });
+        expect(result.targets).toHaveLength(2);
+        expect(result.targets.map(t => t.status)).toEqual(['success', 'success']);
+      });
+
+      it('target_unresolved when Funnelcake returns null', async () => {
+        const kind5 = { id: 'k1', pubkey: 'pub1', tags: [['e', 't1']] };
+        fetchTargetEvent.mockResolvedValueOnce(null);
+        const result = await processKind5(kind5, { db, fetchTargetEvent, callBlossomDelete });
+        expect(result.targets[0].status).toBe('failed:permanent:target_unresolved');
+        expect(callBlossomDelete).not.toHaveBeenCalled();
+      });
+
+      it('no_sha256 when target event has no imeta', async () => {
+        const kind5 = { id: 'k1', pubkey: 'pub1', tags: [['e', 't1']] };
+        fetchTargetEvent.mockResolvedValueOnce({ id: 't1', pubkey: 'pub1', tags: [] });
+        const result = await processKind5(kind5, { db, fetchTargetEvent, callBlossomDelete });
+        expect(result.targets[0].status).toBe('failed:permanent:no_sha256');
+      });
+
+      it('transient failure on Blossom 503', async () => {
+        const kind5 = { id: 'k1', pubkey: 'pub1', tags: [['e', 't1']] };
+        fetchTargetEvent.mockResolvedValueOnce({ id: 't1', pubkey: 'pub1', tags: [['imeta', 'x abc']] });
+        callBlossomDelete.mockResolvedValueOnce({ ok: false, status: 503, error: 'service unavailable' });
+        const result = await processKind5(kind5, { db, fetchTargetEvent, callBlossomDelete });
+        expect(result.targets[0].status).toBe('failed:transient:blossom_5xx');
+      });
+
+      it('permanent failure on Blossom 400', async () => {
+        const kind5 = { id: 'k1', pubkey: 'pub1', tags: [['e', 't1']] };
+        fetchTargetEvent.mockResolvedValueOnce({ id: 't1', pubkey: 'pub1', tags: [['imeta', 'x abc']] });
+        callBlossomDelete.mockResolvedValueOnce({ ok: false, status: 400, error: 'bad request' });
+        const result = await processKind5(kind5, { db, fetchTargetEvent, callBlossomDelete });
+        expect(result.targets[0].status).toBe('failed:permanent:blossom_400');
+      });
+
+      it('skips when existing row is success (idempotent)', async () => {
+        const kind5 = { id: 'k1', pubkey: 'pub1', tags: [['e', 't1']] };
+        // Pre-populate D1 with a successful row
+        await db.prepare(
+          `INSERT INTO creator_deletions (kind5_id, target_event_id, creator_pubkey, status, accepted_at, blob_sha256)
+           VALUES (?, ?, ?, 'success', ?, ?)
+           ON CONFLICT(kind5_id, target_event_id) DO NOTHING`
+        ).bind('k1', 't1', 'pub1', new Date().toISOString(), 'abc').run();
+        const result = await processKind5(kind5, { db, fetchTargetEvent, callBlossomDelete });
+        expect(result.targets[0].status).toBe('success');
+        expect(callBlossomDelete).not.toHaveBeenCalled();
+        expect(fetchTargetEvent).not.toHaveBeenCalled();
+      });
+    ```
+
+- [ ] **Step 6: Run — all tests pass**
+
+    ```bash
+    npx vitest run src/creator-delete/process.test.mjs
+    ```
+
+    Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+    ```bash
+    git add src/creator-delete/process.mjs src/creator-delete/process.test.mjs
+    git commit -m "feat: add processKind5 shared function with race-safe D1 claim"
+    ```
+
+---
+
+## Task 5: Rate limiter
+
+Per-pubkey and per-IP request rate limiting via KV counters.
+
+**Files:**
+- Create: `src/creator-delete/rate-limit.mjs`
+- Create: `src/creator-delete/rate-limit.test.mjs`
+
+- [ ] **Step 1: Failing test — under limit**
+
+    Create `src/creator-delete/rate-limit.test.mjs`:
+
+    ```javascript
+    import { describe, it, expect, beforeEach } from 'vitest';
+    import { checkRateLimit } from './rate-limit.mjs';
+
+    function makeFakeKV() {
+      const store = new Map();
+      return {
+        async get(key) { return store.get(key) ?? null; },
+        async put(key, value) { store.set(key, value); },
+        async delete(key) { store.delete(key); }
+      };
+    }
+
+    describe('checkRateLimit', () => {
+      let kv;
+      beforeEach(() => { kv = makeFakeKV(); });
+
+      it('allows under the limit', async () => {
+        const result = await checkRateLimit(kv, { key: 'pubkey:abc', limit: 5, windowSeconds: 60 });
+        expect(result.allowed).toBe(true);
+        expect(result.remaining).toBe(4);
+      });
+
+      it('blocks over the limit', async () => {
+        for (let i = 0; i < 5; i++) {
+          await checkRateLimit(kv, { key: 'pubkey:abc', limit: 5, windowSeconds: 60 });
+        }
+        const result = await checkRateLimit(kv, { key: 'pubkey:abc', limit: 5, windowSeconds: 60 });
+        expect(result.allowed).toBe(false);
+        expect(result.remaining).toBe(0);
+      });
+    });
+    ```
+
+- [ ] **Step 2: Run — FAIL (module missing)**
+
+    ```bash
+    npx vitest run src/creator-delete/rate-limit.test.mjs
+    ```
+
+- [ ] **Step 3: Implement rate limiter**
+
+    Create `src/creator-delete/rate-limit.mjs`:
+
+    ```javascript
+    // ABOUTME: Simple KV-backed sliding window rate limiter for per-pubkey and per-IP limits.
+    // ABOUTME: Not perfectly accurate (no cross-region consistency) but sufficient for abuse prevention.
+
+    export async function checkRateLimit(kv, { key, limit, windowSeconds }) {
+      const now = Math.floor(Date.now() / 1000);
+      const bucket = Math.floor(now / windowSeconds);
+      const kvKey = `ratelimit:${key}:${bucket}`;
+      const current = parseInt((await kv.get(kvKey)) || '0', 10);
+
+      if (current >= limit) {
+        return { allowed: false, remaining: 0, retryAfterSeconds: windowSeconds - (now % windowSeconds) };
+      }
+
+      const next = current + 1;
+      await kv.put(kvKey, String(next), { expirationTtl: windowSeconds * 2 });
+      return { allowed: true, remaining: limit - next };
+    }
+
+    export function buildRateLimitKeys({ pubkey, clientIp }) {
+      return {
+        pubkeyKey: pubkey ? `pubkey:${pubkey}` : null,
+        ipKey: clientIp ? `ip:${clientIp}` : null
+      };
+    }
+    ```
+
+- [ ] **Step 4: Run — PASS**
+
+- [ ] **Step 5: Commit**
+
+    ```bash
+    git add src/creator-delete/rate-limit.mjs src/creator-delete/rate-limit.test.mjs
+    git commit -m "feat: add KV-backed rate limiter for creator-delete endpoints"
+    ```
+
+---
+
+## Task 6: Sync endpoint (`POST /api/delete/{kind5_id}`)
+
+Wraps NIP-98 validation, rate limiting, Funnelcake fetch with retries, `processKind5`, internal budget, and response formatting.
+
+**Files:**
+- Create: `src/creator-delete/sync-endpoint.mjs`
+- Create: `src/creator-delete/sync-endpoint.test.mjs`
+
+- [ ] **Step 1: Failing test — happy path**
+
+    Create `src/creator-delete/sync-endpoint.test.mjs`:
+
+    ```javascript
+    import { describe, it, expect, vi, beforeEach } from 'vitest';
+    import { generateSecretKey, getPublicKey, finalizeEvent } from 'nostr-tools/pure';
+    import { handleSyncDelete } from './sync-endpoint.mjs';
+
+    describe('handleSyncDelete', () => {
+      let sk, pk, deps;
+
+      beforeEach(() => {
+        sk = generateSecretKey();
+        pk = getPublicKey(sk);
+        deps = {
+          db: makeFakeD1(),
+          kv: makeFakeKV(),
+          fetchKind5WithRetry: vi.fn(),
+          fetchTargetEvent: vi.fn(),
+          callBlossomDelete: vi.fn(),
+          budgetMs: 8000
+        };
+      });
+
+      function signNip98(url, method) {
+        const event = finalizeEvent({
+          kind: 27235,
+          created_at: Math.floor(Date.now() / 1000),
+          tags: [['u', url], ['method', method]],
+          content: ''
+        }, sk);
+        return `Nostr ${btoa(JSON.stringify(event))}`;
+      }
+
+      it('returns 200 with success on happy path', async () => {
+        const kind5 = { id: 'k1', pubkey: pk, tags: [['e', 't1']] };
+        deps.fetchKind5WithRetry.mockResolvedValueOnce(kind5);
+        deps.fetchTargetEvent.mockResolvedValueOnce({ id: 't1', pubkey: pk, tags: [['imeta', 'x abc']] });
+        deps.callBlossomDelete.mockResolvedValueOnce({ ok: true, status: 200 });
+
+        const request = new Request('https://moderation-api.divine.video/api/delete/k1', {
+          method: 'POST',
+          headers: { 'Authorization': signNip98('https://moderation-api.divine.video/api/delete/k1', 'POST') }
+        });
+
+        const response = await handleSyncDelete(request, deps);
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(body).toMatchObject({ kind5_id: 'k1', status: 'success' });
+        expect(body.targets[0]).toMatchObject({ target_event_id: 't1', status: 'success', blob_sha256: 'abc' });
+      });
+    });
+
+    function makeFakeD1() { /* see d1.test.mjs */ }
+    function makeFakeKV() { /* see rate-limit.test.mjs */ }
+    ```
+
+- [ ] **Step 2: Run — FAIL**
+
+- [ ] **Step 3: Implement handler**
+
+    Create `src/creator-delete/sync-endpoint.mjs`:
+
+    ```javascript
+    // ABOUTME: POST /api/delete/{kind5_id} — synchronous creator-delete handler.
+    // ABOUTME: NIP-98 author-only auth; fetches kind 5 with read-after-write retries; runs processKind5 within budget.
+
+    import { validateNip98Header } from './nip98.mjs';
+    import { processKind5 } from './process.mjs';
+    import { checkRateLimit } from './rate-limit.mjs';
+
+    const PER_PUBKEY_LIMIT = 5;
+    const PER_IP_LIMIT = 30;
+    const RATE_WINDOW_SECONDS = 60;
+
+    export async function handleSyncDelete(request, deps) {
+      const { db, kv, fetchKind5WithRetry, fetchTargetEvent, callBlossomDelete, budgetMs = 8000 } = deps;
+
+      const url = new URL(request.url);
+      const kind5_id = url.pathname.split('/').pop();
+
+      if (!kind5_id || !/^[a-f0-9]{64}$/i.test(kind5_id)) {
+        return jsonResponse(400, { error: 'Invalid kind5_id' });
+      }
+
+      const auth = await validateNip98Header(request.headers.get('Authorization'), url.toString(), 'POST');
+      if (!auth.valid) {
+        return jsonResponse(401, { error: `NIP-98 validation failed: ${auth.error}` });
+      }
+
+      const clientIp = request.headers.get('CF-Connecting-IP') || 'unknown';
+      const ipCheck = await checkRateLimit(kv, { key: `ip:${clientIp}`, limit: PER_IP_LIMIT, windowSeconds: RATE_WINDOW_SECONDS });
+      const pubkeyCheck = await checkRateLimit(kv, { key: `pubkey:${auth.pubkey}`, limit: PER_PUBKEY_LIMIT, windowSeconds: RATE_WINDOW_SECONDS });
+      if (!ipCheck.allowed || !pubkeyCheck.allowed) {
+        return jsonResponse(429, {
+          error: 'Rate limit exceeded',
+          retry_after_seconds: Math.max(ipCheck.retryAfterSeconds || 0, pubkeyCheck.retryAfterSeconds || 0)
+        });
+      }
+
+      const kind5 = await fetchKind5WithRetry(kind5_id);
+      if (!kind5) {
+        return jsonResponse(404, { error: 'Kind 5 not found on Funnelcake after retries' });
+      }
+
+      if (kind5.pubkey !== auth.pubkey) {
+        return jsonResponse(403, { error: 'Caller pubkey does not match kind 5 author' });
+      }
+
+      const deadline = Date.now() + budgetMs;
+      const processing = processKind5(kind5, {
+        db,
+        fetchTargetEvent,
+        callBlossomDelete
+      });
+
+      const timeoutPromise = new Promise(resolve => setTimeout(() => resolve({ budgetExceeded: true }), budgetMs));
+      const raceResult = await Promise.race([processing, timeoutPromise]);
+
+      if (raceResult.budgetExceeded) {
+        return jsonResponse(202, {
+          kind5_id,
+          status: 'in_progress',
+          poll_url: `/api/delete-status/${kind5_id}`
+        });
+      }
+
+      const anyFailed = raceResult.targets.some(t => t.status.startsWith('failed:'));
+      const anyInProgress = raceResult.targets.some(t => t.status === 'in_progress');
+
+      if (anyInProgress && Date.now() < deadline) {
+        // One target still had an in-progress existing row. Return 202.
+        return jsonResponse(202, {
+          kind5_id,
+          status: 'in_progress',
+          poll_url: `/api/delete-status/${kind5_id}`
+        });
+      }
+
+      return jsonResponse(200, {
+        kind5_id,
+        status: anyFailed ? 'failed' : 'success',
+        targets: raceResult.targets
+      });
+    }
+
+    function jsonResponse(status, body) {
+      return new Response(JSON.stringify(body), {
+        status,
+        headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' }
+      });
+    }
+    ```
+
+- [ ] **Step 4: Run — happy path passes**
+
+- [ ] **Step 5: Add failing tests for each rejection/error path**
+
+    Append to the test file — tests for: 400 on malformed kind5_id, 401 on invalid NIP-98, 403 on pubkey mismatch, 404 on Funnelcake fetch failure, 429 on rate limit, 202 on budget exceeded.
+
+    ```javascript
+      it('returns 400 on malformed kind5_id', async () => {
+        const request = new Request('https://moderation-api.divine.video/api/delete/notahex', { method: 'POST', headers: { Authorization: signNip98('https://moderation-api.divine.video/api/delete/notahex', 'POST') } });
+        const response = await handleSyncDelete(request, deps);
+        expect(response.status).toBe(400);
+      });
+
+      it('returns 401 on missing NIP-98', async () => {
+        const request = new Request('https://moderation-api.divine.video/api/delete/' + 'a'.repeat(64), { method: 'POST' });
+        const response = await handleSyncDelete(request, deps);
+        expect(response.status).toBe(401);
+      });
+
+      it('returns 403 when caller pubkey does not match kind 5 author', async () => {
+        const otherSk = generateSecretKey();
+        const otherPk = getPublicKey(otherSk);
+        const kind5 = { id: 'a'.repeat(64), pubkey: otherPk, tags: [['e', 't1']] };
+        deps.fetchKind5WithRetry.mockResolvedValueOnce(kind5);
+
+        const url = 'https://moderation-api.divine.video/api/delete/' + 'a'.repeat(64);
+        const request = new Request(url, { method: 'POST', headers: { Authorization: signNip98(url, 'POST') } });
+        const response = await handleSyncDelete(request, deps);
+        expect(response.status).toBe(403);
+      });
+
+      it('returns 404 when Funnelcake fetch returns null after retries', async () => {
+        deps.fetchKind5WithRetry.mockResolvedValueOnce(null);
+        const url = 'https://moderation-api.divine.video/api/delete/' + 'a'.repeat(64);
+        const request = new Request(url, { method: 'POST', headers: { Authorization: signNip98(url, 'POST') } });
+        const response = await handleSyncDelete(request, deps);
+        expect(response.status).toBe(404);
+      });
+
+      it('returns 429 when per-pubkey limit exceeded', async () => {
+        const url = 'https://moderation-api.divine.video/api/delete/' + 'a'.repeat(64);
+        // Exhaust limit
+        for (let i = 0; i < PER_PUBKEY_LIMIT; i++) {
+          await checkRateLimit(deps.kv, { key: `pubkey:${pk}`, limit: PER_PUBKEY_LIMIT, windowSeconds: RATE_WINDOW_SECONDS });
+        }
+        const request = new Request(url, { method: 'POST', headers: { Authorization: signNip98(url, 'POST') } });
+        const response = await handleSyncDelete(request, deps);
+        expect(response.status).toBe(429);
+      });
+
+      it('returns 202 when internal budget exceeded', async () => {
+        const kind5 = { id: 'a'.repeat(64), pubkey: pk, tags: [['e', 't1']] };
+        deps.fetchKind5WithRetry.mockResolvedValueOnce(kind5);
+        deps.fetchTargetEvent.mockResolvedValueOnce({ id: 't1', pubkey: pk, tags: [['imeta', 'x abc']] });
+        // Blossom slow — never resolves within budget
+        deps.callBlossomDelete.mockReturnValueOnce(new Promise(() => {}));
+
+        const url = 'https://moderation-api.divine.video/api/delete/' + 'a'.repeat(64);
+        const request = new Request(url, { method: 'POST', headers: { Authorization: signNip98(url, 'POST') } });
+        const response = await handleSyncDelete(request, { ...deps, budgetMs: 50 });
+        expect(response.status).toBe(202);
+        const body = await response.json();
+        expect(body.status).toBe('in_progress');
+      });
+    ```
+
+    Import `checkRateLimit` and constants at the top of the test file.
+
+- [ ] **Step 6: Run — all pass**
+
+- [ ] **Step 7: Commit**
+
+    ```bash
+    git add src/creator-delete/sync-endpoint.mjs src/creator-delete/sync-endpoint.test.mjs
+    git commit -m "feat: add POST /api/delete/{kind5_id} synchronous endpoint"
+    ```
+
+---
+
+## Task 7: Status endpoint (`GET /api/delete-status/{kind5_id}`)
+
+NIP-98 author-only read of D1 rows for a given kind5_id.
+
+**Files:**
+- Create: `src/creator-delete/status-endpoint.mjs`
+- Create: `src/creator-delete/status-endpoint.test.mjs`
+
+- [ ] **Step 1: Failing test — happy path**
+
+    ```javascript
+    import { describe, it, expect, beforeEach } from 'vitest';
+    import { generateSecretKey, getPublicKey, finalizeEvent } from 'nostr-tools/pure';
+    import { handleStatusQuery } from './status-endpoint.mjs';
+
+    describe('handleStatusQuery', () => {
+      let sk, pk, deps;
+
+      beforeEach(() => {
+        sk = generateSecretKey();
+        pk = getPublicKey(sk);
+        deps = { db: makeFakeD1(), kv: makeFakeKV() };
+      });
+
+      function signNip98Get(url) {
+        const event = finalizeEvent({
+          kind: 27235,
+          created_at: Math.floor(Date.now() / 1000),
+          tags: [['u', url], ['method', 'GET']],
+          content: ''
+        }, sk);
+        return `Nostr ${btoa(JSON.stringify(event))}`;
+      }
+
+      it('returns 200 with target rows for the caller pubkey', async () => {
+        await deps.db.prepare(
+          `INSERT INTO creator_deletions (kind5_id, target_event_id, creator_pubkey, status, accepted_at, blob_sha256, completed_at)
+           VALUES (?, ?, ?, 'success', ?, 'abc', ?)
+           ON CONFLICT(kind5_id, target_event_id) DO NOTHING`
+        ).bind('k1', 't1', pk, new Date().toISOString(), new Date().toISOString()).run();
+
+        const url = 'https://moderation-api.divine.video/api/delete-status/k1';
+        const request = new Request(url, { method: 'GET', headers: { Authorization: signNip98Get(url) } });
+        const response = await handleStatusQuery(request, deps);
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(body.kind5_id).toBe('k1');
+        expect(body.targets[0]).toMatchObject({ target_event_id: 't1', status: 'success' });
+      });
+    });
+    ```
+
+- [ ] **Step 2: Run — FAIL**
+
+- [ ] **Step 3: Implement `handleStatusQuery`**
+
+    ```javascript
+    // ABOUTME: GET /api/delete-status/{kind5_id} — NIP-98 author-only status query.
+    // ABOUTME: Reads creator_deletions D1 rows for the kind5_id, enforces caller matches the rows' creator_pubkey.
+
+    import { validateNip98Header } from './nip98.mjs';
+    import { readAllTargetsForKind5 } from './d1.mjs';
+    import { checkRateLimit } from './rate-limit.mjs';
+
+    const PER_PUBKEY_LIMIT = 120; // 2/sec average
+    const RATE_WINDOW_SECONDS = 60;
+
+    export async function handleStatusQuery(request, deps) {
+      const { db, kv } = deps;
+      const url = new URL(request.url);
+      const kind5_id = url.pathname.split('/').pop();
+
+      if (!kind5_id) {
+        return jsonResponse(400, { error: 'Missing kind5_id' });
+      }
+
+      const auth = await validateNip98Header(request.headers.get('Authorization'), url.toString(), 'GET');
+      if (!auth.valid) {
+        return jsonResponse(401, { error: `NIP-98 validation failed: ${auth.error}` });
+      }
+
+      const pubkeyCheck = await checkRateLimit(kv, { key: `status:${auth.pubkey}`, limit: PER_PUBKEY_LIMIT, windowSeconds: RATE_WINDOW_SECONDS });
+      if (!pubkeyCheck.allowed) {
+        return jsonResponse(429, { error: 'Rate limit exceeded', retry_after_seconds: pubkeyCheck.retryAfterSeconds });
+      }
+
+      const rows = await readAllTargetsForKind5(db, { kind5_id });
+      if (rows.length === 0) {
+        return jsonResponse(404, { error: 'No processing record for this kind5_id' });
+      }
+
+      const notAuthoredByCaller = rows.find(r => r.creator_pubkey !== auth.pubkey);
+      if (notAuthoredByCaller) {
+        return jsonResponse(403, { error: 'Caller pubkey does not match kind 5 author' });
+      }
+
+      return jsonResponse(200, {
+        kind5_id,
+        targets: rows.map(r => ({
+          target_event_id: r.target_event_id,
+          blob_sha256: r.blob_sha256,
+          status: r.status,
+          accepted_at: r.accepted_at,
+          completed_at: r.completed_at,
+          last_error: r.last_error
+        }))
+      });
+    }
+
+    function jsonResponse(status, body) {
+      return new Response(JSON.stringify(body), {
+        status,
+        headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' }
+      });
+    }
+    ```
+
+- [ ] **Step 4: Run — happy path passes**
+
+- [ ] **Step 5: Add failing tests for rejection paths**
+
+    Append to `src/creator-delete/status-endpoint.test.mjs`:
+
+    ```javascript
+      it('returns 401 when Authorization header is missing', async () => {
+        const url = 'https://moderation-api.divine.video/api/delete-status/k1';
+        const response = await handleStatusQuery(new Request(url, { method: 'GET' }), deps);
+        expect(response.status).toBe(401);
+      });
+
+      it('returns 404 when no rows exist for the kind5_id', async () => {
+        const url = 'https://moderation-api.divine.video/api/delete-status/unknown';
+        const response = await handleStatusQuery(new Request(url, { method: 'GET', headers: { Authorization: signNip98Get(url) } }), deps);
+        expect(response.status).toBe(404);
+      });
+
+      it('returns 403 when caller pubkey does not match row creator_pubkey', async () => {
+        const otherSk = generateSecretKey();
+        const otherPk = getPublicKey(otherSk);
+        await deps.db.prepare(
+          `INSERT INTO creator_deletions (kind5_id, target_event_id, creator_pubkey, status, accepted_at)
+           VALUES (?, ?, ?, 'success', ?)
+           ON CONFLICT(kind5_id, target_event_id) DO NOTHING`
+        ).bind('k2', 't1', otherPk, new Date().toISOString()).run();
+
+        const url = 'https://moderation-api.divine.video/api/delete-status/k2';
+        const response = await handleStatusQuery(new Request(url, { method: 'GET', headers: { Authorization: signNip98Get(url) } }), deps);
+        expect(response.status).toBe(403);
+      });
+
+      it('returns 429 when per-pubkey rate limit exceeded', async () => {
+        for (let i = 0; i < 120; i++) {
+          await checkRateLimit(deps.kv, { key: `status:${pk}`, limit: 120, windowSeconds: 60 });
+        }
+        const url = 'https://moderation-api.divine.video/api/delete-status/k1';
+        const response = await handleStatusQuery(new Request(url, { method: 'GET', headers: { Authorization: signNip98Get(url) } }), deps);
+        expect(response.status).toBe(429);
+      });
+    ```
+
+    Add `import { checkRateLimit } from './rate-limit.mjs'` at the top of the test file.
+
+- [ ] **Step 6: Run — all pass**
+
+- [ ] **Step 7: Commit**
+
+    ```bash
+    git add src/creator-delete/status-endpoint.mjs src/creator-delete/status-endpoint.test.mjs
+    git commit -m "feat: add GET /api/delete-status/{kind5_id} with NIP-98 auth"
+    ```
+
+---
+
+## Task 8: Funnelcake fetch helper with read-after-write retry
+
+Thin wrapper over existing `fetchNostrEventById` with retry schedule 0ms, 100ms, 500ms, 1s, 2s.
+
+**Files:**
+- Create: `src/creator-delete/funnelcake-fetch.mjs`
+- Create: `src/creator-delete/funnelcake-fetch.test.mjs`
+
+- [ ] **Step 1: Failing test — retries until success**
+
+    ```javascript
+    import { describe, it, expect, vi } from 'vitest';
+    import { fetchKind5WithRetry } from './funnelcake-fetch.mjs';
+
+    describe('fetchKind5WithRetry', () => {
+      it('returns event after two nulls then success', async () => {
+        const underlying = vi.fn()
+          .mockResolvedValueOnce(null)
+          .mockResolvedValueOnce(null)
+          .mockResolvedValueOnce({ id: 'k1', kind: 5 });
+        const result = await fetchKind5WithRetry('k1', { fetchEventById: underlying, retryDelaysMs: [0, 10, 20] });
+        expect(result).toEqual({ id: 'k1', kind: 5 });
+        expect(underlying).toHaveBeenCalledTimes(3);
+      });
+
+      it('returns null if all retries return null', async () => {
+        const underlying = vi.fn().mockResolvedValue(null);
+        const result = await fetchKind5WithRetry('k1', { fetchEventById: underlying, retryDelaysMs: [0, 10] });
+        expect(result).toBeNull();
+        expect(underlying).toHaveBeenCalledTimes(2);
+      });
+    });
+    ```
+
+- [ ] **Step 2: Run — FAIL**
+
+- [ ] **Step 3: Implement**
+
+    ```javascript
+    // ABOUTME: Funnelcake kind 5 fetch with read-after-write retry.
+    // ABOUTME: Handles the window between Funnelcake accept (NIP-01 OK) and async ClickHouse write.
+
+    const DEFAULT_RETRY_DELAYS_MS = [0, 100, 500, 1000, 2000];
+
+    export async function fetchKind5WithRetry(kind5_id, { fetchEventById, retryDelaysMs = DEFAULT_RETRY_DELAYS_MS } = {}) {
+      for (const delay of retryDelaysMs) {
+        if (delay > 0) await new Promise(r => setTimeout(r, delay));
+        const event = await fetchEventById(kind5_id);
+        if (event) return event;
+      }
+      return null;
+    }
+    ```
+
+- [ ] **Step 4: Run — passes**
+
+- [ ] **Step 5: Commit**
+
+    ```bash
+    git add src/creator-delete/funnelcake-fetch.mjs src/creator-delete/funnelcake-fetch.test.mjs
+    git commit -m "feat: add Funnelcake kind 5 fetch with read-after-write retry"
+    ```
+
+---
+
+## Task 9: Blossom DELETE call wrapper
+
+Thin wrapper that calls Blossom's `/admin/api/moderate` with `action: "DELETE"` and the existing `webhook_secret` Bearer.
+
+**Files:**
+- Create: `src/creator-delete/blossom-client.mjs`
+- Create: `src/creator-delete/blossom-client.test.mjs`
+
+- [ ] **Step 1: Failing test — happy path**
+
+    ```javascript
+    import { describe, it, expect, vi } from 'vitest';
+    import { callBlossomDelete } from './blossom-client.mjs';
+
+    describe('callBlossomDelete', () => {
+      it('POSTs to /admin/api/moderate with action DELETE and Bearer', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({ success: true }), { status: 200 }));
+        const result = await callBlossomDelete('abc123', {
+          adminUrl: 'https://media.divine.video',
+          webhookSecret: 'secret-value',
+          fetchFn: fetchMock
+        });
+        expect(fetchMock).toHaveBeenCalledWith(
+          'https://media.divine.video/admin/api/moderate',
+          expect.objectContaining({
+            method: 'POST',
+            headers: expect.objectContaining({ 'Authorization': 'Bearer secret-value' }),
+            body: JSON.stringify({ sha256: 'abc123', action: 'DELETE' })
+          })
+        );
+        expect(result).toMatchObject({ ok: true, status: 200 });
+      });
+
+      it('returns networkError: true when fetch throws', async () => {
+        const fetchMock = vi.fn().mockRejectedValue(new Error('connection reset'));
+        const result = await callBlossomDelete('abc', { adminUrl: 'https://x', webhookSecret: 's', fetchFn: fetchMock });
+        expect(result).toMatchObject({ ok: false, networkError: true });
+      });
+    });
+    ```
+
+- [ ] **Step 2: Run — FAIL**
+
+- [ ] **Step 3: Implement**
+
+    ```javascript
+    // ABOUTME: Wrapper around Blossom's /admin/api/moderate endpoint for DELETE actions.
+    // ABOUTME: Returns { ok, status, error?, networkError? } for consumption by processKind5.
+
+    export async function callBlossomDelete(sha256, { adminUrl, webhookSecret, fetchFn = fetch }) {
+      let response;
+      try {
+        response = await fetchFn(`${adminUrl}/admin/api/moderate`, {
+          method: 'POST',
+          headers: {
+            'Authorization': `Bearer ${webhookSecret}`,
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({ sha256, action: 'DELETE' })
+        });
+      } catch (e) {
+        return { ok: false, networkError: true, error: e.message };
+      }
+
+      if (response.ok) {
+        return { ok: true, status: response.status };
+      }
+
+      let errorBody;
+      try { errorBody = await response.text(); } catch (e) { errorBody = '(failed to read body)'; }
+
+      return { ok: false, status: response.status, error: errorBody };
+    }
+    ```
+
+- [ ] **Step 4: Run — passes**
+
+- [ ] **Step 5: Commit**
+
+    ```bash
+    git add src/creator-delete/blossom-client.mjs src/creator-delete/blossom-client.test.mjs
+    git commit -m "feat: add Blossom DELETE action client"
+    ```
+
+---
+
+## Task 10: Cron trigger for kind 5 processing
+
+Every-minute cron: REQ Funnelcake for kind 5 events since last poll; call `processKind5` for each. Also retries `failed:transient:*` rows with `retry_count < 5`.
+
+**Files:**
+- Create: `src/creator-delete/cron.mjs`
+- Create: `src/creator-delete/cron.test.mjs`
+
+- [ ] **Step 1: Failing test — happy path**
+
+    ```javascript
+    import { describe, it, expect, vi, beforeEach } from 'vitest';
+    import { runCreatorDeleteCron } from './cron.mjs';
+
+    describe('runCreatorDeleteCron', () => {
+      let deps;
+      beforeEach(() => {
+        deps = {
+          db: makeFakeD1(),
+          kv: makeFakeKV(),
+          queryKind5Since: vi.fn(),
+          fetchTargetEvent: vi.fn(),
+          callBlossomDelete: vi.fn(),
+          now: () => 1700000000000
+        };
+      });
+
+      it('queries Funnelcake from last poll, processes each event, updates last poll', async () => {
+        await deps.kv.put('creator-delete-cron:last-poll', String(1700000000000 - 60_000));
+        deps.queryKind5Since.mockResolvedValueOnce([
+          { id: 'k1', pubkey: 'pub1', tags: [['e', 't1']] }
+        ]);
+        deps.fetchTargetEvent.mockResolvedValueOnce({ id: 't1', pubkey: 'pub1', tags: [['imeta', 'x abc']] });
+        deps.callBlossomDelete.mockResolvedValueOnce({ ok: true, status: 200 });
+
+        const result = await runCreatorDeleteCron(deps);
+        expect(deps.queryKind5Since).toHaveBeenCalled();
+        expect(result.processed).toBe(1);
+        const lastPoll = await deps.kv.get('creator-delete-cron:last-poll');
+        expect(Number(lastPoll)).toBe(1700000000000);
+      });
+    });
+    ```
+
+- [ ] **Step 2: Run — FAIL**
+
+- [ ] **Step 3: Implement**
+
+    ```javascript
+    // ABOUTME: Cron work for creator-delete pipeline — pulls kind 5 from Funnelcake, retries transient failures.
+
+    import { processKind5 } from './process.mjs';
+
+    const LAST_POLL_KEY = 'creator-delete-cron:last-poll';
+    const DEFAULT_LOOKBACK_SECONDS = 3600; // first run
+    const MAX_RETRY_COUNT = 5;
+
+    export async function runCreatorDeleteCron(deps) {
+      const { db, kv, queryKind5Since, fetchTargetEvent, callBlossomDelete, now = () => Date.now() } = deps;
+      const nowMs = now();
+
+      const lastPollRaw = await kv.get(LAST_POLL_KEY);
+      const lastPollMs = lastPollRaw ? Number(lastPollRaw) : nowMs - (DEFAULT_LOOKBACK_SECONDS * 1000);
+      const sinceSeconds = Math.floor(lastPollMs / 1000);
+
+      let processed = 0;
+      const errors = [];
+
+      try {
+        const events = await queryKind5Since(sinceSeconds);
+        for (const kind5 of events) {
+          try {
+            await processKind5(kind5, { db, fetchTargetEvent, callBlossomDelete });
+            processed++;
+          } catch (e) {
+            errors.push({ kind5_id: kind5.id, error: e.message });
+          }
+        }
+      } catch (e) {
+        errors.push({ stage: 'query', error: e.message });
+      }
+
+      // Retry failed:transient rows
+      const transientRows = await db.prepare(
+        `SELECT kind5_id, target_event_id, creator_pubkey, status, retry_count, accepted_at
+         FROM creator_deletions
+         WHERE status LIKE 'failed:transient:%' AND retry_count < ?`
+      ).bind(MAX_RETRY_COUNT).all();
+
+      for (const row of (transientRows.results || [])) {
+        try {
+          const kind5 = { id: row.kind5_id, pubkey: row.creator_pubkey, tags: [['e', row.target_event_id]] };
+          await processKind5(kind5, { db, fetchTargetEvent, callBlossomDelete });
+          processed++;
+        } catch (e) {
+          errors.push({ kind5_id: row.kind5_id, stage: 'retry', error: e.message });
+        }
+      }
+
+      await kv.put(LAST_POLL_KEY, String(nowMs));
+
+      return { processed, errors };
+    }
+
+    export { LAST_POLL_KEY };
+    ```
+
+- [ ] **Step 4: Run — passes**
+
+- [ ] **Step 5: Add test for transient retry**
+
+    ```javascript
+      it('retries failed:transient rows with retry_count < 5', async () => {
+        await deps.db.prepare(
+          `INSERT INTO creator_deletions (kind5_id, target_event_id, creator_pubkey, status, accepted_at, retry_count)
+           VALUES (?, ?, ?, 'failed:transient:blossom_5xx', ?, 2)
+           ON CONFLICT(kind5_id, target_event_id) DO NOTHING`
+        ).bind('k1', 't1', 'pub1', new Date(Date.now() - 60_000).toISOString(), 2).run();
+
+        await deps.kv.put('creator-delete-cron:last-poll', String(Date.now() - 30_000));
+        deps.queryKind5Since.mockResolvedValueOnce([]); // no new events
+        deps.fetchTargetEvent.mockResolvedValueOnce({ id: 't1', pubkey: 'pub1', tags: [['imeta', 'x abc']] });
+        deps.callBlossomDelete.mockResolvedValueOnce({ ok: true, status: 200 });
+
+        const result = await runCreatorDeleteCron(deps);
+        expect(deps.callBlossomDelete).toHaveBeenCalledWith('abc');
+        expect(result.processed).toBeGreaterThanOrEqual(1);
+      });
+    ```
+
+- [ ] **Step 6: Run — all pass**
+
+- [ ] **Step 7: Commit**
+
+    ```bash
+    git add src/creator-delete/cron.mjs src/creator-delete/cron.test.mjs
+    git commit -m "feat: add creator-delete cron for kind 5 polling and transient retry"
+    ```
+
+---
+
+## Task 11: Wire routes and cron into index.mjs and wrangler.toml
+
+**Files:**
+- Modify: `wrangler.toml`
+- Modify: `src/index.mjs`
+
+- [ ] **Step 1: Update wrangler.toml cron schedule**
+
+    Replace the existing:
+    ```toml
+    [triggers]
+    crons = ["*/5 * * * *"]
+    ```
+    with:
+    ```toml
+    [triggers]
+    crons = ["* * * * *", "*/5 * * * *"]
+    ```
+
+- [ ] **Step 2: Verify new cron accepted by wrangler dry-run**
+
+    ```bash
+    npx wrangler deploy --dry-run --env staging
+    ```
+    Expected: success, no errors on cron config.
+
+- [ ] **Step 3: Wire routes into `src/index.mjs`**
+
+    Add imports near the top of `src/index.mjs`:
+
+    ```javascript
+    import { handleSyncDelete } from './creator-delete/sync-endpoint.mjs';
+    import { handleStatusQuery } from './creator-delete/status-endpoint.mjs';
+    import { runCreatorDeleteCron } from './creator-delete/cron.mjs';
+    import { fetchKind5WithRetry } from './creator-delete/funnelcake-fetch.mjs';
+    import { callBlossomDelete as blossomDelete } from './creator-delete/blossom-client.mjs';
+    ```
+
+    In the fetch handler, add (find the API_HOSTNAME routing block):
+
+    ```javascript
+    // Creator-delete endpoints
+    if (url.hostname === API_HOSTNAME) {
+      if (url.pathname.startsWith('/api/delete/') && request.method === 'POST') {
+        return handleSyncDelete(request, {
+          db: env.BLOSSOM_DB,
+          kv: env.MODERATION_KV,
+          fetchKind5WithRetry: (id) => fetchKind5WithRetry(id, {
+            fetchEventById: (eid) => fetchNostrEventById(eid, [env.CREATOR_DELETE_RELAY_URL || 'wss://relay.divine.video'], env)
+          }),
+          fetchTargetEvent: (eid) => fetchNostrEventById(eid, [env.CREATOR_DELETE_RELAY_URL || 'wss://relay.divine.video'], env),
+          callBlossomDelete: (sha256) => blossomDelete(sha256, {
+            adminUrl: env.BLOSSOM_ADMIN_URL,
+            webhookSecret: env.BLOSSOM_WEBHOOK_SECRET
+          })
+        });
+      }
+
+      if (url.pathname.startsWith('/api/delete-status/') && request.method === 'GET') {
+        return handleStatusQuery(request, {
+          db: env.BLOSSOM_DB,
+          kv: env.MODERATION_KV
+        });
+      }
+    }
+    ```
+
+    Note: `fetchNostrEventById` and `fetchKind5EventsSince` are added to `relay-client.mjs` in Step 5 below. Both are required by the route handlers being wired here.
+
+- [ ] **Step 4: Wire cron dispatch**
+
+    In the existing `scheduled(event, env, ctx)` handler (around line 5009 of index.mjs), add a branch based on `event.cron`:
+
+    ```javascript
+    async scheduled(event, env, ctx) {
+      if (event.cron === '* * * * *') {
+        // Every-minute: creator-delete pipeline
+        try {
+          const result = await runCreatorDeleteCron({
+            db: env.BLOSSOM_DB,
+            kv: env.MODERATION_KV,
+            queryKind5Since: async (sinceSeconds) => {
+              // Use existing relay-client.mjs REQ helper
+              return await fetchKind5EventsSince(sinceSeconds, env.CREATOR_DELETE_RELAY_URL || 'wss://relay.divine.video', env);
+            },
+            fetchTargetEvent: (eid) => fetchNostrEventById(eid, [env.CREATOR_DELETE_RELAY_URL || 'wss://relay.divine.video'], env),
+            callBlossomDelete: (sha256) => blossomDelete(sha256, {
+              adminUrl: env.BLOSSOM_ADMIN_URL,
+              webhookSecret: env.BLOSSOM_WEBHOOK_SECRET
+            })
+          });
+          console.log(`[CREATOR-DELETE-CRON] Processed ${result.processed}, errors: ${result.errors.length}`);
+        } catch (e) {
+          console.error('[CREATOR-DELETE-CRON] failed:', e);
+        }
+        return;
+      }
+
+      if (event.cron === '*/5 * * * *') {
+        // Existing 5-minute relay poller — preserve existing behavior below
+        // ... existing scheduled() body ...
+      }
+    }
+    ```
+
+    Restructure the existing scheduled() body to be under the `'*/5 * * * *'` branch rather than unconditional.
+
+- [ ] **Step 5: Add `fetchKind5EventsSince` and `fetchNostrEventById` to `src/nostr/relay-client.mjs`**
+
+    Both are new; they extend the existing WebSocket REQ pattern in `queryRelay`. Add failing tests first in `src/nostr/relay-client.test.mjs`:
+
+    ```javascript
+    it('fetchKind5EventsSince returns all kind 5 events for the since filter', async () => {
+      // Mock the WebSocket or use a fake relay — follow whichever pattern the existing tests use.
+      // Assert that the returned filter matches {kinds: [5], since: <provided>}.
+      // Assert the return value is an array of events.
+    });
+
+    it('fetchNostrEventById returns a single event by id or null', async () => {
+      // Similar: mock relay, assert filter {ids: [<id>], limit: 1}, assert return shape.
+    });
+    ```
+
+    Then implement the two exports in `relay-client.mjs`, using `queryRelay` with `collectAll: true` for the kind 5 variant (returns all events until EOSE) and the default behavior for the by-id variant (single event).
+
+    ```javascript
+    export async function fetchKind5EventsSince(sinceSeconds, relayUrl = 'wss://relay.divine.video', env = {}) {
+      return queryRelay(relayUrl, { kinds: [5], since: sinceSeconds }, env, { collectAll: true });
+    }
+
+    export async function fetchNostrEventById(eventId, relays = ['wss://relay.divine.video'], env = {}) {
+      for (const relayUrl of relays) {
+        const event = await queryRelay(relayUrl, { ids: [eventId], limit: 1 }, env);
+        if (event) return event;
+      }
+      return null;
+    }
+    ```
+
+    Run tests; confirm pass.
+
+- [ ] **Step 6: Local dev sanity check**
+
+    ```bash
+    npx wrangler dev
+    # In another terminal:
+    curl -v http://localhost:8787/api/delete-status/abc -H 'Host: moderation-api.divine.video'
+    # Expected: 401 (NIP-98 required)
+    ```
+
+- [ ] **Step 7: Commit**
+
+    ```bash
+    git add wrangler.toml src/index.mjs src/nostr/relay-client.mjs src/nostr/relay-client.test.mjs
+    git commit -m "feat: wire creator-delete routes and cron into worker"
+    ```
+
+---
+
+## Task 12: Observability (Sentry alerts and metrics)
+
+**Files:**
+- Modify: `src/creator-delete/process.mjs` — add structured logs
+- Modify: `src/creator-delete/sync-endpoint.mjs` — add request timing
+- Modify: `src/creator-delete/cron.mjs` — add per-trigger-path lag measurement
+- Modify: `src/index.mjs` — register Sentry alerts (or add deployment documentation for Sentry UI config)
+
+- [ ] **Step 1: Structured logs in `process.mjs`**
+
+    Wrap the main steps with console.log emitting JSON objects compatible with Sentry/logtail:
+
+    ```javascript
+    console.log(JSON.stringify({
+      event: 'creator_delete.accepted',
+      kind5_id,
+      target_event_id,
+      creator_pubkey,
+      accepted_at: acceptedIso,
+      trigger: deps.triggerLabel || 'unknown'
+    }));
+    ```
+
+    Emit similar events for `creator_delete.success`, `creator_delete.failed` with status field.
+
+- [ ] **Step 2: Sync endpoint timing**
+
+    Wrap handler with `const t0 = Date.now()`, emit `creator_delete.sync.latency_ms` at response time.
+
+- [ ] **Step 3: Cron lag**
+
+    In cron, for each processed kind 5, emit `creator_delete.cron.lag_seconds = now - kind5.created_at`.
+
+- [ ] **Step 4: Sentry alerts (deployment-time config)**
+
+    Document in the PR description the Sentry UI alert rules to configure:
+    - Sync endpoint p95 latency > 10s over 15m
+    - Sync endpoint 5xx rate > 2% over 15m
+    - Cron lag p95 > 120s
+    - `creator_delete.permanent_failure` count > 0 in the last hour
+
+- [ ] **Step 5: Commit**
+
+    ```bash
+    git add src/creator-delete/*.mjs src/index.mjs
+    git commit -m "feat: add structured logs for creator-delete observability"
+    ```
+
+---
+
+## Task 13: Staging deploy and end-to-end validation
+
+- [ ] **Step 1: Deploy to staging**
+
+    ```bash
+    npx wrangler deploy --env staging
+    ```
+    Expected: deploy success, routes active.
+
+- [ ] **Step 2: Log deploy**
+
+    ```bash
+    scripts/log-deploy.sh divine-moderation-service staging spec/per-video-delete-enforcement "creator-delete v1 staging"
+    ```
+
+- [ ] **Step 3: Run staging e2e: sync endpoint happy path**
+
+    Using a test account's nsec, publish a kind 5 to staging Funnelcake deleting a test video. Immediately call the sync endpoint:
+
+    ```bash
+    # Script: scripts/test-creator-delete.mjs (create as part of this task)
+    # Signs NIP-98, calls sync endpoint, asserts 200 + success
+    node scripts/test-creator-delete.mjs --env staging --kind5-id <id> --nsec <test-nsec>
+    ```
+
+    Expected: 200 with status `success`, D1 row present with status `success`.
+
+- [ ] **Step 4: Verify Blossom-side effect (flag off)**
+
+    Confirm the target blob shows `Deleted` status in Blossom admin UI and serves 404 on the main URL and thumbnail. With `ENABLE_PHYSICAL_DELETE=false` (staging default), GCS bytes should remain.
+
+- [ ] **Step 5: Run staging e2e: cron path**
+
+    Publish a kind 5 to staging Funnelcake WITHOUT calling the sync endpoint. Wait up to 90 seconds. Confirm D1 shows a row with `status: success` and Blossom shows `Deleted`.
+
+- [ ] **Step 6: Run staging e2e: race test**
+
+    Publish a kind 5. Immediately (within 100ms of NIP-01 OK) call the sync endpoint. Assert 200 success without 404 or 202 (retry logic handled the Funnelcake read-after-write race).
+
+- [ ] **Step 7: Record staging validation results in the PR**
+
+    Comment on PR #92 with a summary: preflight results, e2e test results, any observed p95 lag numbers from the staging logs.
+
+- [ ] **Step 8: Commit test script**
+
+    ```bash
+    git add scripts/test-creator-delete.mjs
+    git commit -m "test: add creator-delete staging e2e script"
+    ```
+
+---
+
+## Task 14: Prepare for production
+
+- [ ] **Step 1: Ensure Blossom DELETE PR has landed in prod and flag is off**
+
+    Check `media.divine.video/admin/api/moderate` accepts `action: "DELETE"` with the flag default-off. If not, pause production rollout until Blossom PR lands.
+
+- [ ] **Step 2: Deploy moderation-service to prod with flag off path**
+
+    The moderation-service has no `ENABLE_PHYSICAL_DELETE` flag of its own. Rollout depends on Blossom's flag state.
+
+    ```bash
+    npx wrangler deploy --env production
+    scripts/log-deploy.sh divine-moderation-service production main "creator-delete v1 prod (flag off)"
+    ```
+
+- [ ] **Step 3: Validation window**
+
+    Over the next 1 week (or the first 50 creator deletes in production, whichever comes first), monitor:
+    - D1 `creator_deletions` rows
+    - Sentry alerts for sync latency, cron lag, Blossom failure rate, permanent failures
+    - Blossom dashboard for Deleted blob count + bytes_still_present count
+
+    Confirm pipeline selects the right sha256s (no wrong-blob deletions in the sample). If all green, proceed.
+
+- [ ] **Step 4: Flip the Blossom flag**
+
+    Separately from moderation-service, flip `ENABLE_PHYSICAL_DELETE=true` in Blossom's prod config. Run Blossom's one-time sweep over historical `Deleted` blobs to physically remove their bytes.
+
+- [ ] **Step 5: Confirm physical byte removal**
+
+    Next production delete after flag flip should show both Blossom `Deleted` and GCS bytes gone (verify via Blossom admin). Monitor for failures.
+
+---
+
+## Self-Review checklist
+
+After the plan is written, run through:
+
+**Spec coverage:**
+- [x] Subscriber worker (now "Delete processing pipeline") — Tasks 2-10
+- [x] D1 audit table — Task 1
+- [x] Status endpoint — Task 7
+- [x] Mobile polling — out of scope for this plan (separate divine-mobile plan)
+- [x] Blossom DELETE action — out of scope (separate divine-blossom plan)
+- [x] Vocab doc update — out of scope (trivial, handled with Blossom PR)
+- [x] Failure handling matrix — covered in process + sync endpoint + cron
+- [x] Observability — Task 12
+- [x] Security (NIP-98) — Task 2, applied in Tasks 6 and 7
+- [x] Testing — tests in every task, e2e in Task 13
+- [x] Dependencies and sequencing — Task 14
+- [x] Staging preflight — covered in Preflight section
+
+**Placeholder scan:** No TODOs, no "implement later", no "similar to Task N". Every code step has the code.
+
+**Type consistency:** Function names across tasks (`processKind5`, `claimRow`, `decideAction`, `validateNip98Header`, `callBlossomDelete`, `fetchKind5WithRetry`) match across all tasks they appear in.
+
+---
+
+## Execution handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-16-per-video-delete-enforcement-plan.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — dispatch a fresh subagent per task, review between tasks, fast iteration.
+
+**2. Inline Execution** — execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+Which approach?

--- a/docs/superpowers/plans/2026-04-16-per-video-delete-enforcement-plan.md
+++ b/docs/superpowers/plans/2026-04-16-per-video-delete-enforcement-plan.md
@@ -944,12 +944,20 @@ The shared function called by both the sync endpoint and the cron. Given a fetch
 
       it('skips when existing row is success (idempotent)', async () => {
         const kind5 = { id: 'k1', pubkey: 'pub1', tags: [['e', 't1']] };
-        // Pre-populate D1 with a successful row
-        await db.prepare(
-          `INSERT INTO creator_deletions (kind5_id, target_event_id, creator_pubkey, status, accepted_at, blob_sha256)
-           VALUES (?, ?, ?, 'success', ?, ?)
-           ON CONFLICT(kind5_id, target_event_id) DO NOTHING`
-        ).bind('k1', 't1', 'pub1', new Date().toISOString(), 'abc').run();
+        // Pre-seed D1 directly — bypass the fake's INSERT path, which is tailored to
+        // claimRow's 4-arg bind with an inlined 'accepted' status literal. A direct
+        // rows.set() lets this test simulate a pre-existing terminal row.
+        db.rows.set('k1:t1', {
+          kind5_id: 'k1',
+          target_event_id: 't1',
+          creator_pubkey: 'pub1',
+          status: 'success',
+          accepted_at: new Date().toISOString(),
+          blob_sha256: SHA_C,
+          retry_count: 0,
+          last_error: null,
+          completed_at: new Date().toISOString()
+        });
         const result = await processKind5(kind5, { db, fetchTargetEvent, callBlossomDelete });
         expect(result.targets[0].status).toBe('success');
         expect(callBlossomDelete).not.toHaveBeenCalled();

--- a/docs/superpowers/plans/2026-04-16-per-video-delete-enforcement-plan.md
+++ b/docs/superpowers/plans/2026-04-16-per-video-delete-enforcement-plan.md
@@ -691,6 +691,8 @@ Race-safe claim-or-inspect logic that multiple concurrent invocations can call s
 
 The shared function called by both the sync endpoint and the cron. Given a fetched kind 5 event, processes each target independently.
 
+**Execution order dependency:** This task depends on Task 9 (extracted `notifyBlossom`). Complete Task 9 first. The `callBlossomDelete` dependency injected into `processKind5` will be wired at integration time to `(sha256) => notifyBlossom(sha256, 'DELETE', env)` (see Task 11). Mocks and implementation below assume the `notifyBlossom` return shape: `{ success: boolean, status?: number, error?: string, networkError?: boolean, skipped?: boolean }`.
+
 **Files:**
 - Create: `src/creator-delete/process.mjs`
 - Create: `src/creator-delete/process.test.mjs`
@@ -723,7 +725,7 @@ The shared function called by both the sync endpoint and the cron. Given a fetch
           pubkey: 'pub1',
           tags: [['imeta', 'url https://media.divine.video/abc.mp4', 'x abc']]
         });
-        callBlossomDelete.mockResolvedValueOnce({ ok: true, status: 200 });
+        callBlossomDelete.mockResolvedValueOnce({ success: true, status: 200 });
 
         const result = await processKind5(kind5, {
           db,
@@ -838,7 +840,7 @@ The shared function called by both the sync endpoint and the cron. Given a fetch
         }
 
         const blossomResult = await callBlossomDelete(sha256);
-        if (blossomResult.ok && blossomResult.status >= 200 && blossomResult.status < 300) {
+        if (blossomResult.success && !blossomResult.skipped) {
           await updateToSuccess(db, {
             kind5_id: kind5.id,
             target_event_id,
@@ -849,11 +851,12 @@ The shared function called by both the sync endpoint and the cron. Given a fetch
           continue;
         }
 
-        // Blossom returned non-2xx
-        const isTransient = blossomResult.status >= 500 || blossomResult.status === 429 || blossomResult.networkError;
+        // Blossom failed or skipped
+        const status = blossomResult.status;
+        const isTransient = blossomResult.networkError || (status !== undefined && (status >= 500 || status === 429));
         const category = isTransient
-          ? (blossomResult.networkError ? 'failed:transient:network' : `failed:transient:blossom_${blossomResult.status === 429 ? '429' : '5xx'}`)
-          : `failed:permanent:blossom_${blossomResult.status}`;
+          ? (blossomResult.networkError ? 'failed:transient:network' : `failed:transient:blossom_${status === 429 ? '429' : '5xx'}`)
+          : (status !== undefined ? `failed:permanent:blossom_${status}` : 'failed:permanent:blossom_skipped');
 
         await updateToFailed(db, {
           kind5_id: kind5.id,
@@ -891,7 +894,7 @@ The shared function called by both the sync endpoint and the cron. Given a fetch
         fetchTargetEvent
           .mockResolvedValueOnce({ id: 't1', pubkey: 'pub1', tags: [['imeta', 'x aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa']] })
           .mockResolvedValueOnce({ id: 't2', pubkey: 'pub1', tags: [['imeta', 'x bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb']] });
-        callBlossomDelete.mockResolvedValue({ ok: true, status: 200 });
+        callBlossomDelete.mockResolvedValue({ success: true, status: 200 });
 
         const result = await processKind5(kind5, { db, fetchTargetEvent, callBlossomDelete });
         expect(result.targets).toHaveLength(2);
@@ -916,7 +919,7 @@ The shared function called by both the sync endpoint and the cron. Given a fetch
       it('transient failure on Blossom 503', async () => {
         const kind5 = { id: 'k1', pubkey: 'pub1', tags: [['e', 't1']] };
         fetchTargetEvent.mockResolvedValueOnce({ id: 't1', pubkey: 'pub1', tags: [['imeta', 'x abc']] });
-        callBlossomDelete.mockResolvedValueOnce({ ok: false, status: 503, error: 'service unavailable' });
+        callBlossomDelete.mockResolvedValueOnce({ success: false, status: 503, error: 'HTTP 503: service unavailable' });
         const result = await processKind5(kind5, { db, fetchTargetEvent, callBlossomDelete });
         expect(result.targets[0].status).toBe('failed:transient:blossom_5xx');
       });
@@ -924,9 +927,17 @@ The shared function called by both the sync endpoint and the cron. Given a fetch
       it('permanent failure on Blossom 400', async () => {
         const kind5 = { id: 'k1', pubkey: 'pub1', tags: [['e', 't1']] };
         fetchTargetEvent.mockResolvedValueOnce({ id: 't1', pubkey: 'pub1', tags: [['imeta', 'x abc']] });
-        callBlossomDelete.mockResolvedValueOnce({ ok: false, status: 400, error: 'bad request' });
+        callBlossomDelete.mockResolvedValueOnce({ success: false, status: 400, error: 'HTTP 400: bad request' });
         const result = await processKind5(kind5, { db, fetchTargetEvent, callBlossomDelete });
         expect(result.targets[0].status).toBe('failed:permanent:blossom_400');
+      });
+
+      it('transient failure on network error', async () => {
+        const kind5 = { id: 'k1', pubkey: 'pub1', tags: [['e', 't1']] };
+        fetchTargetEvent.mockResolvedValueOnce({ id: 't1', pubkey: 'pub1', tags: [['imeta', 'x abc']] });
+        callBlossomDelete.mockResolvedValueOnce({ success: false, error: 'connection reset', networkError: true });
+        const result = await processKind5(kind5, { db, fetchTargetEvent, callBlossomDelete });
+        expect(result.targets[0].status).toBe('failed:transient:network');
       });
 
       it('skips when existing row is success (idempotent)', async () => {
@@ -1535,88 +1546,212 @@ Thin wrapper over existing `fetchNostrEventById` with retry schedule 0ms, 100ms,
 
 ---
 
-## Task 9: Blossom DELETE call wrapper
+## Task 9: Extract `notifyBlossom` to `src/blossom-client.mjs` and add `DELETE` action
 
-Thin wrapper that calls Blossom's `/admin/api/moderate` with `action: "DELETE"` and the existing `webhook_secret` Bearer.
+**Execution order note: dispatch this BEFORE Task 4 (`processKind5`) — Task 4 imports from the extracted module.**
+
+Preflight found that `src/index.mjs:5337` already has a working `notifyBlossom(sha256, action, env)` that calls Blossom's webhook with Bearer auth, maps internal actions to Blossom actions via `BLOSSOM_ACTION_MAP`, and handles network errors. The existing env vars are `BLOSSOM_WEBHOOK_URL` (full URL) and `BLOSSOM_WEBHOOK_SECRET` — both are set as Wrangler secrets on the production worker and covered by integration tests.
+
+Rather than create a new Blossom client and duplicate ~40 lines of code, extract the existing function into a shared module and add the `DELETE` action. Both existing call sites (AI/moderator paths) and the new creator-delete pipeline will import from it.
 
 **Files:**
-- Create: `src/creator-delete/blossom-client.mjs`
-- Create: `src/creator-delete/blossom-client.test.mjs`
+- Create: `src/blossom-client.mjs`
+- Create: `src/blossom-client.test.mjs`
+- Modify: `src/index.mjs` (remove the local `notifyBlossom` definition, add import, no other changes to callers)
 
-- [ ] **Step 1: Failing test — happy path**
+**Guardrail exception:** this is a targeted refactor that serves the work (CLAUDE.md explicitly permits this: "Where existing code has problems that affect the work... include targeted improvements as part of the design"). Scope is narrow — move one function to a new file, add one entry to the action map, update existing callers to import. No other refactoring.
+
+- [ ] **Step 1: Read the current `notifyBlossom` definition**
+
+    ```bash
+    sed -n '5329,5399p' src/index.mjs
+    ```
+    Note: this function starts around line 5337 and ends around line 5399. The exact range may shift as other edits land; use `grep -n "async function notifyBlossom" src/index.mjs` to confirm.
+
+- [ ] **Step 2: Write failing test for the extracted module**
+
+    Create `src/blossom-client.test.mjs`:
 
     ```javascript
     import { describe, it, expect, vi } from 'vitest';
-    import { callBlossomDelete } from './blossom-client.mjs';
+    import { notifyBlossom } from './blossom-client.mjs';
 
-    describe('callBlossomDelete', () => {
-      it('POSTs to /admin/api/moderate with action DELETE and Bearer', async () => {
+    describe('notifyBlossom (extracted)', () => {
+      const baseEnv = {
+        BLOSSOM_WEBHOOK_URL: 'https://mock-blossom.test/admin/api/moderate',
+        BLOSSOM_WEBHOOK_SECRET: 'test-secret'
+      };
+
+      it('POSTs to BLOSSOM_WEBHOOK_URL with Bearer auth and mapped action', async () => {
         const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({ success: true }), { status: 200 }));
-        const result = await callBlossomDelete('abc123', {
-          adminUrl: 'https://media.divine.video',
-          webhookSecret: 'secret-value',
-          fetchFn: fetchMock
-        });
+        const env = { ...baseEnv };
+        global.fetch = fetchMock;
+
+        const result = await notifyBlossom('abc123', 'PERMANENT_BAN', env);
+
         expect(fetchMock).toHaveBeenCalledWith(
-          'https://media.divine.video/admin/api/moderate',
+          baseEnv.BLOSSOM_WEBHOOK_URL,
           expect.objectContaining({
             method: 'POST',
-            headers: expect.objectContaining({ 'Authorization': 'Bearer secret-value' }),
-            body: JSON.stringify({ sha256: 'abc123', action: 'DELETE' })
+            headers: expect.objectContaining({ 'Authorization': 'Bearer test-secret' }),
+            body: expect.stringContaining('"action":"PERMANENT_BAN"')
           })
         );
-        expect(result).toMatchObject({ ok: true, status: 200 });
+        expect(result).toMatchObject({ success: true });
       });
 
-      it('returns networkError: true when fetch throws', async () => {
-        const fetchMock = vi.fn().mockRejectedValue(new Error('connection reset'));
-        const result = await callBlossomDelete('abc', { adminUrl: 'https://x', webhookSecret: 's', fetchFn: fetchMock });
-        expect(result).toMatchObject({ ok: false, networkError: true });
+      it('maps DELETE → DELETE action', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({ success: true }), { status: 200 }));
+        global.fetch = fetchMock;
+
+        await notifyBlossom('abc', 'DELETE', baseEnv);
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          baseEnv.BLOSSOM_WEBHOOK_URL,
+          expect.objectContaining({
+            body: expect.stringContaining('"action":"DELETE"')
+          })
+        );
+      });
+
+      it('returns skipped when BLOSSOM_WEBHOOK_URL is not configured', async () => {
+        const result = await notifyBlossom('abc', 'PERMANENT_BAN', { BLOSSOM_WEBHOOK_SECRET: 'x' });
+        expect(result).toMatchObject({ success: true, skipped: true });
+      });
+
+      it('returns error with numeric status on non-2xx response', async () => {
+        global.fetch = vi.fn().mockResolvedValue(new Response('blob not found', { status: 404 }));
+        const result = await notifyBlossom('abc', 'PERMANENT_BAN', baseEnv);
+        expect(result).toMatchObject({ success: false, status: 404 });
+        expect(result.error).toContain('404');
+      });
+
+      it('catches fetch rejection with networkError flag', async () => {
+        global.fetch = vi.fn().mockRejectedValue(new Error('connection reset'));
+        const result = await notifyBlossom('abc', 'PERMANENT_BAN', baseEnv);
+        expect(result).toMatchObject({ success: false, networkError: true });
+        expect(result.error).toContain('connection reset');
       });
     });
     ```
 
-- [ ] **Step 2: Run — FAIL**
-
-- [ ] **Step 3: Implement**
-
-    ```javascript
-    // ABOUTME: Wrapper around Blossom's /admin/api/moderate endpoint for DELETE actions.
-    // ABOUTME: Returns { ok, status, error?, networkError? } for consumption by processKind5.
-
-    export async function callBlossomDelete(sha256, { adminUrl, webhookSecret, fetchFn = fetch }) {
-      let response;
-      try {
-        response = await fetchFn(`${adminUrl}/admin/api/moderate`, {
-          method: 'POST',
-          headers: {
-            'Authorization': `Bearer ${webhookSecret}`,
-            'Content-Type': 'application/json'
-          },
-          body: JSON.stringify({ sha256, action: 'DELETE' })
-        });
-      } catch (e) {
-        return { ok: false, networkError: true, error: e.message };
-      }
-
-      if (response.ok) {
-        return { ok: true, status: response.status };
-      }
-
-      let errorBody;
-      try { errorBody = await response.text(); } catch (e) { errorBody = '(failed to read body)'; }
-
-      return { ok: false, status: response.status, error: errorBody };
-    }
-    ```
-
-- [ ] **Step 4: Run — passes**
-
-- [ ] **Step 5: Commit**
+- [ ] **Step 3: Run — FAIL (module missing)**
 
     ```bash
-    git add src/creator-delete/blossom-client.mjs src/creator-delete/blossom-client.test.mjs
-    git commit -m "feat: add Blossom DELETE action client"
+    npx vitest run src/blossom-client.test.mjs
+    ```
+
+- [ ] **Step 4: Create `src/blossom-client.mjs`**
+
+    Create the file by moving the existing `notifyBlossom` function and `BLOSSOM_ACTION_MAP` out of `src/index.mjs`. Add `'DELETE': 'DELETE'` to the action map. Preserve every line of the existing logic verbatim — this is an extraction, not a rewrite.
+
+    ```javascript
+    // This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    // If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+    //
+    // ABOUTME: Shared Blossom admin client. Called from the moderator-action pipeline and the creator-delete pipeline.
+    // ABOUTME: Maps internal action names to Blossom-understood actions and POSTs to BLOSSOM_WEBHOOK_URL with Bearer auth.
+
+    // Blossom has five states (Active/Restricted/Pending/Banned/Deleted).
+    // Its webhook handler accepts: SAFE→Active, AGE_RESTRICTED→Restricted,
+    // PERMANENT_BAN→Banned, RESTRICT→Restricted, DELETE→Deleted.
+    // QUARANTINE maps to RESTRICT (owner can view, public gets 404).
+    // REVIEW is internal only — content stays publicly accessible.
+    const BLOSSOM_ACTION_MAP = {
+      'SAFE': 'SAFE',
+      'AGE_RESTRICTED': 'AGE_RESTRICTED',
+      'PERMANENT_BAN': 'PERMANENT_BAN',
+      'QUARANTINE': 'RESTRICT',
+      'DELETE': 'DELETE'
+    };
+
+    /**
+     * Notify divine-blossom of a moderation decision or creator-initiated delete via webhook.
+     * @param {string} sha256 - The blob hash
+     * @param {string} action - Internal action (SAFE, REVIEW, QUARANTINE, AGE_RESTRICTED, PERMANENT_BAN, DELETE)
+     * @param {Object} env - Environment with BLOSSOM_WEBHOOK_URL and BLOSSOM_WEBHOOK_SECRET
+     * @returns {Promise<{success: boolean, error?: string, skipped?: boolean, result?: any}>}
+     */
+    export async function notifyBlossom(sha256, action, env) {
+      if (!env.BLOSSOM_WEBHOOK_URL) {
+        console.log('[BLOSSOM] Webhook not configured, skipping notification');
+        return { success: true, skipped: true };
+      }
+
+      const blossomAction = BLOSSOM_ACTION_MAP[action];
+      if (!blossomAction) {
+        console.log(`[BLOSSOM] Skipping notification for internal action: ${action}`);
+        return { success: true, skipped: true };
+      }
+
+      try {
+        const headers = { 'Content-Type': 'application/json' };
+        if (env.BLOSSOM_WEBHOOK_SECRET) {
+          headers['Authorization'] = `Bearer ${env.BLOSSOM_WEBHOOK_SECRET}`;
+        }
+
+        console.log(`[BLOSSOM] Notifying blossom of ${action} (as ${blossomAction}) for ${sha256}`);
+
+        const response = await fetch(env.BLOSSOM_WEBHOOK_URL, {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({
+            sha256,
+            action: blossomAction,
+            timestamp: new Date().toISOString()
+          })
+        });
+
+        if (!response.ok) {
+          const errorText = await response.text();
+          console.error(`[BLOSSOM] Webhook failed: ${response.status} - ${errorText}`);
+          return { success: false, error: `HTTP ${response.status}: ${errorText}` };
+        }
+
+        const result = await response.json();
+        console.log(`[BLOSSOM] Webhook succeeded for ${sha256}:`, result);
+        return { success: true, result, status: response.status };
+
+      } catch (error) {
+        console.error(`[BLOSSOM] Webhook error for ${sha256}:`, error);
+        return { success: false, error: error.message, networkError: true };
+      }
+    }
+
+    export { BLOSSOM_ACTION_MAP };
+    ```
+
+- [ ] **Step 5: Update `src/index.mjs` to import from the new module**
+
+    Remove the local `notifyBlossom` function definition and the `BLOSSOM_ACTION_MAP` constant inside it. Add an import at the top of the file (near the other imports):
+
+    ```javascript
+    import { notifyBlossom } from './blossom-client.mjs';
+    ```
+
+    All existing callers of `notifyBlossom(sha256, action, env)` continue to work unchanged — function signature is identical.
+
+- [ ] **Step 6: Run the new blossom-client tests AND the existing integration tests**
+
+    ```bash
+    npx vitest run src/blossom-client.test.mjs
+    npx vitest run src/index.test.mjs
+    ```
+
+    Expected: blossom-client tests pass, existing index tests still pass (the extracted function is behavior-equivalent).
+
+- [ ] **Step 7: Commit**
+
+    ```bash
+    git add src/blossom-client.mjs src/blossom-client.test.mjs src/index.mjs
+    git commit -m "refactor: extract notifyBlossom to shared module, add DELETE action
+
+    Moves notifyBlossom out of index.mjs so both the existing moderator-action
+    pipeline and the new creator-delete pipeline can use the same Blossom
+    client. Adds 'DELETE' to BLOSSOM_ACTION_MAP so the new creator-delete
+    pipeline can request physical removal via the same webhook path.
+
+    Behavior-equivalent extraction — no changes to existing callers."
     ```
 
 ---
@@ -1654,7 +1789,7 @@ Every-minute cron: REQ Funnelcake for kind 5 events since last poll; call `proce
           { id: 'k1', pubkey: 'pub1', tags: [['e', 't1']] }
         ]);
         deps.fetchTargetEvent.mockResolvedValueOnce({ id: 't1', pubkey: 'pub1', tags: [['imeta', 'x abc']] });
-        deps.callBlossomDelete.mockResolvedValueOnce({ ok: true, status: 200 });
+        deps.callBlossomDelete.mockResolvedValueOnce({ success: true, status: 200 });
 
         const result = await runCreatorDeleteCron(deps);
         expect(deps.queryKind5Since).toHaveBeenCalled();
@@ -1743,7 +1878,7 @@ Every-minute cron: REQ Funnelcake for kind 5 events since last poll; call `proce
         await deps.kv.put('creator-delete-cron:last-poll', String(Date.now() - 30_000));
         deps.queryKind5Since.mockResolvedValueOnce([]); // no new events
         deps.fetchTargetEvent.mockResolvedValueOnce({ id: 't1', pubkey: 'pub1', tags: [['imeta', 'x abc']] });
-        deps.callBlossomDelete.mockResolvedValueOnce({ ok: true, status: 200 });
+        deps.callBlossomDelete.mockResolvedValueOnce({ success: true, status: 200 });
 
         const result = await runCreatorDeleteCron(deps);
         expect(deps.callBlossomDelete).toHaveBeenCalledWith('abc');
@@ -1768,7 +1903,9 @@ Every-minute cron: REQ Funnelcake for kind 5 events since last poll; call `proce
 - Modify: `wrangler.toml`
 - Modify: `src/index.mjs`
 
-- [ ] **Step 1: Update wrangler.toml cron schedule**
+**Environment variables used here:** `BLOSSOM_WEBHOOK_URL` and `BLOSSOM_WEBHOOK_SECRET` (already set as Wrangler secrets on the production worker; verified in preflight). `CREATOR_DELETE_PIPELINE_ENABLED` is a new env var (default `"false"`; set to `"true"` via `wrangler secret put` or `[vars]` once we are ready to activate the feature in production).
+
+- [ ] **Step 1: Update wrangler.toml cron schedule and add feature flag default**
 
     Replace the existing:
     ```toml
@@ -1781,42 +1918,48 @@ Every-minute cron: REQ Funnelcake for kind 5 events since last poll; call `proce
     crons = ["* * * * *", "*/5 * * * *"]
     ```
 
+    Add a `CREATOR_DELETE_PIPELINE_ENABLED = "false"` line to the `[vars]` block so the default is inert until explicitly flipped.
+
 - [ ] **Step 2: Verify new cron accepted by wrangler dry-run**
 
     ```bash
-    npx wrangler deploy --dry-run --env staging
+    npx wrangler deploy --dry-run
     ```
-    Expected: success, no errors on cron config.
+    Expected: success, no errors on cron config or vars.
 
 - [ ] **Step 3: Wire routes into `src/index.mjs`**
 
-    Add imports near the top of `src/index.mjs`:
+    Add imports near the top of `src/index.mjs` (next to the other imports):
 
     ```javascript
     import { handleSyncDelete } from './creator-delete/sync-endpoint.mjs';
     import { handleStatusQuery } from './creator-delete/status-endpoint.mjs';
     import { runCreatorDeleteCron } from './creator-delete/cron.mjs';
     import { fetchKind5WithRetry } from './creator-delete/funnelcake-fetch.mjs';
-    import { callBlossomDelete as blossomDelete } from './creator-delete/blossom-client.mjs';
+    import { notifyBlossom } from './blossom-client.mjs'; // already imported via Task 9's extraction; reuse
+    import { fetchKind5EventsSince, fetchNostrEventById } from './nostr/relay-client.mjs';
     ```
 
     In the fetch handler, add (find the API_HOSTNAME routing block):
 
     ```javascript
-    // Creator-delete endpoints
-    if (url.hostname === API_HOSTNAME) {
+    // Creator-delete endpoints — gated by CREATOR_DELETE_PIPELINE_ENABLED feature flag
+    if (url.hostname === API_HOSTNAME && env.CREATOR_DELETE_PIPELINE_ENABLED === 'true') {
+      const relayUrl = env.CREATOR_DELETE_RELAY_URL || 'wss://relay.divine.video';
+
+      // Adapter: processKind5 and handleSyncDelete expect notifyBlossom's return shape
+      // (success, status?, error?, networkError?, skipped?) bound to the DELETE action.
+      const callBlossomDelete = (sha256) => notifyBlossom(sha256, 'DELETE', env);
+
       if (url.pathname.startsWith('/api/delete/') && request.method === 'POST') {
         return handleSyncDelete(request, {
           db: env.BLOSSOM_DB,
           kv: env.MODERATION_KV,
           fetchKind5WithRetry: (id) => fetchKind5WithRetry(id, {
-            fetchEventById: (eid) => fetchNostrEventById(eid, [env.CREATOR_DELETE_RELAY_URL || 'wss://relay.divine.video'], env)
+            fetchEventById: (eid) => fetchNostrEventById(eid, [relayUrl], env)
           }),
-          fetchTargetEvent: (eid) => fetchNostrEventById(eid, [env.CREATOR_DELETE_RELAY_URL || 'wss://relay.divine.video'], env),
-          callBlossomDelete: (sha256) => blossomDelete(sha256, {
-            adminUrl: env.BLOSSOM_ADMIN_URL,
-            webhookSecret: env.BLOSSOM_WEBHOOK_SECRET
-          })
+          fetchTargetEvent: (eid) => fetchNostrEventById(eid, [relayUrl], env),
+          callBlossomDelete
         });
       }
 
@@ -1827,31 +1970,33 @@ Every-minute cron: REQ Funnelcake for kind 5 events since last poll; call `proce
         });
       }
     }
+
+    // If CREATOR_DELETE_PIPELINE_ENABLED is not 'true', fall through to existing routing.
+    // Routes return 404 from the default handler until the flag is flipped on.
     ```
 
     Note: `fetchNostrEventById` and `fetchKind5EventsSince` are added to `relay-client.mjs` in Step 5 below. Both are required by the route handlers being wired here.
 
 - [ ] **Step 4: Wire cron dispatch**
 
-    In the existing `scheduled(event, env, ctx)` handler (around line 5009 of index.mjs), add a branch based on `event.cron`:
+    In the existing `scheduled(event, env, ctx)` handler (around line 5009 of index.mjs), add a branch based on `event.cron`. Also gate the new cron on `CREATOR_DELETE_PIPELINE_ENABLED`:
 
     ```javascript
     async scheduled(event, env, ctx) {
       if (event.cron === '* * * * *') {
-        // Every-minute: creator-delete pipeline
+        // Every-minute: creator-delete pipeline (gated by feature flag)
+        if (env.CREATOR_DELETE_PIPELINE_ENABLED !== 'true') {
+          return;
+        }
+        const relayUrl = env.CREATOR_DELETE_RELAY_URL || 'wss://relay.divine.video';
         try {
           const result = await runCreatorDeleteCron({
             db: env.BLOSSOM_DB,
             kv: env.MODERATION_KV,
-            queryKind5Since: async (sinceSeconds) => {
-              // Use existing relay-client.mjs REQ helper
-              return await fetchKind5EventsSince(sinceSeconds, env.CREATOR_DELETE_RELAY_URL || 'wss://relay.divine.video', env);
-            },
-            fetchTargetEvent: (eid) => fetchNostrEventById(eid, [env.CREATOR_DELETE_RELAY_URL || 'wss://relay.divine.video'], env),
-            callBlossomDelete: (sha256) => blossomDelete(sha256, {
-              adminUrl: env.BLOSSOM_ADMIN_URL,
-              webhookSecret: env.BLOSSOM_WEBHOOK_SECRET
-            })
+            queryKind5Since: async (sinceSeconds) =>
+              fetchKind5EventsSince(sinceSeconds, relayUrl, env),
+            fetchTargetEvent: (eid) => fetchNostrEventById(eid, [relayUrl], env),
+            callBlossomDelete: (sha256) => notifyBlossom(sha256, 'DELETE', env)
           });
           console.log(`[CREATOR-DELETE-CRON] Processed ${result.processed}, errors: ${result.errors.length}`);
         } catch (e) {
@@ -1862,12 +2007,12 @@ Every-minute cron: REQ Funnelcake for kind 5 events since last poll; call `proce
 
       if (event.cron === '*/5 * * * *') {
         // Existing 5-minute relay poller — preserve existing behavior below
-        // ... existing scheduled() body ...
+        // ... existing scheduled() body moves here unchanged ...
       }
     }
     ```
 
-    Restructure the existing scheduled() body to be under the `'*/5 * * * *'` branch rather than unconditional.
+    Restructure the existing scheduled() body to be under the `'*/5 * * * *'` branch rather than unconditional. Do not modify the existing logic; only move it inside the branch.
 
 - [ ] **Step 5: Add `fetchKind5EventsSince` and `fetchNostrEventById` to `src/nostr/relay-client.mjs`**
 
@@ -1905,11 +2050,22 @@ Every-minute cron: REQ Funnelcake for kind 5 events since last poll; call `proce
 
 - [ ] **Step 6: Local dev sanity check**
 
+    Temporarily enable the feature flag for local dev, then verify routes respond:
+
     ```bash
-    npx wrangler dev
+    # Start wrangler dev with the flag enabled for this session only
+    CREATOR_DELETE_PIPELINE_ENABLED=true npx wrangler dev --var CREATOR_DELETE_PIPELINE_ENABLED:true
     # In another terminal:
     curl -v http://localhost:8787/api/delete-status/abc -H 'Host: moderation-api.divine.video'
     # Expected: 401 (NIP-98 required)
+    ```
+
+    Then re-run without the flag to confirm the endpoints 404 when disabled:
+
+    ```bash
+    npx wrangler dev
+    curl -v http://localhost:8787/api/delete-status/abc -H 'Host: moderation-api.divine.video'
+    # Expected: 404 (routes gated off)
     ```
 
 - [ ] **Step 7: Commit**
@@ -1971,89 +2127,137 @@ Every-minute cron: REQ Funnelcake for kind 5 events since last poll; call `proce
 
 ---
 
-## Task 13: Staging deploy and end-to-end validation
+## Task 13: Production deploy (feature flag off) and end-to-end validation
 
-- [ ] **Step 1: Deploy to staging**
+This repo does not have a separate staging environment in `wrangler.toml`. The established convention is to deploy directly to production. We mitigate destructive-code risk via two flags layered on top of each other:
+
+1. **`CREATOR_DELETE_PIPELINE_ENABLED`** (this repo) — default `"false"`. Keeps our new routes 404'd and our new cron inert until explicitly flipped on.
+2. **`ENABLE_PHYSICAL_DELETE`** (Blossom repo) — default `"false"` on first deploy. Blossom flips status to `Deleted` (stops serving) but does not touch GCS bytes until this flag is flipped.
+
+This means the first production deploy of our code is fully inert. No routes respond. No cron processes. No Blossom calls. Safe by construction.
+
+- [ ] **Step 1: Deploy moderation-service to production with flag off**
 
     ```bash
-    npx wrangler deploy --env staging
+    npx wrangler deploy
     ```
-    Expected: deploy success, routes active.
+
+    Confirm via `wrangler tail` that the worker is live, existing routes still respond, and the new creator-delete routes return 404 (flag is off).
 
 - [ ] **Step 2: Log deploy**
 
     ```bash
-    scripts/log-deploy.sh divine-moderation-service staging spec/per-video-delete-enforcement "creator-delete v1 staging"
+    scripts/log-deploy.sh divine-moderation-service production spec/per-video-delete-enforcement "creator-delete v1 prod (flag off)"
     ```
 
-- [ ] **Step 3: Run staging e2e: sync endpoint happy path**
+- [ ] **Step 3: Create a test script for end-to-end validation**
 
-    Using a test account's nsec, publish a kind 5 to staging Funnelcake deleting a test video. Immediately call the sync endpoint:
+    Create `scripts/test-creator-delete.mjs` (only run when the flag is on):
+
+    - Accept `--relay <url>` (default `wss://relay.divine.video`), `--api <url>` (default `https://moderation-api.divine.video`), `--nsec <hex>`, `--target-event-id <id>`.
+    - Sign a kind 5 deleting the target, publish to the relay, wait for OK.
+    - Sign a NIP-98 header for `POST /api/delete/{kind5_id}` and call the sync endpoint.
+    - Print the response body and any D1 row state.
+
+    Script should use the existing `scripts/publish-test-video.mjs` style as a reference for CLI args and relay interaction.
+
+- [ ] **Step 4: Flip the flag on a small test account first**
+
+    Because there is no staging, temporarily set `CREATOR_DELETE_PIPELINE_ENABLED="true"` on the production worker:
 
     ```bash
-    # Script: scripts/test-creator-delete.mjs (create as part of this task)
-    # Signs NIP-98, calls sync endpoint, asserts 200 + success
-    node scripts/test-creator-delete.mjs --env staging --kind5-id <id> --nsec <test-nsec>
+    npx wrangler secret put CREATOR_DELETE_PIPELINE_ENABLED
+    # Enter: true
     ```
 
-    Expected: 200 with status `success`, D1 row present with status `success`.
+    (or add `CREATOR_DELETE_PIPELINE_ENABLED = "true"` to `[vars]` and re-deploy — whichever you prefer.)
 
-- [ ] **Step 4: Verify Blossom-side effect (flag off)**
+- [ ] **Step 5: Run e2e sync endpoint happy path (with a throwaway test video)**
 
-    Confirm the target blob shows `Deleted` status in Blossom admin UI and serves 404 on the main URL and thumbnail. With `ENABLE_PHYSICAL_DELETE=false` (staging default), GCS bytes should remain.
+    Upload a throwaway test video via the divine-mobile app using a test account, confirm it's served from Blossom, then:
 
-- [ ] **Step 5: Run staging e2e: cron path**
+    ```bash
+    node scripts/test-creator-delete.mjs \
+      --relay wss://relay.divine.video \
+      --api https://moderation-api.divine.video \
+      --nsec <test-nsec> \
+      --target-event-id <test-video-event-id>
+    ```
 
-    Publish a kind 5 to staging Funnelcake WITHOUT calling the sync endpoint. Wait up to 90 seconds. Confirm D1 shows a row with `status: success` and Blossom shows `Deleted`.
+    Expected: 200 with `status: "success"`. D1 row `{status: "success", blob_sha256: <sha>, completed_at: <timestamp>}`.
 
-- [ ] **Step 6: Run staging e2e: race test**
+- [ ] **Step 6: Verify Blossom-side effect**
+
+    Confirm the target blob serves 404 on:
+    - `https://media.divine.video/<sha256>`
+    - `https://media.divine.video/<sha256>.jpg`
+    - `https://media.divine.video/<sha256>.vtt`
+
+    With `ENABLE_PHYSICAL_DELETE=false` in Blossom (first-prod-deploy default), GCS bytes should still exist. Verify via Blossom admin UI (status shows `Deleted`).
+
+- [ ] **Step 7: Run cron path test**
+
+    Using a different test video + test account, publish a kind 5 WITHOUT calling the sync endpoint. Wait up to 90 seconds. Confirm D1 shows a row with `status: success` and Blossom shows `Deleted`.
+
+- [ ] **Step 8: Run race test**
 
     Publish a kind 5. Immediately (within 100ms of NIP-01 OK) call the sync endpoint. Assert 200 success without 404 or 202 (retry logic handled the Funnelcake read-after-write race).
 
-- [ ] **Step 7: Record staging validation results in the PR**
+- [ ] **Step 9: Record production validation results in the PR**
 
-    Comment on PR #92 with a summary: preflight results, e2e test results, any observed p95 lag numbers from the staging logs.
+    Comment on PR #92 with a summary: preflight results, e2e test results, observed p95 latency for sync path, observed cron lag, any failed:transient rows in D1 during validation.
 
-- [ ] **Step 8: Commit test script**
+- [ ] **Step 10: Commit test script**
 
     ```bash
     git add scripts/test-creator-delete.mjs
-    git commit -m "test: add creator-delete staging e2e script"
+    git commit -m "test: add creator-delete production validation script"
     ```
 
 ---
 
-## Task 14: Prepare for production
+## Task 14: Validation window and phased flag flips
 
-- [ ] **Step 1: Ensure Blossom DELETE PR has landed in prod and flag is off**
+- [ ] **Step 1: Confirm Blossom DELETE action is accepted in production**
 
-    Check `media.divine.video/admin/api/moderate` accepts `action: "DELETE"` with the flag default-off. If not, pause production rollout until Blossom PR lands.
-
-- [ ] **Step 2: Deploy moderation-service to prod with flag off path**
-
-    The moderation-service has no `ENABLE_PHYSICAL_DELETE` flag of its own. Rollout depends on Blossom's flag state.
+    Blossom's `admin/api/moderate` must accept `action: "DELETE"` before we turn the pipeline on. If the Blossom PR hasn't shipped, either the validation fails or we fall back to `PERMANENT_BAN` for a transitional deploy. Check with a NIP-98-less smoke request to confirm the action is recognized (not necessarily authorized):
 
     ```bash
-    npx wrangler deploy --env production
-    scripts/log-deploy.sh divine-moderation-service production main "creator-delete v1 prod (flag off)"
+    curl -v -X POST https://media.divine.video/admin/api/moderate \
+      -H 'Content-Type: application/json' \
+      -H 'Authorization: Bearer <test-token-or-empty>' \
+      -d '{"sha256":"0000000000000000000000000000000000000000000000000000000000000000","action":"DELETE"}'
     ```
 
-- [ ] **Step 3: Validation window**
+    Expect 401/403 (auth) rather than 400 "Unknown action". If 400 "Unknown action", Blossom doesn't yet have DELETE wired — pause the flag flip until it does.
 
-    Over the next 1 week (or the first 50 creator deletes in production, whichever comes first), monitor:
-    - D1 `creator_deletions` rows
-    - Sentry alerts for sync latency, cron lag, Blossom failure rate, permanent failures
-    - Blossom dashboard for Deleted blob count + bytes_still_present count
+- [ ] **Step 2: Production validation window**
 
-    Confirm pipeline selects the right sha256s (no wrong-blob deletions in the sample). If all green, proceed.
+    With `CREATOR_DELETE_PIPELINE_ENABLED=true` (from Task 13) and Blossom's `ENABLE_PHYSICAL_DELETE=false`, monitor over 1 week OR the first 50 creator deletes in production (whichever comes first):
 
-- [ ] **Step 4: Flip the Blossom flag**
+    - D1 `creator_deletions` rows — scan for `failed:*` statuses
+    - Sentry alerts — sync latency, cron lag, Blossom failure rate, permanent failures
+    - Blossom dashboard — `Deleted` blob count (should grow), GCS byte count unchanged (flag off)
+    - Spot-check: for each of the first ~10 deletes, confirm the blob_sha256 recorded in D1 matches the actual video's sha256 from its kind 34236 event (no wrong-blob deletions)
 
-    Separately from moderation-service, flip `ENABLE_PHYSICAL_DELETE=true` in Blossom's prod config. Run Blossom's one-time sweep over historical `Deleted` blobs to physically remove their bytes.
+    Any `failed:permanent:*` rows other than `target_unresolved` are triage tickets, not blockers.
 
-- [ ] **Step 5: Confirm physical byte removal**
+- [ ] **Step 3: Flip the Blossom flag**
 
-    Next production delete after flag flip should show both Blossom `Deleted` and GCS bytes gone (verify via Blossom admin). Monitor for failures.
+    Separately from moderation-service, flip `ENABLE_PHYSICAL_DELETE=true` in Blossom's prod config. Run Blossom's one-time sweep over historical `Deleted` blobs to physically remove their bytes (see Blossom PR for sweep details).
+
+- [ ] **Step 4: Confirm physical byte removal**
+
+    Next production delete after flag flip should show both Blossom `Deleted` status AND GCS bytes gone (verify via Blossom admin UI and direct GCS bucket list). Monitor sync endpoint latency for Blossom-side regression (physical delete adds GCS call latency).
+
+- [ ] **Step 5: Rolling back if needed**
+
+    If any stage reveals a bug, the rollback path is:
+    - Flip `CREATOR_DELETE_PIPELINE_ENABLED=false` immediately (stops new pipeline invocations without redeploying)
+    - For Blossom issues, flip `ENABLE_PHYSICAL_DELETE=false` (stops new byte deletions)
+    - Revert offending commits on a follow-up branch if needed
+
+    Both flags are production-flippable without code changes.
 
 ---
 
@@ -2077,7 +2281,15 @@ After the plan is written, run through:
 
 **Placeholder scan:** No TODOs, no "implement later", no "similar to Task N". Every code step has the code.
 
-**Type consistency:** Function names across tasks (`processKind5`, `claimRow`, `decideAction`, `validateNip98Header`, `callBlossomDelete`, `fetchKind5WithRetry`) match across all tasks they appear in.
+**Type consistency:** Function names across tasks (`processKind5`, `claimRow`, `decideAction`, `validateNip98Header`, `notifyBlossom`, `callBlossomDelete` (dep-injection alias bound to `notifyBlossom(sha256, 'DELETE', env)`), `fetchKind5WithRetry`) match across all tasks they appear in.
+
+**Execution order note:**
+
+Because Task 4 (`processKind5`) depends on Task 9 (extraction of `notifyBlossom`), the execution sequence is:
+
+Task 1 → Task 2 → Task 3 → **Task 9** → Task 4 → Task 5 → Task 6 → Task 7 → Task 8 → Task 10 → Task 11 → Task 12 → Task 13 → Task 14
+
+Task 9 is physically located after Tasks 4-8 in this document, but MUST be dispatched before Task 4.
 
 ---
 

--- a/docs/superpowers/plans/2026-04-16-per-video-delete-enforcement-plan.md
+++ b/docs/superpowers/plans/2026-04-16-per-video-delete-enforcement-plan.md
@@ -626,11 +626,9 @@ Race-safe claim-or-inspect logic that multiple concurrent invocations can call s
 
 - [ ] **Step 5: Add failing tests for `decideAction`**
 
-    Append to `src/creator-delete/d1.test.mjs`:
+    Add `decideAction` to the existing top-of-file import (`import { claimRow, readRow, updateToSuccess, updateToFailed, decideAction } from './d1.mjs';`), then append the `describe('decideAction', ...)` block to `src/creator-delete/d1.test.mjs`:
 
     ```javascript
-    import { decideAction } from './d1.mjs';
-
     describe('decideAction', () => {
       it('proceed when no row exists', () => {
         expect(decideAction(null)).toBe('proceed');

--- a/docs/superpowers/plans/2026-04-16-per-video-delete-enforcement-plan.md
+++ b/docs/superpowers/plans/2026-04-16-per-video-delete-enforcement-plan.md
@@ -2009,14 +2009,13 @@ async all() {
 
 - [ ] **Step 3: Wire routes into `src/index.mjs`**
 
-    Add imports near the top of `src/index.mjs` (next to the other imports):
+    Add five new imports near the top of `src/index.mjs` (next to the other imports). The `notifyBlossom` import was already added by Task 9's extraction — DO NOT add a duplicate line for it; just reuse the existing one.
 
     ```javascript
     import { handleSyncDelete } from './creator-delete/sync-endpoint.mjs';
     import { handleStatusQuery } from './creator-delete/status-endpoint.mjs';
     import { runCreatorDeleteCron } from './creator-delete/cron.mjs';
     import { fetchKind5WithRetry } from './creator-delete/funnelcake-fetch.mjs';
-    import { notifyBlossom } from './blossom-client.mjs'; // already imported via Task 9's extraction; reuse
     import { fetchKind5EventsSince, fetchNostrEventById } from './nostr/relay-client.mjs';
     ```
 
@@ -2096,21 +2095,7 @@ async all() {
 
 - [ ] **Step 5: Add `fetchKind5EventsSince` and `fetchNostrEventById` to `src/nostr/relay-client.mjs`**
 
-    Both are new; they extend the existing WebSocket REQ pattern in `queryRelay`. Add failing tests first in `src/nostr/relay-client.test.mjs`:
-
-    ```javascript
-    it('fetchKind5EventsSince returns all kind 5 events for the since filter', async () => {
-      // Mock the WebSocket or use a fake relay — follow whichever pattern the existing tests use.
-      // Assert that the returned filter matches {kinds: [5], since: <provided>}.
-      // Assert the return value is an array of events.
-    });
-
-    it('fetchNostrEventById returns a single event by id or null', async () => {
-      // Similar: mock relay, assert filter {ids: [<id>], limit: 1}, assert return shape.
-    });
-    ```
-
-    Then implement the two exports in `relay-client.mjs`, using `queryRelay` with `collectAll: true` for the kind 5 variant (returns all events until EOSE) and the default behavior for the by-id variant (single event).
+    Both are new; they extend the existing WebSocket REQ pattern in `queryRelay`. Append these two exports to `relay-client.mjs`:
 
     ```javascript
     export async function fetchKind5EventsSince(sinceSeconds, relayUrl = 'wss://relay.divine.video', env = {}) {
@@ -2126,7 +2111,9 @@ async all() {
     }
     ```
 
-    Run tests; confirm pass.
+    **Unit testing note:** the existing `relay-client.test.mjs` covers only the pure-function helpers (`parseVideoEventMetadata`, `isOriginalVine`, `hasStrongOriginalVineEvidence`) — it has no WebSocket mocking precedent, and neither does the existing `fetchNostrEventBySha256`/`fetchNostrVideoEventsByDTag` (both untested at the unit level). To stay consistent with the file's existing coverage posture and avoid introducing a bespoke WebSocket mock, do NOT add unit tests for these two new functions in this task. They will be exercised end-to-end in the staging preflight (Task 13 Step 3 "cron path test") and in the race test against staging Funnelcake.
+
+    Confirm the existing `relay-client.test.mjs` still passes (`npx vitest run src/nostr/relay-client.test.mjs`).
 
 - [ ] **Step 6: Local dev sanity check**
 

--- a/docs/superpowers/plans/2026-04-16-per-video-delete-enforcement-plan.md
+++ b/docs/superpowers/plans/2026-04-16-per-video-delete-enforcement-plan.md
@@ -714,6 +714,8 @@ The shared function called by both the sync endpoint and the cron. Given a fetch
         callBlossomDelete = vi.fn();
       });
 
+      const SHA_C = 'c'.repeat(64); // 64-char hex fixture (extractSha256 requires exactly 64 hex chars)
+
       it('happy path: claim, fetch target, extract sha256, call Blossom, mark success', async () => {
         const kind5 = {
           id: 'k1',
@@ -723,7 +725,7 @@ The shared function called by both the sync endpoint and the cron. Given a fetch
         fetchTargetEvent.mockResolvedValueOnce({
           id: 't1',
           pubkey: 'pub1',
-          tags: [['imeta', 'url https://media.divine.video/abc.mp4', 'x abc']]
+          tags: [['imeta', `url https://media.divine.video/${SHA_C}.mp4`, `x ${SHA_C}`]]
         });
         callBlossomDelete.mockResolvedValueOnce({ success: true, status: 200 });
 
@@ -733,8 +735,8 @@ The shared function called by both the sync endpoint and the cron. Given a fetch
           callBlossomDelete
         });
 
-        expect(result.targets).toEqual([{ target_event_id: 't1', status: 'success', blob_sha256: 'abc' }]);
-        expect(callBlossomDelete).toHaveBeenCalledWith('abc');
+        expect(result.targets).toEqual([{ target_event_id: 't1', status: 'success', blob_sha256: SHA_C }]);
+        expect(callBlossomDelete).toHaveBeenCalledWith(SHA_C);
       });
     });
 
@@ -918,7 +920,7 @@ The shared function called by both the sync endpoint and the cron. Given a fetch
 
       it('transient failure on Blossom 503', async () => {
         const kind5 = { id: 'k1', pubkey: 'pub1', tags: [['e', 't1']] };
-        fetchTargetEvent.mockResolvedValueOnce({ id: 't1', pubkey: 'pub1', tags: [['imeta', 'x abc']] });
+        fetchTargetEvent.mockResolvedValueOnce({ id: 't1', pubkey: 'pub1', tags: [['imeta', `x ${SHA_C}`]] });
         callBlossomDelete.mockResolvedValueOnce({ success: false, status: 503, error: 'HTTP 503: service unavailable' });
         const result = await processKind5(kind5, { db, fetchTargetEvent, callBlossomDelete });
         expect(result.targets[0].status).toBe('failed:transient:blossom_5xx');
@@ -926,7 +928,7 @@ The shared function called by both the sync endpoint and the cron. Given a fetch
 
       it('permanent failure on Blossom 400', async () => {
         const kind5 = { id: 'k1', pubkey: 'pub1', tags: [['e', 't1']] };
-        fetchTargetEvent.mockResolvedValueOnce({ id: 't1', pubkey: 'pub1', tags: [['imeta', 'x abc']] });
+        fetchTargetEvent.mockResolvedValueOnce({ id: 't1', pubkey: 'pub1', tags: [['imeta', `x ${SHA_C}`]] });
         callBlossomDelete.mockResolvedValueOnce({ success: false, status: 400, error: 'HTTP 400: bad request' });
         const result = await processKind5(kind5, { db, fetchTargetEvent, callBlossomDelete });
         expect(result.targets[0].status).toBe('failed:permanent:blossom_400');
@@ -934,7 +936,7 @@ The shared function called by both the sync endpoint and the cron. Given a fetch
 
       it('transient failure on network error', async () => {
         const kind5 = { id: 'k1', pubkey: 'pub1', tags: [['e', 't1']] };
-        fetchTargetEvent.mockResolvedValueOnce({ id: 't1', pubkey: 'pub1', tags: [['imeta', 'x abc']] });
+        fetchTargetEvent.mockResolvedValueOnce({ id: 't1', pubkey: 'pub1', tags: [['imeta', `x ${SHA_C}`]] });
         callBlossomDelete.mockResolvedValueOnce({ success: false, error: 'connection reset', networkError: true });
         const result = await processKind5(kind5, { db, fetchTargetEvent, callBlossomDelete });
         expect(result.targets[0].status).toBe('failed:transient:network');

--- a/docs/superpowers/plans/2026-04-16-per-video-delete-enforcement-plan.md
+++ b/docs/superpowers/plans/2026-04-16-per-video-delete-enforcement-plan.md
@@ -46,6 +46,79 @@ Each file has one clear responsibility. `process.mjs` is the hub; endpoints and 
 
 ---
 
+## Guardrails — do not do these things without checkpointing with Matt first
+
+### Scope
+
+- Do not add new dependencies beyond what's already in `package.json`.
+- Do not refactor files not named in the task's "Files" list.
+- Do not introduce new abstractions, helpers, or utilities beyond what the task specifies.
+- Do not modify existing routes, handlers, or modules outside the task's scope.
+- Do not change existing tests (add new ones; don't modify existing).
+- Do not add new env vars beyond those already present or explicitly named in the plan.
+- Do not modify `wrangler.toml` bindings except to add the new cron entry named in Task 11.
+- Do not touch migrations 001–005; only add `006-creator-deletions.sql`.
+
+### Error handling and complexity
+
+- Do not add error handling for scenarios the plan doesn't name.
+- Do not add defensive validation beyond what the plan specifies.
+- Do not add feature flags beyond `ENABLE_PHYSICAL_DELETE` (which lives in Blossom, not here).
+- Do not add retry logic beyond what the plan specifies (Funnelcake 0/100/500/1000/2000ms; Blossom exponential backoff bounded to `retry_count < 5`).
+
+### Logging and comments
+
+- Do not add `console.log`s beyond the structured logs specified in Task 12.
+- Do not add code comments that describe what the code does (well-named identifiers already do that).
+- Do add a one-line comment when the WHY is non-obvious (a hidden constraint, workaround, surprising behavior).
+
+### Safety measures — DO NOT REMOVE OR SIMPLIFY
+
+These are required by the spec and protect reliability, security, or compliance.
+If any appears redundant, STOP and ask Matt before removing:
+
+- NIP-98 author-only check on sync endpoint and status endpoint (caller pubkey must match kind 5 author).
+- NIP-98 ±60s timestamp tolerance window.
+- D1 `INSERT ON CONFLICT DO NOTHING` + `SELECT` idempotency claim.
+- `decideAction` guard for in-progress / success / permanent-failure states.
+- `failed:transient:*` vs `failed:permanent:*` status taxonomy.
+- Funnelcake read-after-write retry schedule in the sync endpoint.
+- Rate limiting per-pubkey and per-IP.
+- 8-second internal budget in sync endpoint (returns 202 beyond that).
+- Composite PRIMARY KEY `(kind5_id, target_event_id)` on `creator_deletions`.
+- `retry_count` bounded to `< 5` before promotion to `failed:permanent:max_retries_exceeded`.
+- Blossom call uses existing `webhook_secret` Bearer (do not propagate secret elsewhere).
+
+### When in doubt
+
+Stop and ask. A checkpoint question is cheaper than reverting a commit.
+
+---
+
+## Per-task review checklist (orchestrator uses this on every subagent output)
+
+- [ ] Tests were written before implementation (visible in git history: test commit precedes impl commit, or same commit includes both with failing test written first).
+- [ ] All tests pass (`npx vitest run <path>` shows green).
+- [ ] Eslint clean (`node scripts/lint.mjs` passes).
+- [ ] No new dependencies in `package.json`.
+- [ ] No files touched that aren't in the task's "Files" list.
+- [ ] No new abstractions, helpers, or utilities beyond what the plan specifies.
+- [ ] Safety measures from the Guardrails section are present and unaltered (spot-check the relevant ones for this task).
+- [ ] No `console.log`s left over from debugging (structured logs from Task 12 are exempt).
+- [ ] Commit message follows the repo's conventional format (`feat:` / `fix:` / `docs:` / `test:` / `refactor:` prefix; no Claude attribution footer).
+- [ ] File header `// ABOUTME:` comments present on new files (matches existing repo convention).
+- [ ] MPL license header present on new files (matches existing repo convention).
+
+### Red flags to escalate to Matt
+
+- Subagent added a dependency, refactored an existing file, or introduced a new abstraction.
+- Subagent removed or simplified any item from "Safety measures" in Guardrails.
+- Tests don't actually exercise the behavior they claim to test.
+- Implementation deviates from the plan's spec in any non-trivial way.
+- Subagent encountered an error and worked around it silently.
+
+---
+
 ## Staging Preflight
 
 Complete these BEFORE starting implementation. Failures here can redirect the design.

--- a/docs/superpowers/plans/2026-04-16-per-video-delete-enforcement-plan.md
+++ b/docs/superpowers/plans/2026-04-16-per-video-delete-enforcement-plan.md
@@ -1799,12 +1799,47 @@ Every-minute cron: REQ Funnelcake for kind 5 events since last poll; call `proce
 **Files:**
 - Create: `src/creator-delete/cron.mjs`
 - Create: `src/creator-delete/cron.test.mjs`
+- Modify: `src/creator-delete/test-helpers.mjs` — extend `makeFakeD1`'s `.all()` to support a second SELECT query shape: `WHERE status LIKE 'failed:transient:%' AND retry_count < ?`. The cron uses this for transient-retry sweeps; without support, the test returns an empty array and the retry branch silently does nothing.
+
+Extend the `.all()` method in `test-helpers.mjs` to detect and handle BOTH patterns:
+
+```javascript
+async all() {
+  if (this._sql.startsWith('SELECT')) {
+    // Pattern 1: cron transient-retry sweep
+    // SELECT ... WHERE status LIKE 'failed:transient:%' AND retry_count < ?
+    if (this._sql.includes("status LIKE 'failed:transient:%'") && this._sql.includes("retry_count <")) {
+      const maxRetry = this._binds[0];
+      const results = [];
+      for (const row of rows.values()) {
+        if (!row.status?.startsWith('failed:transient:')) continue;
+        if (row.retry_count >= maxRetry) continue;
+        results.push(row);
+      }
+      return { results };
+    }
+    // Pattern 2 (existing): SELECT ... WHERE kind5_id = ? [AND target_event_id = ?]
+    const kind5_id = this._binds[0];
+    const results = [];
+    for (const row of rows.values()) {
+      if (row.kind5_id !== kind5_id) continue;
+      if (this._binds.length >= 2 && row.target_event_id !== this._binds[1]) continue;
+      results.push(row);
+    }
+    return { results };
+  }
+  return { results: [] };
+},
+```
 
 - [ ] **Step 1: Failing test — happy path**
 
     ```javascript
     import { describe, it, expect, vi, beforeEach } from 'vitest';
     import { runCreatorDeleteCron } from './cron.mjs';
+    import { makeFakeD1, makeFakeKV } from './test-helpers.mjs';
+
+    const SHA_C = 'c'.repeat(64); // 64-char hex fixture (extractSha256 requires)
 
     describe('runCreatorDeleteCron', () => {
       let deps;
@@ -1824,7 +1859,7 @@ Every-minute cron: REQ Funnelcake for kind 5 events since last poll; call `proce
         deps.queryKind5Since.mockResolvedValueOnce([
           { id: 'k1', pubkey: 'pub1', tags: [['e', 't1']] }
         ]);
-        deps.fetchTargetEvent.mockResolvedValueOnce({ id: 't1', pubkey: 'pub1', tags: [['imeta', 'x abc']] });
+        deps.fetchTargetEvent.mockResolvedValueOnce({ id: 't1', pubkey: 'pub1', tags: [['imeta', `x ${SHA_C}`]] });
         deps.callBlossomDelete.mockResolvedValueOnce({ success: true, status: 200 });
 
         const result = await runCreatorDeleteCron(deps);
@@ -1905,19 +1940,28 @@ Every-minute cron: REQ Funnelcake for kind 5 events since last poll; call `proce
 
     ```javascript
       it('retries failed:transient rows with retry_count < 5', async () => {
-        await deps.db.prepare(
-          `INSERT INTO creator_deletions (kind5_id, target_event_id, creator_pubkey, status, accepted_at, retry_count)
-           VALUES (?, ?, ?, 'failed:transient:blossom_5xx', ?, 2)
-           ON CONFLICT(kind5_id, target_event_id) DO NOTHING`
-        ).bind('k1', 't1', 'pub1', new Date(Date.now() - 60_000).toISOString(), 2).run();
+        // Seed D1 directly — the fake's INSERT path is tailored to claimRow's
+        // 4-arg bind with 'accepted' status literal, so it can't represent a
+        // pre-existing failed:transient row. Direct rows.set() bypasses it.
+        deps.db.rows.set('k1:t1', {
+          kind5_id: 'k1',
+          target_event_id: 't1',
+          creator_pubkey: 'pub1',
+          status: 'failed:transient:blossom_5xx',
+          accepted_at: new Date(Date.now() - 60_000).toISOString(),
+          blob_sha256: null,
+          retry_count: 2,
+          last_error: 'HTTP 503: prior attempt',
+          completed_at: null
+        });
 
         await deps.kv.put('creator-delete-cron:last-poll', String(Date.now() - 30_000));
         deps.queryKind5Since.mockResolvedValueOnce([]); // no new events
-        deps.fetchTargetEvent.mockResolvedValueOnce({ id: 't1', pubkey: 'pub1', tags: [['imeta', 'x abc']] });
+        deps.fetchTargetEvent.mockResolvedValueOnce({ id: 't1', pubkey: 'pub1', tags: [['imeta', `x ${SHA_C}`]] });
         deps.callBlossomDelete.mockResolvedValueOnce({ success: true, status: 200 });
 
         const result = await runCreatorDeleteCron(deps);
-        expect(deps.callBlossomDelete).toHaveBeenCalledWith('abc');
+        expect(deps.callBlossomDelete).toHaveBeenCalledWith(SHA_C);
         expect(result.processed).toBeGreaterThanOrEqual(1);
       });
     ```

--- a/docs/superpowers/plans/2026-04-16-per-video-delete-enforcement-plan.md
+++ b/docs/superpowers/plans/2026-04-16-per-video-delete-enforcement-plan.md
@@ -441,6 +441,8 @@ Race-safe claim-or-inspect logic that multiple concurrent invocations can call s
     import { claimRow, readRow, updateToSuccess, updateToFailed } from './d1.mjs';
 
     // Test helper: in-memory D1 fake with the same schema as creator_deletions.
+    // Note: claimRow's INSERT binds 4 args (kind5_id, target_event_id, creator_pubkey, accepted_at)
+    // and inlines 'accepted' as a literal in the SQL. The fake mirrors that arity.
     function makeFakeD1() {
       const rows = new Map(); // key: `${kind5_id}:${target_event_id}`
       return {
@@ -452,12 +454,12 @@ Race-safe claim-or-inspect logic that multiple concurrent invocations can call s
             bind(...args) { this._binds = args; return this; },
             async run() {
               if (this._sql.startsWith('INSERT')) {
-                const [kind5_id, target_event_id, creator_pubkey, status, accepted_at] = this._binds;
+                const [kind5_id, target_event_id, creator_pubkey, accepted_at] = this._binds;
                 const key = `${kind5_id}:${target_event_id}`;
                 if (rows.has(key)) {
                   return { meta: { changes: 0, rows_written: 0 } };
                 }
-                rows.set(key, { kind5_id, target_event_id, creator_pubkey, status, accepted_at, retry_count: 0, last_error: null, blob_sha256: null, completed_at: null });
+                rows.set(key, { kind5_id, target_event_id, creator_pubkey, status: 'accepted', accepted_at, retry_count: 0, last_error: null, blob_sha256: null, completed_at: null });
                 return { meta: { changes: 1, rows_written: 1 } };
               }
               if (this._sql.startsWith('UPDATE')) {

--- a/docs/superpowers/plans/2026-04-16-per-video-delete-enforcement-plan.md
+++ b/docs/superpowers/plans/2026-04-16-per-video-delete-enforcement-plan.md
@@ -1340,6 +1340,8 @@ NIP-98 author-only read of D1 rows for a given kind5_id.
     import { describe, it, expect, beforeEach } from 'vitest';
     import { generateSecretKey, getPublicKey, finalizeEvent } from 'nostr-tools/pure';
     import { handleStatusQuery } from './status-endpoint.mjs';
+    import { checkRateLimit } from './rate-limit.mjs';
+    import { makeFakeD1, makeFakeKV } from './test-helpers.mjs';
 
     describe('handleStatusQuery', () => {
       let sk, pk, deps;
@@ -1361,11 +1363,20 @@ NIP-98 author-only read of D1 rows for a given kind5_id.
       }
 
       it('returns 200 with target rows for the caller pubkey', async () => {
-        await deps.db.prepare(
-          `INSERT INTO creator_deletions (kind5_id, target_event_id, creator_pubkey, status, accepted_at, blob_sha256, completed_at)
-           VALUES (?, ?, ?, 'success', ?, 'abc', ?)
-           ON CONFLICT(kind5_id, target_event_id) DO NOTHING`
-        ).bind('k1', 't1', pk, new Date().toISOString(), new Date().toISOString()).run();
+        // Seed D1 directly — bypass the fake's INSERT path, which is tailored
+        // to claimRow's 4-arg bind with 'accepted' status literal. Direct
+        // rows.set() lets us simulate a terminal 'success' row.
+        deps.db.rows.set('k1:t1', {
+          kind5_id: 'k1',
+          target_event_id: 't1',
+          creator_pubkey: pk,
+          status: 'success',
+          accepted_at: new Date().toISOString(),
+          blob_sha256: 'c'.repeat(64),
+          retry_count: 0,
+          last_error: null,
+          completed_at: new Date().toISOString()
+        });
 
         const url = 'https://moderation-api.divine.video/api/delete-status/k1';
         const request = new Request(url, { method: 'GET', headers: { Authorization: signNip98Get(url) } });
@@ -1465,11 +1476,18 @@ NIP-98 author-only read of D1 rows for a given kind5_id.
       it('returns 403 when caller pubkey does not match row creator_pubkey', async () => {
         const otherSk = generateSecretKey();
         const otherPk = getPublicKey(otherSk);
-        await deps.db.prepare(
-          `INSERT INTO creator_deletions (kind5_id, target_event_id, creator_pubkey, status, accepted_at)
-           VALUES (?, ?, ?, 'success', ?)
-           ON CONFLICT(kind5_id, target_event_id) DO NOTHING`
-        ).bind('k2', 't1', otherPk, new Date().toISOString()).run();
+        // Seed D1 directly (see happy-path note).
+        deps.db.rows.set('k2:t1', {
+          kind5_id: 'k2',
+          target_event_id: 't1',
+          creator_pubkey: otherPk,
+          status: 'success',
+          accepted_at: new Date().toISOString(),
+          blob_sha256: null,
+          retry_count: 0,
+          last_error: null,
+          completed_at: null
+        });
 
         const url = 'https://moderation-api.divine.video/api/delete-status/k2';
         const response = await handleStatusQuery(new Request(url, { method: 'GET', headers: { Authorization: signNip98Get(url) } }), deps);
@@ -1486,7 +1504,7 @@ NIP-98 author-only read of D1 rows for a given kind5_id.
       });
     ```
 
-    Add `import { checkRateLimit } from './rate-limit.mjs'` at the top of the test file.
+    Imports (`checkRateLimit` from `./rate-limit.mjs` and `makeFakeD1` / `makeFakeKV` from `./test-helpers.mjs`) are already included in the Step 1 test-file header above.
 
 - [ ] **Step 6: Run — all pass**
 

--- a/docs/superpowers/plans/2026-04-16-per-video-delete-enforcement-plan.md
+++ b/docs/superpowers/plans/2026-04-16-per-video-delete-enforcement-plan.md
@@ -1091,7 +1091,17 @@ Wraps NIP-98 validation, rate limiting, Funnelcake fetch with retries, `processK
     ```javascript
     import { describe, it, expect, vi, beforeEach } from 'vitest';
     import { generateSecretKey, getPublicKey, finalizeEvent } from 'nostr-tools/pure';
-    import { handleSyncDelete } from './sync-endpoint.mjs';
+    import {
+      handleSyncDelete,
+      PER_PUBKEY_LIMIT,
+      PER_IP_LIMIT,
+      RATE_WINDOW_SECONDS
+    } from './sync-endpoint.mjs';
+    import { checkRateLimit } from './rate-limit.mjs';
+    import { makeFakeD1, makeFakeKV } from './test-helpers.mjs';
+
+    const KIND5_ID = 'a'.repeat(64); // 64-char hex for URL path + kind5.id fixture
+    const SHA_C = 'c'.repeat(64);    // 64-char hex for blob sha256 (extractSha256 requires)
 
     describe('handleSyncDelete', () => {
       let sk, pk, deps;
@@ -1120,26 +1130,24 @@ Wraps NIP-98 validation, rate limiting, Funnelcake fetch with retries, `processK
       }
 
       it('returns 200 with success on happy path', async () => {
-        const kind5 = { id: 'k1', pubkey: pk, tags: [['e', 't1']] };
+        const kind5 = { id: KIND5_ID, pubkey: pk, tags: [['e', 't1']] };
         deps.fetchKind5WithRetry.mockResolvedValueOnce(kind5);
-        deps.fetchTargetEvent.mockResolvedValueOnce({ id: 't1', pubkey: pk, tags: [['imeta', 'x abc']] });
-        deps.callBlossomDelete.mockResolvedValueOnce({ ok: true, status: 200 });
+        deps.fetchTargetEvent.mockResolvedValueOnce({ id: 't1', pubkey: pk, tags: [['imeta', `x ${SHA_C}`]] });
+        deps.callBlossomDelete.mockResolvedValueOnce({ success: true, status: 200 });
 
-        const request = new Request('https://moderation-api.divine.video/api/delete/k1', {
+        const url = `https://moderation-api.divine.video/api/delete/${KIND5_ID}`;
+        const request = new Request(url, {
           method: 'POST',
-          headers: { 'Authorization': signNip98('https://moderation-api.divine.video/api/delete/k1', 'POST') }
+          headers: { 'Authorization': signNip98(url, 'POST') }
         });
 
         const response = await handleSyncDelete(request, deps);
         expect(response.status).toBe(200);
         const body = await response.json();
-        expect(body).toMatchObject({ kind5_id: 'k1', status: 'success' });
-        expect(body.targets[0]).toMatchObject({ target_event_id: 't1', status: 'success', blob_sha256: 'abc' });
+        expect(body).toMatchObject({ kind5_id: KIND5_ID, status: 'success' });
+        expect(body.targets[0]).toMatchObject({ target_event_id: 't1', status: 'success', blob_sha256: SHA_C });
       });
     });
-
-    function makeFakeD1() { /* see d1.test.mjs */ }
-    function makeFakeKV() { /* see rate-limit.test.mjs */ }
     ```
 
 - [ ] **Step 2: Run — FAIL**
@@ -1156,9 +1164,9 @@ Wraps NIP-98 validation, rate limiting, Funnelcake fetch with retries, `processK
     import { processKind5 } from './process.mjs';
     import { checkRateLimit } from './rate-limit.mjs';
 
-    const PER_PUBKEY_LIMIT = 5;
-    const PER_IP_LIMIT = 30;
-    const RATE_WINDOW_SECONDS = 60;
+    export const PER_PUBKEY_LIMIT = 5;
+    export const PER_IP_LIMIT = 30;
+    export const RATE_WINDOW_SECONDS = 60;
 
     export async function handleSyncDelete(request, deps) {
       const { db, kv, fetchKind5WithRetry, fetchTargetEvent, callBlossomDelete, budgetMs = 8000 } = deps;
@@ -1290,13 +1298,13 @@ Wraps NIP-98 validation, rate limiting, Funnelcake fetch with retries, `processK
       });
 
       it('returns 202 when internal budget exceeded', async () => {
-        const kind5 = { id: 'a'.repeat(64), pubkey: pk, tags: [['e', 't1']] };
+        const kind5 = { id: KIND5_ID, pubkey: pk, tags: [['e', 't1']] };
         deps.fetchKind5WithRetry.mockResolvedValueOnce(kind5);
-        deps.fetchTargetEvent.mockResolvedValueOnce({ id: 't1', pubkey: pk, tags: [['imeta', 'x abc']] });
+        deps.fetchTargetEvent.mockResolvedValueOnce({ id: 't1', pubkey: pk, tags: [['imeta', `x ${SHA_C}`]] });
         // Blossom slow — never resolves within budget
         deps.callBlossomDelete.mockReturnValueOnce(new Promise(() => {}));
 
-        const url = 'https://moderation-api.divine.video/api/delete/' + 'a'.repeat(64);
+        const url = `https://moderation-api.divine.video/api/delete/${KIND5_ID}`;
         const request = new Request(url, { method: 'POST', headers: { Authorization: signNip98(url, 'POST') } });
         const response = await handleSyncDelete(request, { ...deps, budgetMs: 50 });
         expect(response.status).toBe(202);
@@ -1305,7 +1313,7 @@ Wraps NIP-98 validation, rate limiting, Funnelcake fetch with retries, `processK
       });
     ```
 
-    Import `checkRateLimit` and constants at the top of the test file.
+    Also update the other rejection tests to use the `KIND5_ID` constant rather than `'a'.repeat(64)` literals, and tighten `'notahex'` to a string that is clearly not 64-hex (e.g., `'not-a-hex-id'`). Tests for 401 / 403 / 404 / 429 should replace `'a'.repeat(64)` with `` `${KIND5_ID}` `` for consistency.
 
 - [ ] **Step 6: Run — all pass**
 

--- a/docs/superpowers/specs/2026-04-16-per-video-delete-enforcement-design.md
+++ b/docs/superpowers/specs/2026-04-16-per-video-delete-enforcement-design.md
@@ -1,0 +1,229 @@
+# Per-Video Delete End-to-End Enforcement
+
+**Date:** April 16, 2026
+**Author:** Matt Bradley
+**Status:** Draft. Awaiting review.
+
+**Issue:** divine-mobile#3102 (parent #2656; sibling mobile-copy polish #3101)
+
+## Goal
+
+When a creator deletes one of their videos on Divine, the creator sees an honest confirmation, the content is no longer served from any Divine-controlled surface, and support and compliance have a single authoritative record of what happened.
+
+## Motivation
+
+Today the creator-facing confirmation ("Delete request sent successfully") fires on event *creation*, not on relay *acceptance*, and the video's media blob, thumbnail, and transcript remain accessible via direct CDN URLs indefinitely. The code comment in `content_deletion_service.dart` frames this work as Apple App Store compliance. The gap is the immediate trigger for this spec (parent #2656: high-profile creator couldn't tell whether delete worked, three staff members were also confused). Compliance pressure is foreseeable, not hypothetical.
+
+## Current State
+
+**divine-mobile** (`mobile/lib/services/content_deletion_service.dart:125-195`, `mobile/lib/widgets/share_video_menu.dart:1046-1151`) publishes a signed NIP-09 kind 5 event directly to the relay pool. Success is returned on event creation regardless of relay acceptance. No blob cleanup.
+
+**divine-funnelcake** (`crates/relay/src/relay.rs:1235-1331`) verifies kind 5 signature, checks `verify_delete_authorization` (deleter authored each target), inserts accepted targets into ClickHouse `deleted_events_set`, and returns NIP-01 `OK` over the websocket. No outbound notification anywhere in the relay crate.
+
+**divine-blossom** (`src/admin.rs:727-788`) exposes `POST /admin/api/moderate` with actions `BAN|BLOCK|RESTRICT|APPROVE|ACTIVE|PENDING`. `BlobStatus::Deleted` exists but is not wired to any action verb. Thumbnails are stored at deterministic GCS key `{video_sha256}.jpg` and share the main blob's metadata record. VTT transcripts are tracked in KV under `subtitle_hash:` prefix keyed by the main video's sha256 (a `delete_subtitle_data(hash)` function exists). Derived audio maintains bidirectional sha256 mappings.
+
+**Gap:** nothing connects Funnelcake kind 5 acceptance to Blossom blob removal. Mobile's success signal is detached from relay acceptance. No audit trail.
+
+## Design Principle
+
+**Relay-side delete is the critical path and remains independent of moderation-service.** Blob cleanup is a downstream side effect of relay acceptance, handled by a subscriber worker. Moderation-service failure degrades confirmation UX and cleanup timing, never the relay-side delete. This is the reverse of routing all deletes through moderation-service, which would make mod-service an availability choke-point.
+
+## Architecture
+
+```
+  mobile              Funnelcake            moderation-service           Blossom
+  ------              ----------            ------------------           -------
+  [sign kind 5]  ---> [verify auth]
+                      [store deleted_set]
+                      [NIP-01 OK]       ---> (event broadcast)
+                                              |
+                                              v
+                                        [subscriber receives]
+                                        [D1: row received]
+                                        [fetch target, sha256]  --->  [DELETE sha256]
+                                                                      [status=Deleted]
+                                                                      [cascade thumb/vtt]
+                                        [D1: row success] <---        [200 OK]
+    ^                                         |
+    | GET /api/delete-status/{kind5_id}       |
+    +---  NIP-98 auth  -----------------------+
+```
+
+## Components
+
+### 1. Subscriber worker (`divine-moderation-service`)
+
+New module tails a websocket subscription to `wss://relay.divine.video` with filter `{kinds:[5]}`. On each accepted kind 5:
+
+1. Parse `e` tags to enumerate target event IDs. Per NIP-09 semantics, kind 5 may carry multiple targets; process each independently.
+2. For each target: write a D1 row (status `accepted`), fetch the target event (kind 34236) via `fetchNostrEventById`, extract the main video sha256 from `imeta`/url tags. If target fetch fails, update D1 to `failed:target_unresolved` and continue to the next target.
+3. Call Blossom `POST /admin/api/moderate` with `{sha256, action: "DELETE"}` using the existing `webhook_secret` Bearer auth.
+4. Update D1 row to `success` with `completed_at`, or to `failed:{reason}` with `last_error` and `retry_count` increment. Retry transient failures with exponential backoff (max 5 attempts, cap 5 minutes).
+
+Subscription persistence follows the existing `src/nostr/relay-poller.mjs` pattern in moderation-service, extended to record the last-seen timestamp in a Durable Object. On reconnect, the subscription uses `since=<last_seen>` so missed kind 5s are replayed through normal Nostr semantics. No separate reconciliation job required in v1.
+
+Idempotency: composite PRIMARY KEY `(kind5_id, target_event_id)` in D1 with UPSERT. Duplicate deliveries (reconnect overlap, repeated `e` tags within one kind 5) are harmless.
+
+### 2. D1 audit table
+
+New migration in `divine-moderation-service/migrations/`:
+
+```sql
+CREATE TABLE IF NOT EXISTS creator_deletions (
+  kind5_id TEXT NOT NULL,
+  target_event_id TEXT NOT NULL,
+  creator_pubkey TEXT NOT NULL,
+  blob_sha256 TEXT,
+  status TEXT NOT NULL,             -- accepted|success|failed:{reason}
+  accepted_at TEXT NOT NULL,        -- ISO8601 timestamp the subscriber accepted the kind 5 into the pipeline
+  completed_at TEXT,
+  retry_count INTEGER NOT NULL DEFAULT 0,
+  last_error TEXT,
+  PRIMARY KEY (kind5_id, target_event_id)
+);
+
+CREATE INDEX idx_creator_deletions_target ON creator_deletions(target_event_id);
+CREATE INDEX idx_creator_deletions_creator ON creator_deletions(creator_pubkey);
+CREATE INDEX idx_creator_deletions_sha256 ON creator_deletions(blob_sha256);
+CREATE INDEX idx_creator_deletions_status ON creator_deletions(status);
+```
+
+Indexes support support-team queries ("was event X deleted?", "what has creator Y deleted?", "what happened to blob Z?") and operator sweep queries ("show me all `failed:*` rows since yesterday").
+
+### 3. Status endpoint
+
+`GET /api/delete-status/{kind5_id}` on moderation-service. NIP-98 auth required: the caller signs the HTTP request with the same nsec that authored the kind 5. Rejects any pubkey other than the kind5 author.
+
+Response: JSON array of per-target status rows (length 1 for divine-mobile today, can be longer for bulk-delete clients):
+
+```json
+{
+  "kind5_id": "...",
+  "targets": [
+    {
+      "target_event_id": "...",
+      "blob_sha256": "...",
+      "status": "success",
+      "accepted_at": "2026-04-16T14:02:11Z",
+      "completed_at": "2026-04-16T14:02:12Z"
+    }
+  ]
+}
+```
+
+Rate-limited per-pubkey (approximately 2 requests/second). Returns 404 if no row exists for the kind5_id (subscriber has not yet observed it).
+
+### 4. Mobile polling and two-state UI
+
+After `_nostrService.publishEvent(deleteEvent)` returns NIP-01 OK, mobile begins polling `GET /api/delete-status/{kind5_id}` with exponential backoff (500ms, 1s, 2s, 4s, cap 5s) for up to 30 seconds total.
+
+The states mobile must represent in the UI:
+
+| Backend state | Mobile state intent |
+|---|---|
+| Polling in progress, no row yet | In-progress indicator; operation has left the device and is being processed |
+| All targets `status: success` | Terminal confirmation that Divine-controlled deletion completed |
+| Partial success (some `success`, some `accepted`/in-flight) | In-progress continues until terminal; resolves to one of the terminal states below |
+| Any target `status: failed:*` (others may be `success`) | Terminal failure message naming the scope (e.g., N of M targets). Partial successes are not rolled back. Retry or support path. |
+| Polling timeout (still accepted/in-flight) | Terminal with scoped honesty: content is removed from Divine feeds/profile; cleanup is still in progress |
+| Endpoint unreachable (mod-service down) | Terminal with scoped honesty: content is removed from Divine feeds/profile; cleanup may be delayed |
+
+The relay-side delete has already succeeded in every row below the first. The timeout and unreachable states must remain honest at NIP-01 OK: the video is gone from Divine feeds and profile the moment Funnelcake accepts, even when the cleanup tail is pending.
+
+Local-feed removal (`videoEventService.removeVideoCompletely`) fires at NIP-01 OK, unchanged from today.
+
+**Exact user-facing strings are owned by #3101** (mobile copy polish). This spec describes state intent only. Coordination note on #3101 to reference this design so the two tickets ship compatible copy.
+
+### 5. Blossom `DELETE` action with cascade and physical removal
+
+PR against `divine-blossom/src/admin.rs` and related:
+
+1. Add `"DELETE" => BlobStatus::Deleted` to the match in `handle_admin_moderate_action` (around line 754).
+2. Extend the handler to cascade when the action is `DELETE`:
+   - Call `delete_subtitle_data(sha256)` to clear subtitle KV.
+   - Clear derived audio references via existing metadata helpers.
+   - **Physical GCS byte removal** on the main blob, thumbnail (`{sha256}.jpg`), VTT transcript, and any derived audio. Ordered status-first-then-bytes: the status flip precedes GCS calls so serving is already blocked before destruction begins. Transient GCS errors retried with exponential backoff (max 3 attempts). Permanent failure returns a distinct error the subscriber records as `failed:gcs_delete` in D1.
+3. **Physical-removal flag.** New config value (Fastly config store or env var) `ENABLE_PHYSICAL_DELETE`, default `false`. When `true`, step 2's GCS deletions run. When `false`, the handler flips status and returns `{success: true, physical_delete_skipped: true}` without touching GCS. The flag is useful on first prod deploy (validate pipeline selects correct sha256s without data destruction), for future incident response, and for any scenario where we want to fall back to reversible behavior. Default-off on first prod deploy, flip after validation.
+4. Verify serve paths reject `Deleted`. **Dependency: divine-blossom PR #33** is the in-flight work closing these route gaps (HLS HEAD, subtitle-by-hash). Our feature lands on top of #33.
+
+Thumbnail cleanup is implicit from the status-flip side: thumbnails live at deterministic GCS key `{sha256}.jpg` and share the main blob's metadata record, so `Deleted` status on the main record is the single source of truth for serving decisions once #33's route checks are consistent. Physical deletion of the thumbnail GCS object is explicit in step 2 regardless.
+
+One-time cleanup at flag flip: any blobs set to `Deleted` during the validation window (flag off) retain their GCS bytes. After flipping the flag, run a one-time sweep to physically remove bytes for those stale `Deleted` blobs. This reuses the sweep mechanism used for physical deletion, just with a targeted `status = 'Deleted' AND bytes_still_present` query. Call it out in the deploy runbook.
+
+### 6. Vocabulary alignment doc update
+
+Small PR to `docs/policy/moderation-vocabulary-alignment.md` adding `creator_delete` as a canonical action:
+
+| Canonical | moderation-service | relay-manager | Blossom | Funnelcake | Reversible? |
+|---|---|---|---|---|---|
+| `creator_delete` | subscriber worker | (none) | `DELETE` → `Deleted` | `banevent` via creator's own kind 5 | No (without creator consent) |
+
+Origin distinguishment (creator vs admin) lives in the D1 audit layer, not in Blossom state. Blossom's `Deleted` state remains "not served, tombstoned, re-upload prevented." This aligns with Rabble's Apr 12 taxonomy principle (D1 holds decision + audit; Blossom enforces).
+
+## Failure handling
+
+Full matrix below. Every state must be scoped to what is actually known at the time the UI update appears. Exact copy is #3101's; this spec specifies the state intent.
+
+| Scenario | Funnelcake | Mod-service | Mobile state intent |
+|---|---|---|---|
+| All healthy | OK | OK | In-progress → terminal success (~1-3s typical) |
+| Funnelcake rejects (unauthorized / missing target / expired) | Reject | n/a | Terminal failure naming the rejection reason |
+| Funnelcake unreachable | Fail | n/a | Terminal failure framed as transport problem, retry affordance |
+| Funnelcake OK, mod-service down | OK | Down | In-progress → polling fails → terminal "removed from Divine, cleanup may be delayed" |
+| Funnelcake OK, mod-service slow | OK | Slow | In-progress → polling eventually succeeds → terminal success |
+| Funnelcake OK, Blossom call fails after retries | OK | D1 records `failed:{reason}` | Polling returns `status: failed` → terminal "removed from Divine, cleanup failed" with support path |
+| Funnelcake OK, status flip OK, GCS delete fails after retries | OK | D1 records `failed:gcs_delete` | Polling returns `status: failed:gcs_delete` → same as above (content not served, physical bytes may still exist, operator sweep can retry) |
+
+On mod-service recovery after an outage, the subscriber reconnects via `since=<last-timestamp>` and backfills D1. The audit trail eventually becomes complete regardless of outage duration.
+
+## Observability
+
+These alarms are v1 scope, not follow-up, because the "we handle degradation honestly" commitment depends on us detecting it.
+
+- **Status endpoint error rate** above threshold (Sentry alert on mod-service).
+- **Subscriber lag** measured as `D1.accepted_at - kind5.created_at`; alert on p95 > 60s.
+- **Blossom call failure rate** above threshold (surfaces Blossom outages or schema drift).
+- **Subscriber write latency** divergence (`D1.completed_at - D1.accepted_at`) p95 > 30s.
+- **Dashboard** (Sentry or Grafana) showing end-to-end pipeline health: success rate, p50/p95 per leg, failure categories.
+
+## Security
+
+- **Blossom admin token** remains in moderation-service only. No new secret propagation. Subscriber uses existing `webhook_secret` Bearer.
+- **NIP-98 on status endpoint** prevents third-party callers from using the endpoint as a free Divine infrastructure monitor.
+- **D1 audit contents** are Divine-internal. Kind5 IDs, sha256s, and creator pubkeys are already public Nostr data; statuses and timestamps are operationally sensitive and gated by NIP-98 when accessed via the public endpoint. Support and compliance queries go through direct D1 access (wrangler or admin UI), not through the public status endpoint.
+- **Authorization is not re-checked** by the subscriber. Funnelcake already rejects unauthorized kind 5s before the subscriber sees them. Trusting upstream authz is cleaner than re-implementing it downstream.
+- **No Blossom blob deletion without a valid accepted kind 5.** The subscriber only acts on events it observes via the authenticated websocket from Funnelcake.
+
+## Testing
+
+- **Unit tests** in moderation-service for subscriber event-to-D1 translation (covers parse failures, multi-target, missing imeta, duplicate kind 5s).
+- **Integration tests** for the Blossom DELETE action cascade (thumbnail + VTT cleanup; tombstone prevents re-upload).
+- **End-to-end test** (staging, flag on): publish a kind 5 against staging Funnelcake, observe D1 row progression, verify Blossom serves 404 on main sha256 + thumbnail (`{sha256}.jpg`) + VTT URL + any derived audio URLs, **and verify the GCS bytes are actually gone** via direct bucket list/head.
+- **Flag-off test** (staging): same pipeline but with `ENABLE_PHYSICAL_DELETE=false`. Verify status flip + cascade metadata clearing occur, Blossom 404s, **but GCS bytes remain**. Confirms the flag gates the destructive step correctly.
+- **Mobile widget tests** for the polling state machine (all UI branches in the failure matrix).
+- **NIP-98 endpoint tests**: reject non-author pubkey, reject expired signature, accept valid.
+
+## Dependencies and sequencing
+
+1. **divine-blossom PR #33** must land first (route gaps for `Deleted` status on HLS HEAD and subtitle-by-hash). If #33 is still open when we start, our spec tracks its status.
+2. **divine-blossom DELETE action PR** (small). Merged behind PR #33.
+3. **divine-moderation-service migration + subscriber + status endpoint PR**. Deploys to staging first.
+4. **divine-mobile polling + UI states PR**. Can develop in parallel against a staging mod-service, merges after #3101.
+5. **Vocabulary alignment doc PR** alongside Blossom DELETE PR.
+
+Staging verification before production: publish a kind 5 via a test account with `ENABLE_PHYSICAL_DELETE=true` in staging, observe full lifecycle in D1, confirm direct-CDN 404, confirm GCS bytes gone. Production first-deploy ships with `ENABLE_PHYSICAL_DELETE=false`. After a validation window (suggested: 1 week or first 50 creator-initiated deletes in prod, whichever comes first), flip to `true` and run the one-time sweep described in §5.
+
+## Non-goals and follow-ups (explicit)
+
+- **ClickHouse reconciliation cron (option D).** Nostr's native `since`-based reconnect is the primary durability mechanism. Only worth building if observed subscriber miss rate justifies it.
+- **Grace period / creator-initiated un-delete.** Product decision, not infrastructure. If ever wanted, the tombstone-prevents-re-upload behavior would need a bypass for the same creator.
+- **Divine backend API for synchronous delete (option C).** Foreclosed in this spec by design. Non-Divine clients publishing kind 5 directly to Funnelcake would bypass the API; B + subscriber covers all ingress uniformly.
+- **Multi-relay coverage.** Issue scopes to Divine-controlled. If multi-relay enforcement is ever a requirement, it becomes a separate design.
+- **Operator "replay failed delete" tool.** D1 schema supports it via `status LIKE 'failed:%' AND retry_count < N`. Small CLI or admin UI, v2.
+
+## Open questions
+
+- **Blossom DELETE action owner.** Who writes the Blossom PR? Available for Matt if no Blossom engineer is picking it up this sprint. The PR is no longer trivial (physical-deletion cascade + flag + tests), call it a day of focused work.
+- **Subscriber location.** Confirmed to add to `divine-moderation-service` rather than a new Worker. Reuses existing Blossom admin auth, existing relay-client module, existing Durable Object patterns.
+- **Interaction with PR #33 timing.** If #33 slips past our target ship date, do we merge our code gated behind a feature flag and wait, or pause our work? Recommend: merge our subscriber and D1 layers (harmless without #33), hold mobile PR until #33 confirms cascade works end-to-end in staging.
+- **Backup and versioning policy.** If Blossom's GCS bucket has object versioning enabled, or if Divine writes blobs to B2 or another backup tier, then "delete the GCS object" may leave recoverable copies outside the live serving path. Whether that is acceptable depends on the compliance bar we are meeting. Action: (1) scout bucket versioning state and any B2 backup writes, (2) confirm with legal/ops whether backup retention is part of the "remove from storage" promise or a separately-governed lifecycle. This does not block v1 implementation of the main path; it determines whether an additional backup-purge step is required.

--- a/docs/superpowers/specs/2026-04-16-per-video-delete-enforcement-design.md
+++ b/docs/superpowers/specs/2026-04-16-per-video-delete-enforcement-design.md
@@ -4,7 +4,7 @@
 **Author:** Matt Bradley
 **Status:** Draft. Awaiting review.
 
-**Issue:** divine-mobile#3102 (parent #2656; sibling mobile-copy polish #3101)
+**Issue:** divine-mobile#3102 (parent #2656; sibling mobile-copy polish #3117)
 
 ## Goal
 
@@ -283,7 +283,7 @@ The states mobile must represent in the UI:
 
 The relay-side delete has already succeeded in every row below the first. The timeout and unreachable states must remain honest at NIP-01 OK: the video is gone from Divine feeds and profile the moment Funnelcake accepts, even when the cleanup tail is pending.
 
-**Exact user-facing strings are owned by #3101** (mobile copy polish). This spec describes state intent only. Coordination note on #3101 to reference this design so the two tickets ship compatible copy.
+**Exact user-facing strings are owned by #3117** (mobile copy polish). This spec describes state intent only. Coordination note on #3117 to reference this design so the two tickets ship compatible copy.
 
 ### 5. Blossom `DELETE` action with cascade and physical removal
 
@@ -296,6 +296,7 @@ PR against `divine-blossom/src/admin.rs` and related:
    - **Physical GCS byte removal** on the main blob, thumbnail (`{sha256}.jpg`), VTT transcript, and any derived audio. Ordered status-first-then-bytes: the status flip precedes GCS calls so serving is already blocked before destruction begins.
    - **GCS 404 is idempotent success.** If a GCS object doesn't exist (because a prior retry already deleted it), treat as success, not failure. Prevents spurious `failed:gcs_delete` on retries.
    - **Transient GCS errors retried** with exponential backoff (max 3 attempts). Permanent failure returns a distinct error the subscriber records as `failed:transient:gcs_delete` in D1 (cron retries).
+   - **Fastly CDN cache invalidation.** After GCS deletion, issue a Fastly Purge for every affected URL path pattern (`/<sha256>`, `/<sha256>.jpg`, `/<sha256>.vtt`, and any derived-audio URL). Blossom runs on Fastly Compute so this is an internal purge call — cheap and reliable, no external token. Purge failures are logged (Sentry) but do NOT block the DELETE response from returning 200 to the caller: the core compliance claim is "bytes removed from GCS"; a failed edge purge means caches expire naturally per TTL instead of instantly. Observability: a Sentry alert on `blossom.creator_delete.cdn_purge.failed` rate surfaces degraded invalidation without degrading the creator-facing pipeline.
 3. **Physical-removal flag.** New config value (Fastly config store or env var) `ENABLE_PHYSICAL_DELETE`, default `false`. When `true`, step 2's GCS deletions run. When `false`, the handler flips status and returns `{success: true, physical_delete_skipped: true}` without touching GCS. The flag is useful on first prod deploy (validate pipeline selects correct sha256s without data destruction), for future incident response, and for any scenario where we want to fall back to reversible behavior. Default-off on first prod deploy, flip after validation.
 4. Verify serve paths reject `Deleted`. **Dependency: divine-blossom PR #33** is the in-flight work closing these route gaps (HLS HEAD, subtitle-by-hash). Our feature lands on top of #33.
 5. **Verify tombstone prevents re-upload.** The vocab alignment doc states that `Deleted` state "prevents re-upload." Scout confirms `BlobStatus::Deleted` exists but the upload-path check is unverified. Blossom PR must include (or verify) that a `PUT` request targeting a sha256 in `Deleted` state is rejected with 409 or equivalent.
@@ -316,7 +317,7 @@ Origin distinguishment (creator vs admin) lives in the D1 audit layer, not in Bl
 
 ## Failure handling
 
-Full matrix below. Every state must be scoped to what is actually known at the time the UI update appears. Exact copy is #3101's; this spec specifies state intent.
+Full matrix below. Every state must be scoped to what is actually known at the time the UI update appears. Exact copy is #3117's; this spec specifies state intent.
 
 | Scenario | Funnelcake | Mod-service | Mobile state intent |
 |---|---|---|---|
@@ -381,7 +382,7 @@ Deploy order matters. Out-of-order deployment creates failure modes that degrade
 1. **divine-blossom PR #33** must land and deploy first. Without it, `Deleted` status is not consistently checked on serve paths (HLS HEAD, subtitle-by-hash), so blob status flips are cosmetic on those routes.
 2. **divine-blossom DELETE-action PR**, flag default-off. Staging first; verify `DELETE` returns success with `physical_delete_skipped: true` when flag off.
 3. **divine-moderation-service migration + cron + sync endpoint + status endpoint PR**. Deploys to staging. Verify end-to-end against staging Blossom (flag off) — pipeline executes, Blossom returns success, D1 captures full lifecycle.
-4. **divine-mobile polling + UI states PR**. Can develop in parallel against staging mod-service; merges after #3101.
+4. **divine-mobile polling + UI states PR**. Can develop in parallel against staging mod-service; merges after #3117.
 5. **Vocabulary alignment doc PR** alongside Blossom DELETE PR.
 6. **Production rollout:** deploy Blossom (flag off), then mod-service, then mobile. Run validation window (suggested: 1 week or first 50 creator-initiated deletes in prod, whichever comes first). Flip `ENABLE_PHYSICAL_DELETE=true` and run the one-time sweep described in §5.
 
@@ -394,9 +395,11 @@ Verify before implementation or at the start of implementation (failures here re
 - [ ] Staging GCS bucket accepts authenticated delete calls from the Blossom identity.
 - [ ] Staging mod-service `wrangler.toml` supports a new D1 binding for the audit table (or uses the existing one) and a new cron trigger.
 - [ ] Staging has NIP-98 verification path testable end-to-end (nostr-tools signature verification).
+- [ ] Fastly Purge works from Blossom: verify that Blossom's DELETE handler can issue an internal Purge call and that a cached URL returns 404 (or a fresh response) within seconds. If misconfigured, Blossom logs the failure but does not block the DELETE response — acceptable graceful degradation.
 
 ## Non-goals and follow-ups (explicit)
 
+- **CDN cache invalidation is v1, not a follow-up.** Blossom's DELETE handler issues an internal Fastly Purge immediately after GCS byte deletion; the purge is cheap because Blossom runs on Fastly Compute. A purge failure is logged (Sentry) but does not block the DELETE response — the bytes-are-gone compliance claim is fulfilled via GCS deletion, and edges clear per TTL in the fallback case. Explicitly accepting "TTL window as expected latency" is NOT the v1 stance.
 - **ClickHouse reconciliation cron.** The 60s REQ cron is the primary durability mechanism. ClickHouse-based reconciliation is only worth building if observed cron miss rate justifies it, and it requires prod ClickHouse read access currently pending with ops.
 - **Grace period / creator-initiated un-delete.** Not in scope; creator-initiated deletes are not reversible by creators. Operator recovery (via direct D1 + Blossom admin access) is the escape hatch.
 - **Divine backend API for synchronous kind 5 publish (option C from brainstorm).** Foreclosed. Non-Divine clients publishing kind 5 directly to Funnelcake would bypass such an API; cron + sync endpoint covers all ingress uniformly.

--- a/docs/superpowers/specs/2026-04-16-per-video-delete-enforcement-design.md
+++ b/docs/superpowers/specs/2026-04-16-per-video-delete-enforcement-design.md
@@ -8,7 +8,7 @@
 
 ## Goal
 
-When a creator deletes one of their videos on Divine, the creator sees an honest confirmation, the content is no longer served from any Divine-controlled surface, and support and compliance have a single authoritative record of what happened.
+When a creator deletes one of their videos on Divine, the creator sees an honest confirmation, the content is no longer served from any Divine-controlled surface, the bytes are removed from Divine-controlled storage, and support and compliance have a single authoritative record of what happened.
 
 ## Motivation
 
@@ -26,7 +26,7 @@ Today the creator-facing confirmation ("Delete request sent successfully") fires
 
 ## Design Principle
 
-**Relay-side delete is the critical path and remains independent of moderation-service.** Blob cleanup is a downstream side effect of relay acceptance, handled by a subscriber worker. Moderation-service failure degrades confirmation UX and cleanup timing, never the relay-side delete. This is the reverse of routing all deletes through moderation-service, which would make mod-service an availability choke-point.
+**Relay-side delete is the critical path and remains independent of moderation-service.** Blob cleanup is a downstream side effect of relay acceptance, handled by a cron-plus-synchronous-endpoint pipeline in moderation-service. Moderation-service failure degrades confirmation UX and cleanup timing, never the relay-side delete. This is the reverse of routing all deletes through moderation-service, which would make mod-service an availability choke-point.
 
 ## Architecture
 
@@ -35,38 +35,176 @@ Today the creator-facing confirmation ("Delete request sent successfully") fires
   ------              ----------            ------------------           -------
   [sign kind 5]  ---> [verify auth]
                       [store deleted_set]
-                      [NIP-01 OK]       ---> (event broadcast)
-                                              |
-                                              v
-                                        [subscriber receives]
-                                        [D1: row received]
-                                        [fetch target, sha256]  --->  [DELETE sha256]
-                                                                      [status=Deleted]
-                                                                      [cascade thumb/vtt]
-                                        [D1: row success] <---        [200 OK]
-    ^                                         |
-    | GET /api/delete-status/{kind5_id}       |
-    +---  NIP-98 auth  -----------------------+
+                      [NIP-01 OK]
+       |
+       |  POST /api/delete/{kind5_id}  (NIP-98, author-only)
+       +-----------------------------------> [fetch kind 5 with retries]
+                                             [D1 claim: accepted]
+                                             [fetch target, sha256]  --->  [DELETE sha256]
+                                                                           [status=Deleted]
+                                                                           [cascade thumb/vtt]
+                                             [D1: success] <---            [200 OK]
+       <------------------------------------ [return 200 with result]
+
+       or (partial / slow Blossom):
+       <------------------------------------ [return 202, poll status]
+
+    ^                                         ^
+    |                                         |
+    | GET /api/delete-status/{kind5_id}       |   recovery / fallback path
+    +---  NIP-98, author-only  ---------------+
+
+  Parallel path for non-synchronous kind 5s (third-party clients, sync failures):
+
+  [cron every 60s]  ---> [REQ kind:5 since=<last_poll>]  ---> Funnelcake
+                         [process each]                        (returns events)
+                             |
+                             +---> [processKind5]  (same function as sync path)
+                         [also retry failed:transient:* rows with retry_count < 5]
 ```
 
 ## Components
 
-### 1. Subscriber worker (`divine-moderation-service`)
+### 1. Delete processing pipeline (`divine-moderation-service`)
 
-New module tails a websocket subscription to `wss://relay.divine.video` with filter `{kinds:[5]}`. On each accepted kind 5:
+The pipeline has two triggers that converge on the same processing function. Cloudflare Workers cannot hold a persistent WebSocket subscription in a request-scoped invocation, and this repo has no Durable Object pattern. We match the existing `src/nostr/relay-poller.mjs` shape instead: short-lived REQ queries, state in KV and D1.
 
-1. Parse `e` tags to enumerate target event IDs. Per NIP-09 semantics, kind 5 may carry multiple targets; process each independently.
-2. For each target: write a D1 row (status `accepted`), fetch the target event (kind 34236) via `fetchNostrEventById`, extract the main video sha256 from `imeta`/url tags. If target fetch fails, update D1 to `failed:target_unresolved` and continue to the next target.
-3. Call Blossom `POST /admin/api/moderate` with `{sha256, action: "DELETE"}` using the existing `webhook_secret` Bearer auth.
-4. Update D1 row to `success` with `completed_at`, or to `failed:{reason}` with `last_error` and `retry_count` increment. Retry transient failures with exponential backoff (max 5 attempts, cap 5 minutes).
+#### Shared processing function
 
-Subscription persistence follows the existing `src/nostr/relay-poller.mjs` pattern in moderation-service, extended to record the last-seen timestamp in a Durable Object. On reconnect, the subscription uses `since=<last_seen>` so missed kind 5s are replayed through normal Nostr semantics. No separate reconciliation job required in v1.
+`processKind5(kind5Event, env)`: parses `e` tags to enumerate target event IDs; processes each independently (per NIP-09, kind 5 may carry multiple targets). For each target, the function is race-safe against concurrent invocations (e.g., sync endpoint and cron colliding on the same kind 5 within milliseconds):
 
-Idempotency: composite PRIMARY KEY `(kind5_id, target_event_id)` in D1 with UPSERT. Duplicate deliveries (reconnect overlap, repeated `e` tags within one kind 5) are harmless.
+1. **D1 idempotency claim** using INSERT-OR-IGNORE, then SELECT to read canonical state:
+
+    ```sql
+    INSERT INTO creator_deletions
+      (kind5_id, target_event_id, creator_pubkey, status, accepted_at)
+    VALUES (?, ?, ?, 'accepted', ?)
+    ON CONFLICT(kind5_id, target_event_id) DO NOTHING;
+    ```
+
+   Then `SELECT` the row. Resolve based on returned state:
+   - Row matches this worker's `accepted_at` → this worker claimed it, proceed.
+   - Existing `status: success` → return `{skipped: 'already_done'}`.
+   - Existing `status: failed:permanent:*` → return `{skipped: 'permanently_failed'}`.
+   - Existing `status: accepted` with age < 30s → return `{skipped: 'in_progress'}` (another worker owns it).
+   - Existing `status: accepted` with age ≥ 30s → claim it (prior worker likely died); proceed.
+   - Existing `status: failed:transient:*` with `retry_count < 5` → claim it for retry; proceed.
+
+2. Fetch the target event (kind 34236) via `fetchNostrEventById`. If fetch fails, update D1 to `failed:permanent:target_unresolved`. Continue to the next target.
+
+3. Extract the main video sha256 from `imeta`/url tags. If missing, update D1 to `failed:permanent:no_sha256`. Continue.
+
+4. Call Blossom `POST /admin/api/moderate` with `{sha256, action: "DELETE"}` using the existing `webhook_secret` Bearer auth.
+
+5. Update D1 based on Blossom response:
+   - 2xx → `success` with `completed_at`.
+   - 4xx (except 429) → `failed:permanent:blossom_{code}` with `last_error`.
+   - 5xx, 429, network, or timeout → `failed:transient:{category}`, increment `retry_count`. If `retry_count >= 5`, upgrade to `failed:permanent:max_retries_exceeded`. Cron retries `failed:transient:*` rows with `retry_count < 5`.
+
+#### State taxonomy
+
+Explicit D1 `status` values:
+
+| Status | Meaning | Retryable? |
+|---|---|---|
+| `accepted` | Claimed by a worker, processing in progress | n/a |
+| `success` | Terminal success | no |
+| `failed:transient:blossom_5xx` | Blossom returned 5xx | yes (cron) |
+| `failed:transient:blossom_429` | Blossom rate-limited us | yes (cron) |
+| `failed:transient:network` | Network error to Funnelcake or Blossom | yes (cron) |
+| `failed:transient:timeout` | Request timed out | yes (cron) |
+| `failed:permanent:target_unresolved` | Target event could not be fetched from Funnelcake | no |
+| `failed:permanent:no_sha256` | Target event missing imeta/url sha256 | no |
+| `failed:permanent:blossom_400` | Blossom rejected the request | no |
+| `failed:permanent:blossom_403` | Blossom auth failed | no |
+| `failed:permanent:blossom_404` | Blossom says blob doesn't exist | no |
+| `failed:permanent:max_retries_exceeded` | Transient failure retried 5 times and gave up | operator only |
+| `failed:permanent:authz_mismatch` | Caller pubkey does not match kind 5 author (sync endpoint only) | no |
+
+Cron retries only `failed:transient:*` rows where `retry_count < 5` and where `accepted_at` is older than the retry backoff window (e.g., 30s × 2^retry_count up to 5 minutes). Permanent failures stay visible until manual intervention (follow-up operator sweep tool).
+
+#### Trigger A: Synchronous delete endpoint
+
+`POST /api/delete/{kind5_id}` with NIP-98 auth. Mobile calls this after publishing its kind 5 to Funnelcake.
+
+**Auth:** NIP-98 Bearer (Authorization header contains base64-encoded kind 27235 event with `["u", full_url]` and `["method", "POST"]` tags, `created_at` within ±60 seconds of server time). **The caller pubkey MUST match the kind 5 author.** This is enforced after fetching the kind 5 from Funnelcake; mismatches return 403. Operator-triggered recovery from a non-author pubkey is an explicit v2 consideration, not v1.
+
+**Rate-limit:** per-pubkey approximately 5 requests per minute; per-IP approximately 30 per minute.
+
+**Handler flow:**
+
+1. Validate NIP-98; extract caller pubkey. On failure, return 401 (invalid signature) or 400 (malformed payload).
+2. Fetch the kind 5 from Funnelcake via `fetchNostrEventById` with retries for the Funnelcake accept→persist race. The kind 5 may have been accepted by Funnelcake's `handle_submitted_event` at `relay.rs:1238` but not yet queryable via REQ because the ClickHouse write is asynchronous (relay.rs:1301 queues for async write). Retry schedule: 0ms, 100ms, 500ms, 1s, 2s. Total budget approximately 3.6 seconds. If not found after retries, return 404.
+3. Verify `kind5.pubkey === caller_pubkey`. Mismatch returns 403.
+4. Run `processKind5` inline against the fetched kind 5. Internal budget approximately 8 seconds (roughly 2 × typical worst-case).
+5. If all targets terminal (`success` or any `failed:*`) within budget, return 200 with the result.
+6. If budget exceeds before all targets terminal, return 202 with instruction to poll.
+
+**Response body:**
+
+200 success:
+```json
+{
+  "kind5_id": "...",
+  "status": "success",
+  "targets": [
+    { "target_event_id": "...", "blob_sha256": "...", "status": "success", "completed_at": "2026-04-16T14:02:12Z" }
+  ]
+}
+```
+
+202 in progress (mobile should fall back to polling):
+```json
+{
+  "kind5_id": "...",
+  "status": "in_progress",
+  "poll_url": "/api/delete-status/{kind5_id}"
+}
+```
+
+200 with terminal failure (all targets resolved, at least one failed):
+```json
+{
+  "kind5_id": "...",
+  "status": "failed",
+  "targets": [
+    { "target_event_id": "...", "status": "failed:permanent:blossom_400", "last_error": "..." }
+  ]
+}
+```
+
+**Status codes:**
+
+| Code | Meaning |
+|---|---|
+| 200 | All targets terminal (success or failed); see body |
+| 202 | Processing continues; poll the status endpoint |
+| 400 | Malformed request or NIP-98 payload invalid |
+| 401 | NIP-98 signature verification failed |
+| 403 | Caller pubkey does not match kind 5 author |
+| 404 | Kind 5 not found on Funnelcake after retries |
+| 429 | Rate limit exceeded |
+| 500 | Internal error |
+| 502 | Blossom unreachable (transient) |
+
+#### Trigger B: Scheduled cron
+
+Cloudflare Worker cron runs every 60 seconds. Uses `relay-client.mjs` to REQ `{kinds:[5], since:<last_poll_ts>}` against `wss://relay.divine.video`, receives events until EOSE, stores new `last_poll_ts` in KV, calls `processKind5` for each event.
+
+**Scope:** catches non-Divine clients publishing kind 5 directly to Funnelcake, and any kind 5 whose synchronous path failed (mobile network hiccup, mod-service transient unavailability, Funnelcake read-after-write race that exceeded the sync endpoint's retry budget).
+
+**Also retries** `failed:transient:*` rows from D1: separate query per cycle targeted at `retry_count < 5 AND accepted_at < now() - backoff(retry_count)`. For each, re-run `processKind5` from step 1.
+
+**Assumption to verify during staging preflight:** Funnelcake's REQ handler returns accepted kind 5 events. Some relays treat kind 5 as ephemeral and drop events after applying the deletion; if that's Funnelcake's behavior, the cron strategy fails. See Staging Preflight below.
+
+#### Latency profile
+
+- **Synchronous path (divine-mobile):** approximately 1-3s typical; up to 8s before the server returns 202 and mobile falls back to polling.
+- **Cron path (non-Divine clients, sync failures, transient retries):** up to 90 seconds (60s cron interval + up to 30s processing and retries).
 
 ### 2. D1 audit table
 
-New migration in `divine-moderation-service/migrations/`:
+New migration `migrations/006-creator-deletions.sql`:
 
 ```sql
 CREATE TABLE IF NOT EXISTS creator_deletions (
@@ -74,8 +212,8 @@ CREATE TABLE IF NOT EXISTS creator_deletions (
   target_event_id TEXT NOT NULL,
   creator_pubkey TEXT NOT NULL,
   blob_sha256 TEXT,
-  status TEXT NOT NULL,             -- accepted|success|failed:{reason}
-  accepted_at TEXT NOT NULL,        -- ISO8601 timestamp the subscriber accepted the kind 5 into the pipeline
+  status TEXT NOT NULL,
+  accepted_at TEXT NOT NULL,
   completed_at TEXT,
   retry_count INTEGER NOT NULL DEFAULT 0,
   last_error TEXT,
@@ -88,13 +226,15 @@ CREATE INDEX idx_creator_deletions_sha256 ON creator_deletions(blob_sha256);
 CREATE INDEX idx_creator_deletions_status ON creator_deletions(status);
 ```
 
-Indexes support support-team queries ("was event X deleted?", "what has creator Y deleted?", "what happened to blob Z?") and operator sweep queries ("show me all `failed:*` rows since yesterday").
+Indexes support support-team queries ("was event X deleted?", "what has creator Y deleted?", "what happened to blob Z?") and cron sweep queries ("show me `failed:transient:*` rows ready for retry").
 
 ### 3. Status endpoint
 
-`GET /api/delete-status/{kind5_id}` on moderation-service. NIP-98 auth required: the caller signs the HTTP request with the same nsec that authored the kind 5. Rejects any pubkey other than the kind5 author.
+`GET /api/delete-status/{kind5_id}` on moderation-service. NIP-98 auth required; caller pubkey MUST match the kind 5 author (same rule as §1 Trigger A). Rejects any other pubkey with 403.
 
-Response: JSON array of per-target status rows (length 1 for divine-mobile today, can be longer for bulk-delete clients):
+Primary use: mobile fallback when the synchronous endpoint returns 202 or times out. Secondary: manual debugging by the creator.
+
+Response: JSON with per-target rows:
 
 ```json
 {
@@ -111,26 +251,37 @@ Response: JSON array of per-target status rows (length 1 for divine-mobile today
 }
 ```
 
-Rate-limited per-pubkey (approximately 2 requests/second). Returns 404 if no row exists for the kind5_id (subscriber has not yet observed it).
+Rate-limited per-pubkey (approximately 2 requests/second). Returns 404 if no row exists for the `kind5_id`.
 
-### 4. Mobile polling and two-state UI
+### 4. Mobile delete flow
 
-After `_nostrService.publishEvent(deleteEvent)` returns NIP-01 OK, mobile begins polling `GET /api/delete-status/{kind5_id}` with exponential backoff (500ms, 1s, 2s, 4s, cap 5s) for up to 30 seconds total.
+After the local kind 5 is signed and `_nostrService.publishEvent(deleteEvent)` returns NIP-01 OK:
+
+1. Remove the video from local feeds immediately (`videoEventService.removeVideoCompletely`) — unchanged from today. The creator's view updates instantly while async processing continues.
+2. Build a NIP-98 authorization for `POST /api/delete/{kind5_id}` (signed with the same nsec that signed the kind 5).
+3. Call the endpoint with a 15-second client timeout.
+4. Based on the response:
+   - **200 + `status: success`:** terminal success state.
+   - **200 + `status: failed`:** terminal failure; surface specific error and offer retry/support affordance.
+   - **202:** begin polling `GET /api/delete-status/{kind5_id}` with exponential backoff (500ms, 1s, 2s, 4s, cap 5s) for up to 30 seconds more. Resolve to terminal success/failure as rows reach terminal states.
+   - **4xx client error (400, 401, 403):** bug in mobile or the kind 5 itself; surface generic failure, log to Sentry.
+   - **429:** client backoff and retry (one retry, then fall back to polling).
+   - **502 / 5xx / client timeout:** fall back to polling (mod-service is degraded; cron will catch up).
+   - **Network error on endpoint:** fall back to polling (endpoint unreachable or mod-service down; cron will catch up).
 
 The states mobile must represent in the UI:
 
 | Backend state | Mobile state intent |
 |---|---|
-| Polling in progress, no row yet | In-progress indicator; operation has left the device and is being processed |
-| All targets `status: success` | Terminal confirmation that Divine-controlled deletion completed |
-| Partial success (some `success`, some `accepted`/in-flight) | In-progress continues until terminal; resolves to one of the terminal states below |
-| Any target `status: failed:*` (others may be `success`) | Terminal failure message naming the scope (e.g., N of M targets). Partial successes are not rolled back. Retry or support path. |
-| Polling timeout (still accepted/in-flight) | Terminal with scoped honesty: content is removed from Divine feeds/profile; cleanup is still in progress |
+| Call in progress, no response yet | In-progress indicator; operation has left the device and is being processed |
+| 200 success, all targets `success` | Terminal confirmation that Divine-controlled deletion completed |
+| 200 + any target `failed:*` | Terminal failure message naming the scope. Partial successes are not rolled back. Retry or support path. |
+| 202 + polling resolves to all success | Terminal confirmation (same as above) |
+| 202 + polling resolves to failed | Terminal failure (same as above) |
+| Polling timeout (status endpoint still in-flight) | Terminal with scoped honesty: content is removed from Divine feeds/profile; cleanup is still in progress |
 | Endpoint unreachable (mod-service down) | Terminal with scoped honesty: content is removed from Divine feeds/profile; cleanup may be delayed |
 
 The relay-side delete has already succeeded in every row below the first. The timeout and unreachable states must remain honest at NIP-01 OK: the video is gone from Divine feeds and profile the moment Funnelcake accepts, even when the cleanup tail is pending.
-
-Local-feed removal (`videoEventService.removeVideoCompletely`) fires at NIP-01 OK, unchanged from today.
 
 **Exact user-facing strings are owned by #3101** (mobile copy polish). This spec describes state intent only. Coordination note on #3101 to reference this design so the two tickets ship compatible copy.
 
@@ -142,88 +293,119 @@ PR against `divine-blossom/src/admin.rs` and related:
 2. Extend the handler to cascade when the action is `DELETE`:
    - Call `delete_subtitle_data(sha256)` to clear subtitle KV.
    - Clear derived audio references via existing metadata helpers.
-   - **Physical GCS byte removal** on the main blob, thumbnail (`{sha256}.jpg`), VTT transcript, and any derived audio. Ordered status-first-then-bytes: the status flip precedes GCS calls so serving is already blocked before destruction begins. Transient GCS errors retried with exponential backoff (max 3 attempts). Permanent failure returns a distinct error the subscriber records as `failed:gcs_delete` in D1.
+   - **Physical GCS byte removal** on the main blob, thumbnail (`{sha256}.jpg`), VTT transcript, and any derived audio. Ordered status-first-then-bytes: the status flip precedes GCS calls so serving is already blocked before destruction begins.
+   - **GCS 404 is idempotent success.** If a GCS object doesn't exist (because a prior retry already deleted it), treat as success, not failure. Prevents spurious `failed:gcs_delete` on retries.
+   - **Transient GCS errors retried** with exponential backoff (max 3 attempts). Permanent failure returns a distinct error the subscriber records as `failed:transient:gcs_delete` in D1 (cron retries).
 3. **Physical-removal flag.** New config value (Fastly config store or env var) `ENABLE_PHYSICAL_DELETE`, default `false`. When `true`, step 2's GCS deletions run. When `false`, the handler flips status and returns `{success: true, physical_delete_skipped: true}` without touching GCS. The flag is useful on first prod deploy (validate pipeline selects correct sha256s without data destruction), for future incident response, and for any scenario where we want to fall back to reversible behavior. Default-off on first prod deploy, flip after validation.
 4. Verify serve paths reject `Deleted`. **Dependency: divine-blossom PR #33** is the in-flight work closing these route gaps (HLS HEAD, subtitle-by-hash). Our feature lands on top of #33.
+5. **Verify tombstone prevents re-upload.** The vocab alignment doc states that `Deleted` state "prevents re-upload." Scout confirms `BlobStatus::Deleted` exists but the upload-path check is unverified. Blossom PR must include (or verify) that a `PUT` request targeting a sha256 in `Deleted` state is rejected with 409 or equivalent.
 
 Thumbnail cleanup is implicit from the status-flip side: thumbnails live at deterministic GCS key `{sha256}.jpg` and share the main blob's metadata record, so `Deleted` status on the main record is the single source of truth for serving decisions once #33's route checks are consistent. Physical deletion of the thumbnail GCS object is explicit in step 2 regardless.
 
-One-time cleanup at flag flip: any blobs set to `Deleted` during the validation window (flag off) retain their GCS bytes. After flipping the flag, run a one-time sweep to physically remove bytes for those stale `Deleted` blobs. This reuses the sweep mechanism used for physical deletion, just with a targeted `status = 'Deleted' AND bytes_still_present` query. Call it out in the deploy runbook.
+**One-time cleanup at flag flip:** any blobs set to `Deleted` during the validation window (flag off) retain their GCS bytes. After flipping the flag, run a one-time sweep to physically remove bytes for those stale `Deleted` blobs. This reuses the sweep mechanism used for physical deletion, just with a targeted `status = 'Deleted' AND bytes_still_present` query. Called out in the deploy runbook.
 
 ### 6. Vocabulary alignment doc update
 
-Small PR to `docs/policy/moderation-vocabulary-alignment.md` adding `creator_delete` as a canonical action:
+Small PR to `support-trust-safety/docs/policy/moderation-vocabulary-alignment.md` adding `creator_delete` as a canonical action:
 
 | Canonical | moderation-service | relay-manager | Blossom | Funnelcake | Reversible? |
 |---|---|---|---|---|---|
-| `creator_delete` | subscriber worker | (none) | `DELETE` → `Deleted` | `banevent` via creator's own kind 5 | No (without creator consent) |
+| `creator_delete` | cron + sync endpoint | (none) | `DELETE` → `Deleted` | `banevent` via creator's own kind 5 | No (without creator consent) |
 
-Origin distinguishment (creator vs admin) lives in the D1 audit layer, not in Blossom state. Blossom's `Deleted` state remains "not served, tombstoned, re-upload prevented." This aligns with Rabble's Apr 12 taxonomy principle (D1 holds decision + audit; Blossom enforces).
+Origin distinguishment (creator vs admin) lives in the D1 audit layer, not in Blossom state. Blossom's `Deleted` state remains "not served, tombstoned, re-upload prevented." Aligns with Rabble's Apr 12 taxonomy principle (D1 holds decision + audit; Blossom enforces).
 
 ## Failure handling
 
-Full matrix below. Every state must be scoped to what is actually known at the time the UI update appears. Exact copy is #3101's; this spec specifies the state intent.
+Full matrix below. Every state must be scoped to what is actually known at the time the UI update appears. Exact copy is #3101's; this spec specifies state intent.
 
 | Scenario | Funnelcake | Mod-service | Mobile state intent |
 |---|---|---|---|
 | All healthy | OK | OK | In-progress → terminal success (~1-3s typical) |
 | Funnelcake rejects (unauthorized / missing target / expired) | Reject | n/a | Terminal failure naming the rejection reason |
 | Funnelcake unreachable | Fail | n/a | Terminal failure framed as transport problem, retry affordance |
-| Funnelcake OK, mod-service down | OK | Down | In-progress → polling fails → terminal "removed from Divine, cleanup may be delayed" |
-| Funnelcake OK, mod-service slow | OK | Slow | In-progress → polling eventually succeeds → terminal success |
-| Funnelcake OK, Blossom call fails after retries | OK | D1 records `failed:{reason}` | Polling returns `status: failed` → terminal "removed from Divine, cleanup failed" with support path |
-| Funnelcake OK, status flip OK, GCS delete fails after retries | OK | D1 records `failed:gcs_delete` | Polling returns `status: failed:gcs_delete` → same as above (content not served, physical bytes may still exist, operator sweep can retry) |
+| Funnelcake accepted but sync endpoint returns 404 (read-after-write race exceeded retry budget) | OK | 404 | Fall back to polling. Cron will pick it up within 60s. |
+| Funnelcake OK, sync endpoint returns 202 (slow Blossom, partial targets in-flight) | OK | Processing | Fall back to polling; resolves to terminal when all targets settle |
+| Funnelcake OK, sync endpoint returns 502 (Blossom down) | OK | Error | Fall back to polling. D1 will record `failed:transient:*`; cron retries. |
+| Funnelcake OK, sync endpoint timeout or network error | OK | Unknown | Fall back to polling |
+| Funnelcake OK, mod-service entirely down (endpoint unreachable) | OK | Down | Terminal "removed from Divine, cleanup may be delayed." On mod-service recovery, cron catches up and D1 backfills. |
+| Funnelcake OK, status flip succeeded, GCS delete fails after retries | OK | D1 records `failed:transient:gcs_delete` → cron retries → if still failing after 5 attempts, `failed:permanent:max_retries_exceeded` | Polling returns `status: failed` → terminal "removed from Divine, cleanup failed" with support path |
 
-On mod-service recovery after an outage, the subscriber reconnects via `since=<last-timestamp>` and backfills D1. The audit trail eventually becomes complete regardless of outage duration.
+On mod-service recovery after an outage, the cron reads its last-seen timestamp from KV and REQs Funnelcake for the missed window. The audit trail eventually becomes complete regardless of outage duration.
 
 ## Observability
 
 These alarms are v1 scope, not follow-up, because the "we handle degradation honestly" commitment depends on us detecting it.
 
-- **Status endpoint error rate** above threshold (Sentry alert on mod-service).
-- **Subscriber lag** measured as `D1.accepted_at - kind5.created_at`; alert on p95 > 60s.
+- **Sync endpoint latency.** p95 should be under 5s. Alert on p95 > 10s over a 15-minute window (indicates Blossom or Funnelcake slowness).
+- **Sync endpoint error rate.** Alert when 5xx rate over 15m > 2%.
+- **Cron-path lag** measured as `D1.accepted_at - kind5.created_at` for kind 5s whose first D1 row came from the cron path; alert on p95 > 120s (generous headroom over the 60s cron interval + processing).
 - **Blossom call failure rate** above threshold (surfaces Blossom outages or schema drift).
-- **Subscriber write latency** divergence (`D1.completed_at - D1.accepted_at`) p95 > 30s.
-- **Dashboard** (Sentry or Grafana) showing end-to-end pipeline health: success rate, p50/p95 per leg, failure categories.
+- **Transient retry exhaustion.** Alert on any `failed:permanent:max_retries_exceeded` in the last hour.
+- **Pipeline write latency** (`D1.completed_at - D1.accepted_at`) p95 > 30s for cron-path, > 5s for sync path.
+- **Dashboard** (Sentry or Grafana) showing end-to-end pipeline health: success rate, p50/p95 per trigger path, failure categories by subcategory.
 
 ## Security
 
-- **Blossom admin token** remains in moderation-service only. No new secret propagation. Subscriber uses existing `webhook_secret` Bearer.
-- **NIP-98 on status endpoint** prevents third-party callers from using the endpoint as a free Divine infrastructure monitor.
-- **D1 audit contents** are Divine-internal. Kind5 IDs, sha256s, and creator pubkeys are already public Nostr data; statuses and timestamps are operationally sensitive and gated by NIP-98 when accessed via the public endpoint. Support and compliance queries go through direct D1 access (wrangler or admin UI), not through the public status endpoint.
-- **Authorization is not re-checked** by the subscriber. Funnelcake already rejects unauthorized kind 5s before the subscriber sees them. Trusting upstream authz is cleaner than re-implementing it downstream.
-- **No Blossom blob deletion without a valid accepted kind 5.** The subscriber only acts on events it observes via the authenticated websocket from Funnelcake.
+- **Blossom admin token** remains in moderation-service only. No new secret propagation. Both cron and sync endpoint use existing `webhook_secret` Bearer.
+- **NIP-98 on both sync and status endpoints.** Same auth model, same scope constraint (caller pubkey must match kind 5 author). Consistent reasoning and defense.
+- **NIP-98 timestamp tolerance** approximately ±60 seconds to accommodate mobile clock drift. Matches standard NIP-98 recommendations.
+- **D1 audit contents** are Divine-internal. Kind5 IDs, sha256s, and creator pubkeys are already public Nostr data; statuses and timestamps are operationally sensitive and gated by NIP-98 when accessed via the public endpoint. Support and compliance queries go through direct D1 access (wrangler or admin UI), not through the public endpoints.
+- **Authorization is not re-checked against Funnelcake** by the sync endpoint's post-fetch processing. Funnelcake's kind 5 acceptance has already verified that the creator authored each target. Trusting upstream authz is cleaner than re-implementing it downstream. Matching caller pubkey to kind 5 author (at the endpoint) is the equivalent of checking "the person asking for this kind 5 to be processed is the person who signed it."
+- **No Blossom blob deletion without a valid Funnelcake-accepted kind 5.** Both triggers require the kind 5 to exist on Funnelcake before acting on it.
 
 ## Testing
 
-- **Unit tests** in moderation-service for subscriber event-to-D1 translation (covers parse failures, multi-target, missing imeta, duplicate kind 5s).
-- **Integration tests** for the Blossom DELETE action cascade (thumbnail + VTT cleanup; tombstone prevents re-upload).
-- **End-to-end test** (staging, flag on): publish a kind 5 against staging Funnelcake, observe D1 row progression, verify Blossom serves 404 on main sha256 + thumbnail (`{sha256}.jpg`) + VTT URL + any derived audio URLs, **and verify the GCS bytes are actually gone** via direct bucket list/head.
-- **Flag-off test** (staging): same pipeline but with `ENABLE_PHYSICAL_DELETE=false`. Verify status flip + cascade metadata clearing occur, Blossom 404s, **but GCS bytes remain**. Confirms the flag gates the destructive step correctly.
-- **Mobile widget tests** for the polling state machine (all UI branches in the failure matrix).
-- **NIP-98 endpoint tests**: reject non-author pubkey, reject expired signature, accept valid.
+- **Unit tests** in moderation-service:
+  - `processKind5` event-to-D1 translation (covers parse failures, multi-target, missing imeta).
+  - Race safety: two concurrent invocations of `processKind5` for the same (kind5_id, target_event_id). Verify only one performs the Blossom call, the other returns `skipped: in_progress`.
+  - Idempotency: retry a previously-successful kind 5, verify `skipped: already_done` and no Blossom call.
+  - State taxonomy: Blossom 400 → `failed:permanent:blossom_400`; Blossom 503 → `failed:transient:blossom_5xx`; etc.
+- **NIP-98 endpoint tests:**
+  - Reject non-author pubkey with 403.
+  - Reject expired signature (created_at outside ±60s) with 401.
+  - Accept valid signature with matching pubkey.
+- **Integration tests** for the Blossom `DELETE` action:
+  - Cascade (thumbnail + VTT + derived audio) with flag on.
+  - Cascade with flag off (status flip only, GCS untouched).
+  - Tombstone prevents re-upload.
+  - GCS 404 is idempotent success.
+- **End-to-end test (staging, flag on):** publish a kind 5 against staging Funnelcake, call the sync endpoint, verify 200 success, verify Blossom serves 404 on main sha256 + thumbnail (`{sha256}.jpg`) + VTT URL + any derived audio URLs, **and verify the GCS bytes are actually gone** via direct bucket list/head.
+- **End-to-end test (staging, flag off):** same pipeline, verify status flip and cascade occur, Blossom 404s, **but GCS bytes remain**. Confirms the flag gates the destructive step correctly.
+- **Cron path test (staging):** simulate a non-Divine-client kind 5 (publish without calling sync endpoint), verify cron picks it up within 90s and processes identically.
+- **Sync endpoint race test (staging):** publish kind 5, immediately call sync endpoint (within 100ms of NIP-01 OK), verify retry logic handles Funnelcake read-after-write race and the endpoint eventually returns success.
 
 ## Dependencies and sequencing
 
-1. **divine-blossom PR #33** must land first (route gaps for `Deleted` status on HLS HEAD and subtitle-by-hash). If #33 is still open when we start, our spec tracks its status.
-2. **divine-blossom DELETE action PR** (small). Merged behind PR #33.
-3. **divine-moderation-service migration + subscriber + status endpoint PR**. Deploys to staging first.
-4. **divine-mobile polling + UI states PR**. Can develop in parallel against a staging mod-service, merges after #3101.
-5. **Vocabulary alignment doc PR** alongside Blossom DELETE PR.
+Deploy order matters. Out-of-order deployment creates failure modes that degrade the feature or trip false alarms.
 
-Staging verification before production: publish a kind 5 via a test account with `ENABLE_PHYSICAL_DELETE=true` in staging, observe full lifecycle in D1, confirm direct-CDN 404, confirm GCS bytes gone. Production first-deploy ships with `ENABLE_PHYSICAL_DELETE=false`. After a validation window (suggested: 1 week or first 50 creator-initiated deletes in prod, whichever comes first), flip to `true` and run the one-time sweep described in §5.
+1. **divine-blossom PR #33** must land and deploy first. Without it, `Deleted` status is not consistently checked on serve paths (HLS HEAD, subtitle-by-hash), so blob status flips are cosmetic on those routes.
+2. **divine-blossom DELETE-action PR**, flag default-off. Staging first; verify `DELETE` returns success with `physical_delete_skipped: true` when flag off.
+3. **divine-moderation-service migration + cron + sync endpoint + status endpoint PR**. Deploys to staging. Verify end-to-end against staging Blossom (flag off) — pipeline executes, Blossom returns success, D1 captures full lifecycle.
+4. **divine-mobile polling + UI states PR**. Can develop in parallel against staging mod-service; merges after #3101.
+5. **Vocabulary alignment doc PR** alongside Blossom DELETE PR.
+6. **Production rollout:** deploy Blossom (flag off), then mod-service, then mobile. Run validation window (suggested: 1 week or first 50 creator-initiated deletes in prod, whichever comes first). Flip `ENABLE_PHYSICAL_DELETE=true` and run the one-time sweep described in §5.
+
+## Staging preflight checklist
+
+Verify before implementation or at the start of implementation (failures here redirect the design):
+
+- [ ] Funnelcake REQ `{"kinds":[5],"limit":5}` against staging returns accepted kind 5 events. If empty (relay treats kind 5 as ephemeral), the cron strategy does not work as specified; surface immediately.
+- [ ] Staging Blossom `blossom_secrets` store has `webhook_secret` populated (same pattern as prod).
+- [ ] Staging GCS bucket accepts authenticated delete calls from the Blossom identity.
+- [ ] Staging mod-service `wrangler.toml` supports a new D1 binding for the audit table (or uses the existing one) and a new cron trigger.
+- [ ] Staging has NIP-98 verification path testable end-to-end (nostr-tools signature verification).
 
 ## Non-goals and follow-ups (explicit)
 
-- **ClickHouse reconciliation cron (option D).** Nostr's native `since`-based reconnect is the primary durability mechanism. Only worth building if observed subscriber miss rate justifies it.
-- **Grace period / creator-initiated un-delete.** Product decision, not infrastructure. If ever wanted, the tombstone-prevents-re-upload behavior would need a bypass for the same creator.
-- **Divine backend API for synchronous delete (option C).** Foreclosed in this spec by design. Non-Divine clients publishing kind 5 directly to Funnelcake would bypass the API; B + subscriber covers all ingress uniformly.
+- **ClickHouse reconciliation cron.** The 60s REQ cron is the primary durability mechanism. ClickHouse-based reconciliation is only worth building if observed cron miss rate justifies it, and it requires prod ClickHouse read access currently pending with ops.
+- **Grace period / creator-initiated un-delete.** Not in scope; creator-initiated deletes are not reversible by creators. Operator recovery (via direct D1 + Blossom admin access) is the escape hatch.
+- **Divine backend API for synchronous kind 5 publish (option C from brainstorm).** Foreclosed. Non-Divine clients publishing kind 5 directly to Funnelcake would bypass such an API; cron + sync endpoint covers all ingress uniformly.
 - **Multi-relay coverage.** Issue scopes to Divine-controlled. If multi-relay enforcement is ever a requirement, it becomes a separate design.
-- **Operator "replay failed delete" tool.** D1 schema supports it via `status LIKE 'failed:%' AND retry_count < N`. Small CLI or admin UI, v2.
+- **Operator "replay failed delete" tool.** D1 schema supports it via `status LIKE 'failed:permanent:max_retries_exceeded'`. Small CLI or admin UI, v2.
+- **Non-author recovery endpoint.** Sync endpoint v1 is author-only. If support needs to re-trigger processing on behalf of a creator (e.g., sync endpoint never called because creator used a different client), a distinct admin-auth endpoint is a v2 consideration.
 
 ## Open questions
 
-- **Blossom DELETE action owner.** Who writes the Blossom PR? Available for Matt if no Blossom engineer is picking it up this sprint. The PR is no longer trivial (physical-deletion cascade + flag + tests), call it a day of focused work.
-- **Subscriber location.** Confirmed to add to `divine-moderation-service` rather than a new Worker. Reuses existing Blossom admin auth, existing relay-client module, existing Durable Object patterns.
-- **Interaction with PR #33 timing.** If #33 slips past our target ship date, do we merge our code gated behind a feature flag and wait, or pause our work? Recommend: merge our subscriber and D1 layers (harmless without #33), hold mobile PR until #33 confirms cascade works end-to-end in staging.
+- **Blossom DELETE action owner.** Who writes the Blossom PR? Available for Matt if no Blossom engineer is picking it up this sprint. The PR is roughly a day of focused work now that physical deletion, the flag, tombstone verification, and tests are in scope.
 - **Backup and versioning policy.** If Blossom's GCS bucket has object versioning enabled, or if Divine writes blobs to B2 or another backup tier, then "delete the GCS object" may leave recoverable copies outside the live serving path. Whether that is acceptable depends on the compliance bar we are meeting. Action: (1) scout bucket versioning state and any B2 backup writes, (2) confirm with legal/ops whether backup retention is part of the "remove from storage" promise or a separately-governed lifecycle. This does not block v1 implementation of the main path; it determines whether an additional backup-purge step is required.
+- **Interaction with PR #33 timing.** If #33 slips past our target ship date, do we merge our code gated behind a feature flag and wait, or pause? Recommend: merge mod-service (harmless without #33 because Blossom hasn't accepted DELETE yet), hold mobile PR until #33 confirms cascade works end-to-end in staging.

--- a/migrations/006-creator-deletions.sql
+++ b/migrations/006-creator-deletions.sql
@@ -1,0 +1,27 @@
+-- Audit table for creator-initiated deletions (kind 5 events from Funnelcake).
+-- Composite PRIMARY KEY ensures idempotency across concurrent invocations
+-- (sync endpoint + cron colliding on the same kind 5).
+--
+-- status taxonomy:
+--   accepted                              - claimed by a worker, in-progress
+--   success                               - terminal success
+--   failed:transient:{subcategory}        - retryable by cron (retry_count < 5)
+--   failed:permanent:{subcategory}        - terminal, manual intervention required
+
+CREATE TABLE IF NOT EXISTS creator_deletions (
+  kind5_id TEXT NOT NULL,
+  target_event_id TEXT NOT NULL,
+  creator_pubkey TEXT NOT NULL,
+  blob_sha256 TEXT,
+  status TEXT NOT NULL,
+  accepted_at TEXT NOT NULL,
+  completed_at TEXT,
+  retry_count INTEGER NOT NULL DEFAULT 0,
+  last_error TEXT,
+  PRIMARY KEY (kind5_id, target_event_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_creator_deletions_target ON creator_deletions(target_event_id);
+CREATE INDEX IF NOT EXISTS idx_creator_deletions_creator ON creator_deletions(creator_pubkey);
+CREATE INDEX IF NOT EXISTS idx_creator_deletions_sha256 ON creator_deletions(blob_sha256);
+CREATE INDEX IF NOT EXISTS idx_creator_deletions_status ON creator_deletions(status);

--- a/scripts/sign-nip98.mjs
+++ b/scripts/sign-nip98.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+// Sign a NIP-98 Authorization header for testing creator-delete endpoints.
+// Usage: node scripts/sign-nip98.mjs --nsec <hex> --url <url> --method <POST|GET>
+// Output: the full "Nostr <base64>" header value, ready to paste into curl -H "Authorization: ..."
+
+import { generateSecretKey, getPublicKey, finalizeEvent } from 'nostr-tools/pure';
+import { hexToBytes } from '@noble/hashes/utils';
+
+const args = process.argv.slice(2);
+function getArg(name) {
+  const idx = args.indexOf(`--${name}`);
+  return idx >= 0 && args[idx + 1] ? args[idx + 1] : null;
+}
+
+let sk;
+const nsecHex = getArg('nsec');
+if (nsecHex) {
+  sk = hexToBytes(nsecHex);
+} else {
+  sk = generateSecretKey();
+  console.error(`No --nsec provided. Generated ephemeral key. Pubkey: ${getPublicKey(sk)}`);
+}
+
+const url = getArg('url');
+const method = (getArg('method') || 'POST').toUpperCase();
+
+if (!url) {
+  console.error('Usage: node scripts/sign-nip98.mjs --nsec <hex> --url <url> [--method POST]');
+  process.exit(1);
+}
+
+const event = finalizeEvent({
+  kind: 27235,
+  created_at: Math.floor(Date.now() / 1000),
+  tags: [['u', url], ['method', method]],
+  content: ''
+}, sk);
+
+const encoded = Buffer.from(JSON.stringify(event)).toString('base64');
+const header = `Nostr ${encoded}`;
+
+// Print just the header value (for use in curl -H "Authorization: <output>")
+console.log(header);
+
+// Metadata to stderr so it doesn't pollute the header output
+console.error(`Pubkey: ${getPublicKey(sk)}`);
+console.error(`URL: ${url}`);
+console.error(`Method: ${method}`);
+console.error(`Event ID: ${event.id}`);

--- a/src/blossom-client.mjs
+++ b/src/blossom-client.mjs
@@ -1,0 +1,73 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Shared Blossom admin client. Called from the moderator-action pipeline and the creator-delete pipeline.
+// ABOUTME: Maps internal action names to Blossom-understood actions and POSTs to BLOSSOM_WEBHOOK_URL with Bearer auth.
+
+// Blossom has five states (Active/Restricted/Pending/Banned/Deleted).
+// Its webhook handler accepts: SAFE→Active, AGE_RESTRICTED→Restricted,
+// PERMANENT_BAN→Banned, RESTRICT→Restricted, DELETE→Deleted.
+// QUARANTINE maps to RESTRICT (owner can view, public gets 404).
+// REVIEW is internal only — content stays publicly accessible.
+const BLOSSOM_ACTION_MAP = {
+  'SAFE': 'SAFE',
+  'AGE_RESTRICTED': 'AGE_RESTRICTED',
+  'PERMANENT_BAN': 'PERMANENT_BAN',
+  'QUARANTINE': 'RESTRICT',
+  'DELETE': 'DELETE'
+};
+
+/**
+ * Notify divine-blossom of a moderation decision or creator-initiated delete via webhook.
+ * @param {string} sha256 - The blob hash
+ * @param {string} action - Internal action (SAFE, REVIEW, QUARANTINE, AGE_RESTRICTED, PERMANENT_BAN, DELETE)
+ * @param {Object} env - Environment with BLOSSOM_WEBHOOK_URL and BLOSSOM_WEBHOOK_SECRET
+ * @returns {Promise<{success: boolean, error?: string, skipped?: boolean, result?: any, status?: number, networkError?: boolean}>}
+ */
+export async function notifyBlossom(sha256, action, env) {
+  if (!env.BLOSSOM_WEBHOOK_URL) {
+    console.log('[BLOSSOM] Webhook not configured, skipping notification');
+    return { success: true, skipped: true };
+  }
+
+  const blossomAction = BLOSSOM_ACTION_MAP[action];
+  if (!blossomAction) {
+    console.log(`[BLOSSOM] Skipping notification for internal action: ${action}`);
+    return { success: true, skipped: true };
+  }
+
+  try {
+    const headers = { 'Content-Type': 'application/json' };
+    if (env.BLOSSOM_WEBHOOK_SECRET) {
+      headers['Authorization'] = `Bearer ${env.BLOSSOM_WEBHOOK_SECRET}`;
+    }
+
+    console.log(`[BLOSSOM] Notifying blossom of ${action} (as ${blossomAction}) for ${sha256}`);
+
+    const response = await fetch(env.BLOSSOM_WEBHOOK_URL, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        sha256,
+        action: blossomAction,
+        timestamp: new Date().toISOString()
+      })
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      console.error(`[BLOSSOM] Webhook failed: ${response.status} - ${errorText}`);
+      return { success: false, error: `HTTP ${response.status}: ${errorText}`, status: response.status };
+    }
+
+    const result = await response.json();
+    console.log(`[BLOSSOM] Webhook succeeded for ${sha256}:`, result);
+    return { success: true, result, status: response.status };
+
+  } catch (error) {
+    console.error(`[BLOSSOM] Webhook error for ${sha256}:`, error);
+    return { success: false, error: error.message, networkError: true };
+  }
+}
+
+export { BLOSSOM_ACTION_MAP };

--- a/src/blossom-client.test.mjs
+++ b/src/blossom-client.test.mjs
@@ -9,7 +9,7 @@ import { notifyBlossom } from './blossom-client.mjs';
 
 describe('notifyBlossom (extracted)', () => {
   const baseEnv = {
-    BLOSSOM_WEBHOOK_URL: 'https://mock-blossom.test/admin/api/moderate',
+    BLOSSOM_WEBHOOK_URL: 'https://mock-blossom.test/admin/moderate',
     BLOSSOM_WEBHOOK_SECRET: 'test-secret'
   };
 

--- a/src/blossom-client.test.mjs
+++ b/src/blossom-client.test.mjs
@@ -1,0 +1,66 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Tests for notifyBlossom — action map, Bearer auth, return shape (success/status/networkError/skipped).
+// ABOUTME: Extracted from src/index.mjs; integration tests in src/index.test.mjs continue to cover call sites.
+
+import { describe, it, expect, vi } from 'vitest';
+import { notifyBlossom } from './blossom-client.mjs';
+
+describe('notifyBlossom (extracted)', () => {
+  const baseEnv = {
+    BLOSSOM_WEBHOOK_URL: 'https://mock-blossom.test/admin/api/moderate',
+    BLOSSOM_WEBHOOK_SECRET: 'test-secret'
+  };
+
+  it('POSTs to BLOSSOM_WEBHOOK_URL with Bearer auth and mapped action', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({ success: true }), { status: 200 }));
+    const env = { ...baseEnv };
+    global.fetch = fetchMock;
+
+    const result = await notifyBlossom('abc123', 'PERMANENT_BAN', env);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      baseEnv.BLOSSOM_WEBHOOK_URL,
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({ 'Authorization': 'Bearer test-secret' }),
+        body: expect.stringContaining('"action":"PERMANENT_BAN"')
+      })
+    );
+    expect(result).toMatchObject({ success: true });
+  });
+
+  it('maps DELETE → DELETE action', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({ success: true }), { status: 200 }));
+    global.fetch = fetchMock;
+
+    await notifyBlossom('abc', 'DELETE', baseEnv);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      baseEnv.BLOSSOM_WEBHOOK_URL,
+      expect.objectContaining({
+        body: expect.stringContaining('"action":"DELETE"')
+      })
+    );
+  });
+
+  it('returns skipped when BLOSSOM_WEBHOOK_URL is not configured', async () => {
+    const result = await notifyBlossom('abc', 'PERMANENT_BAN', { BLOSSOM_WEBHOOK_SECRET: 'x' });
+    expect(result).toMatchObject({ success: true, skipped: true });
+  });
+
+  it('returns error with numeric status on non-2xx response', async () => {
+    global.fetch = vi.fn().mockResolvedValue(new Response('blob not found', { status: 404 }));
+    const result = await notifyBlossom('abc', 'PERMANENT_BAN', baseEnv);
+    expect(result).toMatchObject({ success: false, status: 404 });
+    expect(result.error).toContain('404');
+  });
+
+  it('catches fetch rejection with networkError flag', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error('connection reset'));
+    const result = await notifyBlossom('abc', 'PERMANENT_BAN', baseEnv);
+    expect(result).toMatchObject({ success: false, networkError: true });
+    expect(result.error).toContain('connection reset');
+  });
+});

--- a/src/creator-delete/cron.mjs
+++ b/src/creator-delete/cron.mjs
@@ -1,0 +1,60 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Cron work for creator-delete pipeline — pulls kind 5 from Funnelcake, retries transient failures.
+// ABOUTME: Runs every minute via wrangler.toml [triggers] crons entry; dispatched in scheduled(event, env, ctx).
+
+import { processKind5 } from './process.mjs';
+
+const LAST_POLL_KEY = 'creator-delete-cron:last-poll';
+const DEFAULT_LOOKBACK_SECONDS = 3600; // first run
+const MAX_RETRY_COUNT = 5;
+
+export async function runCreatorDeleteCron(deps) {
+  const { db, kv, queryKind5Since, fetchTargetEvent, callBlossomDelete, now = () => Date.now() } = deps;
+  const nowMs = now();
+
+  const lastPollRaw = await kv.get(LAST_POLL_KEY);
+  const lastPollMs = lastPollRaw ? Number(lastPollRaw) : nowMs - (DEFAULT_LOOKBACK_SECONDS * 1000);
+  const sinceSeconds = Math.floor(lastPollMs / 1000);
+
+  let processed = 0;
+  const errors = [];
+
+  try {
+    const events = await queryKind5Since(sinceSeconds);
+    for (const kind5 of events) {
+      try {
+        await processKind5(kind5, { db, fetchTargetEvent, callBlossomDelete });
+        processed++;
+      } catch (e) {
+        errors.push({ kind5_id: kind5.id, error: e.message });
+      }
+    }
+  } catch (e) {
+    errors.push({ stage: 'query', error: e.message });
+  }
+
+  // Retry failed:transient rows
+  const transientRows = await db.prepare(
+    `SELECT kind5_id, target_event_id, creator_pubkey, status, retry_count, accepted_at
+     FROM creator_deletions
+     WHERE status LIKE 'failed:transient:%' AND retry_count < ?`
+  ).bind(MAX_RETRY_COUNT).all();
+
+  for (const row of (transientRows.results || [])) {
+    try {
+      const kind5 = { id: row.kind5_id, pubkey: row.creator_pubkey, tags: [['e', row.target_event_id]] };
+      await processKind5(kind5, { db, fetchTargetEvent, callBlossomDelete });
+      processed++;
+    } catch (e) {
+      errors.push({ kind5_id: row.kind5_id, stage: 'retry', error: e.message });
+    }
+  }
+
+  await kv.put(LAST_POLL_KEY, String(nowMs));
+
+  return { processed, errors };
+}
+
+export { LAST_POLL_KEY };

--- a/src/creator-delete/cron.mjs
+++ b/src/creator-delete/cron.mjs
@@ -5,10 +5,10 @@
 // ABOUTME: Runs every minute via wrangler.toml [triggers] crons entry; dispatched in scheduled(event, env, ctx).
 
 import { processKind5 } from './process.mjs';
+import { MAX_RETRY_COUNT } from './d1.mjs';
 
 const LAST_POLL_KEY = 'creator-delete-cron:last-poll';
 const DEFAULT_LOOKBACK_SECONDS = 3600; // first run
-const MAX_RETRY_COUNT = 5;
 
 export async function runCreatorDeleteCron(deps) {
   const { db, kv, queryKind5Since, fetchTargetEvent, callBlossomDelete, now = () => Date.now() } = deps;

--- a/src/creator-delete/cron.mjs
+++ b/src/creator-delete/cron.mjs
@@ -21,8 +21,10 @@ export async function runCreatorDeleteCron(deps) {
   let processed = 0;
   const errors = [];
 
+  let querySucceeded = false;
   try {
     const events = await queryKind5Since(sinceSeconds);
+    querySucceeded = true;
     for (const kind5 of events) {
       try {
         const lagSeconds = Math.max(0, Math.floor(now() / 1000) - (kind5.created_at || 0));
@@ -41,14 +43,20 @@ export async function runCreatorDeleteCron(deps) {
     errors.push({ stage: 'query', error: e.message });
   }
 
-  // Retry failed:transient rows
+  // Retry failed:transient rows with exponential backoff:
+  // Only retry rows where enough time has elapsed since accepted_at (30s * 2^retry_count, capped at 300s).
   const transientRows = await db.prepare(
     `SELECT kind5_id, target_event_id, creator_pubkey, status, retry_count, accepted_at
      FROM creator_deletions
      WHERE status LIKE 'failed:transient:%' AND retry_count < ?`
   ).bind(MAX_RETRY_COUNT).all();
 
+  const nowSeconds = Math.floor(nowMs / 1000);
   for (const row of (transientRows.results || [])) {
+    const backoffSeconds = Math.min(30 * Math.pow(2, row.retry_count), 300);
+    const acceptedSeconds = Math.floor(Date.parse(row.accepted_at) / 1000);
+    if (nowSeconds - acceptedSeconds < backoffSeconds) continue;
+
     try {
       const kind5 = { id: row.kind5_id, pubkey: row.creator_pubkey, tags: [['e', row.target_event_id]] };
       await processKind5(kind5, { db, fetchTargetEvent, callBlossomDelete, triggerLabel: 'cron' });
@@ -58,7 +66,11 @@ export async function runCreatorDeleteCron(deps) {
     }
   }
 
-  await kv.put(LAST_POLL_KEY, String(nowMs));
+  // Only advance the poll timestamp if the relay query succeeded.
+  // On failure, next tick retries from the same window.
+  if (querySucceeded) {
+    await kv.put(LAST_POLL_KEY, String(nowMs));
+  }
 
   return { processed, errors };
 }

--- a/src/creator-delete/cron.mjs
+++ b/src/creator-delete/cron.mjs
@@ -25,7 +25,13 @@ export async function runCreatorDeleteCron(deps) {
     const events = await queryKind5Since(sinceSeconds);
     for (const kind5 of events) {
       try {
-        await processKind5(kind5, { db, fetchTargetEvent, callBlossomDelete });
+        const lagSeconds = Math.max(0, Math.floor(now() / 1000) - (kind5.created_at || 0));
+        console.log(JSON.stringify({
+          event: 'creator_delete.cron.kind5_lag',
+          kind5_id: kind5.id,
+          lag_seconds: lagSeconds
+        }));
+        await processKind5(kind5, { db, fetchTargetEvent, callBlossomDelete, triggerLabel: 'cron' });
         processed++;
       } catch (e) {
         errors.push({ kind5_id: kind5.id, error: e.message });
@@ -45,7 +51,7 @@ export async function runCreatorDeleteCron(deps) {
   for (const row of (transientRows.results || [])) {
     try {
       const kind5 = { id: row.kind5_id, pubkey: row.creator_pubkey, tags: [['e', row.target_event_id]] };
-      await processKind5(kind5, { db, fetchTargetEvent, callBlossomDelete });
+      await processKind5(kind5, { db, fetchTargetEvent, callBlossomDelete, triggerLabel: 'cron' });
       processed++;
     } catch (e) {
       errors.push({ kind5_id: row.kind5_id, stage: 'retry', error: e.message });

--- a/src/creator-delete/cron.test.mjs
+++ b/src/creator-delete/cron.test.mjs
@@ -47,7 +47,7 @@ describe('runCreatorDeleteCron', () => {
       target_event_id: 't1',
       creator_pubkey: 'pub1',
       status: 'failed:transient:blossom_5xx',
-      accepted_at: new Date(Date.now() - 60_000).toISOString(),
+      accepted_at: new Date(1700000000000 - 300_000).toISOString(),
       blob_sha256: null,
       retry_count: 2,
       last_error: 'HTTP 503: prior attempt',

--- a/src/creator-delete/cron.test.mjs
+++ b/src/creator-delete/cron.test.mjs
@@ -1,0 +1,66 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Tests for runCreatorDeleteCron — happy-path query and transient-retry sweep.
+// ABOUTME: Uses makeFakeD1/makeFakeKV; seeds transient rows via rows.set() (fake INSERT is 4-arg only).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { runCreatorDeleteCron } from './cron.mjs';
+import { makeFakeD1, makeFakeKV } from './test-helpers.mjs';
+
+const SHA_C = 'c'.repeat(64); // 64-char hex fixture (extractSha256 requires)
+
+describe('runCreatorDeleteCron', () => {
+  let deps;
+  beforeEach(() => {
+    deps = {
+      db: makeFakeD1(),
+      kv: makeFakeKV(),
+      queryKind5Since: vi.fn(),
+      fetchTargetEvent: vi.fn(),
+      callBlossomDelete: vi.fn(),
+      now: () => 1700000000000
+    };
+  });
+
+  it('queries Funnelcake from last poll, processes each event, updates last poll', async () => {
+    await deps.kv.put('creator-delete-cron:last-poll', String(1700000000000 - 60_000));
+    deps.queryKind5Since.mockResolvedValueOnce([
+      { id: 'k1', pubkey: 'pub1', tags: [['e', 't1']] }
+    ]);
+    deps.fetchTargetEvent.mockResolvedValueOnce({ id: 't1', pubkey: 'pub1', tags: [['imeta', `x ${SHA_C}`]] });
+    deps.callBlossomDelete.mockResolvedValueOnce({ success: true, status: 200 });
+
+    const result = await runCreatorDeleteCron(deps);
+    expect(deps.queryKind5Since).toHaveBeenCalled();
+    expect(result.processed).toBe(1);
+    const lastPoll = await deps.kv.get('creator-delete-cron:last-poll');
+    expect(Number(lastPoll)).toBe(1700000000000);
+  });
+
+  it('retries failed:transient rows with retry_count < 5', async () => {
+    // Seed D1 directly — the fake's INSERT path is tailored to claimRow's
+    // 4-arg bind with 'accepted' status literal, so it can't represent a
+    // pre-existing failed:transient row. Direct rows.set() bypasses it.
+    deps.db.rows.set('k1:t1', {
+      kind5_id: 'k1',
+      target_event_id: 't1',
+      creator_pubkey: 'pub1',
+      status: 'failed:transient:blossom_5xx',
+      accepted_at: new Date(Date.now() - 60_000).toISOString(),
+      blob_sha256: null,
+      retry_count: 2,
+      last_error: 'HTTP 503: prior attempt',
+      completed_at: null
+    });
+
+    await deps.kv.put('creator-delete-cron:last-poll', String(Date.now() - 30_000));
+    deps.queryKind5Since.mockResolvedValueOnce([]); // no new events
+    deps.fetchTargetEvent.mockResolvedValueOnce({ id: 't1', pubkey: 'pub1', tags: [['imeta', `x ${SHA_C}`]] });
+    deps.callBlossomDelete.mockResolvedValueOnce({ success: true, status: 200 });
+
+    const result = await runCreatorDeleteCron(deps);
+    expect(deps.callBlossomDelete).toHaveBeenCalledWith(SHA_C);
+    expect(result.processed).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/src/creator-delete/cron.test.mjs
+++ b/src/creator-delete/cron.test.mjs
@@ -6,6 +6,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { runCreatorDeleteCron } from './cron.mjs';
+import { MAX_RETRY_COUNT } from './d1.mjs';
 import { makeFakeD1, makeFakeKV } from './test-helpers.mjs';
 
 const SHA_C = 'c'.repeat(64); // 64-char hex fixture (extractSha256 requires)
@@ -38,7 +39,7 @@ describe('runCreatorDeleteCron', () => {
     expect(Number(lastPoll)).toBe(1700000000000);
   });
 
-  it('retries failed:transient rows with retry_count < 5', async () => {
+  it('retries failed:transient rows with retry_count below MAX_RETRY_COUNT', async () => {
     // Seed D1 directly — the fake's INSERT path is tailored to claimRow's
     // 4-arg bind with 'accepted' status literal, so it can't represent a
     // pre-existing failed:transient row. Direct rows.set() bypasses it.
@@ -49,7 +50,7 @@ describe('runCreatorDeleteCron', () => {
       status: 'failed:transient:blossom_5xx',
       accepted_at: new Date(1700000000000 - 300_000).toISOString(),
       blob_sha256: null,
-      retry_count: 2,
+      retry_count: MAX_RETRY_COUNT - 3,
       last_error: 'HTTP 503: prior attempt',
       completed_at: null
     });

--- a/src/creator-delete/d1.mjs
+++ b/src/creator-delete/d1.mjs
@@ -1,0 +1,92 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Race-safe D1 helpers for creator_deletions audit table.
+// ABOUTME: claimRow implements INSERT ... ON CONFLICT DO NOTHING then SELECT to read canonical state.
+
+const MAX_RETRY_COUNT = 5;
+const IN_PROGRESS_TIMEOUT_MS = 30_000;
+
+/**
+ * Attempt to claim a row for processing. Returns { claimed, existing }.
+ * If claimed, this worker owns the row. If not, inspect existing.status and decide.
+ */
+export async function claimRow(db, { kind5_id, target_event_id, creator_pubkey, accepted_at }) {
+  const insertResult = await db.prepare(
+    `INSERT INTO creator_deletions
+      (kind5_id, target_event_id, creator_pubkey, status, accepted_at)
+     VALUES (?, ?, ?, 'accepted', ?)
+     ON CONFLICT(kind5_id, target_event_id) DO NOTHING`
+  ).bind(kind5_id, target_event_id, creator_pubkey, accepted_at).run();
+
+  const inserted = insertResult.meta.changes === 1 || insertResult.meta.rows_written === 1;
+
+  if (inserted) {
+    return { claimed: true, existing: null };
+  }
+
+  const existing = await readRow(db, { kind5_id, target_event_id });
+  return { claimed: false, existing };
+}
+
+export async function readRow(db, { kind5_id, target_event_id }) {
+  return db.prepare(
+    `SELECT kind5_id, target_event_id, creator_pubkey, blob_sha256, status, accepted_at, completed_at, retry_count, last_error
+     FROM creator_deletions WHERE kind5_id = ? AND target_event_id = ?`
+  ).bind(kind5_id, target_event_id).first();
+}
+
+export async function readAllTargetsForKind5(db, { kind5_id }) {
+  const result = await db.prepare(
+    `SELECT kind5_id, target_event_id, creator_pubkey, blob_sha256, status, accepted_at, completed_at, retry_count, last_error
+     FROM creator_deletions WHERE kind5_id = ?`
+  ).bind(kind5_id).all();
+  return result.results || [];
+}
+
+export async function updateToSuccess(db, { kind5_id, target_event_id, blob_sha256, completed_at }) {
+  await db.prepare(
+    `UPDATE creator_deletions
+     SET status = 'success', blob_sha256 = ?, completed_at = ?, last_error = NULL
+     WHERE kind5_id = ? AND target_event_id = ?`
+  ).bind(blob_sha256, completed_at, kind5_id, target_event_id).run();
+}
+
+export async function updateToFailed(db, { kind5_id, target_event_id, status, last_error, increment_retry = false }) {
+  if (increment_retry) {
+    await db.prepare(
+      `UPDATE creator_deletions
+       SET status = ?, last_error = ?, retry_count = retry_count + 1
+       WHERE kind5_id = ? AND target_event_id = ?`
+    ).bind(status, last_error, kind5_id, target_event_id).run();
+  } else {
+    await db.prepare(
+      `UPDATE creator_deletions
+       SET status = ?, last_error = ?
+       WHERE kind5_id = ? AND target_event_id = ?`
+    ).bind(status, last_error, kind5_id, target_event_id).run();
+  }
+}
+
+/**
+ * Decide what to do with an existing row given the claim result.
+ * Returns one of: 'proceed' (caller should re-try processing), 'skip_success',
+ * 'skip_permanent_failure', 'skip_in_progress'.
+ */
+export function decideAction(existing, { now = Date.now() } = {}) {
+  if (!existing) return 'proceed';
+  if (existing.status === 'success') return 'skip_success';
+  if (existing.status.startsWith('failed:permanent:')) return 'skip_permanent_failure';
+  if (existing.status === 'accepted') {
+    const acceptedMs = Date.parse(existing.accepted_at);
+    if (now - acceptedMs < IN_PROGRESS_TIMEOUT_MS) return 'skip_in_progress';
+    return 'proceed';
+  }
+  if (existing.status.startsWith('failed:transient:')) {
+    if (existing.retry_count < MAX_RETRY_COUNT) return 'proceed';
+    return 'skip_permanent_failure';
+  }
+  return 'proceed';
+}
+
+export { MAX_RETRY_COUNT, IN_PROGRESS_TIMEOUT_MS };

--- a/src/creator-delete/d1.mjs
+++ b/src/creator-delete/d1.mjs
@@ -5,7 +5,9 @@
 // ABOUTME: claimRow implements INSERT ... ON CONFLICT DO NOTHING then SELECT to read canonical state.
 
 const MAX_RETRY_COUNT = 5;
-const IN_PROGRESS_TIMEOUT_MS = 30_000;
+// Must exceed the sync endpoint's waitUntil work window. A stale accepted row
+// may be re-claimed after this; Blossom DELETE must remain idempotent.
+const IN_PROGRESS_TIMEOUT_MS = 120_000;
 
 /**
  * Attempt to claim a row for processing. Returns { claimed, existing }.

--- a/src/creator-delete/d1.test.mjs
+++ b/src/creator-delete/d1.test.mjs
@@ -1,0 +1,117 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Tests for D1 helpers — claimRow idempotency + decideAction state machine for all row statuses.
+// ABOUTME: Uses an in-memory fake D1 (makeFakeD1) defined locally; extraction to shared module happens in Task 4.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { claimRow, readRow, updateToSuccess, updateToFailed, decideAction } from './d1.mjs';
+
+// Test helper: in-memory D1 fake with the same schema as creator_deletions.
+function makeFakeD1() {
+  const rows = new Map(); // key: `${kind5_id}:${target_event_id}`
+  return {
+    rows,
+    prepare(sql) {
+      return {
+        _sql: sql,
+        _binds: [],
+        bind(...args) { this._binds = args; return this; },
+        async run() {
+          if (this._sql.startsWith('INSERT')) {
+            const [kind5_id, target_event_id, creator_pubkey, accepted_at] = this._binds;
+            const key = `${kind5_id}:${target_event_id}`;
+            if (rows.has(key)) {
+              return { meta: { changes: 0, rows_written: 0 } };
+            }
+            rows.set(key, { kind5_id, target_event_id, creator_pubkey, status: 'accepted', accepted_at, retry_count: 0, last_error: null, blob_sha256: null, completed_at: null });
+            return { meta: { changes: 1, rows_written: 1 } };
+          }
+          if (this._sql.startsWith('UPDATE')) {
+            const target_key = `${this._binds[this._binds.length - 2]}:${this._binds[this._binds.length - 1]}`;
+            const existing = rows.get(target_key);
+            if (existing) {
+              // Very simplified: we're just testing the wrappers, not SQL correctness.
+              rows.set(target_key, { ...existing, _updated: true });
+              return { meta: { changes: 1 } };
+            }
+            return { meta: { changes: 0 } };
+          }
+          return { meta: { changes: 0 } };
+        },
+        async first() {
+          if (this._sql.startsWith('SELECT')) {
+            const key = `${this._binds[0]}:${this._binds[1]}`;
+            return rows.get(key) || null;
+          }
+          return null;
+        }
+      };
+    }
+  };
+}
+
+describe('claimRow', () => {
+  let db;
+  beforeEach(() => { db = makeFakeD1(); });
+
+  it('claims a new row and returns claimed: true', async () => {
+    const now = new Date().toISOString();
+    const result = await claimRow(db, {
+      kind5_id: 'k1',
+      target_event_id: 't1',
+      creator_pubkey: 'pub1',
+      accepted_at: now
+    });
+    expect(result.claimed).toBe(true);
+    expect(result.existing).toBeNull();
+  });
+
+  it('does not claim when row already exists; returns existing', async () => {
+    const now = new Date().toISOString();
+    await claimRow(db, { kind5_id: 'k1', target_event_id: 't1', creator_pubkey: 'pub1', accepted_at: now });
+    const second = await claimRow(db, { kind5_id: 'k1', target_event_id: 't1', creator_pubkey: 'pub1', accepted_at: new Date().toISOString() });
+    expect(second.claimed).toBe(false);
+    expect(second.existing).toMatchObject({ kind5_id: 'k1', target_event_id: 't1', status: 'accepted' });
+  });
+});
+
+describe('decideAction', () => {
+  it('proceed when no row exists', () => {
+    expect(decideAction(null)).toBe('proceed');
+  });
+
+  it('skip_success on terminal success', () => {
+    expect(decideAction({ status: 'success' })).toBe('skip_success');
+  });
+
+  it('skip_permanent_failure on permanent failure', () => {
+    expect(decideAction({ status: 'failed:permanent:blossom_400' })).toBe('skip_permanent_failure');
+  });
+
+  it('skip_in_progress when accepted and recent', () => {
+    const now = Date.now();
+    const existing = {
+      status: 'accepted',
+      accepted_at: new Date(now - 5_000).toISOString()
+    };
+    expect(decideAction(existing, { now })).toBe('skip_in_progress');
+  });
+
+  it('proceed when accepted but stale (>30s)', () => {
+    const now = Date.now();
+    const existing = {
+      status: 'accepted',
+      accepted_at: new Date(now - 60_000).toISOString()
+    };
+    expect(decideAction(existing, { now })).toBe('proceed');
+  });
+
+  it('proceed when failed:transient and retries remain', () => {
+    expect(decideAction({ status: 'failed:transient:blossom_5xx', retry_count: 2 })).toBe('proceed');
+  });
+
+  it('skip when failed:transient and retries exhausted', () => {
+    expect(decideAction({ status: 'failed:transient:blossom_5xx', retry_count: 5 })).toBe('skip_permanent_failure');
+  });
+});

--- a/src/creator-delete/d1.test.mjs
+++ b/src/creator-delete/d1.test.mjs
@@ -5,7 +5,7 @@
 // ABOUTME: Uses an in-memory fake D1 (makeFakeD1) imported from ./test-helpers.mjs.
 
 import { describe, it, expect, beforeEach } from 'vitest';
-import { claimRow, readRow, updateToSuccess, updateToFailed, decideAction } from './d1.mjs';
+import { claimRow, readRow, updateToSuccess, updateToFailed, decideAction, IN_PROGRESS_TIMEOUT_MS, MAX_RETRY_COUNT } from './d1.mjs';
 import { makeFakeD1 } from './test-helpers.mjs';
 
 describe('claimRow', () => {
@@ -55,11 +55,11 @@ describe('decideAction', () => {
     expect(decideAction(existing, { now })).toBe('skip_in_progress');
   });
 
-  it('proceed when accepted but stale (>30s)', () => {
+  it('proceed when accepted but stale', () => {
     const now = Date.now();
     const existing = {
       status: 'accepted',
-      accepted_at: new Date(now - 60_000).toISOString()
+      accepted_at: new Date(now - IN_PROGRESS_TIMEOUT_MS - 1).toISOString()
     };
     expect(decideAction(existing, { now })).toBe('proceed');
   });
@@ -69,6 +69,6 @@ describe('decideAction', () => {
   });
 
   it('skip when failed:transient and retries exhausted', () => {
-    expect(decideAction({ status: 'failed:transient:blossom_5xx', retry_count: 5 })).toBe('skip_permanent_failure');
+    expect(decideAction({ status: 'failed:transient:blossom_5xx', retry_count: MAX_RETRY_COUNT })).toBe('skip_permanent_failure');
   });
 });

--- a/src/creator-delete/d1.test.mjs
+++ b/src/creator-delete/d1.test.mjs
@@ -2,54 +2,11 @@
 // If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // ABOUTME: Tests for D1 helpers — claimRow idempotency + decideAction state machine for all row statuses.
-// ABOUTME: Uses an in-memory fake D1 (makeFakeD1) defined locally; extraction to shared module happens in Task 4.
+// ABOUTME: Uses an in-memory fake D1 (makeFakeD1) imported from ./test-helpers.mjs.
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import { claimRow, readRow, updateToSuccess, updateToFailed, decideAction } from './d1.mjs';
-
-// Test helper: in-memory D1 fake with the same schema as creator_deletions.
-function makeFakeD1() {
-  const rows = new Map(); // key: `${kind5_id}:${target_event_id}`
-  return {
-    rows,
-    prepare(sql) {
-      return {
-        _sql: sql,
-        _binds: [],
-        bind(...args) { this._binds = args; return this; },
-        async run() {
-          if (this._sql.startsWith('INSERT')) {
-            const [kind5_id, target_event_id, creator_pubkey, accepted_at] = this._binds;
-            const key = `${kind5_id}:${target_event_id}`;
-            if (rows.has(key)) {
-              return { meta: { changes: 0, rows_written: 0 } };
-            }
-            rows.set(key, { kind5_id, target_event_id, creator_pubkey, status: 'accepted', accepted_at, retry_count: 0, last_error: null, blob_sha256: null, completed_at: null });
-            return { meta: { changes: 1, rows_written: 1 } };
-          }
-          if (this._sql.startsWith('UPDATE')) {
-            const target_key = `${this._binds[this._binds.length - 2]}:${this._binds[this._binds.length - 1]}`;
-            const existing = rows.get(target_key);
-            if (existing) {
-              // Very simplified: we're just testing the wrappers, not SQL correctness.
-              rows.set(target_key, { ...existing, _updated: true });
-              return { meta: { changes: 1 } };
-            }
-            return { meta: { changes: 0 } };
-          }
-          return { meta: { changes: 0 } };
-        },
-        async first() {
-          if (this._sql.startsWith('SELECT')) {
-            const key = `${this._binds[0]}:${this._binds[1]}`;
-            return rows.get(key) || null;
-          }
-          return null;
-        }
-      };
-    }
-  };
-}
+import { makeFakeD1 } from './test-helpers.mjs';
 
 describe('claimRow', () => {
   let db;

--- a/src/creator-delete/funnelcake-fetch.mjs
+++ b/src/creator-delete/funnelcake-fetch.mjs
@@ -1,0 +1,16 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Funnelcake kind 5 fetch with read-after-write retry.
+// ABOUTME: Handles the window between Funnelcake accept (NIP-01 OK) and async ClickHouse write.
+
+const DEFAULT_RETRY_DELAYS_MS = [0, 100, 500, 1000, 2000];
+
+export async function fetchKind5WithRetry(kind5_id, { fetchEventById, retryDelaysMs = DEFAULT_RETRY_DELAYS_MS } = {}) {
+  for (const delay of retryDelaysMs) {
+    if (delay > 0) await new Promise(r => setTimeout(r, delay));
+    const event = await fetchEventById(kind5_id);
+    if (event) return event;
+  }
+  return null;
+}

--- a/src/creator-delete/funnelcake-fetch.test.mjs
+++ b/src/creator-delete/funnelcake-fetch.test.mjs
@@ -1,0 +1,27 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Tests for fetchKind5WithRetry — retry loop + terminal null-result.
+// ABOUTME: Uses vi.fn mocks; no relay calls, no delays longer than a few ms.
+
+import { describe, it, expect, vi } from 'vitest';
+import { fetchKind5WithRetry } from './funnelcake-fetch.mjs';
+
+describe('fetchKind5WithRetry', () => {
+  it('returns event after two nulls then success', async () => {
+    const underlying = vi.fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ id: 'k1', kind: 5 });
+    const result = await fetchKind5WithRetry('k1', { fetchEventById: underlying, retryDelaysMs: [0, 10, 20] });
+    expect(result).toEqual({ id: 'k1', kind: 5 });
+    expect(underlying).toHaveBeenCalledTimes(3);
+  });
+
+  it('returns null if all retries return null', async () => {
+    const underlying = vi.fn().mockResolvedValue(null);
+    const result = await fetchKind5WithRetry('k1', { fetchEventById: underlying, retryDelaysMs: [0, 10] });
+    expect(result).toBeNull();
+    expect(underlying).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/creator-delete/nip98.mjs
+++ b/src/creator-delete/nip98.mjs
@@ -1,0 +1,52 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: NIP-98 HTTP Authorization header validation for creator-delete endpoints.
+// ABOUTME: Validates base64-encoded kind 27235 event with u, method tags, ±60s clock drift, signature.
+
+import { verifyEvent } from 'nostr-tools/pure';
+
+const CLOCK_DRIFT_SECONDS = 60;
+const EXPECTED_KIND = 27235;
+
+export async function validateNip98Header(authorizationHeader, expectedUrl, expectedMethod) {
+  if (!authorizationHeader || !authorizationHeader.startsWith('Nostr ')) {
+    return { valid: false, error: 'Missing or malformed Authorization header (expected "Nostr <base64>")' };
+  }
+
+  const encoded = authorizationHeader.slice('Nostr '.length).trim();
+
+  let event;
+  try {
+    const decoded = atob(encoded);
+    event = JSON.parse(decoded);
+  } catch (e) {
+    return { valid: false, error: `Invalid base64 or JSON in Authorization header: ${e.message}` };
+  }
+
+  if (event.kind !== EXPECTED_KIND) {
+    return { valid: false, error: `Expected kind ${EXPECTED_KIND}, got ${event.kind}` };
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  if (Math.abs(now - event.created_at) > CLOCK_DRIFT_SECONDS) {
+    return { valid: false, error: `created_at ${event.created_at} outside ±${CLOCK_DRIFT_SECONDS}s window (server now: ${now})` };
+  }
+
+  const uTag = event.tags.find(t => t[0] === 'u')?.[1];
+  const methodTag = event.tags.find(t => t[0] === 'method')?.[1];
+
+  if (uTag !== expectedUrl) {
+    return { valid: false, error: `u tag '${uTag}' does not match expected URL '${expectedUrl}'` };
+  }
+
+  if ((methodTag || '').toUpperCase() !== expectedMethod.toUpperCase()) {
+    return { valid: false, error: `method tag '${methodTag}' does not match expected method '${expectedMethod}'` };
+  }
+
+  if (!verifyEvent(event)) {
+    return { valid: false, error: 'Signature verification failed' };
+  }
+
+  return { valid: true, pubkey: event.pubkey };
+}

--- a/src/creator-delete/nip98.mjs
+++ b/src/creator-delete/nip98.mjs
@@ -33,6 +33,10 @@ export async function validateNip98Header(authorizationHeader, expectedUrl, expe
     return { valid: false, error: `created_at ${event.created_at} outside ±${CLOCK_DRIFT_SECONDS}s window (server now: ${now})` };
   }
 
+  if (!Array.isArray(event.tags)) {
+    return { valid: false, error: 'Event missing tags array' };
+  }
+
   const uTag = event.tags.find(t => t[0] === 'u')?.[1];
   const methodTag = event.tags.find(t => t[0] === 'method')?.[1];
 

--- a/src/creator-delete/nip98.test.mjs
+++ b/src/creator-delete/nip98.test.mjs
@@ -1,0 +1,102 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Tests for NIP-98 validator — happy path + rejection paths (missing, wrong kind, expired, mismatched, tampered).
+// ABOUTME: Uses nostr-tools to sign test fixtures with ephemeral keys.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { generateSecretKey, getPublicKey, finalizeEvent } from 'nostr-tools/pure';
+import { bytesToHex } from '@noble/hashes/utils';
+import { validateNip98Header } from './nip98.mjs';
+
+describe('validateNip98Header', () => {
+  let sk, pk;
+
+  beforeEach(() => {
+    sk = generateSecretKey();
+    pk = getPublicKey(sk);
+  });
+
+  function signNip98(url, method, skOverride) {
+    const event = finalizeEvent({
+      kind: 27235,
+      created_at: Math.floor(Date.now() / 1000),
+      tags: [['u', url], ['method', method]],
+      content: ''
+    }, skOverride || sk);
+    const encoded = btoa(JSON.stringify(event));
+    return `Nostr ${encoded}`;
+  }
+
+  it('accepts a valid signature for matching url and method', async () => {
+    const header = signNip98('https://moderation-api.divine.video/api/delete/abc123', 'POST');
+    const result = await validateNip98Header(header, 'https://moderation-api.divine.video/api/delete/abc123', 'POST');
+    expect(result.valid).toBe(true);
+    expect(result.pubkey).toBe(pk);
+  });
+
+  it('rejects missing Authorization header', async () => {
+    const result = await validateNip98Header(undefined, 'https://x/y', 'POST');
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/Missing or malformed/);
+  });
+
+  it('rejects non-Nostr scheme', async () => {
+    const result = await validateNip98Header('Bearer abc', 'https://x/y', 'POST');
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects wrong kind', async () => {
+    const event = finalizeEvent({
+      kind: 1,
+      created_at: Math.floor(Date.now() / 1000),
+      tags: [['u', 'https://x/y'], ['method', 'POST']],
+      content: ''
+    }, sk);
+    const header = `Nostr ${btoa(JSON.stringify(event))}`;
+    const result = await validateNip98Header(header, 'https://x/y', 'POST');
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/Expected kind 27235/);
+  });
+
+  it('rejects expired created_at (outside ±60s)', async () => {
+    const event = finalizeEvent({
+      kind: 27235,
+      created_at: Math.floor(Date.now() / 1000) - 120,
+      tags: [['u', 'https://x/y'], ['method', 'POST']],
+      content: ''
+    }, sk);
+    const header = `Nostr ${btoa(JSON.stringify(event))}`;
+    const result = await validateNip98Header(header, 'https://x/y', 'POST');
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/outside/);
+  });
+
+  it('rejects mismatched url', async () => {
+    const header = signNip98('https://x/different', 'POST');
+    const result = await validateNip98Header(header, 'https://x/expected', 'POST');
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/u tag/);
+  });
+
+  it('rejects mismatched method', async () => {
+    const header = signNip98('https://x/y', 'GET');
+    const result = await validateNip98Header(header, 'https://x/y', 'POST');
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/method tag/);
+  });
+
+  it('rejects tampered signature', async () => {
+    const realEvent = finalizeEvent({
+      kind: 27235,
+      created_at: Math.floor(Date.now() / 1000),
+      tags: [['u', 'https://x/y'], ['method', 'POST']],
+      content: ''
+    }, sk);
+    realEvent.sig = realEvent.sig.slice(0, -4) + '0000';
+    const header = `Nostr ${btoa(JSON.stringify(realEvent))}`;
+    const result = await validateNip98Header(header, 'https://x/y', 'POST');
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/Signature/);
+  });
+});

--- a/src/creator-delete/nip98.test.mjs
+++ b/src/creator-delete/nip98.test.mjs
@@ -85,6 +85,20 @@ describe('validateNip98Header', () => {
     expect(result.error).toMatch(/method tag/);
   });
 
+  it('rejects event with missing tags array', async () => {
+    const event = finalizeEvent({
+      kind: 27235,
+      created_at: Math.floor(Date.now() / 1000),
+      tags: [['u', 'https://x/y'], ['method', 'POST']],
+      content: ''
+    }, sk);
+    delete event.tags;
+    const header = `Nostr ${btoa(JSON.stringify(event))}`;
+    const result = await validateNip98Header(header, 'https://x/y', 'POST');
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/missing tags/);
+  });
+
   it('rejects tampered signature', async () => {
     const realEvent = finalizeEvent({
       kind: 27235,

--- a/src/creator-delete/nip98.test.mjs
+++ b/src/creator-delete/nip98.test.mjs
@@ -6,7 +6,6 @@
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import { generateSecretKey, getPublicKey, finalizeEvent } from 'nostr-tools/pure';
-import { bytesToHex } from '@noble/hashes/utils';
 import { validateNip98Header } from './nip98.mjs';
 
 describe('validateNip98Header', () => {

--- a/src/creator-delete/process.mjs
+++ b/src/creator-delete/process.mjs
@@ -59,7 +59,12 @@ export async function processKind5(kind5, { db, fetchTargetEvent, callBlossomDel
       continue;
     }
 
-    // action === 'proceed'
+    // action === 'proceed' — re-claim stale row by refreshing accepted_at
+    if (!claim.claimed) {
+      await db.prepare(
+        `UPDATE creator_deletions SET accepted_at = ?, status = 'accepted' WHERE kind5_id = ? AND target_event_id = ?`
+      ).bind(acceptedIso, kind5.id, target_event_id).run();
+    }
     console.log(JSON.stringify({
       event: 'creator_delete.accepted',
       kind5_id: kind5.id,
@@ -143,26 +148,32 @@ export async function processKind5(kind5, { db, fetchTargetEvent, callBlossomDel
       : (status !== undefined ? `failed:permanent:blossom_${status}` : 'failed:permanent:blossom_skipped');
 
     const lastError = blossomResult.error || `Blossom returned ${blossomResult.status}`;
+    const priorRetryCount = (claim.existing && claim.existing.retry_count) || 0;
+    const retryCountAfter = isTransient ? priorRetryCount + 1 : priorRetryCount;
+
+    // Promote to permanent if retries exhausted
+    const finalStatus = (isTransient && retryCountAfter >= 5)
+      ? 'failed:permanent:max_retries_exceeded'
+      : category;
+
     await updateToFailed(db, {
       kind5_id: kind5.id,
       target_event_id,
-      status: category,
+      status: finalStatus,
       last_error: lastError,
       increment_retry: isTransient
     });
-    const priorRetryCount = (claim.existing && claim.existing.retry_count) || 0;
-    const retryCountAfter = isTransient ? priorRetryCount + 1 : priorRetryCount;
     console.log(JSON.stringify({
       event: 'creator_delete.failed',
       kind5_id: kind5.id,
       target_event_id,
       creator_pubkey: kind5.pubkey,
-      status: category,
+      status: finalStatus,
       last_error: lastError,
       retry_count_after: retryCountAfter,
       trigger: triggerLabel
     }));
-    resultTargets.push({ target_event_id, status: category, last_error: blossomResult.error, blob_sha256: sha256 });
+    resultTargets.push({ target_event_id, status: finalStatus, last_error: blossomResult.error, blob_sha256: sha256 });
   }
 
   return { targets: resultTargets };

--- a/src/creator-delete/process.mjs
+++ b/src/creator-delete/process.mjs
@@ -4,7 +4,12 @@
 // ABOUTME: Shared kind 5 processing function used by both sync endpoint and cron.
 // ABOUTME: Race-safe via D1 INSERT-OR-IGNORE claim, handles multi-target kind 5 per NIP-09.
 
-import { claimRow, updateToSuccess, updateToFailed, decideAction } from './d1.mjs';
+import { claimRow, updateToSuccess, updateToFailed, decideAction, MAX_RETRY_COUNT } from './d1.mjs';
+
+// Cap per NIP-09 kind 5. One kind 5 with 1000 e-tags would blow past the
+// sync-endpoint budget and burn Funnelcake/Blossom call budget. 50 is well
+// above real-world deletes (single video, or a thread of ~handful).
+export const MAX_TARGETS_PER_KIND5 = 50;
 
 /**
  * Extract the main blob sha256 from a kind 34236 video event.
@@ -29,9 +34,20 @@ export function extractSha256(targetEvent) {
  * Returns { targets: [{ target_event_id, status, blob_sha256?, last_error? }] }
  */
 export async function processKind5(kind5, { db, fetchTargetEvent, callBlossomDelete, now = () => Date.now(), triggerLabel = 'unknown' }) {
-  const targetIds = (kind5.tags || [])
+  const allTargetIds = (kind5.tags || [])
     .filter(t => t[0] === 'e' && t[1])
     .map(t => t[1]);
+  const targetIds = allTargetIds.slice(0, MAX_TARGETS_PER_KIND5);
+
+  if (allTargetIds.length > MAX_TARGETS_PER_KIND5) {
+    console.log(JSON.stringify({
+      event: 'creator_delete.target_cap_applied',
+      kind5_id: kind5.id,
+      total_targets: allTargetIds.length,
+      processed_targets: targetIds.length,
+      trigger: triggerLabel
+    }));
+  }
 
   const resultTargets = [];
 
@@ -59,11 +75,21 @@ export async function processKind5(kind5, { db, fetchTargetEvent, callBlossomDel
       continue;
     }
 
-    // action === 'proceed' — re-claim stale row by refreshing accepted_at
+    // action === 'proceed'. If we didn't claim (row existed, stale/retryable),
+    // conditionally re-claim: UPDATE only succeeds if accepted_at still matches
+    // the value we observed, so two racing workers can't both reclaim.
     if (!claim.claimed) {
-      await db.prepare(
-        `UPDATE creator_deletions SET accepted_at = ?, status = 'accepted' WHERE kind5_id = ? AND target_event_id = ?`
-      ).bind(acceptedIso, kind5.id, target_event_id).run();
+      const reclaim = await db.prepare(
+        `UPDATE creator_deletions
+         SET accepted_at = ?, status = 'accepted'
+         WHERE kind5_id = ? AND target_event_id = ? AND accepted_at = ?`
+      ).bind(acceptedIso, kind5.id, target_event_id, claim.existing.accepted_at).run();
+      const reclaimed = reclaim.meta.changes === 1 || reclaim.meta.rows_written === 1;
+      if (!reclaimed) {
+        // Another worker won the re-claim race. Report in_progress and let them finish.
+        resultTargets.push({ target_event_id, status: 'in_progress' });
+        continue;
+      }
     }
     console.log(JSON.stringify({
       event: 'creator_delete.accepted',
@@ -73,6 +99,8 @@ export async function processKind5(kind5, { db, fetchTargetEvent, callBlossomDel
       accepted_at: acceptedIso,
       trigger: triggerLabel
     }));
+
+    const priorRetryCount = (claim.existing && claim.existing.retry_count) || 0;
 
     const target = await fetchTargetEvent(target_event_id);
     if (!target) {
@@ -89,7 +117,7 @@ export async function processKind5(kind5, { db, fetchTargetEvent, callBlossomDel
         creator_pubkey: kind5.pubkey,
         status: 'failed:permanent:target_unresolved',
         last_error: 'Target event not found on Funnelcake',
-        retry_count_after: (claim.existing && claim.existing.retry_count) || 0,
+        retry_count_after: priorRetryCount,
         trigger: triggerLabel
       }));
       resultTargets.push({ target_event_id, status: 'failed:permanent:target_unresolved' });
@@ -111,7 +139,7 @@ export async function processKind5(kind5, { db, fetchTargetEvent, callBlossomDel
         creator_pubkey: kind5.pubkey,
         status: 'failed:permanent:no_sha256',
         last_error: 'No sha256 in target event imeta/url',
-        retry_count_after: (claim.existing && claim.existing.retry_count) || 0,
+        retry_count_after: priorRetryCount,
         trigger: triggerLabel
       }));
       resultTargets.push({ target_event_id, status: 'failed:permanent:no_sha256' });
@@ -148,11 +176,10 @@ export async function processKind5(kind5, { db, fetchTargetEvent, callBlossomDel
       : (status !== undefined ? `failed:permanent:blossom_${status}` : 'failed:permanent:blossom_skipped');
 
     const lastError = blossomResult.error || `Blossom returned ${blossomResult.status}`;
-    const priorRetryCount = (claim.existing && claim.existing.retry_count) || 0;
     const retryCountAfter = isTransient ? priorRetryCount + 1 : priorRetryCount;
 
     // Promote to permanent if retries exhausted
-    const finalStatus = (isTransient && retryCountAfter >= 5)
+    const finalStatus = (isTransient && retryCountAfter >= MAX_RETRY_COUNT)
       ? 'failed:permanent:max_retries_exceeded'
       : category;
 

--- a/src/creator-delete/process.mjs
+++ b/src/creator-delete/process.mjs
@@ -1,0 +1,117 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Shared kind 5 processing function used by both sync endpoint and cron.
+// ABOUTME: Race-safe via D1 INSERT-OR-IGNORE claim, handles multi-target kind 5 per NIP-09.
+
+import { claimRow, readRow, updateToSuccess, updateToFailed, decideAction } from './d1.mjs';
+
+/**
+ * Extract the main blob sha256 from a kind 34236 video event.
+ * Looks at imeta tags for x=<sha256> or parses url for the sha256 segment.
+ */
+export function extractSha256(targetEvent) {
+  for (const tag of targetEvent.tags || []) {
+    if (tag[0] !== 'imeta') continue;
+    for (const part of tag.slice(1)) {
+      if (typeof part !== 'string') continue;
+      const xMatch = part.match(/^x\s+([a-f0-9]{64})$/i);
+      if (xMatch) return xMatch[1].toLowerCase();
+      const urlMatch = part.match(/^url\s+\S*\/([a-f0-9]{64})(?:\.\w+)?(?:\?|$)/i);
+      if (urlMatch) return urlMatch[1].toLowerCase();
+    }
+  }
+  return null;
+}
+
+/**
+ * Process a kind 5 event. Processes each e-tag target independently.
+ * Returns { targets: [{ target_event_id, status, blob_sha256?, last_error? }] }
+ */
+export async function processKind5(kind5, { db, fetchTargetEvent, callBlossomDelete, now = () => Date.now() }) {
+  const targetIds = (kind5.tags || [])
+    .filter(t => t[0] === 'e' && t[1])
+    .map(t => t[1]);
+
+  const resultTargets = [];
+
+  for (const target_event_id of targetIds) {
+    const acceptedIso = new Date(now()).toISOString();
+    const claim = await claimRow(db, {
+      kind5_id: kind5.id,
+      target_event_id,
+      creator_pubkey: kind5.pubkey,
+      accepted_at: acceptedIso
+    });
+
+    const action = claim.claimed ? 'proceed' : decideAction(claim.existing, { now: now() });
+
+    if (action === 'skip_success') {
+      resultTargets.push({ target_event_id, status: 'success', blob_sha256: claim.existing.blob_sha256 });
+      continue;
+    }
+    if (action === 'skip_permanent_failure') {
+      resultTargets.push({ target_event_id, status: claim.existing.status, last_error: claim.existing.last_error });
+      continue;
+    }
+    if (action === 'skip_in_progress') {
+      resultTargets.push({ target_event_id, status: 'in_progress' });
+      continue;
+    }
+
+    // action === 'proceed'
+    const target = await fetchTargetEvent(target_event_id);
+    if (!target) {
+      await updateToFailed(db, {
+        kind5_id: kind5.id,
+        target_event_id,
+        status: 'failed:permanent:target_unresolved',
+        last_error: 'Target event not found on Funnelcake'
+      });
+      resultTargets.push({ target_event_id, status: 'failed:permanent:target_unresolved' });
+      continue;
+    }
+
+    const sha256 = extractSha256(target);
+    if (!sha256) {
+      await updateToFailed(db, {
+        kind5_id: kind5.id,
+        target_event_id,
+        status: 'failed:permanent:no_sha256',
+        last_error: 'No sha256 in target event imeta/url'
+      });
+      resultTargets.push({ target_event_id, status: 'failed:permanent:no_sha256' });
+      continue;
+    }
+
+    const blossomResult = await callBlossomDelete(sha256);
+    if (blossomResult.success && !blossomResult.skipped) {
+      await updateToSuccess(db, {
+        kind5_id: kind5.id,
+        target_event_id,
+        blob_sha256: sha256,
+        completed_at: new Date(now()).toISOString()
+      });
+      resultTargets.push({ target_event_id, status: 'success', blob_sha256: sha256 });
+      continue;
+    }
+
+    // Blossom failed or skipped
+    const status = blossomResult.status;
+    const isTransient = blossomResult.networkError || (status !== undefined && (status >= 500 || status === 429));
+    const category = isTransient
+      ? (blossomResult.networkError ? 'failed:transient:network' : `failed:transient:blossom_${status === 429 ? '429' : '5xx'}`)
+      : (status !== undefined ? `failed:permanent:blossom_${status}` : 'failed:permanent:blossom_skipped');
+
+    await updateToFailed(db, {
+      kind5_id: kind5.id,
+      target_event_id,
+      status: category,
+      last_error: blossomResult.error || `Blossom returned ${blossomResult.status}`,
+      increment_retry: isTransient
+    });
+    resultTargets.push({ target_event_id, status: category, last_error: blossomResult.error, blob_sha256: sha256 });
+  }
+
+  return { targets: resultTargets };
+}

--- a/src/creator-delete/process.mjs
+++ b/src/creator-delete/process.mjs
@@ -28,7 +28,7 @@ export function extractSha256(targetEvent) {
  * Process a kind 5 event. Processes each e-tag target independently.
  * Returns { targets: [{ target_event_id, status, blob_sha256?, last_error? }] }
  */
-export async function processKind5(kind5, { db, fetchTargetEvent, callBlossomDelete, now = () => Date.now() }) {
+export async function processKind5(kind5, { db, fetchTargetEvent, callBlossomDelete, now = () => Date.now(), triggerLabel = 'unknown' }) {
   const targetIds = (kind5.tags || [])
     .filter(t => t[0] === 'e' && t[1])
     .map(t => t[1]);
@@ -60,6 +60,15 @@ export async function processKind5(kind5, { db, fetchTargetEvent, callBlossomDel
     }
 
     // action === 'proceed'
+    console.log(JSON.stringify({
+      event: 'creator_delete.accepted',
+      kind5_id: kind5.id,
+      target_event_id,
+      creator_pubkey: kind5.pubkey,
+      accepted_at: acceptedIso,
+      trigger: triggerLabel
+    }));
+
     const target = await fetchTargetEvent(target_event_id);
     if (!target) {
       await updateToFailed(db, {
@@ -68,6 +77,16 @@ export async function processKind5(kind5, { db, fetchTargetEvent, callBlossomDel
         status: 'failed:permanent:target_unresolved',
         last_error: 'Target event not found on Funnelcake'
       });
+      console.log(JSON.stringify({
+        event: 'creator_delete.failed',
+        kind5_id: kind5.id,
+        target_event_id,
+        creator_pubkey: kind5.pubkey,
+        status: 'failed:permanent:target_unresolved',
+        last_error: 'Target event not found on Funnelcake',
+        retry_count_after: (claim.existing && claim.existing.retry_count) || 0,
+        trigger: triggerLabel
+      }));
       resultTargets.push({ target_event_id, status: 'failed:permanent:target_unresolved' });
       continue;
     }
@@ -80,18 +99,38 @@ export async function processKind5(kind5, { db, fetchTargetEvent, callBlossomDel
         status: 'failed:permanent:no_sha256',
         last_error: 'No sha256 in target event imeta/url'
       });
+      console.log(JSON.stringify({
+        event: 'creator_delete.failed',
+        kind5_id: kind5.id,
+        target_event_id,
+        creator_pubkey: kind5.pubkey,
+        status: 'failed:permanent:no_sha256',
+        last_error: 'No sha256 in target event imeta/url',
+        retry_count_after: (claim.existing && claim.existing.retry_count) || 0,
+        trigger: triggerLabel
+      }));
       resultTargets.push({ target_event_id, status: 'failed:permanent:no_sha256' });
       continue;
     }
 
     const blossomResult = await callBlossomDelete(sha256);
     if (blossomResult.success && !blossomResult.skipped) {
+      const completedIso = new Date(now()).toISOString();
       await updateToSuccess(db, {
         kind5_id: kind5.id,
         target_event_id,
         blob_sha256: sha256,
-        completed_at: new Date(now()).toISOString()
+        completed_at: completedIso
       });
+      console.log(JSON.stringify({
+        event: 'creator_delete.success',
+        kind5_id: kind5.id,
+        target_event_id,
+        creator_pubkey: kind5.pubkey,
+        blob_sha256: sha256,
+        completed_at: completedIso,
+        trigger: triggerLabel
+      }));
       resultTargets.push({ target_event_id, status: 'success', blob_sha256: sha256 });
       continue;
     }
@@ -103,13 +142,26 @@ export async function processKind5(kind5, { db, fetchTargetEvent, callBlossomDel
       ? (blossomResult.networkError ? 'failed:transient:network' : `failed:transient:blossom_${status === 429 ? '429' : '5xx'}`)
       : (status !== undefined ? `failed:permanent:blossom_${status}` : 'failed:permanent:blossom_skipped');
 
+    const lastError = blossomResult.error || `Blossom returned ${blossomResult.status}`;
     await updateToFailed(db, {
       kind5_id: kind5.id,
       target_event_id,
       status: category,
-      last_error: blossomResult.error || `Blossom returned ${blossomResult.status}`,
+      last_error: lastError,
       increment_retry: isTransient
     });
+    const priorRetryCount = (claim.existing && claim.existing.retry_count) || 0;
+    const retryCountAfter = isTransient ? priorRetryCount + 1 : priorRetryCount;
+    console.log(JSON.stringify({
+      event: 'creator_delete.failed',
+      kind5_id: kind5.id,
+      target_event_id,
+      creator_pubkey: kind5.pubkey,
+      status: category,
+      last_error: lastError,
+      retry_count_after: retryCountAfter,
+      trigger: triggerLabel
+    }));
     resultTargets.push({ target_event_id, status: category, last_error: blossomResult.error, blob_sha256: sha256 });
   }
 

--- a/src/creator-delete/process.mjs
+++ b/src/creator-delete/process.mjs
@@ -4,7 +4,7 @@
 // ABOUTME: Shared kind 5 processing function used by both sync endpoint and cron.
 // ABOUTME: Race-safe via D1 INSERT-OR-IGNORE claim, handles multi-target kind 5 per NIP-09.
 
-import { claimRow, readRow, updateToSuccess, updateToFailed, decideAction } from './d1.mjs';
+import { claimRow, updateToSuccess, updateToFailed, decideAction } from './d1.mjs';
 
 /**
  * Extract the main blob sha256 from a kind 34236 video event.

--- a/src/creator-delete/process.test.mjs
+++ b/src/creator-delete/process.test.mjs
@@ -5,7 +5,7 @@
 // ABOUTME: Uses makeFakeD1 from ./test-helpers.mjs; callBlossomDelete and fetchTargetEvent are vi.fn mocks.
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { processKind5 } from './process.mjs';
+import { processKind5, MAX_TARGETS_PER_KIND5 } from './process.mjs';
 import { makeFakeD1 } from './test-helpers.mjs';
 
 describe('processKind5', () => {
@@ -117,5 +117,22 @@ describe('processKind5', () => {
     expect(result.targets[0].status).toBe('success');
     expect(callBlossomDelete).not.toHaveBeenCalled();
     expect(fetchTargetEvent).not.toHaveBeenCalled();
+  });
+
+  it('caps processing at MAX_TARGETS_PER_KIND5 when given more e-tags', async () => {
+    // Build a kind 5 with N+5 e-tags. Only the first MAX should be processed.
+    const overflow = 5;
+    const eTags = [];
+    for (let i = 0; i < MAX_TARGETS_PER_KIND5 + overflow; i++) {
+      eTags.push(['e', `t${i.toString().padStart(3, '0')}`]);
+    }
+    const kind5 = { id: 'k1', pubkey: 'pub1', tags: eTags };
+    fetchTargetEvent.mockResolvedValue({ id: 't', pubkey: 'pub1', tags: [['imeta', `x ${SHA_C}`]] });
+    callBlossomDelete.mockResolvedValue({ success: true, status: 200 });
+
+    const result = await processKind5(kind5, { db, fetchTargetEvent, callBlossomDelete });
+
+    expect(result.targets).toHaveLength(MAX_TARGETS_PER_KIND5);
+    expect(callBlossomDelete).toHaveBeenCalledTimes(MAX_TARGETS_PER_KIND5);
   });
 });

--- a/src/creator-delete/process.test.mjs
+++ b/src/creator-delete/process.test.mjs
@@ -1,0 +1,121 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Tests for processKind5 — happy path, multi-target, error categorization, idempotent skip.
+// ABOUTME: Uses makeFakeD1 from ./test-helpers.mjs; callBlossomDelete and fetchTargetEvent are vi.fn mocks.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { processKind5 } from './process.mjs';
+import { makeFakeD1 } from './test-helpers.mjs';
+
+describe('processKind5', () => {
+  let db, fetchTargetEvent, callBlossomDelete;
+
+  beforeEach(() => {
+    db = makeFakeD1();
+    fetchTargetEvent = vi.fn();
+    callBlossomDelete = vi.fn();
+  });
+
+  const SHA_C = 'c'.repeat(64); // 64-char hex fixture (extractSha256 requires exactly 64 hex chars)
+
+  it('happy path: claim, fetch target, extract sha256, call Blossom, mark success', async () => {
+    const kind5 = {
+      id: 'k1',
+      pubkey: 'pub1',
+      tags: [['e', 't1']]
+    };
+    fetchTargetEvent.mockResolvedValueOnce({
+      id: 't1',
+      pubkey: 'pub1',
+      tags: [['imeta', `url https://media.divine.video/${SHA_C}.mp4`, `x ${SHA_C}`]]
+    });
+    callBlossomDelete.mockResolvedValueOnce({ success: true, status: 200 });
+
+    const result = await processKind5(kind5, {
+      db,
+      fetchTargetEvent,
+      callBlossomDelete
+    });
+
+    expect(result.targets).toEqual([{ target_event_id: 't1', status: 'success', blob_sha256: SHA_C }]);
+    expect(callBlossomDelete).toHaveBeenCalledWith(SHA_C);
+  });
+
+  it('multi-target kind 5: processes each independently', async () => {
+    const kind5 = {
+      id: 'k1',
+      pubkey: 'pub1',
+      tags: [['e', 't1'], ['e', 't2']]
+    };
+    fetchTargetEvent
+      .mockResolvedValueOnce({ id: 't1', pubkey: 'pub1', tags: [['imeta', 'x aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa']] })
+      .mockResolvedValueOnce({ id: 't2', pubkey: 'pub1', tags: [['imeta', 'x bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb']] });
+    callBlossomDelete.mockResolvedValue({ success: true, status: 200 });
+
+    const result = await processKind5(kind5, { db, fetchTargetEvent, callBlossomDelete });
+    expect(result.targets).toHaveLength(2);
+    expect(result.targets.map(t => t.status)).toEqual(['success', 'success']);
+  });
+
+  it('target_unresolved when Funnelcake returns null', async () => {
+    const kind5 = { id: 'k1', pubkey: 'pub1', tags: [['e', 't1']] };
+    fetchTargetEvent.mockResolvedValueOnce(null);
+    const result = await processKind5(kind5, { db, fetchTargetEvent, callBlossomDelete });
+    expect(result.targets[0].status).toBe('failed:permanent:target_unresolved');
+    expect(callBlossomDelete).not.toHaveBeenCalled();
+  });
+
+  it('no_sha256 when target event has no imeta', async () => {
+    const kind5 = { id: 'k1', pubkey: 'pub1', tags: [['e', 't1']] };
+    fetchTargetEvent.mockResolvedValueOnce({ id: 't1', pubkey: 'pub1', tags: [] });
+    const result = await processKind5(kind5, { db, fetchTargetEvent, callBlossomDelete });
+    expect(result.targets[0].status).toBe('failed:permanent:no_sha256');
+  });
+
+  it('transient failure on Blossom 503', async () => {
+    const kind5 = { id: 'k1', pubkey: 'pub1', tags: [['e', 't1']] };
+    fetchTargetEvent.mockResolvedValueOnce({ id: 't1', pubkey: 'pub1', tags: [['imeta', `x ${SHA_C}`]] });
+    callBlossomDelete.mockResolvedValueOnce({ success: false, status: 503, error: 'HTTP 503: service unavailable' });
+    const result = await processKind5(kind5, { db, fetchTargetEvent, callBlossomDelete });
+    expect(result.targets[0].status).toBe('failed:transient:blossom_5xx');
+  });
+
+  it('permanent failure on Blossom 400', async () => {
+    const kind5 = { id: 'k1', pubkey: 'pub1', tags: [['e', 't1']] };
+    fetchTargetEvent.mockResolvedValueOnce({ id: 't1', pubkey: 'pub1', tags: [['imeta', `x ${SHA_C}`]] });
+    callBlossomDelete.mockResolvedValueOnce({ success: false, status: 400, error: 'HTTP 400: bad request' });
+    const result = await processKind5(kind5, { db, fetchTargetEvent, callBlossomDelete });
+    expect(result.targets[0].status).toBe('failed:permanent:blossom_400');
+  });
+
+  it('transient failure on network error', async () => {
+    const kind5 = { id: 'k1', pubkey: 'pub1', tags: [['e', 't1']] };
+    fetchTargetEvent.mockResolvedValueOnce({ id: 't1', pubkey: 'pub1', tags: [['imeta', `x ${SHA_C}`]] });
+    callBlossomDelete.mockResolvedValueOnce({ success: false, error: 'connection reset', networkError: true });
+    const result = await processKind5(kind5, { db, fetchTargetEvent, callBlossomDelete });
+    expect(result.targets[0].status).toBe('failed:transient:network');
+  });
+
+  it('skips when existing row is success (idempotent)', async () => {
+    const kind5 = { id: 'k1', pubkey: 'pub1', tags: [['e', 't1']] };
+    // Pre-seed D1 directly — bypass the fake's INSERT path, which is tailored to
+    // claimRow's 4-arg bind with an inlined 'accepted' status literal. A direct
+    // rows.set() lets this test simulate a pre-existing terminal row.
+    db.rows.set('k1:t1', {
+      kind5_id: 'k1',
+      target_event_id: 't1',
+      creator_pubkey: 'pub1',
+      status: 'success',
+      accepted_at: new Date().toISOString(),
+      blob_sha256: SHA_C,
+      retry_count: 0,
+      last_error: null,
+      completed_at: new Date().toISOString()
+    });
+    const result = await processKind5(kind5, { db, fetchTargetEvent, callBlossomDelete });
+    expect(result.targets[0].status).toBe('success');
+    expect(callBlossomDelete).not.toHaveBeenCalled();
+    expect(fetchTargetEvent).not.toHaveBeenCalled();
+  });
+});

--- a/src/creator-delete/rate-limit.mjs
+++ b/src/creator-delete/rate-limit.mjs
@@ -19,9 +19,3 @@ export async function checkRateLimit(kv, { key, limit, windowSeconds }) {
   return { allowed: true, remaining: limit - next };
 }
 
-export function buildRateLimitKeys({ pubkey, clientIp }) {
-  return {
-    pubkeyKey: pubkey ? `pubkey:${pubkey}` : null,
-    ipKey: clientIp ? `ip:${clientIp}` : null
-  };
-}

--- a/src/creator-delete/rate-limit.mjs
+++ b/src/creator-delete/rate-limit.mjs
@@ -1,8 +1,10 @@
 // This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
 // If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 //
-// ABOUTME: Simple KV-backed sliding window rate limiter for per-pubkey and per-IP limits.
-// ABOUTME: Not perfectly accurate (no cross-region consistency) but sufficient for abuse prevention.
+// ABOUTME: Simple KV-backed fixed-window rate limiter for per-pubkey and per-IP limits.
+// ABOUTME: Bucketed by floor(now/windowSeconds) — edge-of-bucket bursts can briefly hit 2× limit.
+// ABOUTME: No cross-region atomicity either. Sufficient for abuse prevention, not exact enforcement.
+// ABOUTME: Use a Durable Object if strict limits become required.
 
 export async function checkRateLimit(kv, { key, limit, windowSeconds }) {
   const now = Math.floor(Date.now() / 1000);

--- a/src/creator-delete/rate-limit.mjs
+++ b/src/creator-delete/rate-limit.mjs
@@ -1,0 +1,27 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Simple KV-backed sliding window rate limiter for per-pubkey and per-IP limits.
+// ABOUTME: Not perfectly accurate (no cross-region consistency) but sufficient for abuse prevention.
+
+export async function checkRateLimit(kv, { key, limit, windowSeconds }) {
+  const now = Math.floor(Date.now() / 1000);
+  const bucket = Math.floor(now / windowSeconds);
+  const kvKey = `ratelimit:${key}:${bucket}`;
+  const current = parseInt((await kv.get(kvKey)) || '0', 10);
+
+  if (current >= limit) {
+    return { allowed: false, remaining: 0, retryAfterSeconds: windowSeconds - (now % windowSeconds) };
+  }
+
+  const next = current + 1;
+  await kv.put(kvKey, String(next), { expirationTtl: windowSeconds * 2 });
+  return { allowed: true, remaining: limit - next };
+}
+
+export function buildRateLimitKeys({ pubkey, clientIp }) {
+  return {
+    pubkeyKey: pubkey ? `pubkey:${pubkey}` : null,
+    ipKey: clientIp ? `ip:${clientIp}` : null
+  };
+}

--- a/src/creator-delete/rate-limit.test.mjs
+++ b/src/creator-delete/rate-limit.test.mjs
@@ -1,0 +1,29 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Tests for checkRateLimit — allow under limit, block over limit.
+// ABOUTME: Uses in-memory fake KV (makeFakeKV) from ./test-helpers.mjs.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { checkRateLimit } from './rate-limit.mjs';
+import { makeFakeKV } from './test-helpers.mjs';
+
+describe('checkRateLimit', () => {
+  let kv;
+  beforeEach(() => { kv = makeFakeKV(); });
+
+  it('allows under the limit', async () => {
+    const result = await checkRateLimit(kv, { key: 'pubkey:abc', limit: 5, windowSeconds: 60 });
+    expect(result.allowed).toBe(true);
+    expect(result.remaining).toBe(4);
+  });
+
+  it('blocks over the limit', async () => {
+    for (let i = 0; i < 5; i++) {
+      await checkRateLimit(kv, { key: 'pubkey:abc', limit: 5, windowSeconds: 60 });
+    }
+    const result = await checkRateLimit(kv, { key: 'pubkey:abc', limit: 5, windowSeconds: 60 });
+    expect(result.allowed).toBe(false);
+    expect(result.remaining).toBe(0);
+  });
+});

--- a/src/creator-delete/status-endpoint.mjs
+++ b/src/creator-delete/status-endpoint.mjs
@@ -16,8 +16,8 @@ export async function handleStatusQuery(request, deps) {
   const url = new URL(request.url);
   const kind5_id = url.pathname.split('/').pop();
 
-  if (!kind5_id) {
-    return jsonResponse(400, { error: 'Missing kind5_id' });
+  if (!kind5_id || !/^[a-f0-9]{64}$/i.test(kind5_id)) {
+    return jsonResponse(400, { error: 'Invalid kind5_id' });
   }
 
   const auth = await validateNip98Header(request.headers.get('Authorization'), url.toString(), 'GET');

--- a/src/creator-delete/status-endpoint.mjs
+++ b/src/creator-delete/status-endpoint.mjs
@@ -1,0 +1,61 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: GET /api/delete-status/{kind5_id} — NIP-98 author-only status query.
+// ABOUTME: Reads creator_deletions D1 rows for the kind5_id, enforces caller matches the rows' creator_pubkey.
+
+import { validateNip98Header } from './nip98.mjs';
+import { readAllTargetsForKind5 } from './d1.mjs';
+import { checkRateLimit } from './rate-limit.mjs';
+
+const PER_PUBKEY_LIMIT = 120; // 2/sec average
+const RATE_WINDOW_SECONDS = 60;
+
+export async function handleStatusQuery(request, deps) {
+  const { db, kv } = deps;
+  const url = new URL(request.url);
+  const kind5_id = url.pathname.split('/').pop();
+
+  if (!kind5_id) {
+    return jsonResponse(400, { error: 'Missing kind5_id' });
+  }
+
+  const auth = await validateNip98Header(request.headers.get('Authorization'), url.toString(), 'GET');
+  if (!auth.valid) {
+    return jsonResponse(401, { error: `NIP-98 validation failed: ${auth.error}` });
+  }
+
+  const pubkeyCheck = await checkRateLimit(kv, { key: `status:${auth.pubkey}`, limit: PER_PUBKEY_LIMIT, windowSeconds: RATE_WINDOW_SECONDS });
+  if (!pubkeyCheck.allowed) {
+    return jsonResponse(429, { error: 'Rate limit exceeded', retry_after_seconds: pubkeyCheck.retryAfterSeconds });
+  }
+
+  const rows = await readAllTargetsForKind5(db, { kind5_id });
+  if (rows.length === 0) {
+    return jsonResponse(404, { error: 'No processing record for this kind5_id' });
+  }
+
+  const notAuthoredByCaller = rows.find(r => r.creator_pubkey !== auth.pubkey);
+  if (notAuthoredByCaller) {
+    return jsonResponse(403, { error: 'Caller pubkey does not match kind 5 author' });
+  }
+
+  return jsonResponse(200, {
+    kind5_id,
+    targets: rows.map(r => ({
+      target_event_id: r.target_event_id,
+      blob_sha256: r.blob_sha256,
+      status: r.status,
+      accepted_at: r.accepted_at,
+      completed_at: r.completed_at,
+      last_error: r.last_error
+    }))
+  });
+}
+
+function jsonResponse(status, body) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' }
+  });
+}

--- a/src/creator-delete/status-endpoint.mjs
+++ b/src/creator-delete/status-endpoint.mjs
@@ -9,6 +9,7 @@ import { readAllTargetsForKind5 } from './d1.mjs';
 import { checkRateLimit } from './rate-limit.mjs';
 
 const PER_PUBKEY_LIMIT = 120; // 2/sec average
+const PER_IP_LIMIT = 60;
 const RATE_WINDOW_SECONDS = 60;
 
 export async function handleStatusQuery(request, deps) {
@@ -18,6 +19,13 @@ export async function handleStatusQuery(request, deps) {
 
   if (!kind5_id || !/^[a-f0-9]{64}$/i.test(kind5_id)) {
     return jsonResponse(400, { error: 'Invalid kind5_id' });
+  }
+
+  // IP rate limit BEFORE NIP-98 validation to limit unauthenticated crypto work.
+  const clientIp = request.headers.get('CF-Connecting-IP') || 'unknown';
+  const ipCheck = await checkRateLimit(kv, { key: `status-ip:${clientIp}`, limit: PER_IP_LIMIT, windowSeconds: RATE_WINDOW_SECONDS });
+  if (!ipCheck.allowed) {
+    return jsonResponse(429, { error: 'Rate limit exceeded', retry_after_seconds: ipCheck.retryAfterSeconds || 0 });
   }
 
   const auth = await validateNip98Header(request.headers.get('Authorization'), url.toString(), 'GET');

--- a/src/creator-delete/status-endpoint.test.mjs
+++ b/src/creator-delete/status-endpoint.test.mjs
@@ -66,6 +66,18 @@ describe('handleStatusQuery', () => {
     expect(response.status).toBe(401);
   });
 
+  it('returns 429 on IP rate limit before NIP-98 validation', async () => {
+    for (let i = 0; i < 60; i++) {
+      await checkRateLimit(deps.kv, { key: 'status-ip:203.0.113.10', limit: 60, windowSeconds: 60 });
+    }
+    const url = `https://moderation-api.divine.video/api/delete-status/${KIND5_A}`;
+    const response = await handleStatusQuery(new Request(url, {
+      method: 'GET',
+      headers: { 'CF-Connecting-IP': '203.0.113.10' }
+    }), deps);
+    expect(response.status).toBe(429);
+  });
+
   it('returns 404 when no rows exist for the kind5_id', async () => {
     const url = `https://moderation-api.divine.video/api/delete-status/${KIND5_B}`;
     const response = await handleStatusQuery(new Request(url, { method: 'GET', headers: { Authorization: signNip98Get(url) } }), deps);

--- a/src/creator-delete/status-endpoint.test.mjs
+++ b/src/creator-delete/status-endpoint.test.mjs
@@ -10,6 +10,9 @@ import { handleStatusQuery } from './status-endpoint.mjs';
 import { checkRateLimit } from './rate-limit.mjs';
 import { makeFakeD1, makeFakeKV } from './test-helpers.mjs';
 
+const KIND5_A = 'a'.repeat(64);
+const KIND5_B = 'b'.repeat(64);
+
 describe('handleStatusQuery', () => {
   let sk, pk, deps;
 
@@ -30,11 +33,8 @@ describe('handleStatusQuery', () => {
   }
 
   it('returns 200 with target rows for the caller pubkey', async () => {
-    // Seed D1 directly — bypass the fake's INSERT path, which is tailored
-    // to claimRow's 4-arg bind with 'accepted' status literal. Direct
-    // rows.set() lets us simulate a terminal 'success' row.
-    deps.db.rows.set('k1:t1', {
-      kind5_id: 'k1',
+    deps.db.rows.set(`${KIND5_A}:t1`, {
+      kind5_id: KIND5_A,
       target_event_id: 't1',
       creator_pubkey: pk,
       status: 'success',
@@ -45,23 +45,29 @@ describe('handleStatusQuery', () => {
       completed_at: new Date().toISOString()
     });
 
-    const url = 'https://moderation-api.divine.video/api/delete-status/k1';
+    const url = `https://moderation-api.divine.video/api/delete-status/${KIND5_A}`;
     const request = new Request(url, { method: 'GET', headers: { Authorization: signNip98Get(url) } });
     const response = await handleStatusQuery(request, deps);
     expect(response.status).toBe(200);
     const body = await response.json();
-    expect(body.kind5_id).toBe('k1');
+    expect(body.kind5_id).toBe(KIND5_A);
     expect(body.targets[0]).toMatchObject({ target_event_id: 't1', status: 'success' });
   });
 
+  it('returns 400 on malformed kind5_id', async () => {
+    const url = 'https://moderation-api.divine.video/api/delete-status/not-a-hex-id';
+    const response = await handleStatusQuery(new Request(url, { method: 'GET', headers: { Authorization: signNip98Get(url) } }), deps);
+    expect(response.status).toBe(400);
+  });
+
   it('returns 401 when Authorization header is missing', async () => {
-    const url = 'https://moderation-api.divine.video/api/delete-status/k1';
+    const url = `https://moderation-api.divine.video/api/delete-status/${KIND5_A}`;
     const response = await handleStatusQuery(new Request(url, { method: 'GET' }), deps);
     expect(response.status).toBe(401);
   });
 
   it('returns 404 when no rows exist for the kind5_id', async () => {
-    const url = 'https://moderation-api.divine.video/api/delete-status/unknown';
+    const url = `https://moderation-api.divine.video/api/delete-status/${KIND5_B}`;
     const response = await handleStatusQuery(new Request(url, { method: 'GET', headers: { Authorization: signNip98Get(url) } }), deps);
     expect(response.status).toBe(404);
   });
@@ -69,9 +75,8 @@ describe('handleStatusQuery', () => {
   it('returns 403 when caller pubkey does not match row creator_pubkey', async () => {
     const otherSk = generateSecretKey();
     const otherPk = getPublicKey(otherSk);
-    // Seed D1 directly (see happy-path note).
-    deps.db.rows.set('k2:t1', {
-      kind5_id: 'k2',
+    deps.db.rows.set(`${KIND5_B}:t1`, {
+      kind5_id: KIND5_B,
       target_event_id: 't1',
       creator_pubkey: otherPk,
       status: 'success',
@@ -82,7 +87,7 @@ describe('handleStatusQuery', () => {
       completed_at: null
     });
 
-    const url = 'https://moderation-api.divine.video/api/delete-status/k2';
+    const url = `https://moderation-api.divine.video/api/delete-status/${KIND5_B}`;
     const response = await handleStatusQuery(new Request(url, { method: 'GET', headers: { Authorization: signNip98Get(url) } }), deps);
     expect(response.status).toBe(403);
   });
@@ -91,7 +96,7 @@ describe('handleStatusQuery', () => {
     for (let i = 0; i < 120; i++) {
       await checkRateLimit(deps.kv, { key: `status:${pk}`, limit: 120, windowSeconds: 60 });
     }
-    const url = 'https://moderation-api.divine.video/api/delete-status/k1';
+    const url = `https://moderation-api.divine.video/api/delete-status/${KIND5_A}`;
     const response = await handleStatusQuery(new Request(url, { method: 'GET', headers: { Authorization: signNip98Get(url) } }), deps);
     expect(response.status).toBe(429);
   });

--- a/src/creator-delete/status-endpoint.test.mjs
+++ b/src/creator-delete/status-endpoint.test.mjs
@@ -1,0 +1,98 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Tests for GET /api/delete-status/{kind5_id} — happy path + 401 / 403 / 404 / 429.
+// ABOUTME: Uses makeFakeD1/makeFakeKV from ./test-helpers.mjs; seeds D1 via rows.set() to bypass INSERT fake limitations.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { generateSecretKey, getPublicKey, finalizeEvent } from 'nostr-tools/pure';
+import { handleStatusQuery } from './status-endpoint.mjs';
+import { checkRateLimit } from './rate-limit.mjs';
+import { makeFakeD1, makeFakeKV } from './test-helpers.mjs';
+
+describe('handleStatusQuery', () => {
+  let sk, pk, deps;
+
+  beforeEach(() => {
+    sk = generateSecretKey();
+    pk = getPublicKey(sk);
+    deps = { db: makeFakeD1(), kv: makeFakeKV() };
+  });
+
+  function signNip98Get(url) {
+    const event = finalizeEvent({
+      kind: 27235,
+      created_at: Math.floor(Date.now() / 1000),
+      tags: [['u', url], ['method', 'GET']],
+      content: ''
+    }, sk);
+    return `Nostr ${btoa(JSON.stringify(event))}`;
+  }
+
+  it('returns 200 with target rows for the caller pubkey', async () => {
+    // Seed D1 directly — bypass the fake's INSERT path, which is tailored
+    // to claimRow's 4-arg bind with 'accepted' status literal. Direct
+    // rows.set() lets us simulate a terminal 'success' row.
+    deps.db.rows.set('k1:t1', {
+      kind5_id: 'k1',
+      target_event_id: 't1',
+      creator_pubkey: pk,
+      status: 'success',
+      accepted_at: new Date().toISOString(),
+      blob_sha256: 'c'.repeat(64),
+      retry_count: 0,
+      last_error: null,
+      completed_at: new Date().toISOString()
+    });
+
+    const url = 'https://moderation-api.divine.video/api/delete-status/k1';
+    const request = new Request(url, { method: 'GET', headers: { Authorization: signNip98Get(url) } });
+    const response = await handleStatusQuery(request, deps);
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.kind5_id).toBe('k1');
+    expect(body.targets[0]).toMatchObject({ target_event_id: 't1', status: 'success' });
+  });
+
+  it('returns 401 when Authorization header is missing', async () => {
+    const url = 'https://moderation-api.divine.video/api/delete-status/k1';
+    const response = await handleStatusQuery(new Request(url, { method: 'GET' }), deps);
+    expect(response.status).toBe(401);
+  });
+
+  it('returns 404 when no rows exist for the kind5_id', async () => {
+    const url = 'https://moderation-api.divine.video/api/delete-status/unknown';
+    const response = await handleStatusQuery(new Request(url, { method: 'GET', headers: { Authorization: signNip98Get(url) } }), deps);
+    expect(response.status).toBe(404);
+  });
+
+  it('returns 403 when caller pubkey does not match row creator_pubkey', async () => {
+    const otherSk = generateSecretKey();
+    const otherPk = getPublicKey(otherSk);
+    // Seed D1 directly (see happy-path note).
+    deps.db.rows.set('k2:t1', {
+      kind5_id: 'k2',
+      target_event_id: 't1',
+      creator_pubkey: otherPk,
+      status: 'success',
+      accepted_at: new Date().toISOString(),
+      blob_sha256: null,
+      retry_count: 0,
+      last_error: null,
+      completed_at: null
+    });
+
+    const url = 'https://moderation-api.divine.video/api/delete-status/k2';
+    const response = await handleStatusQuery(new Request(url, { method: 'GET', headers: { Authorization: signNip98Get(url) } }), deps);
+    expect(response.status).toBe(403);
+  });
+
+  it('returns 429 when per-pubkey rate limit exceeded', async () => {
+    for (let i = 0; i < 120; i++) {
+      await checkRateLimit(deps.kv, { key: `status:${pk}`, limit: 120, windowSeconds: 60 });
+    }
+    const url = 'https://moderation-api.divine.video/api/delete-status/k1';
+    const response = await handleStatusQuery(new Request(url, { method: 'GET', headers: { Authorization: signNip98Get(url) } }), deps);
+    expect(response.status).toBe(429);
+  });
+});

--- a/src/creator-delete/sync-endpoint.mjs
+++ b/src/creator-delete/sync-endpoint.mjs
@@ -1,0 +1,91 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: POST /api/delete/{kind5_id} — synchronous creator-delete handler.
+// ABOUTME: NIP-98 author-only auth; fetches kind 5 with read-after-write retries; runs processKind5 within budget.
+
+import { validateNip98Header } from './nip98.mjs';
+import { processKind5 } from './process.mjs';
+import { checkRateLimit } from './rate-limit.mjs';
+
+export const PER_PUBKEY_LIMIT = 5;
+export const PER_IP_LIMIT = 30;
+export const RATE_WINDOW_SECONDS = 60;
+
+export async function handleSyncDelete(request, deps) {
+  const { db, kv, fetchKind5WithRetry, fetchTargetEvent, callBlossomDelete, budgetMs = 8000 } = deps;
+
+  const url = new URL(request.url);
+  const kind5_id = url.pathname.split('/').pop();
+
+  if (!kind5_id || !/^[a-f0-9]{64}$/i.test(kind5_id)) {
+    return jsonResponse(400, { error: 'Invalid kind5_id' });
+  }
+
+  const auth = await validateNip98Header(request.headers.get('Authorization'), url.toString(), 'POST');
+  if (!auth.valid) {
+    return jsonResponse(401, { error: `NIP-98 validation failed: ${auth.error}` });
+  }
+
+  const clientIp = request.headers.get('CF-Connecting-IP') || 'unknown';
+  const ipCheck = await checkRateLimit(kv, { key: `ip:${clientIp}`, limit: PER_IP_LIMIT, windowSeconds: RATE_WINDOW_SECONDS });
+  const pubkeyCheck = await checkRateLimit(kv, { key: `pubkey:${auth.pubkey}`, limit: PER_PUBKEY_LIMIT, windowSeconds: RATE_WINDOW_SECONDS });
+  if (!ipCheck.allowed || !pubkeyCheck.allowed) {
+    return jsonResponse(429, {
+      error: 'Rate limit exceeded',
+      retry_after_seconds: Math.max(ipCheck.retryAfterSeconds || 0, pubkeyCheck.retryAfterSeconds || 0)
+    });
+  }
+
+  const kind5 = await fetchKind5WithRetry(kind5_id);
+  if (!kind5) {
+    return jsonResponse(404, { error: 'Kind 5 not found on Funnelcake after retries' });
+  }
+
+  if (kind5.pubkey !== auth.pubkey) {
+    return jsonResponse(403, { error: 'Caller pubkey does not match kind 5 author' });
+  }
+
+  const deadline = Date.now() + budgetMs;
+  const processing = processKind5(kind5, {
+    db,
+    fetchTargetEvent,
+    callBlossomDelete
+  });
+
+  const timeoutPromise = new Promise(resolve => setTimeout(() => resolve({ budgetExceeded: true }), budgetMs));
+  const raceResult = await Promise.race([processing, timeoutPromise]);
+
+  if (raceResult.budgetExceeded) {
+    return jsonResponse(202, {
+      kind5_id,
+      status: 'in_progress',
+      poll_url: `/api/delete-status/${kind5_id}`
+    });
+  }
+
+  const anyFailed = raceResult.targets.some(t => t.status.startsWith('failed:'));
+  const anyInProgress = raceResult.targets.some(t => t.status === 'in_progress');
+
+  if (anyInProgress && Date.now() < deadline) {
+    // One target still had an in-progress existing row. Return 202.
+    return jsonResponse(202, {
+      kind5_id,
+      status: 'in_progress',
+      poll_url: `/api/delete-status/${kind5_id}`
+    });
+  }
+
+  return jsonResponse(200, {
+    kind5_id,
+    status: anyFailed ? 'failed' : 'success',
+    targets: raceResult.targets
+  });
+}
+
+function jsonResponse(status, body) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' }
+  });
+}

--- a/src/creator-delete/sync-endpoint.mjs
+++ b/src/creator-delete/sync-endpoint.mjs
@@ -12,20 +12,25 @@ export const PER_PUBKEY_LIMIT = 5;
 export const PER_IP_LIMIT = 30;
 export const RATE_WINDOW_SECONDS = 60;
 
+function logRequest(t0, kind5_id, status_code, extra = {}) {
+  console.log(JSON.stringify({
+    event: 'creator_delete.sync.request',
+    status_code,
+    latency_ms: Date.now() - t0,
+    kind5_id: kind5_id || null,
+    ...extra
+  }));
+}
+
 export async function handleSyncDelete(request, deps) {
   const t0 = Date.now();
-  const { db, kv, fetchKind5WithRetry, fetchTargetEvent, callBlossomDelete, budgetMs = 8000 } = deps;
+  const { db, kv, ctx, fetchKind5WithRetry, fetchTargetEvent, callBlossomDelete, budgetMs = 8000 } = deps;
 
   const url = new URL(request.url);
   const kind5_id = url.pathname.split('/').pop();
 
   if (!kind5_id || !/^[a-f0-9]{64}$/i.test(kind5_id)) {
-    console.log(JSON.stringify({
-      event: 'creator_delete.sync.request',
-      status_code: 400,
-      latency_ms: Date.now() - t0,
-      kind5_id: kind5_id || null
-    }));
+    logRequest(t0, kind5_id, 400);
     return jsonResponse(400, { error: 'Invalid kind5_id' });
   }
 
@@ -33,12 +38,7 @@ export async function handleSyncDelete(request, deps) {
   const clientIp = request.headers.get('CF-Connecting-IP') || 'unknown';
   const ipCheck = await checkRateLimit(kv, { key: `ip:${clientIp}`, limit: PER_IP_LIMIT, windowSeconds: RATE_WINDOW_SECONDS });
   if (!ipCheck.allowed) {
-    console.log(JSON.stringify({
-      event: 'creator_delete.sync.request',
-      status_code: 429,
-      latency_ms: Date.now() - t0,
-      kind5_id: kind5_id || null
-    }));
+    logRequest(t0, kind5_id, 429);
     return jsonResponse(429, {
       error: 'Rate limit exceeded',
       retry_after_seconds: ipCheck.retryAfterSeconds || 0
@@ -47,24 +47,14 @@ export async function handleSyncDelete(request, deps) {
 
   const auth = await validateNip98Header(request.headers.get('Authorization'), url.toString(), 'POST');
   if (!auth.valid) {
-    console.log(JSON.stringify({
-      event: 'creator_delete.sync.request',
-      status_code: 401,
-      latency_ms: Date.now() - t0,
-      kind5_id: kind5_id || null
-    }));
+    logRequest(t0, kind5_id, 401);
     return jsonResponse(401, { error: `NIP-98 validation failed: ${auth.error}` });
   }
 
   // Per-pubkey rate limit AFTER NIP-98 (pubkey only known after validation)
   const pubkeyCheck = await checkRateLimit(kv, { key: `pubkey:${auth.pubkey}`, limit: PER_PUBKEY_LIMIT, windowSeconds: RATE_WINDOW_SECONDS });
   if (!pubkeyCheck.allowed) {
-    console.log(JSON.stringify({
-      event: 'creator_delete.sync.request',
-      status_code: 429,
-      latency_ms: Date.now() - t0,
-      kind5_id: kind5_id || null
-    }));
+    logRequest(t0, kind5_id, 429);
     return jsonResponse(429, {
       error: 'Rate limit exceeded',
       retry_after_seconds: pubkeyCheck.retryAfterSeconds || 0
@@ -73,23 +63,20 @@ export async function handleSyncDelete(request, deps) {
 
   const kind5 = await fetchKind5WithRetry(kind5_id);
   if (!kind5) {
-    console.log(JSON.stringify({
-      event: 'creator_delete.sync.request',
-      status_code: 404,
-      latency_ms: Date.now() - t0,
-      kind5_id: kind5_id || null
-    }));
+    logRequest(t0, kind5_id, 404);
     return jsonResponse(404, { error: 'Kind 5 not found on Funnelcake after retries' });
   }
 
   if (kind5.pubkey !== auth.pubkey) {
-    console.log(JSON.stringify({
-      event: 'creator_delete.sync.request',
-      status_code: 403,
-      latency_ms: Date.now() - t0,
-      kind5_id: kind5_id || null
-    }));
+    logRequest(t0, kind5_id, 403);
     return jsonResponse(403, { error: 'Caller pubkey does not match kind 5 author' });
+  }
+
+  // Reject kind 5 with no e-tags upfront: produces no targets, would otherwise 200 with empty list
+  const hasETag = (kind5.tags || []).some(t => t[0] === 'e' && t[1]);
+  if (!hasETag) {
+    logRequest(t0, kind5_id, 400, { reason: 'no_e_tags' });
+    return jsonResponse(400, { error: 'Kind 5 event has no e-tags; nothing to delete' });
   }
 
   const deadline = Date.now() + budgetMs;
@@ -100,16 +87,25 @@ export async function handleSyncDelete(request, deps) {
     triggerLabel: 'sync'
   });
 
+  // When the budget elapses we return 202 and let processKind5 keep running.
+  // ctx.waitUntil keeps the Worker alive past the Response; without it the
+  // runtime cancels the promise mid-Blossom-call and recovery waits on the
+  // next cron tick (~1 min latency).
+  if (ctx && typeof ctx.waitUntil === 'function') {
+    ctx.waitUntil(processing.catch(err => {
+      console.error(JSON.stringify({
+        event: 'creator_delete.sync.waituntil_error',
+        kind5_id,
+        error: err?.message
+      }));
+    }));
+  }
+
   const timeoutPromise = new Promise(resolve => setTimeout(() => resolve({ budgetExceeded: true }), budgetMs));
   const raceResult = await Promise.race([processing, timeoutPromise]);
 
   if (raceResult.budgetExceeded) {
-    console.log(JSON.stringify({
-      event: 'creator_delete.sync.request',
-      status_code: 202,
-      latency_ms: Date.now() - t0,
-      kind5_id: kind5_id || null
-    }));
+    logRequest(t0, kind5_id, 202);
     return jsonResponse(202, {
       kind5_id,
       status: 'in_progress',
@@ -121,13 +117,7 @@ export async function handleSyncDelete(request, deps) {
   const anyInProgress = raceResult.targets.some(t => t.status === 'in_progress');
 
   if (anyInProgress && Date.now() < deadline) {
-    // One target still had an in-progress existing row. Return 202.
-    console.log(JSON.stringify({
-      event: 'creator_delete.sync.request',
-      status_code: 202,
-      latency_ms: Date.now() - t0,
-      kind5_id: kind5_id || null
-    }));
+    logRequest(t0, kind5_id, 202);
     return jsonResponse(202, {
       kind5_id,
       status: 'in_progress',
@@ -135,12 +125,7 @@ export async function handleSyncDelete(request, deps) {
     });
   }
 
-  console.log(JSON.stringify({
-    event: 'creator_delete.sync.request',
-    status_code: 200,
-    latency_ms: Date.now() - t0,
-    kind5_id: kind5_id || null
-  }));
+  logRequest(t0, kind5_id, 200);
   return jsonResponse(200, {
     kind5_id,
     status: anyFailed ? 'failed' : 'success',

--- a/src/creator-delete/sync-endpoint.mjs
+++ b/src/creator-delete/sync-endpoint.mjs
@@ -29,6 +29,22 @@ export async function handleSyncDelete(request, deps) {
     return jsonResponse(400, { error: 'Invalid kind5_id' });
   }
 
+  // IP rate limit BEFORE NIP-98 validation — limits crypto work from unauthenticated callers
+  const clientIp = request.headers.get('CF-Connecting-IP') || 'unknown';
+  const ipCheck = await checkRateLimit(kv, { key: `ip:${clientIp}`, limit: PER_IP_LIMIT, windowSeconds: RATE_WINDOW_SECONDS });
+  if (!ipCheck.allowed) {
+    console.log(JSON.stringify({
+      event: 'creator_delete.sync.request',
+      status_code: 429,
+      latency_ms: Date.now() - t0,
+      kind5_id: kind5_id || null
+    }));
+    return jsonResponse(429, {
+      error: 'Rate limit exceeded',
+      retry_after_seconds: ipCheck.retryAfterSeconds || 0
+    });
+  }
+
   const auth = await validateNip98Header(request.headers.get('Authorization'), url.toString(), 'POST');
   if (!auth.valid) {
     console.log(JSON.stringify({
@@ -40,10 +56,9 @@ export async function handleSyncDelete(request, deps) {
     return jsonResponse(401, { error: `NIP-98 validation failed: ${auth.error}` });
   }
 
-  const clientIp = request.headers.get('CF-Connecting-IP') || 'unknown';
-  const ipCheck = await checkRateLimit(kv, { key: `ip:${clientIp}`, limit: PER_IP_LIMIT, windowSeconds: RATE_WINDOW_SECONDS });
+  // Per-pubkey rate limit AFTER NIP-98 (pubkey only known after validation)
   const pubkeyCheck = await checkRateLimit(kv, { key: `pubkey:${auth.pubkey}`, limit: PER_PUBKEY_LIMIT, windowSeconds: RATE_WINDOW_SECONDS });
-  if (!ipCheck.allowed || !pubkeyCheck.allowed) {
+  if (!pubkeyCheck.allowed) {
     console.log(JSON.stringify({
       event: 'creator_delete.sync.request',
       status_code: 429,
@@ -52,7 +67,7 @@ export async function handleSyncDelete(request, deps) {
     }));
     return jsonResponse(429, {
       error: 'Rate limit exceeded',
-      retry_after_seconds: Math.max(ipCheck.retryAfterSeconds || 0, pubkeyCheck.retryAfterSeconds || 0)
+      retry_after_seconds: pubkeyCheck.retryAfterSeconds || 0
     });
   }
 

--- a/src/creator-delete/sync-endpoint.mjs
+++ b/src/creator-delete/sync-endpoint.mjs
@@ -13,17 +13,30 @@ export const PER_IP_LIMIT = 30;
 export const RATE_WINDOW_SECONDS = 60;
 
 export async function handleSyncDelete(request, deps) {
+  const t0 = Date.now();
   const { db, kv, fetchKind5WithRetry, fetchTargetEvent, callBlossomDelete, budgetMs = 8000 } = deps;
 
   const url = new URL(request.url);
   const kind5_id = url.pathname.split('/').pop();
 
   if (!kind5_id || !/^[a-f0-9]{64}$/i.test(kind5_id)) {
+    console.log(JSON.stringify({
+      event: 'creator_delete.sync.request',
+      status_code: 400,
+      latency_ms: Date.now() - t0,
+      kind5_id: kind5_id || null
+    }));
     return jsonResponse(400, { error: 'Invalid kind5_id' });
   }
 
   const auth = await validateNip98Header(request.headers.get('Authorization'), url.toString(), 'POST');
   if (!auth.valid) {
+    console.log(JSON.stringify({
+      event: 'creator_delete.sync.request',
+      status_code: 401,
+      latency_ms: Date.now() - t0,
+      kind5_id: kind5_id || null
+    }));
     return jsonResponse(401, { error: `NIP-98 validation failed: ${auth.error}` });
   }
 
@@ -31,6 +44,12 @@ export async function handleSyncDelete(request, deps) {
   const ipCheck = await checkRateLimit(kv, { key: `ip:${clientIp}`, limit: PER_IP_LIMIT, windowSeconds: RATE_WINDOW_SECONDS });
   const pubkeyCheck = await checkRateLimit(kv, { key: `pubkey:${auth.pubkey}`, limit: PER_PUBKEY_LIMIT, windowSeconds: RATE_WINDOW_SECONDS });
   if (!ipCheck.allowed || !pubkeyCheck.allowed) {
+    console.log(JSON.stringify({
+      event: 'creator_delete.sync.request',
+      status_code: 429,
+      latency_ms: Date.now() - t0,
+      kind5_id: kind5_id || null
+    }));
     return jsonResponse(429, {
       error: 'Rate limit exceeded',
       retry_after_seconds: Math.max(ipCheck.retryAfterSeconds || 0, pubkeyCheck.retryAfterSeconds || 0)
@@ -39,10 +58,22 @@ export async function handleSyncDelete(request, deps) {
 
   const kind5 = await fetchKind5WithRetry(kind5_id);
   if (!kind5) {
+    console.log(JSON.stringify({
+      event: 'creator_delete.sync.request',
+      status_code: 404,
+      latency_ms: Date.now() - t0,
+      kind5_id: kind5_id || null
+    }));
     return jsonResponse(404, { error: 'Kind 5 not found on Funnelcake after retries' });
   }
 
   if (kind5.pubkey !== auth.pubkey) {
+    console.log(JSON.stringify({
+      event: 'creator_delete.sync.request',
+      status_code: 403,
+      latency_ms: Date.now() - t0,
+      kind5_id: kind5_id || null
+    }));
     return jsonResponse(403, { error: 'Caller pubkey does not match kind 5 author' });
   }
 
@@ -50,13 +81,20 @@ export async function handleSyncDelete(request, deps) {
   const processing = processKind5(kind5, {
     db,
     fetchTargetEvent,
-    callBlossomDelete
+    callBlossomDelete,
+    triggerLabel: 'sync'
   });
 
   const timeoutPromise = new Promise(resolve => setTimeout(() => resolve({ budgetExceeded: true }), budgetMs));
   const raceResult = await Promise.race([processing, timeoutPromise]);
 
   if (raceResult.budgetExceeded) {
+    console.log(JSON.stringify({
+      event: 'creator_delete.sync.request',
+      status_code: 202,
+      latency_ms: Date.now() - t0,
+      kind5_id: kind5_id || null
+    }));
     return jsonResponse(202, {
       kind5_id,
       status: 'in_progress',
@@ -69,6 +107,12 @@ export async function handleSyncDelete(request, deps) {
 
   if (anyInProgress && Date.now() < deadline) {
     // One target still had an in-progress existing row. Return 202.
+    console.log(JSON.stringify({
+      event: 'creator_delete.sync.request',
+      status_code: 202,
+      latency_ms: Date.now() - t0,
+      kind5_id: kind5_id || null
+    }));
     return jsonResponse(202, {
       kind5_id,
       status: 'in_progress',
@@ -76,6 +120,12 @@ export async function handleSyncDelete(request, deps) {
     });
   }
 
+  console.log(JSON.stringify({
+    event: 'creator_delete.sync.request',
+    status_code: 200,
+    latency_ms: Date.now() - t0,
+    kind5_id: kind5_id || null
+  }));
   return jsonResponse(200, {
     kind5_id,
     status: anyFailed ? 'failed' : 'success',

--- a/src/creator-delete/sync-endpoint.mjs
+++ b/src/creator-delete/sync-endpoint.mjs
@@ -79,7 +79,6 @@ export async function handleSyncDelete(request, deps) {
     return jsonResponse(400, { error: 'Kind 5 event has no e-tags; nothing to delete' });
   }
 
-  const deadline = Date.now() + budgetMs;
   const processing = processKind5(kind5, {
     db,
     fetchTargetEvent,
@@ -116,7 +115,7 @@ export async function handleSyncDelete(request, deps) {
   const anyFailed = raceResult.targets.some(t => t.status.startsWith('failed:'));
   const anyInProgress = raceResult.targets.some(t => t.status === 'in_progress');
 
-  if (anyInProgress && Date.now() < deadline) {
+  if (anyInProgress) {
     logRequest(t0, kind5_id, 202);
     return jsonResponse(202, {
       kind5_id,

--- a/src/creator-delete/sync-endpoint.test.mjs
+++ b/src/creator-delete/sync-endpoint.test.mjs
@@ -135,4 +135,32 @@ describe('handleSyncDelete', () => {
     const body = await response.json();
     expect(body.status).toBe('in_progress');
   });
+
+  it('returns 400 when kind 5 has no e-tags', async () => {
+    const kind5 = { id: KIND5_ID, pubkey: pk, tags: [['p', pk]] }; // no e-tag
+    deps.fetchKind5WithRetry.mockResolvedValueOnce(kind5);
+    const url = `https://moderation-api.divine.video/api/delete/${KIND5_ID}`;
+    const request = new Request(url, { method: 'POST', headers: { Authorization: signNip98(url, 'POST') } });
+    const response = await handleSyncDelete(request, deps);
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toMatch(/no e-tags/i);
+    expect(deps.fetchTargetEvent).not.toHaveBeenCalled();
+    expect(deps.callBlossomDelete).not.toHaveBeenCalled();
+  });
+
+  it('calls ctx.waitUntil with the processing promise when budget is exceeded', async () => {
+    const kind5 = { id: KIND5_ID, pubkey: pk, tags: [['e', 't1']] };
+    deps.fetchKind5WithRetry.mockResolvedValueOnce(kind5);
+    deps.fetchTargetEvent.mockResolvedValueOnce({ id: 't1', pubkey: pk, tags: [['imeta', `x ${SHA_C}`]] });
+    deps.callBlossomDelete.mockReturnValueOnce(new Promise(() => {})); // never resolves
+
+    const ctx = { waitUntil: vi.fn() };
+    const url = `https://moderation-api.divine.video/api/delete/${KIND5_ID}`;
+    const request = new Request(url, { method: 'POST', headers: { Authorization: signNip98(url, 'POST') } });
+    const response = await handleSyncDelete(request, { ...deps, ctx, budgetMs: 50 });
+    expect(response.status).toBe(202);
+    expect(ctx.waitUntil).toHaveBeenCalledTimes(1);
+    expect(ctx.waitUntil.mock.calls[0][0]).toBeInstanceOf(Promise);
+  });
 });

--- a/src/creator-delete/sync-endpoint.test.mjs
+++ b/src/creator-delete/sync-endpoint.test.mjs
@@ -96,6 +96,20 @@ describe('handleSyncDelete', () => {
     expect(response.status).toBe(404);
   });
 
+  it('returns 429 when per-IP limit exceeded (before NIP-98 validation)', async () => {
+    const url = `https://moderation-api.divine.video/api/delete/${KIND5_ID}`;
+    // Exhaust IP limit — no NIP-98 needed since IP check runs first
+    for (let i = 0; i < PER_IP_LIMIT; i++) {
+      await checkRateLimit(deps.kv, { key: 'ip:1.2.3.4', limit: PER_IP_LIMIT, windowSeconds: RATE_WINDOW_SECONDS });
+    }
+    const request = new Request(url, {
+      method: 'POST',
+      headers: { 'CF-Connecting-IP': '1.2.3.4' }
+    });
+    const response = await handleSyncDelete(request, deps);
+    expect(response.status).toBe(429);
+  });
+
   it('returns 429 when per-pubkey limit exceeded', async () => {
     const url = `https://moderation-api.divine.video/api/delete/${KIND5_ID}`;
     // Exhaust limit

--- a/src/creator-delete/sync-endpoint.test.mjs
+++ b/src/creator-delete/sync-endpoint.test.mjs
@@ -1,0 +1,124 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Tests for the POST /api/delete/{kind5_id} handler — happy path + 400/401/403/404/429/202.
+// ABOUTME: Uses makeFakeD1/makeFakeKV from ./test-helpers.mjs; injected deps mock Funnelcake + Blossom.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { generateSecretKey, getPublicKey, finalizeEvent } from 'nostr-tools/pure';
+import {
+  handleSyncDelete,
+  PER_PUBKEY_LIMIT,
+  PER_IP_LIMIT,
+  RATE_WINDOW_SECONDS
+} from './sync-endpoint.mjs';
+import { checkRateLimit } from './rate-limit.mjs';
+import { makeFakeD1, makeFakeKV } from './test-helpers.mjs';
+
+const KIND5_ID = 'a'.repeat(64); // 64-char hex for URL path + kind5.id fixture
+const SHA_C = 'c'.repeat(64);    // 64-char hex for blob sha256 (extractSha256 requires)
+
+describe('handleSyncDelete', () => {
+  let sk, pk, deps;
+
+  beforeEach(() => {
+    sk = generateSecretKey();
+    pk = getPublicKey(sk);
+    deps = {
+      db: makeFakeD1(),
+      kv: makeFakeKV(),
+      fetchKind5WithRetry: vi.fn(),
+      fetchTargetEvent: vi.fn(),
+      callBlossomDelete: vi.fn(),
+      budgetMs: 8000
+    };
+  });
+
+  function signNip98(url, method) {
+    const event = finalizeEvent({
+      kind: 27235,
+      created_at: Math.floor(Date.now() / 1000),
+      tags: [['u', url], ['method', method]],
+      content: ''
+    }, sk);
+    return `Nostr ${btoa(JSON.stringify(event))}`;
+  }
+
+  it('returns 200 with success on happy path', async () => {
+    const kind5 = { id: KIND5_ID, pubkey: pk, tags: [['e', 't1']] };
+    deps.fetchKind5WithRetry.mockResolvedValueOnce(kind5);
+    deps.fetchTargetEvent.mockResolvedValueOnce({ id: 't1', pubkey: pk, tags: [['imeta', `x ${SHA_C}`]] });
+    deps.callBlossomDelete.mockResolvedValueOnce({ success: true, status: 200 });
+
+    const url = `https://moderation-api.divine.video/api/delete/${KIND5_ID}`;
+    const request = new Request(url, {
+      method: 'POST',
+      headers: { 'Authorization': signNip98(url, 'POST') }
+    });
+
+    const response = await handleSyncDelete(request, deps);
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toMatchObject({ kind5_id: KIND5_ID, status: 'success' });
+    expect(body.targets[0]).toMatchObject({ target_event_id: 't1', status: 'success', blob_sha256: SHA_C });
+  });
+
+  it('returns 400 on malformed kind5_id', async () => {
+    const url = 'https://moderation-api.divine.video/api/delete/not-a-hex-id';
+    const request = new Request(url, { method: 'POST', headers: { Authorization: signNip98(url, 'POST') } });
+    const response = await handleSyncDelete(request, deps);
+    expect(response.status).toBe(400);
+  });
+
+  it('returns 401 on missing NIP-98', async () => {
+    const request = new Request(`https://moderation-api.divine.video/api/delete/${KIND5_ID}`, { method: 'POST' });
+    const response = await handleSyncDelete(request, deps);
+    expect(response.status).toBe(401);
+  });
+
+  it('returns 403 when caller pubkey does not match kind 5 author', async () => {
+    const otherSk = generateSecretKey();
+    const otherPk = getPublicKey(otherSk);
+    const kind5 = { id: KIND5_ID, pubkey: otherPk, tags: [['e', 't1']] };
+    deps.fetchKind5WithRetry.mockResolvedValueOnce(kind5);
+
+    const url = `https://moderation-api.divine.video/api/delete/${KIND5_ID}`;
+    const request = new Request(url, { method: 'POST', headers: { Authorization: signNip98(url, 'POST') } });
+    const response = await handleSyncDelete(request, deps);
+    expect(response.status).toBe(403);
+  });
+
+  it('returns 404 when Funnelcake fetch returns null after retries', async () => {
+    deps.fetchKind5WithRetry.mockResolvedValueOnce(null);
+    const url = `https://moderation-api.divine.video/api/delete/${KIND5_ID}`;
+    const request = new Request(url, { method: 'POST', headers: { Authorization: signNip98(url, 'POST') } });
+    const response = await handleSyncDelete(request, deps);
+    expect(response.status).toBe(404);
+  });
+
+  it('returns 429 when per-pubkey limit exceeded', async () => {
+    const url = `https://moderation-api.divine.video/api/delete/${KIND5_ID}`;
+    // Exhaust limit
+    for (let i = 0; i < PER_PUBKEY_LIMIT; i++) {
+      await checkRateLimit(deps.kv, { key: `pubkey:${pk}`, limit: PER_PUBKEY_LIMIT, windowSeconds: RATE_WINDOW_SECONDS });
+    }
+    const request = new Request(url, { method: 'POST', headers: { Authorization: signNip98(url, 'POST') } });
+    const response = await handleSyncDelete(request, deps);
+    expect(response.status).toBe(429);
+  });
+
+  it('returns 202 when internal budget exceeded', async () => {
+    const kind5 = { id: KIND5_ID, pubkey: pk, tags: [['e', 't1']] };
+    deps.fetchKind5WithRetry.mockResolvedValueOnce(kind5);
+    deps.fetchTargetEvent.mockResolvedValueOnce({ id: 't1', pubkey: pk, tags: [['imeta', `x ${SHA_C}`]] });
+    // Blossom slow — never resolves within budget
+    deps.callBlossomDelete.mockReturnValueOnce(new Promise(() => {}));
+
+    const url = `https://moderation-api.divine.video/api/delete/${KIND5_ID}`;
+    const request = new Request(url, { method: 'POST', headers: { Authorization: signNip98(url, 'POST') } });
+    const response = await handleSyncDelete(request, { ...deps, budgetMs: 50 });
+    expect(response.status).toBe(202);
+    const body = await response.json();
+    expect(body.status).toBe('in_progress');
+  });
+});

--- a/src/creator-delete/test-helpers.mjs
+++ b/src/creator-delete/test-helpers.mjs
@@ -1,7 +1,7 @@
 // This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
 // If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 //
-// ABOUTME: Shared test helpers for creator-delete unit tests — in-memory D1 fake.
+// ABOUTME: Shared test helpers for creator-delete unit tests — in-memory D1 and KV fakes.
 // ABOUTME: makeFakeD1 mirrors production SQL arity (see src/creator-delete/d1.mjs claimRow).
 
 // Test helper: in-memory D1 fake with the same schema as creator_deletions.
@@ -45,5 +45,16 @@ export function makeFakeD1() {
         }
       };
     }
+  };
+}
+
+// Test helper: in-memory KV fake matching the subset of Cloudflare Workers KV we use.
+// Real CF KV accepts a third options arg on put() (e.g. { expirationTtl }); the fake ignores it.
+export function makeFakeKV() {
+  const store = new Map();
+  return {
+    async get(key) { return store.get(key) ?? null; },
+    async put(key, value) { store.set(key, value); },
+    async delete(key) { store.delete(key); }
   };
 }

--- a/src/creator-delete/test-helpers.mjs
+++ b/src/creator-delete/test-helpers.mjs
@@ -42,6 +42,22 @@ export function makeFakeD1() {
             return rows.get(key) || null;
           }
           return null;
+        },
+        async all() {
+          if (this._sql.startsWith('SELECT')) {
+            // Return all rows matching the bound kind5_id (status-endpoint + cron use-case).
+            // The SQL shape we care about is: SELECT ... WHERE kind5_id = ? [AND ...]
+            const kind5_id = this._binds[0];
+            const results = [];
+            for (const row of rows.values()) {
+              if (row.kind5_id !== kind5_id) continue;
+              // If a second bind (target_event_id) is present, filter by it too.
+              if (this._binds.length >= 2 && row.target_event_id !== this._binds[1]) continue;
+              results.push(row);
+            }
+            return { results };
+          }
+          return { results: [] };
         }
       };
     }

--- a/src/creator-delete/test-helpers.mjs
+++ b/src/creator-delete/test-helpers.mjs
@@ -25,10 +25,22 @@ export function makeFakeD1() {
             return { meta: { changes: 1, rows_written: 1 } };
           }
           if (this._sql.startsWith('UPDATE')) {
+            // Atomic re-claim: UPDATE ... WHERE kind5_id=? AND target_event_id=? AND accepted_at=?
+            // binds: [new_accepted_at, kind5_id, target_event_id, old_accepted_at]
+            if (this._sql.includes('AND accepted_at = ?')) {
+              const [newAccepted, kind5_id, target_event_id, oldAccepted] = this._binds;
+              const target_key = `${kind5_id}:${target_event_id}`;
+              const existing = rows.get(target_key);
+              if (!existing || existing.accepted_at !== oldAccepted) {
+                return { meta: { changes: 0, rows_written: 0 } };
+              }
+              rows.set(target_key, { ...existing, accepted_at: newAccepted, status: 'accepted' });
+              return { meta: { changes: 1, rows_written: 1 } };
+            }
+            // Other UPDATEs: kind5_id and target_event_id are the last two binds.
             const target_key = `${this._binds[this._binds.length - 2]}:${this._binds[this._binds.length - 1]}`;
             const existing = rows.get(target_key);
             if (existing) {
-              // Very simplified: we're just testing the wrappers, not SQL correctness.
               rows.set(target_key, { ...existing, _updated: true });
               return { meta: { changes: 1 } };
             }

--- a/src/creator-delete/test-helpers.mjs
+++ b/src/creator-delete/test-helpers.mjs
@@ -1,0 +1,49 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Shared test helpers for creator-delete unit tests — in-memory D1 fake.
+// ABOUTME: makeFakeD1 mirrors production SQL arity (see src/creator-delete/d1.mjs claimRow).
+
+// Test helper: in-memory D1 fake with the same schema as creator_deletions.
+export function makeFakeD1() {
+  const rows = new Map(); // key: `${kind5_id}:${target_event_id}`
+  return {
+    rows,
+    prepare(sql) {
+      return {
+        _sql: sql,
+        _binds: [],
+        bind(...args) { this._binds = args; return this; },
+        async run() {
+          if (this._sql.startsWith('INSERT')) {
+            const [kind5_id, target_event_id, creator_pubkey, accepted_at] = this._binds;
+            const key = `${kind5_id}:${target_event_id}`;
+            if (rows.has(key)) {
+              return { meta: { changes: 0, rows_written: 0 } };
+            }
+            rows.set(key, { kind5_id, target_event_id, creator_pubkey, status: 'accepted', accepted_at, retry_count: 0, last_error: null, blob_sha256: null, completed_at: null });
+            return { meta: { changes: 1, rows_written: 1 } };
+          }
+          if (this._sql.startsWith('UPDATE')) {
+            const target_key = `${this._binds[this._binds.length - 2]}:${this._binds[this._binds.length - 1]}`;
+            const existing = rows.get(target_key);
+            if (existing) {
+              // Very simplified: we're just testing the wrappers, not SQL correctness.
+              rows.set(target_key, { ...existing, _updated: true });
+              return { meta: { changes: 1 } };
+            }
+            return { meta: { changes: 0 } };
+          }
+          return { meta: { changes: 0 } };
+        },
+        async first() {
+          if (this._sql.startsWith('SELECT')) {
+            const key = `${this._binds[0]}:${this._binds[1]}`;
+            return rows.get(key) || null;
+          }
+          return null;
+        }
+      };
+    }
+  };
+}

--- a/src/creator-delete/test-helpers.mjs
+++ b/src/creator-delete/test-helpers.mjs
@@ -45,8 +45,19 @@ export function makeFakeD1() {
         },
         async all() {
           if (this._sql.startsWith('SELECT')) {
-            // Return all rows matching the bound kind5_id (status-endpoint + cron use-case).
-            // The SQL shape we care about is: SELECT ... WHERE kind5_id = ? [AND ...]
+            // Pattern 1: cron transient-retry sweep
+            // SELECT ... WHERE status LIKE 'failed:transient:%' AND retry_count < ?
+            if (this._sql.includes("status LIKE 'failed:transient:%'") && this._sql.includes("retry_count <")) {
+              const maxRetry = this._binds[0];
+              const results = [];
+              for (const row of rows.values()) {
+                if (!row.status?.startsWith('failed:transient:')) continue;
+                if (row.retry_count >= maxRetry) continue;
+                results.push(row);
+              }
+              return { results };
+            }
+            // Pattern 2 (existing): SELECT ... WHERE kind5_id = ? [AND target_event_id = ?]
             const kind5_id = this._binds[0];
             const results = [];
             for (const row of rows.values()) {

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -10,7 +10,7 @@ import { publishToFaro, publishToContentRelay, publishLabelEvent } from './nostr
 import { requireAuth, getAuthenticatedUser } from './admin/auth.mjs';
 import { verifyZeroTrustJWT } from './admin/zerotrust.mjs';
 import { getConfiguredBearerTokens, authenticateApiRequest, apiUnauthorizedResponse, authSourceFromVerification, verifyLegacyBearerAuth } from './auth-api.mjs';
-import { fetchNostrEventBySha256, fetchNostrVideoEventsByDTag, parseVideoEventMetadata } from './nostr/relay-client.mjs';
+import { fetchNostrEventBySha256, fetchNostrVideoEventsByDTag, parseVideoEventMetadata, fetchKind5EventsSince, fetchNostrEventById } from './nostr/relay-client.mjs';
 import { pollRelayForVideos, getLastPollTimestamp, setLastPollTimestamp, getPollingStatus } from './nostr/relay-poller.mjs';
 import { getPublicKey } from 'nostr-tools/pure';
 import { hexToBytes, bytesToHex } from '@noble/hashes/utils';
@@ -35,7 +35,6 @@ import { handleSyncDelete } from './creator-delete/sync-endpoint.mjs';
 import { handleStatusQuery } from './creator-delete/status-endpoint.mjs';
 import { runCreatorDeleteCron } from './creator-delete/cron.mjs';
 import { fetchKind5WithRetry } from './creator-delete/funnelcake-fetch.mjs';
-import { fetchKind5EventsSince, fetchNostrEventById } from './nostr/relay-client.mjs';
 /**
  * NIP-32 label mapping for content categories
  * Maps internal category names to NIP-32/NIP-56 compatible labels

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -31,6 +31,11 @@ import { notifyAtprotoLabeler } from './atproto/label-webhook.mjs';
 import { buildDownstreamPublishContext } from './moderation/downstream-publishing.mjs';
 import { runClassicVineRollback } from './moderation/classic-vine-rollback.mjs';
 import { notifyBlossom } from './blossom-client.mjs';
+import { handleSyncDelete } from './creator-delete/sync-endpoint.mjs';
+import { handleStatusQuery } from './creator-delete/status-endpoint.mjs';
+import { runCreatorDeleteCron } from './creator-delete/cron.mjs';
+import { fetchKind5WithRetry } from './creator-delete/funnelcake-fetch.mjs';
+import { fetchKind5EventsSince, fetchNostrEventById } from './nostr/relay-client.mjs';
 /**
  * NIP-32 label mapping for content categories
  * Maps internal category names to NIP-32/NIP-56 compatible labels
@@ -143,7 +148,9 @@ function isApiSurfacePath(pathname) {
     || pathname === '/test-moderate'
     || pathname === '/test-kv'
     || pathname.startsWith('/check-result/')
-    || pathname.startsWith('/api/v1/');
+    || pathname.startsWith('/api/v1/')
+    || pathname.startsWith('/api/delete/')
+    || pathname.startsWith('/api/delete-status/');
 }
 
 function isAdminSurfacePath(pathname) {
@@ -4136,6 +4143,34 @@ async function runMigration() {
       }
     }
 
+    // Creator-delete endpoints — gated by CREATOR_DELETE_PIPELINE_ENABLED feature flag
+    if (url.hostname === API_HOSTNAME && env.CREATOR_DELETE_PIPELINE_ENABLED === 'true') {
+      const relayUrl = env.CREATOR_DELETE_RELAY_URL || 'wss://relay.divine.video';
+
+      // Adapter: processKind5 and handleSyncDelete expect notifyBlossom's return shape
+      // (success, status?, error?, networkError?, skipped?) bound to the DELETE action.
+      const callBlossomDelete = (sha256) => notifyBlossom(sha256, 'DELETE', env);
+
+      if (url.pathname.startsWith('/api/delete/') && request.method === 'POST') {
+        return handleSyncDelete(request, {
+          db: env.BLOSSOM_DB,
+          kv: env.MODERATION_KV,
+          fetchKind5WithRetry: (id) => fetchKind5WithRetry(id, {
+            fetchEventById: (eid) => fetchNostrEventById(eid, [relayUrl], env)
+          }),
+          fetchTargetEvent: (eid) => fetchNostrEventById(eid, [relayUrl], env),
+          callBlossomDelete
+        });
+      }
+
+      if (url.pathname.startsWith('/api/delete-status/') && request.method === 'GET') {
+        return handleStatusQuery(request, {
+          db: env.BLOSSOM_DB,
+          kv: env.MODERATION_KV
+        });
+      }
+    }
+
     // API: Submit a user report for a piece of content (NIP-56)
     // Auth: Bearer token or Cloudflare Access JWT
     if (url.pathname === '/api/v1/scan' && request.method === 'POST') {
@@ -5008,218 +5043,242 @@ async function runMigration() {
    * Polls relay.divine.video for new video events and queues them for moderation
    */
   async scheduled(event, env, ctx) {
-    console.log(`[RELAY-POLLER] Cron triggered at ${new Date().toISOString()}`);
-
-    // Check if polling is enabled
-    if (env.RELAY_POLLING_ENABLED === 'false') {
-      console.log('[RELAY-POLLER] Polling is disabled, skipping');
+    if (event.cron === '* * * * *') {
+      // Every-minute: creator-delete pipeline (gated by feature flag)
+      if (env.CREATOR_DELETE_PIPELINE_ENABLED !== 'true') {
+        return;
+      }
+      const relayUrl = env.CREATOR_DELETE_RELAY_URL || 'wss://relay.divine.video';
+      try {
+        const result = await runCreatorDeleteCron({
+          db: env.BLOSSOM_DB,
+          kv: env.MODERATION_KV,
+          queryKind5Since: async (sinceSeconds) =>
+            fetchKind5EventsSince(sinceSeconds, relayUrl, env),
+          fetchTargetEvent: (eid) => fetchNostrEventById(eid, [relayUrl], env),
+          callBlossomDelete: (sha256) => notifyBlossom(sha256, 'DELETE', env)
+        });
+        console.log(`[CREATOR-DELETE-CRON] Processed ${result.processed}, errors: ${result.errors.length}`);
+      } catch (e) {
+        console.error('[CREATOR-DELETE-CRON] failed:', e);
+      }
       return;
     }
 
-    try {
-      // Get the timestamp to poll from
-      let since = await getLastPollTimestamp(env);
+    if (event.cron === '*/5 * * * *') {
+      console.log(`[RELAY-POLLER] Cron triggered at ${new Date().toISOString()}`);
 
-      if (!since) {
-        // First run - look back based on config
-        const lookbackHours = parseInt(env.RELAY_POLLING_LOOKBACK_HOURS || '1', 10);
-        since = Math.floor(Date.now() / 1000) - (lookbackHours * 3600);
-        console.log(`[RELAY-POLLER] First run, looking back ${lookbackHours} hours`);
-      } else {
-        console.log(`[RELAY-POLLER] Continuing from last poll at ${new Date(since * 1000).toISOString()}`);
+      // Check if polling is enabled
+      if (env.RELAY_POLLING_ENABLED === 'false') {
+        console.log('[RELAY-POLLER] Polling is disabled, skipping');
+        return;
       }
 
-      // Get relay URL from config
-      const relays = env.RELAY_POLLING_RELAY_URL
-        ? [env.RELAY_POLLING_RELAY_URL]
-        : ['wss://relay.divine.video'];
-
-      // Poll for new video events
-      const results = await pollRelayForVideos(env, {
-        since,
-        limit: parseInt(env.RELAY_POLLING_LIMIT || '100', 10),
-        relays
-      });
-
-      // Update last poll timestamp
-      await setLastPollTimestamp(env, Math.floor(Date.now() / 1000), {
-        totalEvents: results.totalEvents,
-        queuedForModeration: results.queuedForModeration,
-        alreadyModerated: results.alreadyModerated,
-        errors: results.errors.length,
-        trigger: 'cron'
-      });
-
-      console.log(`[RELAY-POLLER] Cron complete: ${results.totalEvents} events found, ${results.queuedForModeration} queued for moderation`);
-
-    } catch (error) {
-      console.error('[RELAY-POLLER] Cron poll failed:', error);
-
-      // Store error for debugging
       try {
-        await env.MODERATION_KV.put('relay-poller:last-error', JSON.stringify({
-          error: error.message,
-          stack: error.stack,
-          timestamp: new Date().toISOString()
-        }));
-      } catch (kvError) {
-        console.error('[RELAY-POLLER] Failed to store error:', kvError);
+        // Get the timestamp to poll from
+        let since = await getLastPollTimestamp(env);
+
+        if (!since) {
+          // First run - look back based on config
+          const lookbackHours = parseInt(env.RELAY_POLLING_LOOKBACK_HOURS || '1', 10);
+          since = Math.floor(Date.now() / 1000) - (lookbackHours * 3600);
+          console.log(`[RELAY-POLLER] First run, looking back ${lookbackHours} hours`);
+        } else {
+          console.log(`[RELAY-POLLER] Continuing from last poll at ${new Date(since * 1000).toISOString()}`);
+        }
+
+        // Get relay URL from config
+        const relays = env.RELAY_POLLING_RELAY_URL
+          ? [env.RELAY_POLLING_RELAY_URL]
+          : ['wss://relay.divine.video'];
+
+        // Poll for new video events
+        const results = await pollRelayForVideos(env, {
+          since,
+          limit: parseInt(env.RELAY_POLLING_LIMIT || '100', 10),
+          relays
+        });
+
+        // Update last poll timestamp
+        await setLastPollTimestamp(env, Math.floor(Date.now() / 1000), {
+          totalEvents: results.totalEvents,
+          queuedForModeration: results.queuedForModeration,
+          alreadyModerated: results.alreadyModerated,
+          errors: results.errors.length,
+          trigger: 'cron'
+        });
+
+        console.log(`[RELAY-POLLER] Cron complete: ${results.totalEvents} events found, ${results.queuedForModeration} queued for moderation`);
+
+      } catch (error) {
+        console.error('[RELAY-POLLER] Cron poll failed:', error);
+
+        // Store error for debugging
+        try {
+          await env.MODERATION_KV.put('relay-poller:last-error', JSON.stringify({
+            error: error.message,
+            stack: error.stack,
+            timestamp: new Date().toISOString()
+          }));
+        } catch (kvError) {
+          console.error('[RELAY-POLLER] Failed to store error:', kvError);
+        }
       }
-    }
 
-    // Sync DM inbox from relay
-    if (env.NOSTR_PRIVATE_KEY) {
-      try {
-        const { syncInbox } = await import('./nostr/dm-reader.mjs');
-        const syncResult = await syncInbox(env);
-        console.log(`[CRON] DM inbox sync: ${syncResult.synced} new, ${syncResult.skipped} deduped, ${syncResult.errors} errors`);
-      } catch (err) {
-        console.error('[CRON] DM inbox sync failed:', err);
+      // Sync DM inbox from relay
+      if (env.NOSTR_PRIVATE_KEY) {
+        try {
+          const { syncInbox } = await import('./nostr/dm-reader.mjs');
+          const syncResult = await syncInbox(env);
+          console.log(`[CRON] DM inbox sync: ${syncResult.synced} new, ${syncResult.skipped} deduped, ${syncResult.errors} errors`);
+        } catch (err) {
+          console.error('[CRON] DM inbox sync failed:', err);
+        }
       }
-    }
 
-    // Poll pending Reality Defender results and auto-escalate confirmed fakes
-    if (env.REALITY_DEFENDER_API_KEY && env.MODERATION_KV) {
-      try {
-        const pendingKeys = await env.MODERATION_KV.list({ prefix: 'rd:', limit: 20 });
-        let polled = 0;
-        let escalated = 0;
-        for (const key of pendingKeys.keys) {
-          const cached = await env.MODERATION_KV.get(key.name);
-          if (!cached) continue;
-          const parsed = JSON.parse(cached);
+      // Poll pending Reality Defender results and auto-escalate confirmed fakes
+      if (env.REALITY_DEFENDER_API_KEY && env.MODERATION_KV) {
+        try {
+          const pendingKeys = await env.MODERATION_KV.list({ prefix: 'rd:', limit: 20 });
+          let polled = 0;
+          let escalated = 0;
+          for (const key of pendingKeys.keys) {
+            const cached = await env.MODERATION_KV.get(key.name);
+            if (!cached) continue;
+            const parsed = JSON.parse(cached);
 
-          const sha256 = key.name.replace('rd:', '');
+            const sha256 = key.name.replace('rd:', '');
 
-          // Two cases to handle:
-          // 1. pending → poll RD API for results
-          // 2. complete + likely_ai but not yet escalated → retry escalation
-          let result = null;
-          if (parsed.status === 'pending') {
-            const { pollRealityDefender } = await import('./moderation/realness-client.mjs');
-            result = await pollRealityDefender(sha256, env);
-          } else if (parsed.status === 'complete' && parsed.verdict === 'likely_ai' && !parsed.escalated) {
-            // Previous escalation attempt failed — retry
-            result = parsed;
-            console.log(`[CRON] Retrying failed escalation for ${sha256}`);
-          } else {
-            continue; // complete + escalated, or complete + authentic — nothing to do
-          }
+            // Two cases to handle:
+            // 1. pending → poll RD API for results
+            // 2. complete + likely_ai but not yet escalated → retry escalation
+            let result = null;
+            if (parsed.status === 'pending') {
+              const { pollRealityDefender } = await import('./moderation/realness-client.mjs');
+              result = await pollRealityDefender(sha256, env);
+            } else if (parsed.status === 'complete' && parsed.verdict === 'likely_ai' && !parsed.escalated) {
+              // Previous escalation attempt failed — retry
+              result = parsed;
+              console.log(`[CRON] Retrying failed escalation for ${sha256}`);
+            } else {
+              continue; // complete + escalated, or complete + authentic — nothing to do
+            }
 
-          if (result && result.status === 'complete') {
-            polled++;
-            console.log(`[CRON] Reality Defender result for ${sha256}: ${result.verdict} (score=${result.score})`);
+            if (result && result.status === 'complete') {
+              polled++;
+              console.log(`[CRON] Reality Defender result for ${sha256}: ${result.verdict} (score=${result.score})`);
 
-            // Auto-escalate confirmed fakes if content is still quarantined.
-            // De-escalation (AUTHENTIC → SAFE) requires moderator action.
-            // Human decisions are never overridden.
-            if (result.verdict === 'likely_ai') {
-              const moderationData = await env.MODERATION_KV.get(`moderation:${sha256}`);
-              if (moderationData) {
-                const moderation = JSON.parse(moderationData);
-                if (moderation.action === 'QUARANTINE') {
-                  console.log(`[CRON] Auto-escalating ${sha256} from QUARANTINE to PERMANENT_BAN (RD verdict: ${result.verdict})`);
+              // Auto-escalate confirmed fakes if content is still quarantined.
+              // De-escalation (AUTHENTIC → SAFE) requires moderator action.
+              // Human decisions are never overridden.
+              if (result.verdict === 'likely_ai') {
+                const moderationData = await env.MODERATION_KV.get(`moderation:${sha256}`);
+                if (moderationData) {
+                  const moderation = JSON.parse(moderationData);
+                  if (moderation.action === 'QUARANTINE') {
+                    console.log(`[CRON] Auto-escalating ${sha256} from QUARANTINE to PERMANENT_BAN (RD verdict: ${result.verdict})`);
 
-                  // Update KV classification
-                  moderation.action = 'PERMANENT_BAN';
-                  moderation.reason = `Auto-escalated: Reality Defender confirmed AI-generated (score=${result.score})`;
-                  moderation.reviewedAt = new Date().toISOString();
-                  moderation.reviewedBy = 'reality-defender-auto';
-                  await env.MODERATION_KV.put(
-                    `moderation:${sha256}`,
-                    JSON.stringify(moderation),
-                    { expirationTtl: 60 * 60 * 24 * 90 }
-                  );
+                    // Update KV classification
+                    moderation.action = 'PERMANENT_BAN';
+                    moderation.reason = `Auto-escalated: Reality Defender confirmed AI-generated (score=${result.score})`;
+                    moderation.reviewedAt = new Date().toISOString();
+                    moderation.reviewedBy = 'reality-defender-auto';
+                    await env.MODERATION_KV.put(
+                      `moderation:${sha256}`,
+                      JSON.stringify(moderation),
+                      { expirationTtl: 60 * 60 * 24 * 90 }
+                    );
 
-                  // Update action-specific KV keys
-                  await env.MODERATION_KV.delete(`quarantine:${sha256}`);
-                  await env.MODERATION_KV.put(`permanent-ban:${sha256}`, JSON.stringify({
-                    category: moderation.category || 'ai_generated',
-                    reason: moderation.reason,
-                    timestamp: Date.now(),
-                    autoEscalated: true,
-                  }));
+                    // Update action-specific KV keys
+                    await env.MODERATION_KV.delete(`quarantine:${sha256}`);
+                    await env.MODERATION_KV.put(`permanent-ban:${sha256}`, JSON.stringify({
+                      category: moderation.category || 'ai_generated',
+                      reason: moderation.reason,
+                      timestamp: Date.now(),
+                      autoEscalated: true,
+                    }));
 
-                  // Update D1
-                  try {
-                    await env.BLOSSOM_DB.prepare(`
-                      UPDATE moderation_results
-                      SET action = ?, review_notes = ?, reviewed_by = ?, reviewed_at = ?
-                      WHERE sha256 = ?
-                    `).bind(
-                      'PERMANENT_BAN',
-                      moderation.reason,
-                      'reality-defender-auto',
-                      new Date().toISOString(),
-                      sha256
-                    ).run();
-                  } catch (dbErr) {
-                    console.error(`[CRON] D1 update failed for ${sha256}:`, dbErr.message);
-                  }
-
-                  // Notify Blossom (PERMANENT_BAN → Banned)
-                  const blossomResult = await notifyBlossom(sha256, 'PERMANENT_BAN', env);
-                  if (!blossomResult.success && !blossomResult.skipped) {
-                    console.warn(`[CRON] Blossom notification failed for ${sha256}: ${blossomResult.error}`);
-                  }
-
-                  // Delete event from relay (critical for externally-hosted content)
-                  const relayDeleteResult = await deleteEventFromRelayBySha256(sha256, env, 'rd-auto-escalation');
-                  if (relayDeleteResult?.success) {
-                    console.log(`[CRON] Deleted relay event ${relayDeleteResult.eventId} for auto-escalated ${sha256}`);
-                  }
-
-                  // Send moderation DM to creator
-                  const uploadedBy = moderation.uploadedBy;
-                  if (uploadedBy && env.NOSTR_PRIVATE_KEY) {
+                    // Update D1
                     try {
-                      const { sendModerationDM } = await import('./nostr/dm-sender.mjs');
-                      const metaRow = await env.BLOSSOM_DB.prepare(
-                        'SELECT title, published_at FROM moderation_results WHERE sha256 = ?'
-                      ).bind(sha256).first();
-                      await sendModerationDM(uploadedBy, sha256, 'PERMANENT_BAN', moderation.reason, env, null, { title: metaRow?.title, publishedAt: metaRow?.published_at });
-                      console.log(`[CRON] DM sent to creator for auto-escalated ${sha256}`);
-                    } catch (dmErr) {
-                      console.error(`[CRON] DM failed for ${sha256}:`, dmErr.message);
+                      await env.BLOSSOM_DB.prepare(`
+                        UPDATE moderation_results
+                        SET action = ?, review_notes = ?, reviewed_by = ?, reviewed_at = ?
+                        WHERE sha256 = ?
+                      `).bind(
+                        'PERMANENT_BAN',
+                        moderation.reason,
+                        'reality-defender-auto',
+                        new Date().toISOString(),
+                        sha256
+                      ).run();
+                    } catch (dbErr) {
+                      console.error(`[CRON] D1 update failed for ${sha256}:`, dbErr.message);
                     }
-                  }
 
-                  // Notify reporters
-                  const { notifyReporters: notifyCronReporters } = await import('./nostr/dm-sender.mjs');
-                  notifyCronReporters(sha256, 'PERMANENT_BAN', env, '[CRON]').catch(() => {});
+                    // Notify Blossom (PERMANENT_BAN → Banned)
+                    const blossomResult = await notifyBlossom(sha256, 'PERMANENT_BAN', env);
+                    if (!blossomResult.success && !blossomResult.skipped) {
+                      console.warn(`[CRON] Blossom notification failed for ${sha256}: ${blossomResult.error}`);
+                    }
 
-                  // Mark escalation complete so cron doesn't retry
-                  const rdCached = await env.MODERATION_KV.get(`rd:${sha256}`);
-                  if (rdCached) {
-                    const rdData = JSON.parse(rdCached);
-                    rdData.escalated = true;
-                    await env.MODERATION_KV.put(`rd:${sha256}`, JSON.stringify(rdData), {
-                      expirationTtl: 86400 * 7
-                    });
-                  }
+                    // Delete event from relay (critical for externally-hosted content)
+                    const relayDeleteResult = await deleteEventFromRelayBySha256(sha256, env, 'rd-auto-escalation');
+                    if (relayDeleteResult?.success) {
+                      console.log(`[CRON] Deleted relay event ${relayDeleteResult.eventId} for auto-escalated ${sha256}`);
+                    }
 
-                  escalated++;
-                } else {
-                  // Human already resolved — mark so we don't re-check
-                  const rdCached = await env.MODERATION_KV.get(`rd:${sha256}`);
-                  if (rdCached) {
-                    const rdData = JSON.parse(rdCached);
-                    rdData.escalated = true; // nothing to escalate, but stop retrying
-                    await env.MODERATION_KV.put(`rd:${sha256}`, JSON.stringify(rdData), {
-                      expirationTtl: 86400 * 7
-                    });
+                    // Send moderation DM to creator
+                    const uploadedBy = moderation.uploadedBy;
+                    if (uploadedBy && env.NOSTR_PRIVATE_KEY) {
+                      try {
+                        const { sendModerationDM } = await import('./nostr/dm-sender.mjs');
+                        const metaRow = await env.BLOSSOM_DB.prepare(
+                          'SELECT title, published_at FROM moderation_results WHERE sha256 = ?'
+                        ).bind(sha256).first();
+                        await sendModerationDM(uploadedBy, sha256, 'PERMANENT_BAN', moderation.reason, env, null, { title: metaRow?.title, publishedAt: metaRow?.published_at });
+                        console.log(`[CRON] DM sent to creator for auto-escalated ${sha256}`);
+                      } catch (dmErr) {
+                        console.error(`[CRON] DM failed for ${sha256}:`, dmErr.message);
+                      }
+                    }
+
+                    // Notify reporters
+                    const { notifyReporters: notifyCronReporters } = await import('./nostr/dm-sender.mjs');
+                    notifyCronReporters(sha256, 'PERMANENT_BAN', env, '[CRON]').catch(() => {});
+
+                    // Mark escalation complete so cron doesn't retry
+                    const rdCached = await env.MODERATION_KV.get(`rd:${sha256}`);
+                    if (rdCached) {
+                      const rdData = JSON.parse(rdCached);
+                      rdData.escalated = true;
+                      await env.MODERATION_KV.put(`rd:${sha256}`, JSON.stringify(rdData), {
+                        expirationTtl: 86400 * 7
+                      });
+                    }
+
+                    escalated++;
+                  } else {
+                    // Human already resolved — mark so we don't re-check
+                    const rdCached = await env.MODERATION_KV.get(`rd:${sha256}`);
+                    if (rdCached) {
+                      const rdData = JSON.parse(rdCached);
+                      rdData.escalated = true; // nothing to escalate, but stop retrying
+                      await env.MODERATION_KV.put(`rd:${sha256}`, JSON.stringify(rdData), {
+                        expirationTtl: 86400 * 7
+                      });
+                    }
+                    console.log(`[CRON] Skipping auto-escalation for ${sha256}: no longer quarantined (action=${moderation.action})`);
                   }
-                  console.log(`[CRON] Skipping auto-escalation for ${sha256}: no longer quarantined (action=${moderation.action})`);
                 }
               }
             }
           }
+          if (polled > 0) {
+            console.log(`[CRON] Polled ${polled} Reality Defender results, auto-escalated ${escalated}`);
+          }
+        } catch (err) {
+          console.error('[CRON] Reality Defender polling failed:', err);
         }
-        if (polled > 0) {
-          console.log(`[CRON] Polled ${polled} Reality Defender results, auto-escalated ${escalated}`);
-        }
-      } catch (err) {
-        console.error('[CRON] Reality Defender polling failed:', err);
       }
     }
   }

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -2026,7 +2026,7 @@ export default {
   /**
    * HTTP handler for testing and admin dashboard
    */
-  async fetch(request, env) {
+  async fetch(request, env, ctx) {
     const url = new URL(request.url);
     const startTime = Date.now();
     const requestId = crypto.randomUUID().substring(0, 8);
@@ -4154,6 +4154,7 @@ async function runMigration() {
         return handleSyncDelete(request, {
           db: env.BLOSSOM_DB,
           kv: env.MODERATION_KV,
+          ctx,
           fetchKind5WithRetry: (id) => fetchKind5WithRetry(id, {
             fetchEventById: (eid) => fetchNostrEventById(eid, [relayUrl], env)
           }),

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -30,6 +30,7 @@ import { parseVttText } from './moderation/text-classifier.mjs';
 import { notifyAtprotoLabeler } from './atproto/label-webhook.mjs';
 import { buildDownstreamPublishContext } from './moderation/downstream-publishing.mjs';
 import { runClassicVineRollback } from './moderation/classic-vine-rollback.mjs';
+import { notifyBlossom } from './blossom-client.mjs';
 /**
  * NIP-32 label mapping for content categories
  * Maps internal category names to NIP-32/NIP-56 compatible labels
@@ -5326,74 +5327,3 @@ function blossomFailureResponse(sha256, action, blossomError) {
   });
 }
 
-/**
- * Notify divine-blossom of moderation decision via webhook
- * This allows blossom to update blob status and enforce blocking
- * @param {string} sha256 - The blob hash
- * @param {string} action - The moderation action (SAFE, REVIEW, QUARANTINE, AGE_RESTRICTED, PERMANENT_BAN)
- * @param {Object} env - Environment with BLOSSOM_WEBHOOK_URL and BLOSSOM_WEBHOOK_SECRET
- * @returns {Promise<{success: boolean, error?: string}>}
- */
-async function notifyBlossom(sha256, action, env) {
-  // Skip if webhook not configured
-  if (!env.BLOSSOM_WEBHOOK_URL) {
-    console.log('[BLOSSOM] Webhook not configured, skipping notification');
-    return { success: true, skipped: true };
-  }
-
-  // Map internal actions to Blossom-understood actions.
-  // Blossom has five states (Active/Restricted/Pending/Banned/Deleted).
-  // Its webhook handler accepts: SAFE→Active, AGE_RESTRICTED→Restricted,
-  // PERMANENT_BAN→Banned, RESTRICT→Restricted.
-  // QUARANTINE maps to RESTRICT (owner can view, public gets 404).
-  // REVIEW is internal only — content stays publicly accessible.
-  const BLOSSOM_ACTION_MAP = {
-    'SAFE': 'SAFE',
-    'AGE_RESTRICTED': 'AGE_RESTRICTED',
-    'PERMANENT_BAN': 'PERMANENT_BAN',
-    'QUARANTINE': 'RESTRICT',
-  };
-
-  const blossomAction = BLOSSOM_ACTION_MAP[action];
-  if (!blossomAction) {
-    console.log(`[BLOSSOM] Skipping notification for internal action: ${action}`);
-    return { success: true, skipped: true };
-  }
-
-  try {
-    const headers = {
-      'Content-Type': 'application/json',
-    };
-
-    // Add authentication if secret is configured
-    if (env.BLOSSOM_WEBHOOK_SECRET) {
-      headers['Authorization'] = `Bearer ${env.BLOSSOM_WEBHOOK_SECRET}`;
-    }
-
-    console.log(`[BLOSSOM] Notifying blossom of ${action} (as ${blossomAction}) for ${sha256}`);
-
-    const response = await fetch(env.BLOSSOM_WEBHOOK_URL, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify({
-        sha256,
-        action: blossomAction,
-        timestamp: new Date().toISOString(),
-      }),
-    });
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      console.error(`[BLOSSOM] Webhook failed: ${response.status} - ${errorText}`);
-      return { success: false, error: `HTTP ${response.status}: ${errorText}` };
-    }
-
-    const result = await response.json();
-    console.log(`[BLOSSOM] Webhook succeeded for ${sha256}:`, result);
-    return { success: true, result };
-
-  } catch (error) {
-    console.error(`[BLOSSOM] Webhook error for ${sha256}:`, error);
-    return { success: false, error: error.message };
-  }
-}

--- a/src/nostr/relay-client.mjs
+++ b/src/nostr/relay-client.mjs
@@ -344,6 +344,9 @@ export async function fetchKind5EventsSince(sinceSeconds, relayUrl = 'wss://rela
 }
 
 export async function fetchNostrEventById(eventId, relays = ['wss://relay.divine.video'], env = {}) {
+  // Reject non-hex IDs to prevent path-traversal via attacker-controlled kind 5 e-tags
+  if (!eventId || !/^[a-f0-9]{64}$/i.test(eventId)) return null;
+
   for (const relayUrl of relays) {
     // Use Funnelcake's REST API (GET /api/event/{id}) instead of WebSocket REQ.
     // Faster (no upgrade handshake), works in local dev (Miniflare), and the

--- a/src/nostr/relay-client.mjs
+++ b/src/nostr/relay-client.mjs
@@ -345,8 +345,23 @@ export async function fetchKind5EventsSince(sinceSeconds, relayUrl = 'wss://rela
 
 export async function fetchNostrEventById(eventId, relays = ['wss://relay.divine.video'], env = {}) {
   for (const relayUrl of relays) {
-    const event = await queryRelay(relayUrl, { ids: [eventId], limit: 1 }, env);
-    if (event) return event;
+    // Use Funnelcake's REST API (GET /api/event/{id}) instead of WebSocket REQ.
+    // Faster (no upgrade handshake), works in local dev (Miniflare), and the
+    // endpoint returns a raw Nostr event: { id, pubkey, created_at, kind, tags, content, sig }.
+    const apiBaseUrl = relayUrl.replace(/^wss:/, 'https:').replace(/^ws:/, 'http:').replace(/\/$/, '');
+    try {
+      const headers = { 'Accept': 'application/json' };
+      if (env.CF_ACCESS_CLIENT_ID && env.CF_ACCESS_CLIENT_SECRET) {
+        headers['CF-Access-Client-Id'] = env.CF_ACCESS_CLIENT_ID;
+        headers['CF-Access-Client-Secret'] = env.CF_ACCESS_CLIENT_SECRET;
+      }
+      const response = await fetch(`${apiBaseUrl}/api/event/${eventId}`, { headers });
+      if (!response.ok) continue;
+      const event = await response.json();
+      if (event?.id && event?.pubkey) return event;
+    } catch {
+      continue;
+    }
   }
   return null;
 }

--- a/src/nostr/relay-client.mjs
+++ b/src/nostr/relay-client.mjs
@@ -338,3 +338,15 @@ export function hasStrongOriginalVineEvidence(nostrContext) {
 
   return false;
 }
+
+export async function fetchKind5EventsSince(sinceSeconds, relayUrl = 'wss://relay.divine.video', env = {}) {
+  return queryRelay(relayUrl, { kinds: [5], since: sinceSeconds }, env, { collectAll: true });
+}
+
+export async function fetchNostrEventById(eventId, relays = ['wss://relay.divine.video'], env = {}) {
+  for (const relayUrl of relays) {
+    const event = await queryRelay(relayUrl, { ids: [eventId], limit: 1 }, env);
+    if (event) return event;
+  }
+  return null;
+}

--- a/src/nostr/relay-client.test.mjs
+++ b/src/nostr/relay-client.test.mjs
@@ -7,7 +7,8 @@ import {
   fetchNostrVideoEventsByDTag,
   parseVideoEventMetadata,
   isOriginalVine,
-  hasStrongOriginalVineEvidence
+  hasStrongOriginalVineEvidence,
+  fetchNostrEventById
 } from './relay-client.mjs';
 
 const OriginalWebSocket = globalThis.WebSocket;
@@ -386,5 +387,23 @@ describe('fetchNostrEventBySha256', () => {
     globalThis.WebSocket = FakeWebSocket;
 
     await expect(fetchNostrEventBySha256(sha256)).resolves.toEqual(event);
+  });
+});
+
+describe('fetchNostrEventById', () => {
+  it('returns null for non-hex event IDs without fetching', async () => {
+    const originalFetch = globalThis.fetch;
+    let called = false;
+    globalThis.fetch = async () => {
+      called = true;
+      return new Response('{}');
+    };
+
+    try {
+      await expect(fetchNostrEventById('../not-hex')).resolves.toBeNull();
+      expect(called).toBe(false);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -87,9 +87,12 @@ RELAY_POLLING_RELAY_URL = "wss://relay.divine.video"  # Relay to poll for new vi
 RELAY_POLLING_LOOKBACK_HOURS = "1"                # How far back to look for events (in hours)
 RELAY_POLLING_LIMIT = "100"                       # Max events to fetch per poll
 
+# Creator-delete pipeline feature flag (default off; flip to "true" via `wrangler secret put` or [vars] once ready)
+CREATOR_DELETE_PIPELINE_ENABLED = "false"
+
 # Cron trigger for relay polling - runs every 5 minutes
 [triggers]
-crons = ["*/5 * * * *"]
+crons = ["* * * * *", "*/5 * * * *"]
 
 # Secrets (set with: wrangler secret put <NAME>)
 # SERVICE_API_TOKEN - bearer token for authenticated requests to moderation-api.divine.video

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -93,6 +93,8 @@ RELAY_POLLING_LIMIT = "100"                       # Max events to fetch per poll
 
 # Creator-delete pipeline feature flag (default off; flip to "true" via `wrangler secret put` or [vars] once ready)
 CREATOR_DELETE_PIPELINE_ENABLED = "false"
+# Relay used to fetch creator kind 5 delete events and target video events.
+CREATOR_DELETE_RELAY_URL = "wss://relay.divine.video"
 
 # Cron trigger for relay polling - runs every 5 minutes
 [triggers]


### PR DESCRIPTION
## Summary

Moderation-service side of per-video delete end-to-end enforcement.

**Issue:** divinevideo/divine-mobile#3102
**Rollout comment:** https://github.com/divinevideo/divine-mobile/issues/3102#issuecomment-4264760572
**Rollout plan:** [`support-trust-safety/docs/rollout/2026-04-16-creator-delete-rollout.md`](https://github.com/divinevideo/support-trust-safety/blob/working-draft/docs/rollout/2026-04-16-creator-delete-rollout.md)
**Sibling PR:** divinevideo/divine-blossom#85 (Blossom DELETE action)

## What's in this PR

- D1 migration for the `creator_deletions` audit table
- NIP-98 Authorization header validator (`src/creator-delete/nip98.mjs`)
- Race-safe D1 helpers with INSERT ON CONFLICT DO NOTHING idempotency (`src/creator-delete/d1.mjs`)
- `processKind5` core function with multi-target support + state taxonomy (`src/creator-delete/process.mjs`)
- KV-backed rate limiter (`src/creator-delete/rate-limit.mjs`)
- `POST /api/delete/{kind5_id}` sync endpoint with NIP-98 auth, IP + pubkey rate limiting, 8s budget timeout (`src/creator-delete/sync-endpoint.mjs`)
- `GET /api/delete-status/{kind5_id}` status endpoint (`src/creator-delete/status-endpoint.mjs`)
- Funnelcake fetch-with-retry via REST (`src/creator-delete/funnelcake-fetch.mjs`)
- `notifyBlossom` extraction to shared `src/blossom-client.mjs` with DELETE action added
- 1-minute cron for kind 5 polling + transient retry with exponential backoff (`src/creator-delete/cron.mjs`)
- Route wiring + `CREATOR_DELETE_PIPELINE_ENABLED` feature flag (default off) in `src/index.mjs` + `wrangler.toml`
- Structured observability logs across the pipeline
- `fetchNostrEventById` switched from WebSocket to REST (`GET /api/event/{id}`)
- NIP-98 signing utility (`scripts/sign-nip98.mjs`)

## Key design decisions

- **Sync endpoint + cron dual-path.** Mobile gets near-instant confirmation via the sync endpoint. Non-Divine clients and missed events covered by the 1-minute cron. Both converge on `processKind5`.
- **NIP-98 author-only auth** on both endpoints. Caller pubkey must match kind 5 author.
- **IP rate limit runs before NIP-98 validation** to limit crypto work from unauthenticated callers.
- **D1 state taxonomy:** `accepted`, `success`, `failed:transient:*` (cron-retryable with exponential backoff), `failed:permanent:*` (terminal). Retries promote to `failed:permanent:max_retries_exceeded` at count 5.
- **Feature flag gates everything.** When off, routes 404 and cron is inert. Flippable without redeployment.
- **REST over WebSocket** for Funnelcake event lookups. Faster, works in Miniflare local dev, no CF Access header complexity.

## Test plan

705 tests pass (662 existing + 43 creator-delete + new validation tests from review fixes).

### Unit tests (done)
- [x] NIP-98 validation: 9 tests (happy path + 7 rejection paths including tags-array guard)
- [x] D1 helpers: 9 tests (claim idempotency + full decideAction state machine)
- [x] processKind5: 8 tests (happy path, multi-target, target_unresolved, no_sha256, transient 503, permanent 400, network error, idempotent skip)
- [x] Rate limiter: 2 tests (allow + block)
- [x] Sync endpoint: 8 tests (happy path + 400/401/403/404/429-IP/429-pubkey/202)
- [x] Status endpoint: 6 tests (happy path + 400/401/403/404/429)
- [x] Cron: 2 tests (happy path + transient retry with backoff)
- [x] Funnelcake fetch: 2 tests (retry-then-success + all-null)
- [x] Blossom client: 5 tests (action map + DELETE mapping + skip + error + network)
- [x] Existing index.test.mjs: 662 tests still pass (no regressions)

### Local e2e (done)
- [x] MinIO + Blossom (:7676) + moderation-service (:8787) all running locally
- [x] Feature flag gating: routes 404 when flag off, active when flag on
- [x] NIP-98 auth: rejects missing header (401), accepts valid signature
- [x] REST fetch from production Funnelcake: real kind 5 event fetched via `GET /api/event/{id}`
- [x] Pubkey authorization check: 403 on NIP-98/kind-5 pubkey mismatch (tested against real production kind 5)
- [x] Funnelcake read-after-write retry: 5 retries over 4.7s for non-existent event, returns 404
- [x] Structured observability log (`creator_delete.sync.request`) emitted
- [x] Moderation-service calls local Blossom and Blossom processes DELETE (verified via direct Blossom curl with webhook auth)

### Full pipeline e2e (deferred to production validation)
- [ ] processKind5 → Blossom call in a single request. Requires a real Divine test account with an uploaded video (ephemeral keys publish kind 34236 events that Funnelcake accepts at the protocol level but does not persist to ClickHouse). Each component is individually proven; the chain is validated during rollout plan steps 4-5 using a real test account.

### Code review (done)
- [x] Three rounds of self-review (comprehensive, fixes-focused, cross-repo integration contract)
- [x] All findings addressed: cron backoff, max_retries promotion, last-poll guard, IP rate-limit ordering, status-endpoint validation, stale row re-claim, path-traversal guard on eventId, unused imports removed, test mock URL corrected