### PR TITLE
feat: bundle admin relay metadata and moderation tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ old_files/
 old_files/
 cost-projections-internal.md
 .worktrees/
+.claude/worktrees/
+.playwright-mcp/
+tmp/

--- a/docs/superpowers/plans/2026-04-08-nudity-enforcement-plan.md
+++ b/docs/superpowers/plans/2026-04-08-nudity-enforcement-plan.md
@@ -1,0 +1,388 @@
+# Nudity Enforcement Policy Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop auto-restricting benign nudity while preserving label/downstream signals, auto-warning sexual content, and keeping explicit pornographic content ban-eligible.
+
+**Architecture:** Split broad nudity labeling from enforcement-grade sexual signals. Narrow Hive class normalization so benign male-coded and generic nudity classes stay in label/downstream context, while explicit sexual classes feed new enforcement categories (`sexual`, `porn`) that the classifier maps to `AGE_RESTRICTED` and `PERMANENT_BAN`.
+
+**Tech Stack:** Cloudflare Workers, Vitest, JavaScript ESM, Hive.AI moderation provider, existing moderation pipeline/classifier stack
+
+---
+
+## File Structure
+
+### Core enforcement logic
+
+- Modify: `src/moderation/providers/hiveai/normalizer.mjs`
+  - Narrow Hive nudity mapping.
+  - Introduce explicit enforcement-grade categories for `sexual` and `porn`.
+  - Keep benign nudity classes available for labeling/downstream signals.
+
+- Modify: `src/moderation/classifier.mjs`
+  - Remove broad `nudity` from automatic enforcement.
+  - Add `sexual` => `AGE_RESTRICTED`.
+  - Add `porn` => `PERMANENT_BAN`.
+  - Preserve existing non-nudity moderation behavior.
+
+- Modify: `src/moderation/vocabulary.mjs`
+  - Ensure classifier categories `sexual` and `porn` emit canonical labels.
+
+### Regression coverage
+
+- Modify: `src/moderation/providers/hiveai/normalizer.test.mjs`
+  - Cover benign male-coded nudity vs explicit sexual classes.
+
+- Modify: `src/moderation/classifier.test.mjs`
+  - Cover benign nudity => `SAFE`.
+  - Cover `sexual` => `AGE_RESTRICTED`.
+  - Cover `porn` => `PERMANENT_BAN`.
+
+- Modify: `src/moderation/vocabulary.test.mjs`
+  - Cover label mapping for `sexual` and `porn`.
+
+- Modify: `src/moderation/pipeline.test.mjs`
+  - Prove end-to-end `SAFE` serving plus retained downstream nudity signals for benign male/swimwear content.
+  - Prove sexual content still auto-warns.
+
+### Optional if coverage reveals a gap
+
+- Modify: `src/moderation/downstream-publishing.test.mjs`
+  - Strengthen assertions around `SAFE` plus retained nudity labels if pipeline regressions expose ambiguity.
+
+---
+
+## Chunk 1: Narrow Hive Signal Mapping
+
+### Task 1: Add failing Hive normalizer tests for benign vs explicit nudity
+
+**Files:**
+- Modify: `src/moderation/providers/hiveai/normalizer.test.mjs`
+- Modify: `src/moderation/providers/hiveai/normalizer.mjs`
+
+- [ ] **Step 1: Write the failing test for benign male-coded nudity**
+
+Add a case asserting a response containing only benign male-coded classes stays in broad `nudity` and does not create `sexual` or `porn`.
+
+```js
+it('treats male-coded swimwear and shirtless classes as label-only nudity', () => {
+  const result = normalizeHiveAIResponse({
+    moderation: {
+      status: [{
+        response: {
+          output: [{
+            time: 0,
+            classes: [
+              { class: 'yes_male_nudity', score: 0.91 },
+              { class: 'yes_male_swimwear', score: 0.88 },
+              { class: 'yes_male_underwear', score: 0.83 }
+            ]
+          }]
+        }
+      }]
+    },
+    aiDetection: null
+  });
+
+  expect(result.scores.nudity).toBe(0.91);
+  expect(result.scores.sexual).toBe(0);
+  expect(result.scores.porn).toBe(0);
+});
+```
+
+- [ ] **Step 2: Write the failing tests for warning-grade and ban-grade explicit classes**
+
+Add two tests:
+
+- `yes_sexual_display` / `yes_sex_toy` => `sexual`
+- `yes_sexual_activity` / `animated_explicit_sexual_content` => `porn`
+
+```js
+expect(result.scores.sexual).toBe(0.9);
+expect(result.scores.porn).toBe(0.95);
+```
+
+- [ ] **Step 3: Run the targeted normalizer tests and verify failure**
+
+Run: `npx vitest run src/moderation/providers/hiveai/normalizer.test.mjs`
+
+Expected:
+- FAIL because `sexual` and `porn` are not yet in the normalized score object
+- FAIL because the existing mapping still collapses all of these classes into `nudity`
+
+- [ ] **Step 4: Implement the minimal Hive mapping change**
+
+In `src/moderation/providers/hiveai/normalizer.mjs`:
+
+- keep these as broad `nudity` only:
+  - `yes_male_nudity`
+  - `yes_male_underwear`
+  - `yes_male_swimwear`
+  - `yes_female_nudity`
+  - `yes_female_underwear`
+  - `yes_female_swimwear`
+  - `general_nsfw`
+  - `general_suggestive`
+  - `animated_male_nudity`
+  - `animated_female_nudity`
+  - `animated_suggestive`
+- map warning-grade explicit classes to `sexual`:
+  - `yes_sexual_display`
+  - `yes_sex_toy`
+- map ban-grade explicit classes to `porn`:
+  - `yes_sexual_activity`
+  - `animated_explicit_sexual_content`
+
+Update the default score object so `sexual` and `porn` always exist.
+
+- [ ] **Step 5: Run the targeted normalizer tests and verify pass**
+
+Run: `npx vitest run src/moderation/providers/hiveai/normalizer.test.mjs`
+
+Expected:
+- PASS
+
+- [ ] **Step 6: Commit the mapping change**
+
+```bash
+git add src/moderation/providers/hiveai/normalizer.mjs src/moderation/providers/hiveai/normalizer.test.mjs
+git commit -m "fix: narrow hive nudity enforcement mapping"
+```
+
+---
+
+## Chunk 2: Rewire Enforcement Decisions
+
+### Task 2: Add failing classifier tests for benign nudity, sexual warnings, and porn bans
+
+**Files:**
+- Modify: `src/moderation/classifier.test.mjs`
+- Modify: `src/moderation/classifier.mjs`
+
+- [ ] **Step 1: Write the failing benign nudity classifier test**
+
+Add a test proving broad nudity no longer auto-enforces:
+
+```js
+it('keeps benign nudity SAFE when no explicit sexual signal is present', () => {
+  const result = classifyModerationResult({
+    maxScores: {
+      nudity: 0.92,
+      sexual: 0,
+      porn: 0
+    }
+  });
+
+  expect(result.action).toBe('SAFE');
+  expect(result.category).toBeNull();
+});
+```
+
+- [ ] **Step 2: Write the failing explicit sexual classifier tests**
+
+Add:
+
+- `sexual: 0.85` => `AGE_RESTRICTED`
+- `porn: 0.9` => `PERMANENT_BAN`
+
+```js
+expect(result.action).toBe('AGE_RESTRICTED');
+expect(result.action).toBe('PERMANENT_BAN');
+```
+
+- [ ] **Step 3: Run the targeted classifier tests and verify failure**
+
+Run: `npx vitest run src/moderation/classifier.test.mjs`
+
+Expected:
+- FAIL because `nudity` still auto-restricts
+- FAIL because `sexual` and `porn` are not yet classified
+
+- [ ] **Step 4: Implement the minimal classifier change**
+
+In `src/moderation/classifier.mjs`:
+
+- add default score keys for `sexual` and `porn`
+- remove `nudity` from `AGE_RESTRICTED_CATEGORIES`
+- add explicit handling:
+  - `porn >= threshold` => `PERMANENT_BAN`
+  - `sexual >= threshold` => `AGE_RESTRICTED`
+- keep the existing `nudity` score for labels/downstream signals only
+- update `getCategoryLabel()` for `sexual` and `porn`
+- update any tests that assert the exact score-key count
+
+Use the existing NSFW thresholds for `sexual` and `porn` to avoid introducing new environment/config plumbing in this change:
+
+```js
+sexual: {
+  high: parseFloat(env.NSFW_THRESHOLD_HIGH || DEFAULT_NSFW_HIGH),
+  medium: parseFloat(env.NSFW_THRESHOLD_MEDIUM || DEFAULT_NSFW_MEDIUM)
+},
+porn: {
+  high: parseFloat(env.NSFW_THRESHOLD_HIGH || DEFAULT_NSFW_HIGH),
+  medium: parseFloat(env.NSFW_THRESHOLD_MEDIUM || DEFAULT_NSFW_MEDIUM)
+}
+```
+
+- [ ] **Step 5: Run the targeted classifier tests and verify pass**
+
+Run: `npx vitest run src/moderation/classifier.test.mjs`
+
+Expected:
+- PASS
+
+- [ ] **Step 6: Commit the classifier change**
+
+```bash
+git add src/moderation/classifier.mjs src/moderation/classifier.test.mjs
+git commit -m "fix: enforce sexual content separately from broad nudity"
+```
+
+---
+
+## Chunk 3: Preserve Labels and End-to-End Behavior
+
+### Task 3: Add failing vocabulary and label-mapping tests
+
+**Files:**
+- Modify: `src/moderation/vocabulary.test.mjs`
+- Modify: `src/moderation/vocabulary.mjs`
+
+- [ ] **Step 1: Write the failing vocabulary tests**
+
+Add:
+
+```js
+expect(classifierCategoryToLabels('sexual')).toEqual(['sexual']);
+expect(classifierCategoryToLabels('porn')).toEqual(['porn']);
+```
+
+- [ ] **Step 2: Run the targeted vocabulary tests and verify failure**
+
+Run: `npx vitest run src/moderation/vocabulary.test.mjs`
+
+Expected:
+- FAIL because `classifierCategoryToLabels()` does not yet map `sexual` or `porn`
+
+- [ ] **Step 3: Implement the minimal vocabulary change**
+
+In `src/moderation/vocabulary.mjs`, extend the classifier-category map:
+
+```js
+sexual: ['sexual'],
+porn: ['porn'],
+```
+
+- [ ] **Step 4: Run the targeted vocabulary tests and verify pass**
+
+Run: `npx vitest run src/moderation/vocabulary.test.mjs`
+
+Expected:
+- PASS
+
+- [ ] **Step 5: Commit the vocabulary change**
+
+```bash
+git add src/moderation/vocabulary.mjs src/moderation/vocabulary.test.mjs
+git commit -m "fix: preserve sexual content labels in moderation output"
+```
+
+### Task 4: Add pipeline regression tests and make the full path pass
+
+**Files:**
+- Modify: `src/moderation/pipeline.test.mjs`
+- Modify: `src/moderation/pipeline.mjs` (only if the tests expose additional glue changes)
+- Optionally modify: `src/moderation/downstream-publishing.test.mjs`
+
+- [ ] **Step 1: Write the failing benign-content pipeline regression**
+
+Add a Hive-backed moderation pipeline test where benign male-coded classes are high but explicit sexual classes are absent:
+
+```js
+expect(result.action).toBe('SAFE');
+expect(result.downstreamSignals?.hasSignals).toBe(true);
+expect(result.downstreamSignals?.scores?.nudity).toBeGreaterThan(0.8);
+expect(result.downstreamSignals?.scores?.sexual ?? 0).toBe(0);
+expect(result.downstreamSignals?.scores?.porn ?? 0).toBe(0);
+```
+
+- [ ] **Step 2: Write the failing warning regression**
+
+Add a Hive-backed pipeline test where `yes_sexual_display` or `yes_sex_toy` is high:
+
+```js
+expect(result.action).toBe('AGE_RESTRICTED');
+expect(result.primaryConcern).toBe('sexual');
+```
+
+- [ ] **Step 3: Write the failing explicit-ban regression**
+
+Add a Hive-backed pipeline test where `yes_sexual_activity` or `animated_explicit_sexual_content` is high:
+
+```js
+expect(result.action).toBe('PERMANENT_BAN');
+expect(result.primaryConcern).toBe('porn');
+```
+
+- [ ] **Step 4: Run the targeted pipeline tests and verify failure**
+
+Run: `npx vitest run src/moderation/pipeline.test.mjs`
+
+Expected:
+- FAIL until the new score categories are flowing cleanly end to end
+
+- [ ] **Step 5: Make the smallest pipeline-level adjustment needed**
+
+Expected minimal or no code changes outside the already-modified files. Only touch `src/moderation/pipeline.mjs` or `src/moderation/downstream-publishing.test.mjs` if:
+
+- score defaults are missing from end-to-end output
+- downstream signal assertions need an explicit regression harness
+
+Do **not** change Blossom mapping or unrelated moderation rules.
+
+- [ ] **Step 6: Run the targeted pipeline tests and verify pass**
+
+Run: `npx vitest run src/moderation/pipeline.test.mjs`
+
+Expected:
+- PASS
+
+- [ ] **Step 7: Run the relevant focused suite**
+
+Run:
+
+```bash
+npx vitest run src/moderation/providers/hiveai/normalizer.test.mjs src/moderation/classifier.test.mjs src/moderation/vocabulary.test.mjs src/moderation/pipeline.test.mjs
+```
+
+Expected:
+- PASS
+
+- [ ] **Step 8: Run the repo verification commands**
+
+Run:
+
+```bash
+npm run lint
+npm test
+```
+
+Expected:
+- PASS
+
+- [ ] **Step 9: Commit the regression coverage and any remaining glue**
+
+```bash
+git add src/moderation/pipeline.test.mjs src/moderation/pipeline.mjs src/moderation/downstream-publishing.test.mjs
+git commit -m "test: cover benign nudity and explicit sexual enforcement"
+```
+
+---
+
+## Notes For Implementers
+
+- Do not touch `notifyBlossom()` mapping in `src/index.mjs`. The serving bug is caused by upstream action selection, not Blossom transport.
+- Do not reintroduce broad `nudity` into automatic enforcement.
+- Do not broaden `porn` to include generic topless / swimwear classes. If the provider does not explicitly distinguish pornographic context, bias toward non-enforcement.
+- Preserve `downstreamSignals` for benign nudity so trust-and-safety labels still flow.
+- Keep AI/deepfake, self-harm, hate, gore, weapon, and drug logic unchanged unless a test proves collateral regression.

--- a/docs/superpowers/plans/2026-04-10-classic-vine-age-restriction-downgrade-plan.md
+++ b/docs/superpowers/plans/2026-04-10-classic-vine-age-restriction-downgrade-plan.md
@@ -1,0 +1,69 @@
+# Classic Vine Age Restriction Downgrade Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Discover legacy Vine archive videos with stale machine-applied moderation and downgrade eligible non-`SAFE` rows to `AGE_RESTRICTED` without touching human-reviewed items.
+
+**Architecture:** Implement a standalone operational script with preview and execute modes. Reuse relay discovery patterns and the existing moderation API, but keep filtering logic local and conservative.
+
+**Tech Stack:** Node.js ESM scripts, Vitest, relay WebSocket queries, moderation API
+
+---
+
+### Task 1: Add Failing Script Tests
+
+**Files:**
+- Create: `scripts/downgrade-classic-vines-to-age-restricted.test.mjs`
+- Create: `scripts/downgrade-classic-vines-to-age-restricted.mjs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Cover:
+- classic Vine event discovery by `x` / `imeta x`
+- skip rows with `reviewed_by`
+- skip rows with `review_notes`
+- accept machine-applied non-`SAFE` rows
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run scripts/downgrade-classic-vines-to-age-restricted.test.mjs`
+
+Expected: FAIL because the script helpers do not exist yet.
+
+### Task 2: Implement Discovery And Eligibility Helpers
+
+**Files:**
+- Modify: `scripts/downgrade-classic-vines-to-age-restricted.mjs`
+
+- [ ] **Step 1: Write minimal implementation**
+
+Export pure helpers for:
+- config parsing
+- legacy Vine detection
+- moderation-row eligibility filtering
+- API request building
+
+- [ ] **Step 2: Run tests**
+
+Run: `npx vitest run scripts/downgrade-classic-vines-to-age-restricted.test.mjs`
+
+Expected: PASS
+
+### Task 3: Implement Script Execution Flow
+
+**Files:**
+- Modify: `scripts/downgrade-classic-vines-to-age-restricted.mjs`
+
+- [ ] **Step 1: Add preview/execute flow**
+
+Implement:
+- relay pagination
+- moderation decision lookups
+- checkpoint/report writing
+- `AGE_RESTRICTED` update calls via `/api/v1/moderate`
+
+- [ ] **Step 2: Run focused verification**
+
+Run: `npx vitest run scripts/downgrade-classic-vines-to-age-restricted.test.mjs src/nostr/relay-client.test.mjs src/moderation/classic-vine-rollback.test.mjs`
+
+Expected: PASS

--- a/docs/superpowers/plans/2026-04-10-legacy-vine-sha-rollback-discovery-plan.md
+++ b/docs/superpowers/plans/2026-04-10-legacy-vine-sha-rollback-discovery-plan.md
@@ -1,0 +1,54 @@
+# Legacy Vine SHA Rollback Discovery Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make classic Vine rollback discovery find legacy Vine events by blob SHA when the Nostr `d` tag is the Vine ID.
+
+**Architecture:** Extend relay lookup with a SHA-aware event search based on `x` and `imeta x`, then switch rollback discovery to that helper. Keep the event format and moderation policy unchanged.
+
+**Tech Stack:** Cloudflare Workers, Vitest, Nostr WebSocket relay queries, ESM modules
+
+---
+
+### Task 1: Add Failing Discovery Tests
+
+**Files:**
+- Modify: `src/nostr/relay-client.test.mjs`
+- Modify: `src/moderation/classic-vine-rollback.test.mjs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add coverage for a legacy Vine event whose `d` tag is a Vine ID and whose blob SHA is exposed via `x` / `imeta x`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/nostr/relay-client.test.mjs src/moderation/classic-vine-rollback.test.mjs`
+
+Expected: FAIL because SHA-based lookup still assumes `#d = sha256`.
+
+### Task 2: Implement SHA-Aware Relay Lookup
+
+**Files:**
+- Modify: `src/nostr/relay-client.mjs`
+- Modify: `src/moderation/classic-vine-rollback.mjs`
+
+- [ ] **Step 1: Write minimal implementation**
+
+Add a helper that fetches candidate video events and matches the requested SHA against `x` and `imeta x`, then use it from rollback discovery.
+
+- [ ] **Step 2: Run targeted tests**
+
+Run: `npx vitest run src/nostr/relay-client.test.mjs src/moderation/classic-vine-rollback.test.mjs`
+
+Expected: PASS
+
+### Task 3: Verify No Regression In Rollback Path
+
+**Files:**
+- Test: `src/index.test.mjs`
+
+- [ ] **Step 1: Run focused rollback tests**
+
+Run: `npx vitest run src/index.test.mjs -t "classic vine rollback"`
+
+Expected: PASS

--- a/docs/superpowers/plans/2026-04-14-provenance-and-creator-context-plan.md
+++ b/docs/superpowers/plans/2026-04-14-provenance-and-creator-context-plan.md
@@ -1,0 +1,610 @@
+# Provenance And Creator Context Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add normalized provenance and creator-context data to admin moderation surfaces so moderators can identify likely original Vine, pre-2022 legacy, and C2PA/ProofMode-attested content, plus inspect creator history. Provenance is guidance-only EXCEPT two targeted enforcement rules: (1) valid ProofMode capture-authentication downgrades Hive/RD AI-driven QUARANTINE to REVIEW so humans decide, and (2) valid C2PA signed by a known AI-generation tool is an independent trigger for QUARANTINE — the tool's own cryptographic declaration is authoritative AI evidence, so we don't serve the content until a human makes a labeling/approval call.
+
+**Architecture:** Compute provenance once on the backend. Age/origin signals come from Nostr/import/ingest evidence; C2PA/ProofMode signals come from the `divine-inquisitor` microservice (`github.com/divinevideo/divine-inquisitor`), called from the moderation pipeline **before Hive** so that signed-AI content short-circuits the Hive call entirely. Results are persisted on the moderation record and KV-cached. Return a normalized `provenance` object in every admin video payload. Enrich creator data with local moderation stats plus public `api.divine.video` profile/social endpoints. Render compact provenance badges (age-origin + proofmode, independent) and an on-demand `Creator Info` panel in dashboard and swipe review.
+
+**Tech Stack:** Cloudflare Workers, Vitest, D1, KV, static admin HTML/JS, public Funnelcake REST API (`api.divine.video`), divine-inquisitor (HTTP `POST /verify`)
+
+**External service:** Divine-inquisitor is live at `https://inquisitor.divine.video` (confirmed 2026-04-17: `/health` returns `{"status":"ok","service":"divine-inquisitor","version":"0.1.0"}`). No auth required per current k8s config. Configure the worker with `INQUISITOR_BASE_URL=https://inquisitor.divine.video`.
+
+---
+
+## File Structure
+
+- Create: `src/admin/provenance.mjs`
+  Backend-only helper for provenance normalization, date-source ranking, and C2PA state normalization.
+- Create: `src/admin/provenance.test.mjs`
+  Unit tests for provenance classification, guardrails, and C2PA state derivation.
+- Create: `src/admin/creator-context.mjs`
+  Backend helper for local + Funnelcake creator enrichment.
+- Create: `src/admin/creator-context.test.mjs`
+  Unit tests for Funnelcake enrichment and fallback behavior.
+- Create: `src/moderation/inquisitor-client.mjs`
+  HTTP client for `divine-inquisitor` C2PA verification — URL mode, timeout, graceful degradation.
+- Create: `src/moderation/inquisitor-client.test.mjs`
+  Unit tests for inquisitor client with mocked fetch.
+- Modify: `src/moderation/pipeline.mjs`
+  Call inquisitor in parallel with existing providers; persist C2PA result; apply ProofMode enforcement rule (valid_proofmode + AI flag → REVIEW instead of QUARANTINE).
+- Modify: `src/moderation/pipeline.test.mjs`
+  Cover the ProofMode enforcement rule and fall-through behavior for every other state.
+- Modify: `src/nostr/relay-client.mjs`
+  Preserve `publishedAt`, `createdAt`, platform, sourceUrl, and Vine IDs for age/origin provenance.
+- Modify: `src/nostr/relay-client.test.mjs`
+  Extend parsing coverage for preserved metadata fields.
+- Modify: `src/index.mjs`
+  Thread provenance (age/origin + proofmode) and creator context through admin lookup/list/review payloads.
+- Modify: `src/index.test.mjs`
+  Add end-to-end admin payload coverage.
+- Modify: `src/admin/dashboard.html`
+  Render independent age-origin and ProofMode badges, support line, and add `Creator Info` modal/popover behavior.
+- Modify: `src/admin/swipe-review.html`
+  Render the same provenance summary and creator-info affordance.
+- Modify: `wrangler.toml`
+  Add `INQUISITOR_BASE_URL` var, `C2PA_CACHE` KV namespace binding (or reuse existing KV with a `c2pa:` prefix — decide in Chunk 6).
+
+## Chunk 1: Backend Provenance Normalization
+
+### Task 1: Add provenance helper with failing tests first
+
+**Files:**
+- Create: `src/admin/provenance.test.mjs`
+- Create: `src/admin/provenance.mjs`
+- Modify: `src/nostr/relay-client.mjs`
+- Modify: `src/nostr/relay-client.test.mjs`
+
+- [ ] **Step 1: Write the failing provenance unit tests**
+
+```js
+import { describe, expect, it } from 'vitest';
+import { buildProvenance } from './provenance.mjs';
+
+describe('buildProvenance', () => {
+  it('classifies strong Vine evidence as original_vine', () => {
+    const result = buildProvenance({
+      nostrContext: {
+        platform: 'vine',
+        sourceUrl: 'https://vine.co/v/abc',
+        publishedAt: 1408579200
+      },
+      receivedAt: '2026-04-14T00:00:00.000Z'
+    });
+
+    expect(result.status).toBe('original_vine');
+    expect(result.isOriginalVine).toBe(true);
+    expect(result.dateSource).toBe('published_at');
+  });
+
+  it('classifies published_at before 2022 as pre_2022_legacy', () => {
+    const result = buildProvenance({
+      nostrContext: { publishedAt: 1637193600 },
+      receivedAt: '2026-04-14T00:00:00.000Z'
+    });
+
+    expect(result.status).toBe('pre_2022_legacy');
+    expect(result.isPre2022).toBe(true);
+  });
+
+  it('does not treat receivedAt alone as legacy', () => {
+    const result = buildProvenance({
+      nostrContext: null,
+      receivedAt: '2020-01-01T00:00:00.000Z'
+    });
+
+    expect(result.status).toBe('unknown_or_modern');
+    expect(result.dateSource).toBe('none');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/admin/provenance.test.mjs src/nostr/relay-client.test.mjs`
+
+Expected: FAIL because `src/admin/provenance.mjs` does not exist and preserved-field expectations are not implemented.
+
+- [ ] **Step 3: Write the minimal provenance implementation**
+
+```js
+import { hasStrongOriginalVineEvidence } from '../nostr/relay-client.mjs';
+
+const PRE_2022_CUTOFF = Date.UTC(2022, 0, 1) / 1000;
+
+export function buildProvenance({ nostrContext, receivedAt }) {
+  const reasons = [];
+  const publishedAt = nostrContext?.publishedAt ?? null;
+  const nostrCreatedAt = nostrContext?.createdAt ?? null;
+
+  if (hasStrongOriginalVineEvidence(nostrContext || {})) {
+    reasons.push('vine-signal');
+  }
+
+  // Pick the best trusted age signal without letting receivedAt imply legacy.
+  // Return a normalized object for all admin payloads.
+}
+```
+
+- [ ] **Step 4: Preserve needed metadata in relay parsing**
+
+Add/retain these fields in `parseVideoEventMetadata` output:
+- `publishedAt`
+- `createdAt`
+- `platform`
+- `sourceUrl`
+- Vine-specific IDs
+
+Note: Do NOT try to parse a "proofmode" tag from the Nostr event. C2PA/ProofMode data lives inside the media file itself and is read by `divine-inquisitor` from the media bytes. Chunk 6 handles this end-to-end.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npm test -- src/admin/provenance.test.mjs src/nostr/relay-client.test.mjs`
+
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/admin/provenance.mjs src/admin/provenance.test.mjs src/nostr/relay-client.mjs src/nostr/relay-client.test.mjs
+git commit -m "feat: normalize admin provenance signals"
+```
+
+## Chunk 2: Backend Creator Context Enrichment
+
+### Task 2: Add creator-context helper with local + Funnelcake fallback
+
+**Files:**
+- Create: `src/admin/creator-context.test.mjs`
+- Create: `src/admin/creator-context.mjs`
+- Modify: `src/index.mjs`
+- Modify: `src/index.test.mjs`
+
+- [ ] **Step 1: Write the failing creator-context unit tests**
+
+```js
+import { describe, expect, it, vi } from 'vitest';
+import { buildCreatorContext } from './creator-context.mjs';
+
+describe('buildCreatorContext', () => {
+  it('merges local moderation stats with Funnelcake profile/social data', async () => {
+    const fetchFn = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        pubkey: 'f'.repeat(64),
+        profile: { display_name: 'Alice', name: 'alice', picture: 'https://cdn/p.png' },
+        stats: { video_count: 12, total_events: 88, first_activity: '2019-01-01T00:00:00Z', last_activity: '2026-04-14T00:00:00Z' }
+      })))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        follower_count: 100,
+        following_count: 20
+      })));
+
+    const result = await buildCreatorContext({
+      pubkey: 'f'.repeat(64),
+      uploaderStats: { total_scanned: 5, flagged_count: 2, risk_level: 'elevated' },
+      uploaderEnforcement: { approval_required: false, relay_banned: true }
+    }, { fetchFn });
+
+    expect(result.name).toBe('Alice');
+    expect(result.stats.totalScanned).toBe(5);
+    expect(result.social.followerCount).toBe(100);
+    expect(result.enforcement.relayBanned).toBe(true);
+  });
+
+  it('returns local-only context when api.divine.video fails', async () => {
+    const result = await buildCreatorContext({
+      pubkey: 'f'.repeat(64),
+      uploaderStats: { total_scanned: 2, flagged_count: 0, risk_level: 'normal' },
+      uploaderEnforcement: { approval_required: false, relay_banned: false }
+    }, {
+      fetchFn: vi.fn().mockRejectedValue(new Error('boom'))
+    });
+
+    expect(result.stats.totalScanned).toBe(2);
+    expect(result.social).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- src/admin/creator-context.test.mjs src/index.test.mjs`
+
+Expected: FAIL because `buildCreatorContext` is missing and admin payloads do not expose `creatorContext`.
+
+- [ ] **Step 3: Implement creator-context helper**
+
+```js
+const FUNNEL_BASE_URL = 'https://api.divine.video';
+
+export async function buildCreatorContext(input, { fetchFn = fetch } = {}) {
+  const { pubkey, uploaderStats, uploaderEnforcement } = input;
+  if (!pubkey) return null;
+
+  // Fetch /api/users/{pubkey} and /api/users/{pubkey}/social in parallel.
+  // Merge public profile/social data with local moderation stats.
+  // Never throw on remote failures; return local-only context instead.
+}
+```
+
+- [ ] **Step 4: Thread creator context through admin payload builders**
+
+Update `src/index.mjs` to:
+- call `buildCreatorContext` in focused lookup enrichment
+- include `creatorContext` in dashboard list items when a pubkey is present
+- preserve full pubkey for profile links instead of relying only on truncated display values
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npm test -- src/admin/creator-context.test.mjs src/index.test.mjs`
+
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/admin/creator-context.mjs src/admin/creator-context.test.mjs src/index.mjs src/index.test.mjs
+git commit -m "feat: enrich admin videos with creator context"
+```
+
+## Chunk 3: Propagate Provenance Through Admin APIs
+
+### Task 3: Return normalized provenance in all admin video shapes
+
+**Files:**
+- Modify: `src/index.mjs`
+- Modify: `src/index.test.mjs`
+
+- [ ] **Step 1: Write/extend failing admin API tests**
+
+Add assertions to existing admin lookup/list tests:
+
+```js
+expect(body.video.provenance).toMatchObject({
+  status: 'original_vine',
+  isPre2022: true,
+  isOriginalVine: true
+});
+
+expect(body.video.provenance.reasons).toContain('platform:vine');
+expect(body.video.creatorContext.stats.totalScanned).toBe(3);
+```
+
+Also add a list-route test that verifies `publishedAt` survives into the returned payload and is not replaced by `receivedAt`.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- src/index.test.mjs`
+
+Expected: FAIL because `/admin/api/video/:id`, `/admin/api/videos`, and swipe-review data do not include the normalized objects.
+
+- [ ] **Step 3: Implement payload normalization**
+
+For each backend path that returns admin videos:
+- build `provenance` from preserved Nostr/import metadata
+- attach `creatorContext`
+- keep raw timestamps available for operational use
+- ensure provenance is computed once per item, not re-derived in frontend code
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- src/index.test.mjs`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/index.mjs src/index.test.mjs
+git commit -m "feat: expose provenance on admin video payloads"
+```
+
+## Chunk 4: Render Provenance And Creator Info In Admin UI
+
+### Task 4: Add provenance badges and Creator Info affordance to dashboard
+
+**Files:**
+- Modify: `src/admin/dashboard.html`
+
+- [ ] **Step 1: Write a failing regression test for dashboard UI hooks**
+
+Create a lightweight test that reads the dashboard HTML and asserts the expected hooks exist:
+
+```js
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+describe('dashboard provenance UI', () => {
+  it('contains creator info modal hooks', () => {
+    const html = readFileSync(new URL('./dashboard.html', import.meta.url), 'utf8');
+    expect(html).toContain('Creator Info');
+    expect(html).toContain('openCreatorInfo');
+    expect(html).toContain('provenance');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/admin/dashboard-ui.test.mjs`
+
+Expected: FAIL because the new hooks/labels do not exist yet.
+
+- [ ] **Step 3: Implement dashboard rendering**
+
+Add to each card:
+- provenance badge
+- provenance support line with date source
+- `Creator Info` button
+
+Add a shared modal/popover renderer that shows:
+- creator name/avatar/pubkey
+- Divine profile link
+- local moderation counters/risk/enforcement badges
+- Funnelcake social stats when available
+- provenance evidence details and reasons
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/admin/dashboard-ui.test.mjs`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/admin/dashboard.html src/admin/dashboard-ui.test.mjs
+git commit -m "feat: show provenance and creator info in dashboard"
+```
+
+### Task 5: Add the same provenance and Creator Info affordance to swipe review
+
+**Files:**
+- Modify: `src/admin/swipe-review.html`
+
+- [ ] **Step 1: Write a failing regression test for swipe-review UI hooks**
+
+Use the same HTML-file assertion pattern for:
+- `Creator Info`
+- provenance badge/support text
+- modal/popover open function
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/admin/swipe-review-ui.test.mjs`
+
+Expected: FAIL because swipe review does not include the new hooks.
+
+- [ ] **Step 3: Implement swipe-review rendering**
+
+Render the normalized provenance summary from backend payloads and reuse the creator-info UI pattern from dashboard, keeping card density intact.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/admin/swipe-review-ui.test.mjs`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/admin/swipe-review.html src/admin/swipe-review-ui.test.mjs
+git commit -m "feat: show provenance and creator info in swipe review"
+```
+
+## Chunk 5a: Divine-Inquisitor Client
+
+### Task 6a: Build the inquisitor HTTP client with failing tests first
+
+**Files:**
+- Create: `src/moderation/inquisitor-client.test.mjs`
+- Create: `src/moderation/inquisitor-client.mjs`
+- Modify: `wrangler.toml`
+
+- [ ] **Step 1: Write the failing inquisitor-client unit tests**
+
+Tests should cover:
+- URL-mode request shape (`POST`, `Content-Type: application/json`, body `{url, mime_type}`)
+- Successful response parsing into normalized state: `valid_proofmode`, `valid_c2pa`, `valid_ai_signed`, `invalid`, `absent`
+- `is_proofmode=true && valid=true` → state `valid_proofmode`
+- `valid=true && !is_proofmode && claim_generator` matches AI-tool pattern → state `valid_ai_signed`
+- `valid=true && !is_proofmode` with neutral claim_generator → state `valid_c2pa`
+- `has_c2pa=true && valid=false` → state `invalid`
+- `has_c2pa=false` → state `absent`
+- Timeout/network error → state `unchecked` with error captured, never throws
+- Honors configured base URL and request timeout
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- src/moderation/inquisitor-client.test.mjs`
+
+Expected: FAIL because `inquisitor-client.mjs` does not exist.
+
+- [ ] **Step 3: Implement the client**
+
+Keep it thin — mirror the shape of `src/moderation/realness-client.mjs` (separate concerns: network call, response normalization, error-to-state mapping). Normalize into:
+
+```js
+{
+  state: 'valid_proofmode' | 'valid_c2pa' | 'valid_ai_signed' | 'invalid' | 'absent' | 'unchecked',
+  hasC2pa: boolean,
+  valid: boolean,
+  isProofmode: boolean,
+  validationState: string,
+  claimGenerator: string | null,
+  captureDevice: string | null,
+  captureTime: string | null,
+  signer: string | null,
+  assertions: string[],
+  verifiedAt: string,
+  checkedAt: string,
+  error: string | null
+}
+```
+
+Known AI claim-generator substrings to watch for (case-insensitive): `adobe firefly`, `dall·e`, `dall-e`, `midjourney`, `stable diffusion`, `sora`, `runway`, `ideogram`. Keep the list in one place for easy edits.
+
+- [ ] **Step 4: Add wrangler binding**
+
+Add `INQUISITOR_BASE_URL` to `wrangler.toml` vars. Document the expected value format in a comment.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npm test -- src/moderation/inquisitor-client.test.mjs`
+
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/moderation/inquisitor-client.mjs src/moderation/inquisitor-client.test.mjs wrangler.toml
+git commit -m "feat: add divine-inquisitor C2PA verification client"
+```
+
+## Chunk 5b: Pipeline Integration + ProofMode + Signed-AI Enforcement Rules
+
+### Task 6b: Wire inquisitor into the pipeline and implement the two enforcement rules
+
+**Files:**
+- Modify: `src/moderation/pipeline.mjs`
+- Modify: `src/moderation/pipeline.test.mjs`
+- Modify: `src/admin/provenance.mjs` (attach proofmode result into the provenance object)
+- Modify: `src/admin/provenance.test.mjs`
+
+- [ ] **Step 1: Write failing pipeline tests for both enforcement rules**
+
+Cover every row of the policy table in `policy_proofmode_ai.md`. The pipeline's call order is inquisitor → then Hive only if not short-circuited.
+
+Signed-AI short-circuit (inquisitor-first):
+- `valid_ai_signed` returned by inquisitor → action = QUARANTINE, **Hive is never called**, Reality Defender is not scheduled. Assert the Hive mock receives zero calls. The reason string includes the claim_generator.
+- `valid_ai_signed` also works when Hive would have flagged (assert short-circuit still skips Hive — the order matters).
+
+ProofMode downgrade (post-Hive):
+- `valid_proofmode` + Hive flags AI → Hive IS called, then action downgrades from QUARANTINE to REVIEW.
+- `valid_proofmode` + Hive does NOT flag AI → action stays SAFE.
+
+Fall-through (Hive runs as today):
+- `valid_c2pa` + Hive flags AI → action stays QUARANTINE.
+- `valid_c2pa` + Hive does NOT flag AI → action stays SAFE.
+- `invalid` + Hive flags AI → action stays QUARANTINE.
+- `invalid` + Hive does NOT flag AI → action stays SAFE (invalid alone does not escalate).
+- `absent` + Hive flags AI → action stays QUARANTINE.
+- `unchecked` (inquisitor timeout/error) → Hive IS called, action determined by Hive as today. `unchecked` is treated as absent — never block moderation on verification latency, and never short-circuit Hive.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- src/moderation/pipeline.test.mjs`
+
+Expected: FAIL — pipeline does not call inquisitor or apply either rule yet.
+
+- [ ] **Step 3: Implement pipeline integration**
+
+Changes in `src/moderation/pipeline.mjs` — the new call order is inquisitor-first with a short-circuit:
+
+1. **Call inquisitor first** (`POST /verify`, URL mode, against the media.divine.video URL). Apply the realness-client timeout discipline — never block moderation on verification failure; on timeout/error, record state `unchecked` and continue.
+2. Cache the inquisitor result in KV under `c2pa:{sha256}` with a 30-day TTL.
+3. **Signed-AI short-circuit:** if C2PA state is `valid_ai_signed`, set action = QUARANTINE, reason = `c2pa-ai-signed:{claimGenerator}`, **return early — do not call Hive, do not schedule Reality Defender polling**. Persist the moderation record with a marker that this path was taken so the admin payload can show which rule fired.
+4. **Otherwise, call Hive** as today and run classify() to produce the proposed action.
+5. **ProofMode downgrade:** if the proposed action is QUARANTINE and the AI-driven reason triggered it (Hive `ai_generated`/`deepfake`, or RD confirming AI), AND C2PA state is `valid_proofmode`, downgrade action to REVIEW and append reason like `proofmode-capture-authenticated`.
+6. Persist the normalized C2PA object on the moderation record so the admin payload can return it without re-verifying.
+
+The two rules are mutually exclusive by construction: `valid_proofmode` requires `is_proofmode=true`, and `valid_ai_signed` requires the claim_generator to be an AI tool (capture tools and AI tools do not overlap). Add a test to prove both cannot fire on the same record, and a test asserting the Hive mock receives zero calls on the `valid_ai_signed` path.
+
+- [ ] **Step 4: Attach proofmode into the provenance object**
+
+In `src/admin/provenance.mjs`, accept an optional `proofmode` input and emit it on the returned object as `provenance.proofmode`. Add tests for the three representative states (valid_proofmode, invalid, absent).
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npm test -- src/moderation/pipeline.test.mjs src/admin/provenance.test.mjs`
+
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/moderation/pipeline.mjs src/moderation/pipeline.test.mjs src/admin/provenance.mjs src/admin/provenance.test.mjs
+git commit -m "feat: C2PA pipeline integration with ProofMode downgrade and signed-AI upgrade rules"
+```
+
+## Chunk 5c: Dashboard ProofMode Badge
+
+### Task 6c: Render ProofMode state as a distinct badge alongside the age-origin badge
+
+**Files:**
+- Modify: `src/admin/dashboard.html`
+- Modify: `src/admin/swipe-review.html`
+- Modify: `src/admin/dashboard-ui.test.mjs` (from earlier Task 4)
+- Modify: `src/admin/swipe-review-ui.test.mjs` (from earlier Task 5)
+
+- [ ] **Step 1: Extend UI-hook tests**
+
+Assert the HTML contains:
+- a proofmode-badge hook (id/class)
+- label text for each state: `Valid ProofMode`, `Valid C2PA`, `Valid but AI-signed`, `Invalid Proof`
+- a supporting-line pattern like `ProofMode captured` when capture_time and capture_device are present
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- src/admin/dashboard-ui.test.mjs src/admin/swipe-review-ui.test.mjs`
+
+Expected: FAIL.
+
+- [ ] **Step 3: Implement UI rendering**
+
+- Render the ProofMode badge independently from the age-origin badge — they measure different things and should both be visible when both are informative.
+- Hide the ProofMode badge entirely when `state === "absent"` (most content).
+- Use distinct visual weight: `valid_proofmode` green, `valid_c2pa` blue, `valid_ai_signed` orange, `invalid` gray.
+- Expose full C2PA detail (signer, assertions, validation results) inside the existing `Creator Info` modal, not on the card.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- src/admin/dashboard-ui.test.mjs src/admin/swipe-review-ui.test.mjs`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/admin/dashboard.html src/admin/swipe-review.html src/admin/dashboard-ui.test.mjs src/admin/swipe-review-ui.test.mjs
+git commit -m "feat: show ProofMode and C2PA state on moderation cards"
+```
+
+## Chunk 5: Full Verification
+
+### Task 6: Run focused verification and capture manual checks
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-04-14-provenance-and-creator-context-design.md` (only if implementation changed the design)
+
+- [ ] **Step 1: Run the focused automated suite**
+
+Run:
+
+```bash
+npm test -- src/admin/provenance.test.mjs src/admin/creator-context.test.mjs src/nostr/relay-client.test.mjs src/index.test.mjs src/admin/dashboard-ui.test.mjs src/admin/swipe-review-ui.test.mjs
+```
+
+Expected: PASS
+
+- [ ] **Step 2: Run the broader suite before handoff**
+
+Run: `npm test`
+
+Expected: PASS
+
+- [ ] **Step 3: Manually verify in the admin UI**
+
+Check:
+- a known original Vine shows `Original Vine`
+- a known pre-2022 non-Vine import shows `Pre-2022 Legacy`
+- a modern or unknown sample shows `Unknown Provenance`
+- `Creator Info` opens in both dashboard and swipe review
+- external `api.divine.video` failure still leaves local moderation stats visible
+
+- [ ] **Step 4: Commit any final polish**
+
+```bash
+git add src/admin src/index.mjs src/index.test.mjs src/nostr/relay-client.mjs src/nostr/relay-client.test.mjs
+git commit -m "test: verify provenance and creator context rollout"
+```

--- a/docs/superpowers/specs/2026-04-10-classic-vine-age-restriction-downgrade-design.md
+++ b/docs/superpowers/specs/2026-04-10-classic-vine-age-restriction-downgrade-design.md
@@ -1,0 +1,48 @@
+# Classic Vine Age Restriction Downgrade Design
+
+## Summary
+
+Legacy Vine imports are still carrying stale machine-applied moderation outcomes that are too restrictive. The new operational policy is to downgrade eligible machine-applied non-`SAFE` legacy Vine rows to `AGE_RESTRICTED`, while skipping anything with evidence of human or trust-and-safety review.
+
+## Goal
+
+Add an operational script that:
+
+- discovers legacy Vine imports from live relay data
+- resolves their blob SHA-256 from `x` / `imeta x`
+- checks current moderation state
+- skips anything with human-review signals
+- downgrades remaining machine-applied non-`SAFE` rows to `AGE_RESTRICTED`
+
+## Approach
+
+Use a new script in `scripts/` with preview and execute modes.
+
+Discovery:
+- query kind `34236` events from the relay
+- confirm classic Vine via `platform=vine`, archive client markers, `vine.co` source URL, or pre-2018 archive metadata
+- extract media SHA from `imeta x` or `x`
+
+Eligibility:
+- current moderation decision exists
+- current action is not `SAFE`
+- skip if `reviewed_by` is set
+- skip if `review_notes` is set
+- skip if no moderation row exists
+
+Execution:
+- call existing authenticated `/api/v1/moderate` with `action = AGE_RESTRICTED`
+- store checkpoints and a JSON report for resumable runs
+
+## Constraints
+
+- Do not change legacy Vine event format.
+- Do not override rows with human/T&S review evidence.
+- Do not add a new bulk endpoint in this patch unless forced by missing API surface.
+- Keep the default mode as preview.
+
+## Verification
+
+- Unit tests cover classic-Vine discovery and eligibility filtering.
+- Unit tests prove rows with `reviewed_by` or `review_notes` are skipped.
+- Unit tests prove eligible rows generate `AGE_RESTRICTED` updates.

--- a/docs/superpowers/specs/2026-04-10-legacy-vine-sha-rollback-discovery-design.md
+++ b/docs/superpowers/specs/2026-04-10-legacy-vine-sha-rollback-discovery-design.md
@@ -1,0 +1,31 @@
+# Legacy Vine SHA Rollback Discovery Design
+
+## Summary
+
+Legacy Vine imports intentionally use the Nostr `d` tag for the Vine ID, not the media SHA-256. The classic Vine rollback path currently tries to resolve archive events by querying `#d = sha256`, which misses those events and leaves stale moderation enforcement in place.
+
+## Goal
+
+Allow the classic Vine rollback flow to resolve legacy Vine archive events by media SHA-256 using the event's `x` tag or `imeta x` value, without changing the event format or legacy Vine policy.
+
+## Approach
+
+Add a relay lookup helper that finds kind `34235`/`34236` events by scanning returned events for a matching blob hash in:
+
+- top-level `x` tags
+- `imeta` parameters with `x <sha256>`
+
+Then update the classic Vine rollback helper to use that SHA-aware lookup instead of assuming `d = sha256`.
+
+## Constraints
+
+- Keep legacy Vine event shape unchanged: `d = vine_id` remains intentional.
+- Do not broaden moderation policy in this patch.
+- Do not re-run paid moderation providers.
+- Keep the fix scoped to relay lookup and rollback discovery.
+
+## Verification
+
+- A failing test proves a legacy Vine event with `d = vine_id` and `x = sha256` is discoverable by SHA.
+- A failing test proves rollback candidate resolution accepts that event as a classic Vine.
+- Existing rollback tests remain green.

--- a/docs/superpowers/specs/2026-04-14-provenance-and-creator-context-design.md
+++ b/docs/superpowers/specs/2026-04-14-provenance-and-creator-context-design.md
@@ -7,7 +7,7 @@ Moderators need a reliable way to tell whether a video is likely original legacy
 1. Is this likely an original Vine or other pre-2022 legacy upload?
 2. Who posted it, and what is their moderation and platform history?
 
-This change is guidance-only for now. It does not automatically suppress or downgrade AI-generated moderation outcomes.
+This design was originally guidance-only. As of 2026-04-17 it also covers a single targeted enforcement change for C2PA ProofMode: a cryptographically-valid ProofMode capture attestation downgrades a Hive/RD AI-driven QUARANTINE to REVIEW so a human decides. All other provenance surfaces remain guidance-only. See the "ProofMode Enforcement" section below.
 
 ## Goals
 
@@ -19,7 +19,8 @@ This change is guidance-only for now. It does not automatically suppress or down
 
 ## Non-Goals
 
-- Automatically changing moderation actions based on provenance.
+- Automatically changing moderation actions based on provenance, **except** the one targeted rule in "ProofMode Enforcement" below.
+- Using generic C2PA validity (non-ProofMode, non-capture-authenticated) to rebut AI detectors — C2PA happily signs AI-generated manifests.
 - Inventing creator metrics we cannot source authoritatively.
 - Using creator-only analytics endpoints that require the creator's own NIP-98 auth.
 
@@ -90,15 +91,73 @@ Guardrails:
 - `proofmode` can support `pre_2022_legacy` but does not by itself imply `original_vine`.
 - UI copy must always disclose the evidence source used.
 
-### Proofmode Support
+### ProofMode / C2PA Verification
 
-The current service does not yet parse `proofmode`, but the provenance model should reserve space for it. When present, preserve:
+Verification is performed by `divine-inquisitor` (Rust microservice at `github.com/divinevideo/divine-inquisitor`), **not** by `proofsign.divine.video` (which is the signing side only, no verify endpoint). Divine-moderation-service calls inquisitor with the media URL and normalizes the response into `provenance.proofmode`.
 
-- proof timestamp
-- proof source/device if available
-- proof or attestation reference/hash if available
+`provenance.proofmode` shape (replaces the earlier null placeholder):
 
-This allows imported authenticity evidence to become part of provenance without redesigning the API again.
+```json
+{
+  "state": "valid_proofmode | valid_c2pa | valid_ai_signed | invalid | absent | unchecked",
+  "hasC2pa": true,
+  "valid": true,
+  "isProofmode": true,
+  "validationState": "valid",
+  "claimGenerator": "ProofMode/1.1.9 Android/14",
+  "captureDevice": "Google Pixel 8 Pro",
+  "captureTime": "2024:07:22 14:33:51",
+  "signer": "...Issuer DN... (moderator-only)",
+  "assertions": ["stds.exif", "org.proofmode.location", "c2pa.hash.data"],
+  "verifiedAt": "2026-04-17T10:00:00.000Z",
+  "checkedAt": "2026-04-17T10:00:00.000Z"
+}
+```
+
+Normalization of `state` (derived from inquisitor response):
+
+- `valid_proofmode` — `has_c2pa=true && valid=true && is_proofmode=true`. The strong capture-authenticity signal.
+- `valid_c2pa` — `has_c2pa=true && valid=true && !is_proofmode` and `claim_generator` does not match a known AI tool. Generic authenticated provenance.
+- `valid_ai_signed` — `has_c2pa=true && valid=true` and `claim_generator` matches a known AI-generation tool (Adobe Firefly, DALL·E, etc.). Valid signature, but the signature itself asserts AI origin.
+- `invalid` — `has_c2pa=true && valid=false`. Manifest present but signature check failed. Often innocent (transcoding, clock skew, buggy app) — treat as neutral.
+- `absent` — `has_c2pa=false`. No manifest. The default for most content.
+- `unchecked` — verification failed (inquisitor timeout/error) or not yet run.
+
+### Inquisitor API Contract (summary)
+
+`POST /verify` on divine-inquisitor accepts:
+
+- JSON mode: `Content-Type: application/json`, body `{url, mime_type}`. Inquisitor range-fetches up to `RANGE_FETCH_BYTES` (default 2 MB) from the URL. Typical 100-500 ms.
+- Bytes mode: raw body, `x-mime-type` header, optional `x-content-hash`. Typical <50 ms.
+
+Response fields consumed: `has_c2pa`, `valid`, `validation_state`, `is_proofmode`, `claim_generator`, `capture_device`, `capture_time`, `signer`, `signature_info`, `assertions`, `actions`, `ingredients`, `verified_at`, `content_hash`, `error`. Full schema in `reference_divine_inquisitor.md` (project memory).
+
+### ProofMode / C2PA Enforcement
+
+Two targeted, automatic moderation-action rules are driven by provenance. Both are independent of each other and of Hive/RD.
+
+**Rule 1 — ProofMode downgrade:**
+If Hive AI or Reality Defender flag a video as AI-generated AND `provenance.proofmode.state === "valid_proofmode"`, the moderation action downgrades from QUARANTINE to REVIEW. The video stays visible to users while it sits in the moderator review queue.
+
+**Rule 2 — Signed-AI short-circuit:**
+If `provenance.proofmode.state === "valid_ai_signed"` (valid C2PA signature whose `claim_generator` is a known AI-generation tool — Adobe Firefly, DALL·E, Midjourney, Stable Diffusion, Sora, Runway, Ideogram, etc.), the moderation action is forced to QUARANTINE and **Hive is not called at all**. Reality Defender is also skipped. The tool's own cryptographic declaration is authoritative AI evidence, so paying for Hive or polling RD adds cost and latency with no new information. The pipeline call order is therefore: inquisitor first, then short-circuit to QUARANTINE on `valid_ai_signed`, otherwise continue into the existing Hive/RD flow. Humans review every signed-AI QUARANTINE for labeling or approval.
+
+This loses Hive's non-AI category scores (nudity, violence, self-harm) on signed-AI content. That's an acceptable trade because moderators review every QUARANTINE manually, the volume of signed-AI content should be small, and an opt-in Hive call can be added at review time if a moderator wants those scores.
+
+All other states (`valid_c2pa`, `invalid`, `absent`, `unchecked`) fall through to the existing Hive/RD routing — no auto-downgrade, no auto-escalate.
+
+Rationale:
+- `valid_c2pa` without ProofMode does not rebut AI detection (generic C2PA can sign AI manifests), but it also doesn't imply AI — it's a neutral "authenticated provenance" signal.
+- `invalid` is dominated by non-malicious causes (transcoding strips signatures, buggy capture apps, clock skew, re-encoding pipeline) — escalating on invalid would punish the wrong users, including penalizing our own pipeline for stripping signatures.
+- `unchecked` means inquisitor timed out or errored — we treat it as absent and never block moderation on verification latency.
+
+The dashboard surfaces every state as a distinct badge so moderators can spot patterns (e.g. a user consistently producing invalid proofs) even though the system doesn't auto-act on every state.
+
+### Caching and Triggering
+
+- Verification runs in the moderation pipeline on ingest, alongside the Hive submission, with the result persisted to the moderation record and cached in KV under `c2pa:{sha256}` for 30 days. Do not re-verify on every admin render.
+- Re-verify on demand only when a moderator hits a dashboard control or when the cache is empty.
+- On inquisitor timeout/error, record `state: "unchecked"` and fall through to default routing — never block moderation on verification latency.
 
 ### Creator Context Model
 
@@ -147,17 +206,27 @@ Do not depend on `GET /api/users/{pubkey}/analytics`, because it requires creato
 
 ### Card-Level Provenance
 
-Every moderation card in dashboard and swipe review should display:
+Every moderation card in dashboard and swipe review should display two independent badges — an age/origin badge and a ProofMode badge — because they measure different things.
 
-- a prominent badge:
-  `Original Vine`, `Pre-2022 Legacy`, or `Unknown Provenance`
-- a supporting line:
-  - `Published Aug 21, 2014 via published_at`
-  - `Proofmode Jun 3, 2019`
-  - `Posted Nov 18, 2021 via Nostr`
-  - `Unknown provenance`
+Age/origin badge (one of):
+- `Original Vine`
+- `Pre-2022 Legacy`
+- `Unknown Provenance`
 
-`Original Vine` and `Pre-2022 Legacy` should visually read as "AI unlikely" without changing scoring behavior. `Unknown Provenance` should stay neutral.
+ProofMode / C2PA badge (one of):
+- `Valid ProofMode` (green — capture-authenticated, only this state downgrades AI quarantine)
+- `Valid C2PA` (blue — authenticated provenance, neutral for enforcement)
+- `Valid but AI-signed` (orange — valid signature claims AI origin)
+- `Invalid Proof` (gray — often transcoding or clock skew, informational only)
+- no badge when `state === "absent"` (most content)
+
+Supporting line beneath the badges:
+- `Published Aug 21, 2014 via published_at`
+- `ProofMode captured 2024:07:22 on Google Pixel 8 Pro`
+- `Posted Nov 18, 2021 via Nostr`
+- `Unknown provenance`
+
+`Original Vine`, `Pre-2022 Legacy`, and `Valid ProofMode` should visually read as "AI unlikely" without changing scoring behavior (except the one ProofMode enforcement rule above). `Unknown Provenance`, `Valid C2PA`, and `Invalid Proof` should stay neutral.
 
 ### Creator Info Affordance
 
@@ -193,7 +262,7 @@ When building admin payloads, preserve:
 - `createdAt` / `event.created_at`
 - Vine metadata fields
 - source URL
-- proofmode fields when present
+- C2PA / ProofMode verification result fetched from divine-inquisitor and normalized into `provenance.proofmode`
 
 Existing D1 persistence of `published_at` remains useful, but the admin response builders must stop dropping it.
 

--- a/docs/superpowers/specs/2026-04-17-divine-content-policy-v0.md
+++ b/docs/superpowers/specs/2026-04-17-divine-content-policy-v0.md
@@ -1,0 +1,151 @@
+# Divine Content Policy v0 (gpt-oss-safeguard prompt)
+
+Starter policy doc for evaluating gpt-oss-safeguard against Divine's moderation corpus.
+Follows the four-section format from the OpenAI cookbook guide
+(Instructions / Definitions / Criteria / Examples). The model reads this doc plus a
+per-video content bundle (Hive scores, Hive VLM description, title, tags, transcript,
+creator context) and returns a structured action.
+
+This is v0 — meant to be run against an exported eval set, diffed against human
+ground-truth decisions, and iterated in PRs before any production wiring.
+
+---
+
+## Divine Content Policy (#DCP)
+
+### INSTRUCTIONS
+
+You are the content moderator for Divine, a creator-focused short-video platform
+(including the Classic Vine archive from 2013–2017). Classify the supplied video into
+exactly one action per this policy. Output a JSON object with these fields:
+
+```
+{
+  "action":     "SAFE" | "REVIEW" | "AGE_RESTRICTED" | "QUARANTINE" | "PERMANENT_BAN",
+  "category":   "<short label, e.g. sexual, porn, self-harm, ai-generated, hate>",
+  "confidence": "low" | "medium" | "high",
+  "rationale":  "<1–3 sentences explaining the decision against this policy>"
+}
+```
+
+Ground the rationale in: the Hive VLM scene description, explicit policy clauses, and
+any contextual signals (Classic Vine era, creative framing, creator history). Do not
+invent facts absent from the bundle. If evidence is thin, prefer REVIEW over guessing.
+
+### DEFINITIONS
+
+- **Creative nudity**: non-sexualized nudity in artistic, educational, documentary,
+  athletic, or cultural context (classical sculpture, body painting, life drawing,
+  breastfeeding, beach/pool, shirtless athletic activity).
+- **Sexualized content**: nudity or suggestive behavior whose primary purpose is
+  sexual arousal (camera focus on genitals/breasts, sexual acts, simulated sex,
+  sexually posed undressing).
+- **Classic Vine content**: kind 34236 events archiving 2013–2017 Vine uploads.
+  Evaluated under relaxed norms reflecting the era's comedy conventions (slapstick,
+  cartoon violence, crude humor). Identifiable by metadata: author field, pre-2018
+  `published_at`, and/or "vine" in tags or title.
+- **Targeting**: content naming, depicting, or directing action at an identifiable
+  individual with apparent intent to harass, threaten, or incite harassment against
+  them.
+- **CSAM indicators**: any content involving, depicting, suggesting, or sexualizing
+  minors. Err on the side of over-flagging — human review is the safety net.
+- **AI-generated**: content flagged by Hive AI detection. A Hive flag alone is
+  enough to QUARANTINE pending Reality Defender secondary verification. If RD
+  confirms at medium/high confidence, stays QUARANTINE. If RD returns clean,
+  downgrade to SAFE. Matches production behavior as of 2026-04-17.
+
+### CRITERIA
+
+#### DCP0 — SAFE
+
+Default when no policy rule fires. Includes:
+
+- Skateboarding, sports, comedy, music, art, vlogs, food, animals, travel
+- Creative nudity (see definition) regardless of Hive `nudity` score
+- Shirtless/topless non-sexual content, swimwear, beach, breastfeeding
+- Classic Vine slapstick, pratfalls, crude-but-non-hateful humor
+- Cartoon or clearly non-real violence
+- Mature themes discussed without graphic depiction
+
+**Output:** `SAFE`
+
+#### DCP1 — REVIEW
+
+Genuinely ambiguous cases that warrant human review. Use sparingly; the point of
+this policy is to resolve the borderline, not punt. Reasonable triggers:
+
+- VLM description is too sparse or contradictory to apply the criteria
+- Conflicting signals (e.g., Hive says porn, VLM describes medical/educational)
+- Novel pattern not covered by examples below
+
+**Output:** `REVIEW`
+
+#### DCP2 — AGE_RESTRICTED
+
+Content that is not safe for all audiences but is legal and permitted on Divine
+behind a maturity gate. Examples:
+
+- Sexually suggestive content that stops short of explicit acts
+- Twerking, grinding, or sexualized dancing in a clearly sexual context
+- Sexualized display of underwear, lingerie, or tiny swimwear
+- **Tobacco, alcohol, or recreational drug use depicted on-camera** — AGE_RESTRICTED
+  regardless of Hive score magnitude. Never QUARANTINE or PERMANENT_BAN these.
+- Strong profanity or mature themes as the primary focus
+- Graphic real-world injury footage (news, sports injuries) without gore
+- Sex-toy display in non-explicit context
+
+**Output:** `AGE_RESTRICTED`
+
+#### DCP3 — QUARANTINE
+
+Hidden from user feeds, visible only to moderators. Pending secondary review:
+
+- Sexualized nudity that is not clearly pornographic (full-frontal without
+  sexual context may land here pending review)
+- AI-generated/deepfake content flagged by Hive (stays here until Reality
+  Defender confirms or clears — see definition)
+- High-confidence self-harm content (detailed methods, glorification)
+- Extreme non-fatal violence or real gore without news/documentary framing
+
+**Output:** `QUARANTINE`
+
+#### DCP4 — PERMANENT_BAN
+
+Never permitted on Divine:
+
+- Pornography, explicit sex acts, simulated sex presented as porn
+- Any CSAM indicator (see definition) — always escalate
+- Naked flash mobs or other coordinated public sexual displays
+- Targeted harassment campaigns (see definition)
+- Hate content advocating violence against protected groups
+- Incitement to violence, credible threats
+
+**Output:** `PERMANENT_BAN` + flag `"escalate": true` in rationale
+
+### EXAMPLES
+
+1. **Input:** VLM: *"Nude male figure, marble sculpture, museum gallery lighting."*
+   Hive: `nudity=0.92, sexual=0.04`. Title: *"Michelangelo's David at the Accademia"*.
+   **Output:** `{"action":"SAFE","category":"creative-nudity","confidence":"high","rationale":"Classical sculpture in museum context; creative nudity per DCP definitions; Hive nudity score reflects anatomy, not sexualization."}`
+
+2. **Input:** VLM: *"Person skateboarding down handrail, falls hard onto concrete."*
+   Hive: `violence=0.55`. Classic Vine era (2015). Tags: `[skate, fail]`.
+   **Output:** `{"action":"SAFE","category":"sports","confidence":"high","rationale":"Skateboard accident footage is standard sports content; Classic Vine era relaxed norms apply; violence score reflects impact, not assault."}`
+
+3. **Input:** VLM: *"Woman in lingerie dancing, camera focuses on chest and hips."*
+   Hive: `sexual=0.7, nudity=0.4`. Title: *"new bedroom fit"*.
+   **Output:** `{"action":"AGE_RESTRICTED","category":"sexual-suggestive","confidence":"high","rationale":"Sexualized framing and suggestive dance per DCP2; not explicit enough for QUARANTINE but not safe for all audiences."}`
+
+4. **Input:** VLM: *"Two adults engaged in explicit sexual act."* Hive: `sexual=0.98, porn=0.95`.
+   **Output:** `{"action":"PERMANENT_BAN","category":"porn","confidence":"high","rationale":"Explicit sexual act matches DCP4 porn definition."}`
+
+5. **Input:** VLM: *"Teenage-looking person in swimwear, poolside."* Hive: `nudity=0.2, minor=0.65`.
+   **Output:** `{"action":"REVIEW","category":"possible-minor","confidence":"medium","rationale":"Apparent minor signal present; not sexualized in VLM description but requires human age verification before any automated action."}`
+
+6. **Input:** VLM: *"Close-up of fire pit, flames, embers, low-light setting."*
+   Hive: `ai_generated=0.96`. RD: not yet verified.
+   **Output:** `{"action":"QUARANTINE","category":"ai-generated","confidence":"high","rationale":"Hive flags AI-generated with high confidence; per DCP3 AI rule, quarantine pending Reality Defender confirmation. Will downgrade to SAFE if RD clears."}`
+
+7. **Input:** VLM: *"Person dancing on stairs while smoking, wearing orange pants, smiling."*
+   Hive: `tobacco=0.99, nudity=0.0, sexual=0.0`.
+   **Output:** `{"action":"AGE_RESTRICTED","category":"tobacco","confidence":"high","rationale":"Tobacco depicted on-camera per DCP2. Tobacco/drugs/alcohol always AGE_RESTRICTED on Divine, never quarantined or banned, regardless of score magnitude."}`

--- a/relay-llm-guide.md
+++ b/relay-llm-guide.md
@@ -1,0 +1,2714 @@
+- generic [ref=e2]:
+  - link "← Back to Documentation" [ref=e3] [cursor=pointer]:
+    - /url: /docs
+  - generic [ref=e4]:
+    - heading "FunnelCake API Guide for LLM Coding Agents" [level=1] [ref=e5]
+    - paragraph [ref=e6]: This document provides comprehensive information for AI coding agents to interact with FunnelCake - a Nostr video relay and analytics platform. Use this as a reference when building applications that integrate with divine.video.
+    - heading "Overview" [level=2] [ref=e7]
+    - paragraph [ref=e8]:
+      - strong [ref=e9]: FunnelCake
+      - text: "is a specialized Nostr relay for video content. It consists of:"
+    - list [ref=e10]:
+      - listitem [ref=e11]:
+        - strong [ref=e12]: WebSocket Relay
+        - text: "- Standard NIP-01 Nostr protocol for real-time event publishing and subscriptions"
+      - listitem [ref=e13]:
+        - strong [ref=e14]: REST API
+        - text: "- HTTP endpoints for analytics, search, and bulk operations"
+    - heading "Base URLs" [level=3] [ref=e15]
+    - table [ref=e16]:
+      - rowgroup [ref=e17]:
+        - row "Environment WebSocket REST API" [ref=e18]:
+          - columnheader "Environment" [ref=e19]
+          - columnheader "WebSocket" [ref=e20]
+          - columnheader "REST API" [ref=e21]
+      - rowgroup [ref=e22]:
+        - row "Production wss://relay.divine.video https://relay.divine.video/api/" [ref=e23]:
+          - cell "Production" [ref=e24]
+          - cell "wss://relay.divine.video" [ref=e25]:
+            - code [ref=e26]: wss://relay.divine.video
+          - cell "https://relay.divine.video/api/" [ref=e27]:
+            - code [ref=e28]: https://relay.divine.video/api/
+        - row "Staging wss://relay.staging.divine.video https://relay.staging.divine.video/api/" [ref=e29]:
+          - cell "Staging" [ref=e30]
+          - cell "wss://relay.staging.divine.video" [ref=e31]:
+            - code [ref=e32]: wss://relay.staging.divine.video
+          - cell "https://relay.staging.divine.video/api/" [ref=e33]:
+            - code [ref=e34]: https://relay.staging.divine.video/api/
+    - paragraph [ref=e35]:
+      - text: "Legacy staging alias:"
+      - code [ref=e36]: relay.staging.dvines.org
+      - text: currently points at the same service, but
+      - code [ref=e37]: relay.staging.divine.video
+      - text: is the preferred hostname for docs and client configuration.
+    - separator [ref=e38]
+    - heading "When to Use WebSocket vs REST" [level=2] [ref=e39]
+    - heading "Use WebSocket (NIP-01) for:" [level=3] [ref=e40]
+    - list [ref=e41]:
+      - listitem [ref=e42]:
+        - strong [ref=e43]: Publishing events
+        - text: "- All event creation goes through WebSocket"
+      - listitem [ref=e44]:
+        - strong [ref=e45]: Real-time subscriptions
+        - text: "- Live updates for new videos, comments, reactions"
+      - listitem [ref=e46]:
+        - strong [ref=e47]: Signature verification
+        - text: "- When you need cryptographically verifiable events"
+      - listitem [ref=e48]:
+        - strong [ref=e49]: Standard Nostr client operations
+        - text: "- Following the protocol spec"
+    - heading "Use REST API for:" [level=3] [ref=e50]
+    - list [ref=e51]:
+      - listitem [ref=e52]:
+        - strong [ref=e53]: Analytics and stats
+        - text: "- Engagement metrics, view counts, trending scores"
+      - listitem [ref=e54]:
+        - strong [ref=e55]: Bulk operations
+        - text: "- Fetching multiple videos/users in one request"
+      - listitem [ref=e56]:
+        - strong [ref=e57]: Search
+        - text: "- Full-text search and hashtag discovery"
+      - listitem [ref=e58]:
+        - strong [ref=e59]: Pre-computed data
+        - text: "- Denormalized views like"
+        - code [ref=e60]: author_avatar
+        - text: ", social counts"
+      - listitem [ref=e61]:
+        - strong [ref=e62]: Pagination
+        - text: "- Cursor-based pagination with"
+        - code [ref=e63]: next_cursor
+    - separator [ref=e64]
+    - heading "Nostr Protocol Basics" [level=2] [ref=e65]
+    - heading "Event Structure" [level=3] [ref=e66]
+    - paragraph [ref=e67]: "Every Nostr event has this structure:"
+    - code [ref=e69]: "{ \"id\": \"64-char-hex-sha256-of-serialized-event\", \"pubkey\": \"64-char-hex-public-key\", \"created_at\": 1700000000, \"kind\": 34236, \"tags\": [ [\"d\", \"unique-identifier\"], [\"title\", \"My Video\"], [\"t\", \"hashtag\"] ], \"content\": \"Description text\", \"sig\": \"128-char-hex-schnorr-signature\" }"
+    - heading "Computing Event ID" [level=3] [ref=e70]
+    - paragraph [ref=e71]:
+      - text: The
+      - code [ref=e72]: id
+      - text: "is SHA256 of the serialized event array (NOT the full object):"
+    - code [ref=e74]: "// Serialization format for ID computation: const serialized = JSON.stringify([ 0, // Always 0 event.pubkey, // 64-char hex pubkey event.created_at, // Unix timestamp (number) event.kind, // Kind number event.tags, // Tags array event.content // Content string ]); const id = sha256(serialized); // Returns 64-char hex"
+    - paragraph [ref=e75]:
+      - strong [ref=e76]: "Important:"
+      - text: "The serialization must be compact JSON (no extra whitespace). Special characters in content must be escaped:"
+      - code [ref=e77]: \n
+      - text: ","
+      - code [ref=e78]: \"
+      - text: ","
+      - code [ref=e79]: \\
+      - text: .
+    - 'heading "Key Formats: Hex vs Bech32 (npub/nsec)" [level=3] [ref=e80]'
+    - paragraph [ref=e81]:
+      - strong [ref=e82]: All API interactions use hex format (64 characters).
+    - paragraph [ref=e83]:
+      - text: Users often share keys in bech32 format (
+      - code [ref=e84]: npub1...
+      - text: ","
+      - code [ref=e85]: nsec1...
+      - text: "). Convert before API use:"
+    - code [ref=e87]: "// npub1qqqqqq... -> hex pubkey // Use a library like nostr-tools: import { nip19 } from 'nostr-tools'; const { data: hexPubkey } = nip19.decode('npub1...'); // hexPubkey is now \"abc123...\" (64 chars) // Or for event IDs: const { data: hexId } = nip19.decode('note1...'); // For nevent: const { data: { id: hexId } } = nip19.decode('nevent1...');"
+    - paragraph [ref=e88]:
+      - text: If you receive an
+      - code [ref=e89]: npub
+      - text: or
+      - code [ref=e90]: note
+      - text: from a user,
+      - strong [ref=e91]: always decode to hex
+      - text: before using with the API.
+    - heading "Supported Event Kinds" [level=3] [ref=e92]
+    - paragraph [ref=e93]: "FunnelCake accepts these event kinds:"
+    - table [ref=e94]:
+      - rowgroup [ref=e95]:
+        - row "Kind Name NIP Purpose" [ref=e96]:
+          - columnheader "Kind" [ref=e97]
+          - columnheader "Name" [ref=e98]
+          - columnheader "NIP" [ref=e99]
+          - columnheader "Purpose" [ref=e100]
+      - rowgroup [ref=e101]:
+        - row "0 Profile NIP-01 User metadata (name, avatar, bio)" [ref=e102]:
+          - cell "0" [ref=e103]
+          - cell "Profile" [ref=e104]
+          - cell "NIP-01" [ref=e105]
+          - cell "User metadata (name, avatar, bio)" [ref=e106]
+        - row "1 Text Note NIP-01 Legacy text posts" [ref=e107]:
+          - cell "1" [ref=e108]
+          - cell "Text Note" [ref=e109]
+          - cell "NIP-01" [ref=e110]
+          - cell "Legacy text posts" [ref=e111]
+        - row "3 Contact List NIP-02 Follow lists" [ref=e112]:
+          - cell "3" [ref=e113]
+          - cell "Contact List" [ref=e114]
+          - cell "NIP-02" [ref=e115]
+          - cell "Follow lists" [ref=e116]
+        - row "5 Deletion NIP-09 Delete events" [ref=e117]:
+          - cell "5" [ref=e118]
+          - cell "Deletion" [ref=e119]
+          - cell "NIP-09" [ref=e120]
+          - cell "Delete events" [ref=e121]
+        - row "6 Repost NIP-18 Simple reposts" [ref=e122]:
+          - cell "6" [ref=e123]
+          - cell "Repost" [ref=e124]
+          - cell "NIP-18" [ref=e125]
+          - cell "Simple reposts" [ref=e126]
+        - row "7 Reaction NIP-25 Likes/reactions" [ref=e127]:
+          - cell "7" [ref=e128]
+          - cell "Reaction" [ref=e129]
+          - cell "NIP-25" [ref=e130]
+          - cell "Likes/reactions" [ref=e131]
+        - row "16 Generic Repost NIP-18 Reshare any event" [ref=e132]:
+          - cell "16" [ref=e133]
+          - cell "Generic Repost" [ref=e134]
+          - cell "NIP-18" [ref=e135]
+          - cell "Reshare any event" [ref=e136]
+        - row "1111 Comment NIP-22 Comments on videos" [ref=e137]:
+          - cell "1111" [ref=e138]
+          - cell "Comment" [ref=e139]
+          - cell "NIP-22" [ref=e140]
+          - cell "Comments on videos" [ref=e141]
+        - row "10000 Mute List NIP-51 Blocked content" [ref=e142]:
+          - cell "10000" [ref=e143]
+          - cell "Mute List" [ref=e144]
+          - cell "NIP-51" [ref=e145]
+          - cell "Blocked content" [ref=e146]
+        - row "10003 Bookmark List NIP-51 Saved bookmarks" [ref=e147]:
+          - cell "10003" [ref=e148]
+          - cell "Bookmark List" [ref=e149]
+          - cell "NIP-51" [ref=e150]
+          - cell "Saved bookmarks" [ref=e151]
+        - row "30003 Bookmark Set NIP-51 Categorized bookmarks" [ref=e152]:
+          - cell "30003" [ref=e153]
+          - cell "Bookmark Set" [ref=e154]
+          - cell "NIP-51" [ref=e155]
+          - cell "Categorized bookmarks" [ref=e156]
+        - row "30005 Curation Set NIP-51 Video playlists" [ref=e157]:
+          - cell "30005" [ref=e158]
+          - cell "Curation Set" [ref=e159]
+          - cell "NIP-51" [ref=e160]
+          - cell "Video playlists" [ref=e161]
+        - row "34235 Horizontal Video NIP-71 Long-form video" [ref=e162]:
+          - cell "34235" [ref=e163]
+          - cell "Horizontal Video" [ref=e164]
+          - cell "NIP-71" [ref=e165]
+          - cell "Long-form video" [ref=e166]
+        - row "34236 Vertical Video NIP-71 Short-form video" [ref=e167]:
+          - cell "34236" [ref=e168]
+          - cell "Vertical Video" [ref=e169]
+          - cell "NIP-71" [ref=e170]
+          - cell "Short-form video" [ref=e171]
+        - row "34237 Video Chapters NIP-71 Chapter markers" [ref=e172]:
+          - cell "34237" [ref=e173]
+          - cell "Video Chapters" [ref=e174]
+          - cell "NIP-71" [ref=e175]
+          - cell "Chapter markers" [ref=e176]
+    - heading "Replaceable Events" [level=3] [ref=e177]
+    - list [ref=e178]:
+      - listitem [ref=e179]:
+        - strong [ref=e180]: Kinds 0, 3, 10000-19999
+        - text: ": Replaceable by pubkey - latest wins"
+      - listitem [ref=e181]:
+        - strong [ref=e182]: Kinds 30000-39999
+        - text: ": Parameterized replaceable - requires"
+        - code [ref=e183]: d
+        - text: tag
+        - list [ref=e184]:
+          - listitem [ref=e185]:
+            - text: "Address format:"
+            - code [ref=e186]: kind:pubkey:d-tag
+            - text: (e.g.,
+            - code [ref=e187]: 34236:abc123:my-video
+            - text: )
+          - listitem [ref=e188]:
+            - text: The relay REJECTS parameterized replaceable events missing a
+            - code [ref=e189]: d
+            - text: tag
+    - separator [ref=e190]
+    - heading "WebSocket Protocol (NIP-01)" [level=2] [ref=e191]
+    - heading "Connection" [level=3] [ref=e192]
+    - code [ref=e194]: const ws = new WebSocket('wss://relay.divine.video');
+    - heading "Client Messages" [level=3] [ref=e195]
+    - heading "EVENT - Publish an event" [level=4] [ref=e196]
+    - code [ref=e198]: "[\"EVENT\", <event-object>]"
+    - heading "REQ - Subscribe to events" [level=4] [ref=e199]
+    - code [ref=e201]: "[\"REQ\", \"<subscription-id>\", <filter1>, <filter2>, ...]"
+    - heading "CLOSE - Close subscription" [level=4] [ref=e202]
+    - code [ref=e204]: "[\"CLOSE\", \"<subscription-id>\"]"
+    - heading "COUNT - Count matching events (NIP-45)" [level=4] [ref=e205]
+    - code [ref=e207]: "[\"COUNT\", \"<subscription-id>\", <filter>]"
+    - heading "Relay Messages" [level=3] [ref=e208]
+    - heading "EVENT - Receive matching events" [level=4] [ref=e209]
+    - code [ref=e211]: "[\"EVENT\", \"<subscription-id>\", <event-object>]"
+    - heading "OK - Event publish result" [level=4] [ref=e212]
+    - code [ref=e214]: "[\"OK\", \"<event-id>\", true, \"\"] [\"OK\", \"<event-id>\", false, \"blocked: pubkey is banned\"]"
+    - heading "EOSE - End of stored events" [level=4] [ref=e215]
+    - code [ref=e217]: "[\"EOSE\", \"<subscription-id>\"]"
+    - paragraph [ref=e218]:
+      - strong [ref=e219]: "After EOSE:"
+      - text: The subscription stays open! You'll continue receiving new EVENT messages for any newly published events that match your filter. EOSE just means "I've sent you all the historical/stored events."
+    - heading "COUNT - Count response" [level=4] [ref=e220]
+    - code [ref=e222]: "[\"COUNT\", \"<subscription-id>\", {\"count\": 42}]"
+    - heading "CLOSED - Subscription closed" [level=4] [ref=e223]
+    - code [ref=e225]: "[\"CLOSED\", \"<subscription-id>\", \"rate limited\"]"
+    - heading "Filter Structure" [level=3] [ref=e226]
+    - code [ref=e228]: "{ \"ids\": [\"<id-prefix>\", ...], \"authors\": [\"<pubkey-prefix>\", ...], \"kinds\": [34235, 34236], \"#e\": [\"<event-id>\", ...], \"#p\": [\"<pubkey>\", ...], \"#t\": [\"hashtag\", ...], \"#d\": [\"identifier\", ...], \"since\": 1700000000, \"until\": 1700100000, \"limit\": 50, \"search\": \"full text query\" }"
+    - paragraph [ref=e229]:
+      - strong [ref=e230]: "Notes:"
+    - list [ref=e231]:
+      - listitem [ref=e232]:
+        - code [ref=e233]: ids
+        - text: and
+        - code [ref=e234]: authors
+        - text: must be exact 64-char hex strings
+      - listitem [ref=e235]:
+        - text: Tag filters use
+        - code [ref=e236]: "#"
+        - text: prefix (e.g.,
+        - code [ref=e237]: "#e"
+        - text: ","
+        - code [ref=e238]: "#p"
+        - text: ","
+        - code [ref=e239]: "#t"
+        - text: ","
+        - code [ref=e240]: "#d"
+        - text: )
+      - listitem [ref=e241]:
+        - code [ref=e242]: search
+        - text: enables NIP-50 full-text search
+    - 'heading "Example: Subscribe to Recent Videos" [level=3] [ref=e243]'
+    - code [ref=e245]: "[\"REQ\", \"videos-feed\", { \"kinds\": [34235, 34236], \"limit\": 50 }]"
+    - 'heading "Example: Subscribe to Comments on a Video" [level=3] [ref=e246]'
+    - code [ref=e248]: "[\"REQ\", \"video-comments\", { \"kinds\": [1111], \"#E\": [\"<video-event-id>\"] }]"
+    - separator [ref=e249]
+    - heading "Video Events (NIP-71)" [level=2] [ref=e250]
+    - heading "Structure" [level=3] [ref=e251]
+    - code [ref=e253]: "{ \"kind\": 34236, \"tags\": [ [\"d\", \"unique-video-id\"], [\"title\", \"My Amazing Video\"], [\"imeta\", \"url https://example.com/video.mp4\", \"m video/mp4\", \"dim 1080x1920\", \"duration 30\", \"x sha256hash\", \"image https://example.com/thumb.jpg\", \"size 5242880\", \"blurhash LEHV6nWB2yk8pyoJadR*.7kCMdnj\" ], [\"t\", \"nostr\"], [\"t\", \"bitcoin\"] ], \"content\": \"Video description here\" }"
+    - heading "Required Tags" [level=3] [ref=e254]
+    - table [ref=e255]:
+      - rowgroup [ref=e256]:
+        - row "Tag Description" [ref=e257]:
+          - columnheader "Tag" [ref=e258]
+          - columnheader "Description" [ref=e259]
+      - rowgroup [ref=e260]:
+        - row "d Unique identifier (REQUIRED for all parameterized replaceable)" [ref=e261]:
+          - cell "d" [ref=e262]:
+            - code [ref=e263]: d
+          - cell "Unique identifier (REQUIRED for all parameterized replaceable)" [ref=e264]
+        - row "title Video title" [ref=e265]:
+          - cell "title" [ref=e266]:
+            - code [ref=e267]: title
+          - cell "Video title" [ref=e268]
+        - row "Source Either imeta with url or legacy url tag" [ref=e269]:
+          - cell "Source" [ref=e270]
+          - cell "Either imeta with url or legacy url tag" [ref=e271]:
+            - text: Either
+            - code [ref=e272]: imeta
+            - text: with
+            - code [ref=e273]: url
+            - text: or legacy
+            - code [ref=e274]: url
+            - text: tag
+        - row "Thumbnail Either imeta with image, or thumb/thumbnail/image tag" [ref=e275]:
+          - cell "Thumbnail" [ref=e276]
+          - cell "Either imeta with image, or thumb/thumbnail/image tag" [ref=e277]:
+            - text: Either
+            - code [ref=e278]: imeta
+            - text: with
+            - code [ref=e279]: image
+            - text: ", or"
+            - code [ref=e280]: thumb
+            - text: /
+            - code [ref=e281]: thumbnail
+            - text: /
+            - code [ref=e282]: image
+            - text: tag
+    - heading "imeta Tag Format" [level=3] [ref=e283]
+    - paragraph [ref=e284]:
+      - text: The
+      - code [ref=e285]: imeta
+      - text: "tag packs media metadata in a single tag:"
+    - code [ref=e287]: "[\"imeta\", \"url <video-url>\", # Required \"m <mime-type>\", # video/mp4, video/webm, etc. \"dim <width>x<height>\", # Dimensions \"duration <seconds>\", # Duration in seconds \"x <sha256-hash>\", # File hash \"image <thumbnail-url>\", # Thumbnail \"size <bytes>\", # File size \"blurhash <hash>\", # Placeholder blur \"alt <description>\" # Accessibility text ]"
+    - separator [ref=e288]
+    - heading "Comment Events (NIP-22)" [level=2] [ref=e289]
+    - paragraph [ref=e290]: "Comments use uppercase tags for root scope and lowercase for parent:"
+    - code [ref=e292]: "{ \"kind\": 1111, \"tags\": [ [\"E\", \"<video-event-id>\"], [\"K\", \"34236\"], [\"P\", \"<video-author-pubkey>\"], [\"e\", \"<parent-event-id>\"], [\"k\", \"34236\"], [\"p\", \"<parent-author-pubkey>\"] ], \"content\": \"Great video!\" }"
+    - paragraph [ref=e293]:
+      - strong [ref=e294]: "Required tags:"
+    - list [ref=e295]:
+      - listitem [ref=e296]:
+        - code [ref=e297]: K
+        - text: "- Root event kind (the video)"
+      - listitem [ref=e298]:
+        - code [ref=e299]: k
+        - text: "- Parent event kind (video for top-level, 1111 for reply)"
+      - listitem [ref=e300]:
+        - code [ref=e301]: E
+        - text: "- Root event ID (always the video)"
+      - listitem [ref=e302]:
+        - code [ref=e303]: e
+        - text: "- Parent event ID (video or comment being replied to)"
+    - separator [ref=e304]
+    - heading "Reactions (NIP-25)" [level=2] [ref=e305]
+    - paragraph [ref=e306]: "Like/react to a video:"
+    - code [ref=e308]: "{ \"kind\": 7, \"tags\": [ [\"e\", \"<video-event-id>\"], [\"p\", \"<video-author-pubkey>\"], [\"k\", \"34236\"] ], \"content\": \"+\" }"
+    - paragraph [ref=e309]:
+      - strong [ref=e310]: "Content values:"
+    - list [ref=e311]:
+      - listitem [ref=e312]:
+        - code [ref=e313]: +
+        - text: or empty - Like
+      - listitem [ref=e314]:
+        - code [ref=e315]: "-"
+        - text: "- Dislike"
+      - listitem [ref=e316]:
+        - text: Emoji - Custom reaction (e.g.,
+        - code [ref=e317]: 🔥
+        - text: ","
+        - code [ref=e318]: ❤️
+        - text: )
+    - separator [ref=e319]
+    - heading "Reposts (NIP-18)" [level=2] [ref=e320]
+    - heading "Simple Repost (Kind 6)" [level=3] [ref=e321]
+    - paragraph [ref=e322]: "For kind 1 text notes only:"
+    - code [ref=e324]: "{ \"kind\": 6, \"tags\": [ [\"e\", \"<event-id>\", \"<relay-url>\"], [\"p\", \"<author-pubkey>\"] ], \"content\": \"\" }"
+    - heading "Generic Repost (Kind 16)" [level=3] [ref=e325]
+    - paragraph [ref=e326]: "For any event kind including videos:"
+    - code [ref=e328]: "{ \"kind\": 16, \"tags\": [ [\"e\", \"<video-event-id>\", \"<relay-url>\"], [\"p\", \"<video-author-pubkey>\"], [\"k\", \"34236\"] ], \"content\": \"\" }"
+    - paragraph [ref=e329]:
+      - strong [ref=e330]: Use kind 16 for reposting videos.
+    - separator [ref=e331]
+    - heading "Deletion (NIP-09)" [level=2] [ref=e332]
+    - paragraph [ref=e333]: "Delete your own events:"
+    - code [ref=e335]: "{ \"kind\": 5, \"tags\": [ [\"e\", \"<event-id-to-delete>\"], [\"e\", \"<another-event-id>\"], [\"a\", \"34236:<your-pubkey>:<d-tag>\"] ], \"content\": \"optional reason\" }"
+    - list [ref=e336]:
+      - listitem [ref=e337]:
+        - text: Use
+        - code [ref=e338]: e
+        - text: tags for specific event IDs
+      - listitem [ref=e339]:
+        - text: Use
+        - code [ref=e340]: a
+        - text: tags for addressable events (kind:pubkey:d-tag format)
+      - listitem [ref=e341]: You can only delete events YOU authored
+      - listitem [ref=e342]: Relay will reject deletion of others' events
+    - separator [ref=e343]
+    - heading "Profile Events (Kind 0)" [level=2] [ref=e344]
+    - paragraph [ref=e345]: "User metadata is stored in kind 0 with JSON content:"
+    - code [ref=e347]: "{ \"kind\": 0, \"tags\": [], \"content\": \"{\\\"name\\\":\\\"username\\\",\\\"display_name\\\":\\\"Display Name\\\",\\\"picture\\\":\\\"https://example.com/avatar.jpg\\\",\\\"banner\\\":\\\"https://example.com/banner.jpg\\\",\\\"about\\\":\\\"Bio text\\\",\\\"nip05\\\":\\\"user@domain.com\\\",\\\"lud16\\\":\\\"user@getalby.com\\\",\\\"website\\\":\\\"https://example.com\\\"}\" }"
+    - paragraph [ref=e348]:
+      - strong [ref=e349]: "Profile JSON fields:"
+    - table [ref=e350]:
+      - rowgroup [ref=e351]:
+        - row "Field Description" [ref=e352]:
+          - columnheader "Field" [ref=e353]
+          - columnheader "Description" [ref=e354]
+      - rowgroup [ref=e355]:
+        - row "name Username (lowercase, no spaces)" [ref=e356]:
+          - cell "name" [ref=e357]:
+            - code [ref=e358]: name
+          - cell "Username (lowercase, no spaces)" [ref=e359]
+        - row "display_name Display name" [ref=e360]:
+          - cell "display_name" [ref=e361]:
+            - code [ref=e362]: display_name
+          - cell "Display name" [ref=e363]
+        - row "picture Avatar URL" [ref=e364]:
+          - cell "picture" [ref=e365]:
+            - code [ref=e366]: picture
+          - cell "Avatar URL" [ref=e367]
+        - row "banner Banner image URL" [ref=e368]:
+          - cell "banner" [ref=e369]:
+            - code [ref=e370]: banner
+          - cell "Banner image URL" [ref=e371]
+        - row "about Bio/description" [ref=e372]:
+          - cell "about" [ref=e373]:
+            - code [ref=e374]: about
+          - cell "Bio/description" [ref=e375]
+        - row "nip05 NIP-05 identifier (user@domain.com)" [ref=e376]:
+          - cell "nip05" [ref=e377]:
+            - code [ref=e378]: nip05
+          - cell "NIP-05 identifier (user@domain.com)" [ref=e379]:
+            - text: NIP-05 identifier (
+            - link "user@domain.com" [ref=e380] [cursor=pointer]:
+              - /url: mailto:user@domain.com
+            - text: )
+        - row "lud16 Lightning address" [ref=e381]:
+          - cell "lud16" [ref=e382]:
+            - code [ref=e383]: lud16
+          - cell "Lightning address" [ref=e384]
+        - row "website Website URL" [ref=e385]:
+          - cell "website" [ref=e386]:
+            - code [ref=e387]: website
+          - cell "Website URL" [ref=e388]
+    - separator [ref=e389]
+    - heading "Contact Lists (Kind 3)" [level=2] [ref=e390]
+    - paragraph [ref=e391]: "Follow list stored in tags:"
+    - code [ref=e393]: "{ \"kind\": 3, \"tags\": [ [\"p\", \"<pubkey-1>\", \"<relay-url>\", \"<petname>\"], [\"p\", \"<pubkey-2>\", \"<relay-url>\", \"<petname>\"], [\"p\", \"<pubkey-3>\"] ], \"content\": \"\" }"
+    - paragraph [ref=e394]:
+      - text: Each
+      - code [ref=e395]: p
+      - text: tag is a followed pubkey. Relay URL and petname are optional.
+    - separator [ref=e396]
+    - heading "Addressable Event References" [level=2] [ref=e397]
+    - paragraph [ref=e398]:
+      - text: For parameterized replaceable events (kinds 30000-39999), use the
+      - code [ref=e399]: a
+      - text: "tag:"
+    - code [ref=e401]: "[\"a\", \"<kind>:<pubkey>:<d-tag>\", \"<relay-url>\"]"
+    - paragraph [ref=e402]: "Example - reference a video in a playlist:"
+    - code [ref=e404]: "[\"a\", \"34236:abc123def456...:my-video-id\", \"wss://relay.divine.video\"]"
+    - paragraph [ref=e405]:
+      - strong [ref=e406]: "Querying by address:"
+    - code [ref=e408]: "[\"REQ\", \"sub-id\", { \"#a\": [\"34236:abc123def456...:my-video-id\"] }]"
+    - separator [ref=e409]
+    - heading "Curation Sets / Playlists (Kind 30005)" [level=2] [ref=e410]
+    - paragraph [ref=e411]: "Create a video playlist:"
+    - code [ref=e413]: "{ \"kind\": 30005, \"tags\": [ [\"d\", \"my-playlist\"], [\"title\", \"My Favorite Videos\"], [\"description\", \"A collection of great content\"], [\"image\", \"https://example.com/playlist-cover.jpg\"], [\"a\", \"34236:pubkey1:video-d-tag-1\", \"wss://relay.divine.video\"], [\"a\", \"34236:pubkey2:video-d-tag-2\", \"wss://relay.divine.video\"], [\"e\", \"video-event-id-3\"] ], \"content\": \"\" }"
+    - paragraph [ref=e414]:
+      - strong [ref=e415]: "Tags:"
+    - list [ref=e416]:
+      - listitem [ref=e417]:
+        - code [ref=e418]: d
+        - text: "- Playlist identifier (REQUIRED)"
+      - listitem [ref=e419]:
+        - code [ref=e420]: title
+        - text: or
+        - code [ref=e421]: name
+        - text: "- Playlist title"
+      - listitem [ref=e422]:
+        - code [ref=e423]: description
+        - text: "- Playlist description"
+      - listitem [ref=e424]:
+        - code [ref=e425]: image
+        - text: "- Cover image URL"
+      - listitem [ref=e426]:
+        - code [ref=e427]: a
+        - text: tags - References to videos by address (preferred)
+      - listitem [ref=e428]:
+        - code [ref=e429]: e
+        - text: tags - References to videos by event ID
+    - separator [ref=e430]
+    - heading "Bookmarks (NIP-51)" [level=2] [ref=e431]
+    - heading "Bookmark List (Kind 10003)" [level=3] [ref=e432]
+    - paragraph [ref=e433]: "Simple list of bookmarked content:"
+    - code [ref=e435]: "{ \"kind\": 10003, \"tags\": [ [\"e\", \"<video-id-1>\"], [\"a\", \"34236:<pubkey>:<d-tag>\"] ], \"content\": \"\" }"
+    - heading "Bookmark Set (Kind 30003)" [level=3] [ref=e436]
+    - paragraph [ref=e437]: "Categorized bookmarks with a name:"
+    - code [ref=e439]: "{ \"kind\": 30003, \"tags\": [ [\"d\", \"watch-later\"], [\"title\", \"Watch Later\"], [\"e\", \"<video-id-1>\"], [\"a\", \"34236:<pubkey>:<d-tag>\"] ], \"content\": \"\" }"
+    - separator [ref=e440]
+    - heading "REST API Reference" [level=2] [ref=e441]
+    - heading "Request Headers" [level=3] [ref=e442]
+    - paragraph [ref=e443]: "For all POST requests:"
+    - code [ref=e445]: "Content-Type: application/json"
+    - heading "Timestamps" [level=3] [ref=e446]
+    - paragraph [ref=e447]:
+      - strong [ref=e448]: "Important:"
+      - text: "The REST API returns timestamps in two formats depending on the endpoint:"
+    - list [ref=e449]:
+      - listitem [ref=e450]:
+        - text: "Most list endpoints: ISO 8601 string ("
+        - code [ref=e451]: "\"2024-01-15T10:30:00Z\""
+        - text: )
+      - listitem [ref=e452]:
+        - text: Raw event endpoints (
+        - code [ref=e453]: "/api/event/{id}"
+        - text: ","
+        - code [ref=e454]: "/api/videos/{id}"
+        - text: "): Unix timestamp integer"
+    - paragraph [ref=e455]:
+      - text: Always check the response structure. When in doubt, the
+      - code [ref=e456]: created_at
+      - text: field can be parsed as either.
+    - heading "Videos" [level=3] [ref=e457]
+    - heading "GET /api/videos" [level=4] [ref=e458]
+    - paragraph [ref=e459]: List videos with sorting and filtering.
+    - paragraph [ref=e460]:
+      - strong [ref=e461]: "Query Parameters:"
+    - table [ref=e462]:
+      - rowgroup [ref=e463]:
+        - row "Param Type Description" [ref=e464]:
+          - columnheader "Param" [ref=e465]
+          - columnheader "Type" [ref=e466]
+          - columnheader "Description" [ref=e467]
+      - rowgroup [ref=e468]:
+        - row "sort string recent (default), trending, popular, loops, likes, comments, engagement, published" [ref=e469]:
+          - cell "sort" [ref=e470]:
+            - code [ref=e471]: sort
+          - cell "string" [ref=e472]
+          - cell "recent (default), trending, popular, loops, likes, comments, engagement, published" [ref=e473]:
+            - code [ref=e474]: recent
+            - text: (default),
+            - code [ref=e475]: trending
+            - text: ","
+            - code [ref=e476]: popular
+            - text: ","
+            - code [ref=e477]: loops
+            - text: ","
+            - code [ref=e478]: likes
+            - text: ","
+            - code [ref=e479]: comments
+            - text: ","
+            - code [ref=e480]: engagement
+            - text: ","
+            - code [ref=e481]: published
+        - row "kind number Filter by kind (34235 or 34236)" [ref=e482]:
+          - cell "kind" [ref=e483]:
+            - code [ref=e484]: kind
+          - cell "number" [ref=e485]
+          - cell "Filter by kind (34235 or 34236)" [ref=e486]
+        - row "limit number Max results (1-100, default 50)" [ref=e487]:
+          - cell "limit" [ref=e488]:
+            - code [ref=e489]: limit
+          - cell "number" [ref=e490]
+          - cell "Max results (1-100, default 50)" [ref=e491]
+        - row "offset number Skip N results for pagination (use with limit)" [ref=e492]:
+          - cell "offset" [ref=e493]:
+            - code [ref=e494]: offset
+          - cell "number" [ref=e495]
+          - cell "Skip N results for pagination (use with limit)" [ref=e496]:
+            - text: Skip N results for pagination (use with
+            - code [ref=e497]: limit
+            - text: )
+        - row "tag string Filter by hashtag" [ref=e498]:
+          - cell "tag" [ref=e499]:
+            - code [ref=e500]: tag
+          - cell "string" [ref=e501]
+          - cell "Filter by hashtag" [ref=e502]
+        - row "before number Unix timestamp for pagination" [ref=e503]:
+          - cell "before" [ref=e504]:
+            - code [ref=e505]: before
+          - cell "number" [ref=e506]
+          - cell "Unix timestamp for pagination" [ref=e507]
+        - row "after number Videos created after timestamp" [ref=e508]:
+          - cell "after" [ref=e509]:
+            - code [ref=e510]: after
+          - cell "number" [ref=e511]
+          - cell "Videos created after timestamp" [ref=e512]
+        - row "platform string Filter by platform (e.g., vine)" [ref=e513]:
+          - cell "platform" [ref=e514]:
+            - code [ref=e515]: platform
+          - cell "string" [ref=e516]
+          - cell "Filter by platform (e.g., vine)" [ref=e517]:
+            - text: Filter by platform (e.g.,
+            - code [ref=e518]: vine
+            - text: )
+        - row "has_embedded_stats boolean Only videos with loop counts" [ref=e519]:
+          - cell "has_embedded_stats" [ref=e520]:
+            - code [ref=e521]: has_embedded_stats
+          - cell "boolean" [ref=e522]
+          - cell "Only videos with loop counts" [ref=e523]
+        - row "d_tag string Filter by exact NIP-33 d tag" [ref=e524]:
+          - cell "d_tag" [ref=e525]:
+            - code [ref=e526]: d_tag
+          - cell "string" [ref=e527]
+          - cell "Filter by exact NIP-33 d tag" [ref=e528]:
+            - text: Filter by exact NIP-33
+            - code [ref=e529]: d
+            - text: tag
+        - row "classic boolean Shortcut for before + sort by loops" [ref=e530]:
+          - cell "classic" [ref=e531]:
+            - code [ref=e532]: classic
+          - cell "boolean" [ref=e533]
+          - cell "Shortcut for before + sort by loops" [ref=e534]:
+            - text: Shortcut for
+            - code [ref=e535]: before
+            - text: + sort by loops
+        - row "nsfw string Set to show to include default-hidden moderation labels on /api/videos" [ref=e536]:
+          - cell "nsfw" [ref=e537]:
+            - code [ref=e538]: nsfw
+          - cell "string" [ref=e539]
+          - cell "Set to show to include default-hidden moderation labels on /api/videos" [ref=e540]:
+            - text: Set to
+            - code [ref=e541]: show
+            - text: to include default-hidden moderation labels on
+            - code [ref=e542]: /api/videos
+        - row "label string Filter by any effective content label, including moderation labels and discovery labels such as topic:music" [ref=e543]:
+          - cell "label" [ref=e544]:
+            - code [ref=e545]: label
+          - cell "string" [ref=e546]
+          - cell "Filter by any effective content label, including moderation labels and discovery labels such as topic:music" [ref=e547]:
+            - text: Filter by any effective content label, including moderation labels and discovery labels such as
+            - code [ref=e548]: topic:music
+        - row "category string Convenience alias for label=topic:<category>" [ref=e549]:
+          - cell "category" [ref=e550]:
+            - code [ref=e551]: category
+          - cell "string" [ref=e552]
+          - cell "Convenience alias for label=topic:<category>" [ref=e553]:
+            - text: Convenience alias for
+            - code [ref=e554]: label=topic:<category>
+    - paragraph [ref=e555]:
+      - strong [ref=e556]: "Note on sort options:"
+    - list [ref=e557]:
+      - listitem [ref=e558]:
+        - code [ref=e559]: recent
+        - text: "- Newest first (default)"
+      - listitem [ref=e560]:
+        - code [ref=e561]: trending
+        - text: or
+        - code [ref=e562]: popular
+        - text: "- Sorted by engagement/trending score"
+      - listitem [ref=e563]:
+        - code [ref=e564]: loops
+        - text: "- Sorted by embedded loop count (primarily Vine archive data)"
+      - listitem [ref=e565]:
+        - code [ref=e566]: likes
+        - text: ","
+        - code [ref=e567]: comments
+        - text: ","
+        - code [ref=e568]: engagement
+        - text: ","
+        - code [ref=e569]: published
+        - text: "- Alternate ranking modes for discovery/creator views"
+    - paragraph [ref=e570]:
+      - strong [ref=e571]: "Note:"
+      - text: When
+      - code [ref=e572]: sort=loops
+      - text: ", the response includes additional fields like"
+      - code [ref=e573]: embedded_likes
+      - text: ","
+      - code [ref=e574]: sha256
+      - text: ","
+      - code [ref=e575]: platform
+      - text: ", etc., plus"
+      - code [ref=e576]: reactions
+      - text: ","
+      - code [ref=e577]: comments
+      - text: ","
+      - code [ref=e578]: reposts
+      - text: ", and"
+      - code [ref=e579]: engagement_score
+      - text: . When filters like
+      - code [ref=e580]: before
+      - text: ","
+      - code [ref=e581]: after
+      - text: ","
+      - code [ref=e582]: platform
+      - text: ", or"
+      - code [ref=e583]: has_embedded_stats
+      - text: are used, these also use the extended response format. All response formats now include
+      - code [ref=e584]: loops
+      - text: (safe loop count).
+    - paragraph [ref=e585]:
+      - strong [ref=e586]: "Response:"
+    - code [ref=e588]: "[ { \"id\": \"64-char-hex\", \"pubkey\": \"64-char-hex\", \"created_at\": \"2024-01-15T10:30:00Z\", \"kind\": 34236, \"d_tag\": \"my-video\", \"title\": \"Video Title\", \"content\": \"Description\", \"thumbnail\": \"https://...\", \"video_url\": \"https://...\", \"reactions\": 150, \"comments\": 42, \"reposts\": 10, \"engagement_score\": 254, \"loops\": 5000, \"views\": 12345, \"author_name\": \"CreatorName\", \"author_avatar\": \"https://...\", \"published_at\": 1705314600, \"language\": \"en\", \"text_track_ref\": \"39307:pubkey:d-tag\", \"text_track_content\": \"WEBVTT...\", \"tags\": [[\"d\", \"my-video\"], [\"verification\", \"human\"], [\"platform\", \"vine\"]], \"verification\": \"human\", \"proofmode\": \"proofmode-v1\", \"device_attestation\": \"apple\", \"pgp_fingerprint\": \"ABCD1234\", \"c2pa_manifest_id\": \"manifest-123\", \"platform\": \"vine\", \"client\": \"divine-web\", \"moderation_status\": \"human_made\", \"ai_score\": 0.03, \"ai_source\": \"content_labels\", \"ai_checked_at\": 1705314700, \"trending_score\": 0.85, \"content_labels\": [\"safe\"] } ]"
+    - paragraph [ref=e589]:
+      - strong [ref=e590]:
+        - text: Note on
+        - code [ref=e591]: content_labels
+        - text: ":"
+      - code [ref=e592]: content_labels
+      - text: is a mixed-purpose field. It can contain moderation labels such as
+      - code [ref=e593]: nudity
+      - text: or
+      - code [ref=e594]: violence
+      - text: ", and generic classifier/discovery labels such as"
+      - code [ref=e595]: topic:music
+      - text: or
+      - code [ref=e596]: activity:listening-to-music
+      - text: . There is no separate
+      - code [ref=e597]: moderation_labels
+      - text: field today. See
+      - link "Content Moderation" [ref=e598] [cursor=pointer]:
+        - /url: "#content-moderation"
+      - text: below for the stable moderation vocabulary, merge rules, and server/client responsibility split.
+    - paragraph [ref=e599]:
+      - strong [ref=e600]: "Note on safety filtering:"
+      - code [ref=e601]: /api/videos
+      - text: supports legacy
+      - code [ref=e602]: nsfw=show
+      - text: . There is no stable per-label hide parameter such as
+      - code [ref=e603]: exclude_label
+      - text: or
+      - code [ref=e604]: exclude_moderation_labels
+      - text: today.
+    - paragraph [ref=e605]:
+      - strong [ref=e606]:
+        - text: Note on
+        - code [ref=e607]: views
+        - text: ":"
+      - text: The
+      - code [ref=e608]: views
+      - text: field is the total view count from the view tracking system. It is included in all video list endpoints (
+      - code [ref=e609]: /api/videos
+      - text: ","
+      - code [ref=e610]: "/api/users/{pubkey}/videos"
+      - text: ","
+      - code [ref=e611]: /api/search
+      - text: ","
+      - code [ref=e612]: /api/videos/bulk
+      - text: ", etc.)."
+    - paragraph [ref=e613]:
+      - strong [ref=e614]:
+        - text: Note on
+        - code [ref=e615]: loops
+        - text: ":"
+      - text: The
+      - code [ref=e616]: loops
+      - text: "field uses safe loop logic: prefers computed loops from view tracking, falls back to capped embedded loops for pre-2025 videos (Vine imports), and 0 for newer videos without view data."
+    - paragraph [ref=e617]:
+      - strong [ref=e618]: "Note on list/feed metadata fields:"
+      - text: Public video list endpoints (
+      - code [ref=e619]: /api/videos
+      - text: ","
+      - code [ref=e620]: "/api/users/{pubkey}/videos"
+      - text: ","
+      - code [ref=e621]: "/api/users/{pubkey}/feed"
+      - text: ","
+      - code [ref=e622]: /api/search
+      - text: ") include:"
+    - list [ref=e623]:
+      - listitem [ref=e624]:
+        - text: full
+        - code [ref=e625]: tags
+        - text: from the source video event,
+      - listitem [ref=e626]:
+        - text: badge-critical extracted fields (
+        - code [ref=e627]: verification
+        - text: ","
+        - code [ref=e628]: proofmode
+        - text: ","
+        - code [ref=e629]: device_attestation
+        - text: ","
+        - code [ref=e630]: pgp_fingerprint
+        - text: ","
+        - code [ref=e631]: c2pa_manifest_id
+        - text: ","
+        - code [ref=e632]: platform
+        - text: ","
+        - code [ref=e633]: client
+        - text: ","
+        - code [ref=e634]: text_track_ref
+        - text: ","
+        - code [ref=e635]: text_track_content
+        - text: ),
+      - listitem [ref=e636]:
+        - text: public moderation fields (
+        - code [ref=e637]: moderation_status
+        - text: ","
+        - code [ref=e638]: ai_score
+        - text: ","
+        - code [ref=e639]: ai_source
+        - text: ","
+        - code [ref=e640]: ai_checked_at
+        - text: ),
+      - listitem [ref=e641]:
+        - code [ref=e642]: language
+        - text: from NIP-32 self-labeling tags.
+    - heading "GET /api/videos/events" [level=4] [ref=e643]
+    - paragraph [ref=e644]: List videos with full verifiable Nostr events.
+    - paragraph [ref=e645]:
+      - strong [ref=e646]: "Query Parameters:"
+    - table [ref=e647]:
+      - rowgroup [ref=e648]:
+        - row "Param Type Description" [ref=e649]:
+          - columnheader "Param" [ref=e650]
+          - columnheader "Type" [ref=e651]
+          - columnheader "Description" [ref=e652]
+      - rowgroup [ref=e653]:
+        - row "sort string recent (default), trending, popular, or loops" [ref=e654]:
+          - cell "sort" [ref=e655]:
+            - code [ref=e656]: sort
+          - cell "string" [ref=e657]
+          - cell "recent (default), trending, popular, or loops" [ref=e658]:
+            - code [ref=e659]: recent
+            - text: (default),
+            - code [ref=e660]: trending
+            - text: ","
+            - code [ref=e661]: popular
+            - text: ", or"
+            - code [ref=e662]: loops
+        - row "kind number Filter by kind (34235 or 34236)" [ref=e663]:
+          - cell "kind" [ref=e664]:
+            - code [ref=e665]: kind
+          - cell "number" [ref=e666]
+          - cell "Filter by kind (34235 or 34236)" [ref=e667]
+        - row "limit number Max results (1-100, default 50)" [ref=e668]:
+          - cell "limit" [ref=e669]:
+            - code [ref=e670]: limit
+          - cell "number" [ref=e671]
+          - cell "Max results (1-100, default 50)" [ref=e672]
+        - row "before number Unix timestamp for cursor-based pagination" [ref=e673]:
+          - cell "before" [ref=e674]:
+            - code [ref=e675]: before
+          - cell "number" [ref=e676]
+          - cell "Unix timestamp for cursor-based pagination" [ref=e677]
+        - row "d_tag string Filter by exact NIP-33 d tag" [ref=e678]:
+          - cell "d_tag" [ref=e679]:
+            - code [ref=e680]: d_tag
+          - cell "string" [ref=e681]
+          - cell "Filter by exact NIP-33 d tag" [ref=e682]:
+            - text: Filter by exact NIP-33
+            - code [ref=e683]: d
+            - text: tag
+        - row "tag string Filter by hashtag (t tag)" [ref=e684]:
+          - cell "tag" [ref=e685]:
+            - code [ref=e686]: tag
+          - cell "string" [ref=e687]
+          - cell "Filter by hashtag (t tag)" [ref=e688]:
+            - text: Filter by hashtag (
+            - code [ref=e689]: t
+            - text: tag)
+        - row "platform string Filter by platform (e.g., vine)" [ref=e690]:
+          - cell "platform" [ref=e691]:
+            - code [ref=e692]: platform
+          - cell "string" [ref=e693]
+          - cell "Filter by platform (e.g., vine)" [ref=e694]:
+            - text: Filter by platform (e.g.,
+            - code [ref=e695]: vine
+            - text: )
+        - row "classic boolean If true and sort is omitted, defaults to loops" [ref=e696]:
+          - cell "classic" [ref=e697]:
+            - code [ref=e698]: classic
+          - cell "boolean" [ref=e699]
+          - cell "If true and sort is omitted, defaults to loops" [ref=e700]:
+            - text: If true and
+            - code [ref=e701]: sort
+            - text: is omitted, defaults to
+            - code [ref=e702]: loops
+    - paragraph [ref=e703]:
+      - strong [ref=e704]: "Response:"
+    - code [ref=e706]: "{ \"videos\": [ { \"event\": { /* full Nostr event */ }, \"stats\": { \"reactions\": 150, \"comments\": 42, \"reposts\": 10, \"engagement_score\": 254, \"author_name\": \"CreatorName\", \"author_avatar\": \"https://...\", \"text_track_ref\": \"\", \"text_track_content\": \"\", \"content_labels\": [\"safe\"] } } ], \"next_cursor\": \"1700000000\", \"has_more\": true }"
+    - 'heading "GET /api/videos/{id}" [level=4] [ref=e707]'
+    - paragraph [ref=e708]: Get a single video with event and stats.
+    - paragraph [ref=e709]:
+      - text: The
+      - code [ref=e710]: "{id}"
+      - text: "parameter accepts either:"
+    - list [ref=e711]:
+      - listitem [ref=e712]:
+        - strong [ref=e713]: Event ID
+        - text: ": 64-character hex Nostr event ID (fast primary key lookup)"
+      - listitem [ref=e714]:
+        - strong [ref=e715]: D-tag
+        - text: ": Addressable event identifier that stays stable across edits (fallback lookup)"
+    - paragraph [ref=e716]: This means shared video URLs survive edits — when a user edits video metadata, the event ID changes but the d-tag stays the same.
+    - paragraph [ref=e717]:
+      - strong [ref=e718]: "Response:"
+    - code [ref=e720]: "{ \"event\": { \"id\": \"64-char-hex\", \"pubkey\": \"64-char-hex\", \"created_at\": 1700000000, \"kind\": 34236, \"content\": \"Description\", \"tags\": [[\"d\", \"...\"], [\"text-track\", \"https://...\", \"subtitles\", \"en\", \"text/vtt\"], ...], \"sig\": \"128-char-hex\" }, \"stats\": { \"reactions\": 150, \"comments\": 42, \"reposts\": 10, \"engagement_score\": 254, \"author_name\": \"CreatorName\", \"author_avatar\": \"https://...\", \"trending_score\": 0.85, \"embedded_loops\": 0, \"text_track_ref\": \"https://cdn.example.com/subtitles/en.vtt\", \"text_track_content\": \"WEBVTT\\n\\n00:00:01.000 --> 00:00:04.000\\nHello world\", \"content_labels\": [\"safe\"] } }"
+    - list [ref=e721]:
+      - listitem [ref=e722]:
+        - code [ref=e723]: text_track_ref
+        - text: ": URL from the video event's"
+        - code [ref=e724]: text-track
+        - text: tag (empty string if none)
+      - listitem [ref=e725]:
+        - code [ref=e726]: text_track_content
+        - text: ": WebVTT subtitle content from associated Kind 39307 event (empty string if none)"
+    - 'heading "GET /api/videos/{id}/stats" [level=4] [ref=e727]'
+    - paragraph [ref=e728]: Get engagement and view stats (reactions, comments, reposts, views, loops).
+    - paragraph [ref=e729]:
+      - strong [ref=e730]: "Response:"
+    - code [ref=e732]: "{ \"id\": \"64-char-hex\", \"pubkey\": \"64-char-hex\", \"created_at\": \"2024-01-15T10:30:00Z\", \"kind\": 34236, \"d_tag\": \"my-video\", \"title\": \"Video Title\", \"content\": \"Description\", \"thumbnail\": \"https://...\", \"video_url\": \"https://...\", \"reactions\": 150, \"comments\": 42, \"reposts\": 10, \"engagement_score\": 254, \"loops\": 5000, \"views\": 12345, \"author_name\": \"CreatorName\", \"author_avatar\": \"https://...\", \"published_at\": 1705314600, \"expiration_at\": null, \"language\": \"en\", \"text_track_ref\": \"39307:pubkey:d-tag\", \"text_track_content\": \"WEBVTT...\", \"tags\": [[\"d\", \"my-video\"], [\"verification\", \"human\"]], \"verification\": \"human\", \"proofmode\": \"proofmode-v1\", \"device_attestation\": \"apple\", \"pgp_fingerprint\": \"ABCD1234\", \"c2pa_manifest_id\": \"manifest-123\", \"platform\": \"vine\", \"client\": \"divine-web\", \"moderation_status\": \"human_made\", \"ai_score\": 0.03, \"ai_source\": \"content_labels\", \"ai_checked_at\": 1705314700, \"content_labels\": [\"safe\"] }"
+    - 'heading "GET /api/videos/{id}/views" [level=4] [ref=e733]'
+    - paragraph [ref=e734]: Get view statistics.
+    - paragraph [ref=e735]:
+      - strong [ref=e736]: "Response:"
+    - code [ref=e738]: "{ \"views\": 1000, \"unique_viewers\": 750, \"total_watch_time\": 45000, \"avg_completion\": 0.75 }"
+    - 'heading "GET /api/videos/{id}/analytics" [level=4] [ref=e739]'
+    - paragraph [ref=e740]: Get post-detail analytics for a single video.
+    - paragraph [ref=e741]:
+      - strong [ref=e742]: "Query:"
+      - code [ref=e743]: window
+      - text: "- Time window:"
+      - code [ref=e744]: 7d
+      - text: ","
+      - code [ref=e745]: 28d
+      - text: ","
+      - code [ref=e746]: 30d
+      - text: (default),
+      - code [ref=e747]: 90d
+      - text: ", or"
+      - code [ref=e748]: all
+    - paragraph [ref=e749]:
+      - strong [ref=e750]: "Response:"
+    - code [ref=e752]: "{ \"id\": \"64-char-hex\", \"window\": \"30d\", \"summary\": { \"views\": 12345, \"unique_viewers\": 6789, \"reactions\": 150, \"comments\": 42, \"reposts\": 10, \"shares\": null, \"saves\": null, \"followers_gained\": null, \"profile_visits\": null, \"total_watch_seconds\": 45000.5, \"avg_watch_seconds\": 12.3, \"completion_rate\": 0.74, \"rewatch_rate\": 0.11, \"engagement_rate\": 0.016, \"has_view_data\": true }, \"traffic_sources\": { \"for_you\": 0.42, \"following\": 0.18, \"profile\": 0.12, \"search\": 0.09, \"hashtag\": 0.07, \"external\": 0.08, \"shares\": 0.04 }, \"retention_curve\": [ { \"second\": 0, \"viewer_pct\": 1.0 }, { \"second\": 3, \"viewer_pct\": 0.86 } ] }"
+    - paragraph [ref=e753]:
+      - strong [ref=e754]: "Notes:"
+    - list [ref=e755]:
+      - listitem [ref=e756]:
+        - code [ref=e757]: window
+        - text: defaults to
+        - code [ref=e758]: 30d
+      - listitem [ref=e759]:
+        - text: Summary fields may be
+        - code [ref=e760]: "null"
+        - text: when view-tracking data is unavailable for the selected period
+    - 'heading "GET /api/videos/{id}/comments" [level=4] [ref=e761]'
+    - paragraph [ref=e762]: Get NIP-22 comments (Kind 1111) for a video. Accepts event ID or d-tag.
+    - paragraph [ref=e763]:
+      - strong [ref=e764]: "Parameters:"
+    - table [ref=e765]:
+      - rowgroup [ref=e766]:
+        - row "Param Type Default Description" [ref=e767]:
+          - columnheader "Param" [ref=e768]
+          - columnheader "Type" [ref=e769]
+          - columnheader "Default" [ref=e770]
+          - columnheader "Description" [ref=e771]
+      - rowgroup [ref=e772]:
+        - 'row "sort string newest Sort order: newest or oldest" [ref=e773]':
+          - cell "sort" [ref=e774]:
+            - code [ref=e775]: sort
+          - cell "string" [ref=e776]
+          - cell "newest" [ref=e777]:
+            - code [ref=e778]: newest
+          - 'cell "Sort order: newest or oldest" [ref=e779]':
+            - text: "Sort order:"
+            - code [ref=e780]: newest
+            - text: or
+            - code [ref=e781]: oldest
+        - row "limit number 25 Max comments (max 100)" [ref=e782]:
+          - cell "limit" [ref=e783]:
+            - code [ref=e784]: limit
+          - cell "number" [ref=e785]
+          - cell "25" [ref=e786]:
+            - code [ref=e787]: "25"
+          - cell "Max comments (max 100)" [ref=e788]
+        - row "offset number 0 Pagination offset" [ref=e789]:
+          - cell "offset" [ref=e790]:
+            - code [ref=e791]: offset
+          - cell "number" [ref=e792]
+          - cell "0" [ref=e793]:
+            - code [ref=e794]: "0"
+          - cell "Pagination offset" [ref=e795]
+    - paragraph [ref=e796]:
+      - strong [ref=e797]: "Response:"
+    - code [ref=e799]: "{ \"comments\": [ { \"id\": \"abc123...\", \"pubkey\": \"def456...\", \"created_at\": 1700000000, \"kind\": 1111, \"content\": \"Great video!\", \"sig\": \"sig_hex...\", \"tags\": [[\"E\",\"video_id\"],[\"K\",\"34236\"]], \"reply_to_event_id\": null, \"reply_to_pubkey\": null, \"author_name\": \"Alice\", \"author_avatar\": \"https://example.com/alice.jpg\" } ], \"total\": 42 }"
+    - paragraph [ref=e800]:
+      - strong [ref=e801]: "Notes:"
+    - list [ref=e802]:
+      - listitem [ref=e803]:
+        - code [ref=e804]: reply_to_event_id
+        - text: /
+        - code [ref=e805]: reply_to_pubkey
+        - text: are null for top-level comments, populated for replies
+      - listitem [ref=e806]: Author metadata comes from Kind 0 profiles
+      - listitem [ref=e807]: 30s cache
+    - separator [ref=e808]
+    - 'heading "GET /api/videos/{id}/live-views" [level=4] [ref=e809]'
+    - paragraph [ref=e810]: Server-Sent Events (SSE) stream for real-time view count updates.
+    - paragraph [ref=e811]:
+      - strong [ref=e812]: "Content-Type:"
+      - code [ref=e813]: text/event-stream
+    - paragraph [ref=e814]: This endpoint streams updates every ~2.5 seconds. No authentication required.
+    - paragraph [ref=e815]:
+      - strong [ref=e816]: "Event format:"
+    - code [ref=e818]: "event: view_update data: {\"views\": 1500, \"loops\": 1125.5, \"viewers_now\": 12}"
+    - paragraph [ref=e819]:
+      - strong [ref=e820]: "Fields:"
+    - table [ref=e821]:
+      - rowgroup [ref=e822]:
+        - row "Field Type Description" [ref=e823]:
+          - columnheader "Field" [ref=e824]
+          - columnheader "Type" [ref=e825]
+          - columnheader "Description" [ref=e826]
+      - rowgroup [ref=e827]:
+        - row "views number Total view count" [ref=e828]:
+          - cell "views" [ref=e829]:
+            - code [ref=e830]: views
+          - cell "number" [ref=e831]
+          - cell "Total view count" [ref=e832]
+        - row "loops float Total computed loops (from watch time)" [ref=e833]:
+          - cell "loops" [ref=e834]:
+            - code [ref=e835]: loops
+          - cell "float" [ref=e836]
+          - cell "Total computed loops (from watch time)" [ref=e837]
+        - row "viewers_now number Currently active viewers (5-min TTL window)" [ref=e838]:
+          - cell "viewers_now" [ref=e839]:
+            - code [ref=e840]: viewers_now
+          - cell "number" [ref=e841]
+          - cell "Currently active viewers (5-min TTL window)" [ref=e842]
+    - paragraph [ref=e843]:
+      - strong [ref=e844]: "Usage:"
+    - code [ref=e846]: "const eventSource = new EventSource('/api/videos/' + videoId + '/live-views'); eventSource.addEventListener('view_update', (event) => { const stats = JSON.parse(event.data); updateViewCounter(stats.views); updateLoopCounter(stats.loops); updateActiveViewers(stats.viewers_now); }); eventSource.addEventListener('error', (event) => { console.warn('Live view error:', event.data); }); // Clean up when done eventSource.close();"
+    - paragraph [ref=e847]:
+      - strong [ref=e848]: "Note:"
+      - text: The stream includes a keep-alive ping every 15 seconds. Connection will stay open indefinitely until the client closes it.
+    - separator [ref=e849]
+    - heading "POST /api/videos/stats/bulk" [level=4] [ref=e850]
+    - paragraph [ref=e851]: Get stats for multiple videos. Maximum 100 event IDs per request.
+    - paragraph [ref=e852]:
+      - strong [ref=e853]: "Request:"
+    - code [ref=e855]: "{ \"event_ids\": [\"id1\", \"id2\", \"id3\"] }"
+    - paragraph [ref=e856]:
+      - strong [ref=e857]: "Response:"
+    - code [ref=e859]: "{ \"stats\": { \"id1\": { \"reactions\": 150, \"comments\": 42, \"reposts\": 10, \"engagement_score\": 254, \"views\": 1234, \"loops\": 987.5, \"embedded_loops\": 5000 }, \"id2\": { \"reactions\": 80, \"comments\": 15, \"reposts\": 5, \"engagement_score\": 120, \"views\": 0, \"loops\": 0.0, \"embedded_loops\": null } }, \"missing\": [\"id3\"] }"
+    - heading "POST /api/videos/bulk" [level=4] [ref=e860]
+    - paragraph [ref=e861]: Get multiple videos with full stats.
+    - paragraph [ref=e862]:
+      - strong [ref=e863]: "Request:"
+    - code [ref=e865]: "{ \"event_ids\": [\"id1\", \"id2\"], \"from_event\": { \"kind\": 30005, \"pubkey\": \"curator-pubkey\", \"d_tag\": \"playlist-name\" } }"
+    - paragraph [ref=e866]:
+      - strong [ref=e867]: "Response:"
+    - code [ref=e869]: "{ \"videos\": [ { \"id\": \"64-char-hex\", \"pubkey\": \"64-char-hex\", \"created_at\": \"2024-01-15T10:30:00Z\", \"kind\": 34236, \"d_tag\": \"my-video\", \"title\": \"Video Title\", \"content\": \"Description\", \"thumbnail\": \"https://...\", \"video_url\": \"https://...\", \"reactions\": 150, \"comments\": 42, \"reposts\": 10, \"engagement_score\": 254, \"author_name\": \"CreatorName\", \"author_avatar\": \"https://...\", \"content_labels\": [\"safe\"] } ], \"missing\": [\"id-that-wasnt-found\"], \"source_event_id\": \"64-char-hex\" }"
+    - heading "Events" [level=3] [ref=e870]
+    - 'heading "GET /api/event/{id}" [level=4] [ref=e871]'
+    - paragraph [ref=e872]: Get any Nostr event by ID.
+    - paragraph [ref=e873]:
+      - strong [ref=e874]: "Response:"
+    - code [ref=e876]: "{ \"id\": \"64-char-hex\", \"pubkey\": \"64-char-hex\", \"created_at\": 1700000000, \"kind\": 0, \"tags\": [], \"content\": \"{}\", \"sig\": \"128-char-hex\" }"
+    - heading "Users" [level=3] [ref=e877]
+    - 'heading "GET /api/users/{pubkey}" [level=4] [ref=e878]'
+    - paragraph [ref=e879]: Get user profile and statistics.
+    - paragraph [ref=e880]:
+      - strong [ref=e881]: "Query:"
+      - text: "No"
+      - code [ref=e882]: include
+      - text: parameter is currently supported on this endpoint.
+    - paragraph [ref=e883]:
+      - strong [ref=e884]: "Response:"
+    - code [ref=e886]: "{ \"pubkey\": \"64-char-hex\", \"profile\": { \"profile_updated\": \"2024-01-15T10:30:00Z\", \"name\": \"username\", \"display_name\": \"Display Name\", \"picture\": \"https://...\", \"banner\": \"https://...\", \"about\": \"Bio text\", \"nip05\": \"user@domain.com\", \"lud16\": \"user@getalby.com\", \"website\": \"https://...\" }, \"social\": { \"follower_count\": 1000, \"following_count\": 500 }, \"stats\": { \"video_count\": 50, \"horizontal_videos\": 10, \"vertical_videos\": 40, \"note_count\": 100, \"reaction_count\": 200, \"comment_count\": 50, \"repost_count\": 30, \"first_activity\": \"2023-06-01T00:00:00Z\", \"last_activity\": \"2024-01-15T10:30:00Z\", \"total_events\": 1200 }, \"engagement\": { \"total_reactions\": 5000, \"total_comments\": 1200, \"total_reposts\": 300, \"unique_reactors\": 2500, \"unique_commenters\": 800, \"unique_reposters\": 200 } }"
+    - paragraph [ref=e887]:
+      - strong [ref=e888]: "Note:"
+      - text: "Badge awards and external identity claims are exposed through dedicated endpoints:"
+      - code [ref=e889]: "GET /api/users/{pubkey}/badges"
+      - text: and
+      - code [ref=e890]: "GET /api/users/{pubkey}/identities"
+      - text: .
+    - 'heading "GET /api/users/{pubkey}/videos" [level=4] [ref=e891]'
+    - paragraph [ref=e892]: Get videos by a user.
+    - paragraph [ref=e893]:
+      - strong [ref=e894]: "Query:"
+      - code [ref=e895]: limit
+      - text: (1-100, default 50),
+      - code [ref=e896]: offset
+      - text: (skip N results),
+      - code [ref=e897]: before
+      - text: (timestamp cursor),
+      - code [ref=e898]: sort
+      - text: (
+      - code [ref=e899]: recent
+      - text: default,
+      - code [ref=e900]: trending
+      - text: ","
+      - code [ref=e901]: popular
+      - text: ","
+      - code [ref=e902]: loops
+      - text: ","
+      - code [ref=e903]: likes
+      - text: ","
+      - code [ref=e904]: comments
+      - text: ","
+      - code [ref=e905]: published
+      - text: )
+    - paragraph [ref=e906]:
+      - strong [ref=e907]: "Note:"
+      - text: When
+      - code [ref=e908]: sort=loops
+      - text: ", the response uses the extended format with"
+      - code [ref=e909]: embedded_likes
+      - text: ","
+      - code [ref=e910]: platform
+      - text: ", etc., plus"
+      - code [ref=e911]: reactions
+      - text: ","
+      - code [ref=e912]: comments
+      - text: ","
+      - code [ref=e913]: reposts
+      - text: ", and"
+      - code [ref=e914]: engagement_score
+      - text: (same as the main
+      - code [ref=e915]: /api/videos?sort=loops
+      - text: response). All formats include
+      - code [ref=e916]: loops
+      - text: and
+      - code [ref=e917]: views
+      - text: .
+    - paragraph [ref=e918]:
+      - strong [ref=e919]: "Note:"
+      - text: The response objects include the same metadata fields as
+      - code [ref=e920]: /api/videos
+      - text: ", including"
+      - code [ref=e921]: tags
+      - text: ", extracted badge tag fields, and moderation fields ("
+      - code [ref=e922]: moderation_status
+      - text: ","
+      - code [ref=e923]: ai_score
+      - text: ","
+      - code [ref=e924]: ai_source
+      - text: ","
+      - code [ref=e925]: ai_checked_at
+      - text: ).
+    - paragraph [ref=e926]:
+      - strong [ref=e927]: "Note:"
+      - text: This endpoint returns
+      - code [ref=e928]: content_labels
+      - text: on each item, but it does not currently expose
+      - code [ref=e929]: nsfw
+      - text: ","
+      - code [ref=e930]: content_safety
+      - text: ", or"
+      - code [ref=e931]: exclude_label
+      - text: query parameters. Treat it as a label-returning endpoint, not a preference-aware safety-filter endpoint.
+    - paragraph [ref=e932]:
+      - strong [ref=e933]: "Response:"
+    - code [ref=e935]: "[ { \"id\": \"64-char-hex\", \"pubkey\": \"64-char-hex\", \"created_at\": \"2024-01-15T10:30:00Z\", \"kind\": 34236, \"d_tag\": \"my-video\", \"title\": \"Video Title\", \"content\": \"Description\", \"thumbnail\": \"https://...\", \"video_url\": \"https://...\", \"reactions\": 150, \"comments\": 42, \"reposts\": 10, \"engagement_score\": 254, \"loops\": 5000, \"views\": 12345, \"author_name\": \"CreatorName\", \"author_avatar\": \"https://...\", \"tags\": [[\"d\", \"my-video\"], [\"verification\", \"human\"]], \"moderation_status\": \"human_made\", \"ai_score\": 0.03, \"ai_source\": \"content_labels\", \"ai_checked_at\": 1705314700, \"content_labels\": [\"safe\"] } ]"
+    - 'heading "GET /api/users/{pubkey}/collabs" [level=4] [ref=e936]'
+    - paragraph [ref=e937]:
+      - text: Get videos where a user appears as a collaborator (
+      - code [ref=e938]: p
+      - text: tag) but is not the author.
+    - paragraph [ref=e939]:
+      - strong [ref=e940]: "Query:"
+      - code [ref=e941]: limit
+      - text: (1-100, default 50),
+      - code [ref=e942]: offset
+      - text: (skip N results),
+      - code [ref=e943]: sort
+      - text: (
+      - code [ref=e944]: recent
+      - text: default,
+      - code [ref=e945]: popular
+      - text: ","
+      - code [ref=e946]: likes
+      - text: ","
+      - code [ref=e947]: comments
+      - text: ","
+      - code [ref=e948]: published
+      - text: )
+    - paragraph [ref=e949]:
+      - strong [ref=e950]: "Response:"
+      - text: Same schema as
+      - code [ref=e951]: "GET /api/users/{pubkey}/videos"
+      - text: .
+    - 'heading "GET /api/users/{pubkey}/followers" [level=4] [ref=e952]'
+    - paragraph [ref=e953]: Get user's followers (paginated).
+    - paragraph [ref=e954]:
+      - strong [ref=e955]: "Query:"
+      - code [ref=e956]: limit
+      - text: (1-100, default 50),
+      - code [ref=e957]: offset
+      - text: (skip N results),
+      - code [ref=e958]: include
+      - text: (set to
+      - code [ref=e959]: profiles
+      - text: to include full user data)
+    - paragraph [ref=e960]:
+      - strong [ref=e961]: "Response (default):"
+    - code [ref=e963]: "{ \"followers\": [ \"pubkey1-64-char-hex\", \"pubkey2-64-char-hex\", \"pubkey3-64-char-hex\" ], \"total\": 1500, \"offset\": 0, \"limit\": 50 }"
+    - paragraph [ref=e964]:
+      - strong [ref=e965]:
+        - text: Response (with
+        - code [ref=e966]: include=profiles
+        - text: "):"
+    - code [ref=e968]: "{ \"followers\": [ { \"pubkey\": \"64-char-hex\", \"profile\": { \"name\": \"username\", \"display_name\": \"Display Name\", \"picture\": \"https://...\", \"about\": \"Bio text\" }, \"social\": { \"follower_count\": 500, \"following_count\": 200 }, \"stats\": { ... }, \"engagement\": { ... } } ], \"total\": 1500, \"offset\": 0, \"limit\": 50 }"
+    - 'heading "GET /api/users/{pubkey}/following" [level=4] [ref=e969]'
+    - paragraph [ref=e970]: Get who the user follows.
+    - paragraph [ref=e971]:
+      - strong [ref=e972]: "Query:"
+      - code [ref=e973]: limit
+      - text: (1-100, default 50),
+      - code [ref=e974]: offset
+      - text: (skip N results),
+      - code [ref=e975]: include
+      - text: (set to
+      - code [ref=e976]: profiles
+      - text: to include full user data)
+    - paragraph [ref=e977]:
+      - strong [ref=e978]: "Response (default):"
+    - code [ref=e980]: "{ \"following\": [ \"pubkey1-64-char-hex\", \"pubkey2-64-char-hex\", \"pubkey3-64-char-hex\" ], \"total\": 250 }"
+    - paragraph [ref=e981]:
+      - strong [ref=e982]:
+        - text: Response (with
+        - code [ref=e983]: include=profiles
+        - text: "):"
+    - code [ref=e985]: "{ \"following\": [ { \"pubkey\": \"64-char-hex\", \"profile\": { \"name\": \"username\", \"display_name\": \"Display Name\", \"picture\": \"https://...\", \"about\": \"Bio text\" }, \"social\": { \"follower_count\": 500, \"following_count\": 200 }, \"stats\": { ... }, \"engagement\": { ... } } ], \"total\": 250, \"offset\": 0, \"limit\": 50 }"
+    - 'heading "GET /api/users/{pubkey}/social" [level=4] [ref=e986]'
+    - paragraph [ref=e987]: Get follower/following counts only (lightweight endpoint for social stats).
+    - paragraph [ref=e988]:
+      - strong [ref=e989]: "Response:"
+    - code [ref=e991]: "{ \"follower_count\": 1500, \"following_count\": 250 }"
+    - 'heading "GET /api/users/{pubkey}/feed" [level=4] [ref=e992]'
+    - paragraph [ref=e993]:
+      - text: Get the user's
+      - strong [ref=e994]: home feed
+      - text: "- personalized video feed from followed accounts. This is the main timeline showing content from people the user follows."
+    - paragraph [ref=e995]:
+      - strong [ref=e996]: "Query Parameters:"
+    - table [ref=e997]:
+      - rowgroup [ref=e998]:
+        - row "Param Type Description" [ref=e999]:
+          - columnheader "Param" [ref=e1000]
+          - columnheader "Type" [ref=e1001]
+          - columnheader "Description" [ref=e1002]
+      - rowgroup [ref=e1003]:
+        - row "sort string recent (default), trending, likes, comments, or published" [ref=e1004]:
+          - cell "sort" [ref=e1005]:
+            - code [ref=e1006]: sort
+          - cell "string" [ref=e1007]
+          - cell "recent (default), trending, likes, comments, or published" [ref=e1008]:
+            - code [ref=e1009]: recent
+            - text: (default),
+            - code [ref=e1010]: trending
+            - text: ","
+            - code [ref=e1011]: likes
+            - text: ","
+            - code [ref=e1012]: comments
+            - text: ", or"
+            - code [ref=e1013]: published
+        - row "limit number Max results (1-1000, default 50)" [ref=e1014]:
+          - cell "limit" [ref=e1015]:
+            - code [ref=e1016]: limit
+          - cell "number" [ref=e1017]
+          - cell "Max results (1-1000, default 50)" [ref=e1018]
+        - row "before number Unix timestamp cursor for pagination" [ref=e1019]:
+          - cell "before" [ref=e1020]:
+            - code [ref=e1021]: before
+          - cell "number" [ref=e1022]
+          - cell "Unix timestamp cursor for pagination" [ref=e1023]
+        - row "offset number Skip N results for offset-based pagination" [ref=e1024]:
+          - cell "offset" [ref=e1025]:
+            - code [ref=e1026]: offset
+          - cell "number" [ref=e1027]
+          - cell "Skip N results for offset-based pagination" [ref=e1028]
+    - paragraph [ref=e1029]:
+      - strong [ref=e1030]: "Note:"
+      - code [ref=e1031]: videos
+      - text: in this response use the same schema as
+      - code [ref=e1032]: /api/videos
+      - text: ", including"
+      - code [ref=e1033]: tags
+      - text: ", extracted badge fields, and public moderation metadata."
+    - paragraph [ref=e1034]:
+      - strong [ref=e1035]: "Note:"
+      - text: This endpoint returns
+      - code [ref=e1036]: content_labels
+      - text: on each video, but it does not currently expose
+      - code [ref=e1037]: nsfw
+      - text: ","
+      - code [ref=e1038]: content_safety
+      - text: ", or"
+      - code [ref=e1039]: exclude_label
+      - text: query parameters.
+    - paragraph [ref=e1040]:
+      - strong [ref=e1041]: "Response:"
+    - code [ref=e1043]: "{ \"videos\": [...], \"next_cursor\": \"1700000000\", \"has_more\": true }"
+    - 'heading "GET /api/users/{pubkey}/notifications" [level=4] [ref=e1044]'
+    - paragraph [ref=e1045]: Get user notifications (requires NIP-98 auth).
+    - paragraph [ref=e1046]:
+      - strong [ref=e1047]: "Query:"
+    - list [ref=e1048]:
+      - listitem [ref=e1049]:
+        - code [ref=e1050]: types
+        - text: "- Filter by type (comma-separated):"
+        - code [ref=e1051]: reaction
+        - text: ","
+        - code [ref=e1052]: reply
+        - text: ","
+        - code [ref=e1053]: repost
+        - text: ","
+        - code [ref=e1054]: mention
+        - text: ","
+        - code [ref=e1055]: follow
+        - text: ","
+        - code [ref=e1056]: zap
+      - listitem [ref=e1057]:
+        - code [ref=e1058]: unread_only
+        - text: "- Only show unread (default false)"
+      - listitem [ref=e1059]:
+        - code [ref=e1060]: limit
+        - text: "- Max results (default 50)"
+      - listitem [ref=e1061]:
+        - code [ref=e1062]: before
+        - text: "- Cursor for pagination (timestamp)"
+    - paragraph [ref=e1063]:
+      - strong [ref=e1064]: "Response:"
+    - code [ref=e1066]: "{ \"notifications\": [ { \"source_pubkey\": \"64-char-hex\", \"source_event_id\": \"64-char-hex\", \"source_kind\": 7, \"source_created_at\": 1700000000, \"referenced_event_id\": \"64-char-hex\", \"notification_type\": \"reaction\", \"created_at\": 1700000000, \"read\": false } ], \"unread_count\": 5, \"next_cursor\": \"1699999000\", \"has_more\": true }"
+    - paragraph [ref=e1067]:
+      - strong [ref=e1068]: "Notification Types:"
+    - list [ref=e1069]:
+      - listitem [ref=e1070]:
+        - code [ref=e1071]: reaction
+        - text: "- Someone liked your video"
+      - listitem [ref=e1072]:
+        - code [ref=e1073]: reply
+        - text: "- Someone commented on your video"
+      - listitem [ref=e1074]:
+        - code [ref=e1075]: repost
+        - text: "- Someone reposted your video"
+      - listitem [ref=e1076]:
+        - code [ref=e1077]: mention
+        - text: "- Someone mentioned you"
+      - listitem [ref=e1078]:
+        - code [ref=e1079]: follow
+        - text: "- Someone followed you"
+      - listitem [ref=e1080]:
+        - code [ref=e1081]: zap
+        - text: "- Someone zapped you (lightning payment)"
+    - 'heading "POST /api/users/{pubkey}/notifications/read" [level=4] [ref=e1082]'
+    - paragraph [ref=e1083]: Mark notifications as read (requires NIP-98 auth).
+    - paragraph [ref=e1084]:
+      - strong [ref=e1085]: "Request:"
+    - code [ref=e1087]: "{ \"notification_ids\": [\"event-id-1\", \"event-id-2\"] }"
+    - paragraph [ref=e1088]: "To mark ALL as read, send empty array or omit:"
+    - code [ref=e1090]: "{ \"notification_ids\": [] }"
+    - paragraph [ref=e1091]:
+      - strong [ref=e1092]: "Response:"
+    - code [ref=e1094]: "{ \"marked_count\": 5, \"marked_all\": true }"
+    - 'heading "GET /api/users/{pubkey}/identities" [level=4] [ref=e1095]'
+    - paragraph [ref=e1096]: Get a user's NIP-39 external identity claims.
+    - paragraph [ref=e1097]:
+      - strong [ref=e1098]: "Response:"
+    - code [ref=e1100]: "{ \"identities\": [ { \"platform\": \"github\", \"username\": \"alice\", \"proof\": \"https://github.com/alice\" }, { \"platform\": \"twitter\", \"username\": \"alice_dev\", \"proof\": \"\" } ] }"
+    - 'heading "GET /api/users/{pubkey}/analytics" [level=4] [ref=e1101]'
+    - paragraph [ref=e1102]: Get creator analytics for your own content (requires NIP-98 auth).
+    - paragraph [ref=e1103]:
+      - strong [ref=e1104]: "Query:"
+      - code [ref=e1105]: period
+      - text: "- Time period:"
+      - code [ref=e1106]: 7d
+      - text: ","
+      - code [ref=e1107]: 30d
+      - text: (default),
+      - code [ref=e1108]: 90d
+      - text: ", or"
+      - code [ref=e1109]: all
+    - paragraph [ref=e1110]:
+      - strong [ref=e1111]: "Response:"
+    - code [ref=e1113]: "{ \"total_views\": 50000, \"total_loops\": 37500.5, \"total_watch_time\": 125000, \"unique_viewers\": 12000, \"videos\": [ { \"id\": \"64-char-hex\", \"views\": 10000, \"loops\": 7500.25, \"unique_viewers\": 3000, \"avg_completion\": 0.85 } ], \"daily_stats\": [ { \"date\": \"2024-01-15\", \"views\": 1500, \"loops\": 1125.0 } ], \"period\": \"30d\" }"
+    - 'heading "GET /api/users/{pubkey}/recommendations" [level=4] [ref=e1114]'
+    - paragraph [ref=e1115]: Get personalized video recommendations for a user. Uses Gorse ML recommendation engine when available, with fallback to popular/recent videos.
+    - paragraph [ref=e1116]:
+      - strong [ref=e1117]: "Query Parameters:"
+    - list [ref=e1118]:
+      - listitem [ref=e1119]:
+        - code [ref=e1120]: limit
+        - text: "- Max results (1-100, default 20)"
+      - listitem [ref=e1121]:
+        - code [ref=e1122]: category
+        - text: "- Filter by hashtag/category"
+      - listitem [ref=e1123]:
+        - code [ref=e1124]: fallback
+        - text: "- Strategy when personalization unavailable: \"popular\" (default) or \"recent\""
+    - paragraph [ref=e1125]:
+      - strong [ref=e1126]: "Response:"
+    - code [ref=e1128]: "{ \"videos\": [ { \"id\": \"event-id\", \"pubkey\": \"creator-pubkey\", \"title\": \"Video Title\", \"thumbnail\": \"https://...\", \"reactions\": 42, \"comments\": 5, \"reposts\": 2, \"author_name\": \"CreatorName\", \"author_avatar\": \"https://...\", \"content_labels\": [\"safe\"] } ], \"source\": \"personalized\" // or \"popular\", \"recent\" }"
+    - paragraph [ref=e1129]:
+      - strong [ref=e1130]: "Source Values:"
+    - list [ref=e1131]:
+      - listitem [ref=e1132]:
+        - code [ref=e1133]: personalized
+        - text: "- ML-based recommendations from Gorse"
+      - listitem [ref=e1134]:
+        - code [ref=e1135]: popular
+        - text: "- Fallback: 60% trending + 40% recent (shuffled)"
+      - listitem [ref=e1136]:
+        - code [ref=e1137]: recent
+        - text: "- Fallback: most recent videos"
+    - paragraph [ref=e1138]:
+      - strong [ref=e1139]: "Note:"
+      - text: Cold-start users (no interaction history) automatically receive fallback recommendations.
+    - paragraph [ref=e1140]:
+      - strong [ref=e1141]: "Note:"
+      - text: Recommendations do not currently expose
+      - code [ref=e1142]: nsfw
+      - text: ","
+      - code [ref=e1143]: content_safety
+      - text: ", or per-label hide parameters."
+    - 'heading "GET /api/users/{pubkey}/badges" [level=4] [ref=e1144]'
+    - paragraph [ref=e1145]: Get NIP-58 badges awarded to a user.
+    - paragraph [ref=e1146]:
+      - strong [ref=e1147]: "Query:"
+      - code [ref=e1148]: accepted_only
+      - text: "- boolean, default"
+      - code [ref=e1149]: "true"
+      - text: . When
+      - code [ref=e1150]: "true"
+      - text: ", only accepted badge awards are returned."
+    - paragraph [ref=e1151]:
+      - strong [ref=e1152]: "Response:"
+    - code [ref=e1154]: "{ \"badges\": [ { \"definition\": { \"d_tag\": \"founding-creator\", \"creator_pubkey\": \"64-char-hex\", \"name\": \"Founding Creator\", \"description\": \"Early contributor to divine.video\", \"image\": \"https://example.com/badges/founding-creator.png\", \"thumb\": \"https://example.com/badges/founding-creator-thumb.png\", \"created_at\": \"2025-01-15T10:30:00Z\", \"coordinate\": \"30009:64-char-hex:founding-creator\" }, \"award_event_id\": \"64-char-hex\", \"awarded_at\": \"2025-01-20T12:00:00Z\", \"awarded_by\": \"64-char-hex\" } ] }"
+    - 'heading "GET /api/badges/{creator_pubkey}/{d_tag}" [level=4] [ref=e1155]'
+    - paragraph [ref=e1156]: Get the badge definition metadata for a single badge.
+    - paragraph [ref=e1157]:
+      - strong [ref=e1158]: "Response:"
+    - code [ref=e1160]: "{ \"d_tag\": \"founding-creator\", \"creator_pubkey\": \"64-char-hex\", \"name\": \"Founding Creator\", \"description\": \"Early contributor to divine.video\", \"image\": \"https://example.com/badges/founding-creator.png\", \"thumb\": \"https://example.com/badges/founding-creator-thumb.png\", \"created_at\": \"2025-01-15T10:30:00Z\", \"coordinate\": \"30009:64-char-hex:founding-creator\" }"
+    - 'heading "GET /api/users/{pubkey}/identities" [level=4] [ref=e1161]'
+    - paragraph [ref=e1162]: Get a user's external identity claims published via NIP-39.
+    - paragraph [ref=e1163]:
+      - strong [ref=e1164]: "Response:"
+    - code [ref=e1166]: "{ \"identities\": [ { \"platform\": \"github\", \"username\": \"rabble\", \"proof\": \"https://gist.github.com/rabble/identity-proof\" }, { \"platform\": \"mastodon\", \"username\": \"@rabble@mastodon.social\", \"proof\": \"https://mastodon.social/@rabble/1234567890\" } ] }"
+    - heading "GET /api/users/top" [level=4] [ref=e1167]
+    - paragraph [ref=e1168]: Get top creators ranked by total loop count.
+    - paragraph [ref=e1169]:
+      - strong [ref=e1170]: "Query Parameters:"
+    - table [ref=e1171]:
+      - rowgroup [ref=e1172]:
+        - row "Param Type Description" [ref=e1173]:
+          - columnheader "Param" [ref=e1174]
+          - columnheader "Type" [ref=e1175]
+          - columnheader "Description" [ref=e1176]
+      - rowgroup [ref=e1177]:
+        - 'row "platform string vine for classic Viners, all for everyone (default: all)" [ref=e1178]':
+          - cell "platform" [ref=e1179]:
+            - code [ref=e1180]: platform
+          - cell "string" [ref=e1181]
+          - 'cell "vine for classic Viners, all for everyone (default: all)" [ref=e1182]':
+            - code [ref=e1183]: vine
+            - text: for classic Viners,
+            - code [ref=e1184]: all
+            - text: "for everyone (default: all)"
+        - row "limit number Max results (1-100, default 50)" [ref=e1185]:
+          - cell "limit" [ref=e1186]:
+            - code [ref=e1187]: limit
+          - cell "number" [ref=e1188]
+          - cell "Max results (1-100, default 50)" [ref=e1189]
+    - paragraph [ref=e1190]:
+      - strong [ref=e1191]: "Response:"
+    - code [ref=e1193]: "[ { \"pubkey\": \"64-char-hex\", \"name\": \"King Bach\", \"picture\": \"https://...\", \"total_loops\": 5000000, \"video_count\": 150, \"platform\": \"vine\" } ]"
+    - paragraph [ref=e1194]:
+      - strong [ref=e1195]: "Note:"
+      - text: This is different from
+      - code [ref=e1196]: /api/leaderboard/creators
+      - text: which ranks by views over time periods. This endpoint ranks by embedded loop counts (primarily for Vine archive data).
+    - heading "POST /api/users/bulk" [level=4] [ref=e1197]
+    - paragraph [ref=e1198]: Get multiple users in one request.
+    - paragraph [ref=e1199]:
+      - strong [ref=e1200]: "Request:"
+    - code [ref=e1202]: "{ \"pubkeys\": [\"pk1\", \"pk2\"], \"from_event\": { \"kind\": 3, \"pubkey\": \"user-pubkey\" } }"
+    - paragraph [ref=e1203]:
+      - strong [ref=e1204]: "Response:"
+    - code [ref=e1206]: "{ \"users\": [ { \"pubkey\": \"64-char-hex\", \"profile\": { \"profile_updated\": \"2024-01-15T10:30:00Z\", \"name\": \"username\", \"display_name\": \"Display Name\", \"picture\": \"https://...\", \"banner\": \"https://...\", \"about\": \"Bio text\", \"nip05\": \"user@domain.com\", \"lud16\": \"user@getalby.com\", \"website\": \"https://...\" }, \"social\": { \"follower_count\": 1000, \"following_count\": 500 }, \"stats\": { \"video_count\": 50, \"horizontal_videos\": 10, \"vertical_videos\": 40, \"note_count\": 100, \"reaction_count\": 200, \"comment_count\": 50, \"repost_count\": 30, \"first_activity\": \"2023-06-01T00:00:00Z\", \"last_activity\": \"2024-01-15T10:30:00Z\", \"total_events\": 1200 }, \"engagement\": { \"total_reactions\": 5000, \"total_comments\": 1200, \"total_reposts\": 300, \"unique_reactors\": 2500, \"unique_commenters\": 800, \"unique_reposters\": 200 } } ], \"missing\": [\"pk-that-wasnt-found\"], \"source_event_id\": \"64-char-hex\" }"
+    - paragraph [ref=e1207]:
+      - strong [ref=e1208]:
+        - text: The
+        - code [ref=e1209]: from_event
+        - text: "pattern:"
+    - paragraph [ref=e1210]:
+      - text: Instead of providing explicit
+      - code [ref=e1211]: pubkeys
+      - text: ", you can reference an event that contains pubkeys:"
+    - list [ref=e1212]:
+      - listitem [ref=e1213]:
+        - code [ref=e1214]: "kind: 3"
+        - text: "- Resolve pubkeys from a user's contact list (follow list)"
+        - list [ref=e1215]:
+          - listitem [ref=e1216]:
+            - text: Fetches all
+            - code [ref=e1217]: p
+            - text: tags from the user's kind 3 event
+          - listitem [ref=e1218]: "Useful for: \"Get profiles of everyone this user follows\""
+    - code [ref=e1220]: "// Get profiles of everyone alice follows { \"from_event\": { \"kind\": 3, \"pubkey\": \"alice-pubkey\" } }"
+    - paragraph [ref=e1221]:
+      - text: Similarly,
+      - code [ref=e1222]: /api/videos/bulk
+      - text: "supports:"
+    - list [ref=e1223]:
+      - listitem [ref=e1224]:
+        - code [ref=e1225]: "kind: 30005"
+        - text: "- Resolve videos from a curation set/playlist"
+        - list [ref=e1226]:
+          - listitem [ref=e1227]:
+            - text: Fetches all
+            - code [ref=e1228]: e
+            - text: and
+            - code [ref=e1229]: a
+            - text: tags from the playlist
+    - code [ref=e1231]: "// Get all videos in a playlist { \"from_event\": { \"kind\": 30005, \"pubkey\": \"curator-pubkey\", \"d_tag\": \"playlist-name\" } }"
+    - heading "Search" [level=3] [ref=e1232]
+    - heading "GET /api/search" [level=4] [ref=e1233]
+    - paragraph [ref=e1234]: Search videos by hashtag or text.
+    - paragraph [ref=e1235]:
+      - strong [ref=e1236]: "Query:"
+    - list [ref=e1237]:
+      - listitem [ref=e1238]:
+        - code [ref=e1239]: tag
+        - text: "- Search by hashtag"
+      - listitem [ref=e1240]:
+        - code [ref=e1241]: q
+        - text: "- Full-text search"
+      - listitem [ref=e1242]:
+        - code [ref=e1243]: limit
+        - text: "- Max results (1-100, default 50)"
+      - listitem [ref=e1244]:
+        - code [ref=e1245]: offset
+        - text: "- Skip N results for pagination"
+      - listitem [ref=e1246]:
+        - code [ref=e1247]: label
+        - text: "- Filter by any effective content label (for example"
+        - code [ref=e1248]: nudity
+        - text: or
+        - code [ref=e1249]: topic:music
+        - text: )
+    - paragraph [ref=e1250]:
+      - strong [ref=e1251]: "Note:"
+      - text: Search does not currently expose
+      - code [ref=e1252]: nsfw=show
+      - text: ","
+      - code [ref=e1253]: content_safety
+      - text: ", or per-label hide parameters."
+    - paragraph [ref=e1254]:
+      - strong [ref=e1255]: "Response:"
+    - code [ref=e1257]: "[ { \"id\": \"64-char-hex\", \"pubkey\": \"64-char-hex\", \"created_at\": \"2024-01-15T10:30:00Z\", \"kind\": 34236, \"d_tag\": \"my-video\", \"title\": \"Video Title\", \"content\": \"Description\", \"thumbnail\": \"https://...\", \"video_url\": \"https://...\", \"reactions\": 150, \"comments\": 42, \"reposts\": 10, \"engagement_score\": 254, \"loops\": 5000, \"views\": 12345, \"language\": \"en\", \"tags\": [[\"d\", \"my-video\"], [\"verification\", \"human\"]], \"moderation_status\": \"human_made\", \"ai_score\": 0.03, \"ai_source\": \"content_labels\", \"ai_checked_at\": 1705314700, \"author_name\": \"CreatorName\", \"author_avatar\": \"https://...\", \"content_labels\": [\"safe\"] } ]"
+    - heading "GET /api/search/profiles" [level=4] [ref=e1258]
+    - paragraph [ref=e1259]: Search user profiles by name, display_name, nip05, or about/bio.
+    - paragraph [ref=e1260]:
+      - strong [ref=e1261]: "Query:"
+      - code [ref=e1262]: q
+      - text: (required),
+      - code [ref=e1263]: limit
+      - text: (1-100, default 50),
+      - code [ref=e1264]: offset
+      - text: (skip N results),
+      - code [ref=e1265]: sort_by
+      - text: ("followers" or "relevance", default "relevance"),
+      - code [ref=e1266]: has_videos
+      - text: (boolean, filter to users with video content)
+    - paragraph [ref=e1267]:
+      - strong [ref=e1268]: "Relevance ranking (default):"
+    - list [ref=e1269]:
+      - listitem [ref=e1270]: "Tier 1: exact name match"
+      - listitem [ref=e1271]: "Tier 2: prefix match"
+      - listitem [ref=e1272]:
+        - text: "Tier 3: substring match (includes handles like"
+        - code [ref=e1273]: jackandjackofficial
+        - text: for query
+        - code [ref=e1274]: jack
+        - text: )
+      - listitem [ref=e1275]: "Then social signals as tie-breakers: follower count, video count, and profile picture presence"
+      - listitem [ref=e1276]: "NIP-05 signals: verified identifiers are boosted; empty/squatter-like unverified profiles are penalized"
+    - paragraph [ref=e1277]:
+      - code [ref=e1278]: sort_by=followers
+      - text: keeps follower count as the primary sort key.
+    - paragraph [ref=e1279]:
+      - strong [ref=e1280]: "Response:"
+    - code [ref=e1282]: "[ { \"pubkey\": \"64-char-hex\", \"name\": \"username\", \"display_name\": \"Display Name\", \"nip05\": \"user@domain.com\", \"about\": \"Bio text\", \"picture\": \"https://example.com/avatar.jpg\", \"banner\": \"https://example.com/banner.jpg\", \"follower_count\": 1234, \"video_count\": 42, \"nip05_verified\": 1 } ]"
+    - heading "Hashtags" [level=3] [ref=e1283]
+    - heading "GET /api/hashtags" [level=4] [ref=e1284]
+    - paragraph [ref=e1285]: Get popular hashtags.
+    - paragraph [ref=e1286]:
+      - strong [ref=e1287]: "Query:"
+      - code [ref=e1288]: limit
+      - text: (1-100, default 50),
+      - code [ref=e1289]: offset
+      - text: (default 0),
+      - code [ref=e1290]: q
+      - text: (optional, case-insensitive substring filter, max 100 chars)
+    - paragraph [ref=e1291]:
+      - strong [ref=e1292]: "Response:"
+    - code [ref=e1294]: "[ { \"hashtag\": \"nostr\", \"video_count\": 500, \"unique_creators\": 150, \"total_loops\": 125000, \"last_used\": \"2024-01-15T10:30:00Z\", \"thumbnail\": \"https://...\" }, { \"hashtag\": \"bitcoin\", \"video_count\": 300, \"unique_creators\": 80, \"total_loops\": 75000, \"last_used\": \"2024-01-14T18:45:00Z\", \"thumbnail\": \"https://...\" } ]"
+    - heading "GET /api/hashtags/trending" [level=4] [ref=e1295]
+    - paragraph [ref=e1296]: Get trending hashtags (time-weighted by recent activity).
+    - paragraph [ref=e1297]:
+      - strong [ref=e1298]: "Query:"
+      - code [ref=e1299]: limit
+      - text: (1-100, default 50),
+      - code [ref=e1300]: offset
+      - text: (default 0),
+      - code [ref=e1301]: q
+      - text: (optional, case-insensitive substring filter, max 100 chars)
+    - paragraph [ref=e1302]:
+      - strong [ref=e1303]: "Response:"
+    - code [ref=e1305]: "[ { \"hashtag\": \"nostr\", \"video_count\": 500, \"videos_24h\": 50, \"videos_7d\": 200, \"unique_creators\": 150, \"last_used\": \"2024-01-15T10:30:00Z\", \"trending_score\": 8500, \"thumbnail\": \"https://...\" } ]"
+    - heading "Categories" [level=3] [ref=e1306]
+    - heading "GET /api/categories" [level=4] [ref=e1307]
+    - paragraph [ref=e1308]: Get popular content categories with video counts. Categories are derived from VLM (Vision-Language Model) classification of video content.
+    - paragraph [ref=e1309]:
+      - strong [ref=e1310]: "Query:"
+      - code [ref=e1311]: limit
+      - text: (1-100, default 50),
+      - code [ref=e1312]: offset
+      - text: (default 0),
+      - code [ref=e1313]: q
+      - text: (optional, case-insensitive substring filter)
+    - paragraph [ref=e1314]:
+      - strong [ref=e1315]: "Response:"
+    - code [ref=e1317]: "[ { \"name\": \"music\", \"video_count\": 1500 }, { \"name\": \"comedy\", \"video_count\": 1200 }, { \"name\": \"dance\", \"video_count\": 800 } ]"
+    - paragraph [ref=e1318]:
+      - strong [ref=e1319]: "Common categories:"
+      - text: music, comedy, dance, sports, food, animals, fashion, gaming, nature, travel, education, technology, art, beauty, fitness, pets, cooking, DIY, news, entertainment
+    - heading "Filtering videos by category" [level=4] [ref=e1320]
+    - paragraph [ref=e1321]:
+      - text: Use the
+      - code [ref=e1322]: category
+      - text: "query parameter on the videos endpoint:"
+    - code [ref=e1324]: GET /api/videos?category=music
+    - paragraph [ref=e1325]:
+      - text: This is a convenience shorthand for
+      - code [ref=e1326]: label=topic:music
+      - text: . The
+      - code [ref=e1327]: category
+      - text: parameter maps to the underlying label system.
+    - heading "Stats" [level=3] [ref=e1328]
+    - heading "GET /api/stats" [level=4] [ref=e1329]
+    - paragraph [ref=e1330]: Get platform statistics.
+    - paragraph [ref=e1331]:
+      - strong [ref=e1332]: "Response:"
+    - code [ref=e1334]: "{ \"total_events\": 162586, \"total_videos\": 18919, \"vine_videos\": 15000 }"
+    - heading "Leaderboards" [level=3] [ref=e1335]
+    - paragraph [ref=e1336]: Leaderboards show top videos and creators ranked by views for different time periods.
+    - heading "Time Periods" [level=4] [ref=e1337]
+    - table [ref=e1338]:
+      - rowgroup [ref=e1339]:
+        - row "Value Description Aliases" [ref=e1340]:
+          - columnheader "Value" [ref=e1341]
+          - columnheader "Description" [ref=e1342]
+          - columnheader "Aliases" [ref=e1343]
+      - rowgroup [ref=e1344]:
+        - row "day Last 24 hours daily, today, 24h" [ref=e1345]:
+          - cell "day" [ref=e1346]:
+            - code [ref=e1347]: day
+          - cell "Last 24 hours" [ref=e1348]
+          - cell "daily, today, 24h" [ref=e1349]:
+            - code [ref=e1350]: daily
+            - text: ","
+            - code [ref=e1351]: today
+            - text: ","
+            - code [ref=e1352]: 24h
+        - row "week Last 7 days weekly, 7d" [ref=e1353]:
+          - cell "week" [ref=e1354]:
+            - code [ref=e1355]: week
+          - cell "Last 7 days" [ref=e1356]
+          - cell "weekly, 7d" [ref=e1357]:
+            - code [ref=e1358]: weekly
+            - text: ","
+            - code [ref=e1359]: 7d
+        - row "month Last 30 days (default) monthly, 30d" [ref=e1360]:
+          - cell "month" [ref=e1361]:
+            - code [ref=e1362]: month
+          - cell "Last 30 days (default)" [ref=e1363]
+          - cell "monthly, 30d" [ref=e1364]:
+            - code [ref=e1365]: monthly
+            - text: ","
+            - code [ref=e1366]: 30d
+        - row "year Last 365 days yearly, 365d" [ref=e1367]:
+          - cell "year" [ref=e1368]:
+            - code [ref=e1369]: year
+          - cell "Last 365 days" [ref=e1370]
+          - cell "yearly, 365d" [ref=e1371]:
+            - code [ref=e1372]: yearly
+            - text: ","
+            - code [ref=e1373]: 365d
+        - row "alltime All time all, all_time, forever" [ref=e1374]:
+          - cell "alltime" [ref=e1375]:
+            - code [ref=e1376]: alltime
+          - cell "All time" [ref=e1377]
+          - cell "all, all_time, forever" [ref=e1378]:
+            - code [ref=e1379]: all
+            - text: ","
+            - code [ref=e1380]: all_time
+            - text: ","
+            - code [ref=e1381]: forever
+    - heading "GET /api/leaderboard/videos" [level=4] [ref=e1382]
+    - paragraph [ref=e1383]: Get top videos ranked by views for a time period.
+    - paragraph [ref=e1384]:
+      - strong [ref=e1385]: "Parameters:"
+    - list [ref=e1386]:
+      - listitem [ref=e1387]:
+        - code [ref=e1388]: period
+        - text: "(optional): Time period -"
+        - code [ref=e1389]: day
+        - text: ","
+        - code [ref=e1390]: week
+        - text: ","
+        - code [ref=e1391]: month
+        - text: (default),
+        - code [ref=e1392]: year
+        - text: ", or"
+        - code [ref=e1393]: alltime
+      - listitem [ref=e1394]:
+        - code [ref=e1395]: limit
+        - text: "(optional): Max results 1-100, default 50"
+      - listitem [ref=e1396]:
+        - code [ref=e1397]: offset
+        - text: "(optional): Pagination offset, default 0"
+    - paragraph [ref=e1398]:
+      - strong [ref=e1399]: "Example:"
+    - code [ref=e1401]: "# Top videos this week curl \"https://api.divine.video/api/leaderboard/videos?period=week&limit=20\" # Page 2 of monthly leaderboard curl \"https://api.divine.video/api/leaderboard/videos?period=month&limit=50&offset=50\""
+    - paragraph [ref=e1402]:
+      - strong [ref=e1403]: "Response:"
+    - code [ref=e1405]: "{ \"period\": \"week\", \"entries\": [ { \"id\": \"abc123...\", \"pubkey\": \"creator456...\", \"title\": \"Viral Video Title\", \"thumbnail\": \"https://cdn.example.com/thumb.jpg\", \"d_tag\": \"my-video-1\", \"video_url\": \"https://cdn.example.com/video.mp4\", \"kind\": 34236, \"author_name\": \"King Bach\", \"author_avatar\": \"https://cdn.example.com/avatar.jpg\", \"views\": 50000, \"unique_viewers\": 25000, \"loops\": 37500 } ] }"
+    - heading "GET /api/leaderboard/creators" [level=4] [ref=e1406]
+    - paragraph [ref=e1407]: Get top creators (Viners) ranked by total views for a time period.
+    - paragraph [ref=e1408]:
+      - strong [ref=e1409]: "Parameters:"
+    - list [ref=e1410]:
+      - listitem [ref=e1411]:
+        - code [ref=e1412]: period
+        - text: "(optional): Time period -"
+        - code [ref=e1413]: day
+        - text: ","
+        - code [ref=e1414]: week
+        - text: ","
+        - code [ref=e1415]: month
+        - text: (default),
+        - code [ref=e1416]: year
+        - text: ", or"
+        - code [ref=e1417]: alltime
+      - listitem [ref=e1418]:
+        - code [ref=e1419]: limit
+        - text: "(optional): Max results 1-100, default 50"
+      - listitem [ref=e1420]:
+        - code [ref=e1421]: offset
+        - text: "(optional): Pagination offset, default 0"
+    - paragraph [ref=e1422]:
+      - strong [ref=e1423]: "Example:"
+    - code [ref=e1425]: "# Top creators all time curl \"https://api.divine.video/api/leaderboard/creators?period=alltime&limit=100\" # Top creators today curl \"https://api.divine.video/api/leaderboard/creators?period=day\""
+    - paragraph [ref=e1426]:
+      - strong [ref=e1427]: "Response:"
+    - code [ref=e1429]: "{ \"period\": \"alltime\", \"entries\": [ { \"pubkey\": \"creator456...\", \"name\": \"King Bach\", \"display_name\": \"Bach\", \"picture\": \"https://cdn.example.com/avatar.jpg\", \"views\": 5000000, \"unique_viewers\": 1000000, \"loops\": 3750000, \"videos_with_views\": 150 } ] }"
+    - separator [ref=e1430]
+    - heading "RSS Feeds" [level=2] [ref=e1431]
+    - paragraph [ref=e1432]:
+      - text: DiVine provides RSS 2.0 feeds with podcast namespace extensions (
+      - code [ref=e1433]: podcast
+      - text: ","
+      - code [ref=e1434]: itunes
+      - text: ","
+      - code [ref=e1435]: media
+      - text: ","
+      - code [ref=e1436]: atom
+      - text: ). All feeds return
+      - code [ref=e1437]: "Content-Type: application/rss+xml"
+      - text: and are cached for 5 minutes.
+    - heading "Feed Endpoints" [level=3] [ref=e1438]
+    - table [ref=e1439]:
+      - rowgroup [ref=e1440]:
+        - row "Endpoint Description" [ref=e1441]:
+          - columnheader "Endpoint" [ref=e1442]
+          - columnheader "Description" [ref=e1443]
+      - rowgroup [ref=e1444]:
+        - row "GET /feed/latest Latest videos globally" [ref=e1445]:
+          - cell "GET /feed/latest" [ref=e1446]:
+            - code [ref=e1447]: GET /feed/latest
+          - cell "Latest videos globally" [ref=e1448]
+        - row "GET /feed/trending Trending videos" [ref=e1449]:
+          - cell "GET /feed/trending" [ref=e1450]:
+            - code [ref=e1451]: GET /feed/trending
+          - cell "Trending videos" [ref=e1452]
+        - 'row "GET /feed/tag/{hashtag} Videos filtered by hashtag" [ref=e1453]':
+          - 'cell "GET /feed/tag/{hashtag}" [ref=e1454]':
+            - code [ref=e1455]: "GET /feed/tag/{hashtag}"
+          - cell "Videos filtered by hashtag" [ref=e1456]
+        - 'row "GET /feed/category/{category} Videos filtered by category (VLM topic label)" [ref=e1457]':
+          - 'cell "GET /feed/category/{category}" [ref=e1458]':
+            - code [ref=e1459]: "GET /feed/category/{category}"
+          - cell "Videos filtered by category (VLM topic label)" [ref=e1460]
+        - 'row "GET /feed/{npub}/videos A creator''s published videos" [ref=e1461]':
+          - 'cell "GET /feed/{npub}/videos" [ref=e1462]':
+            - code [ref=e1463]: "GET /feed/{npub}/videos"
+          - cell "A creator's published videos" [ref=e1464]
+        - 'row "GET /feed/{npub}/feed Videos from accounts a user follows" [ref=e1465]':
+          - 'cell "GET /feed/{npub}/feed" [ref=e1466]':
+            - code [ref=e1467]: "GET /feed/{npub}/feed"
+          - cell "Videos from accounts a user follows" [ref=e1468]
+    - paragraph [ref=e1469]:
+      - strong [ref=e1470]: "Notes:"
+    - list [ref=e1471]:
+      - listitem [ref=e1472]:
+        - code [ref=e1473]: "{npub}"
+        - text: must be a valid Nostr npub bech32 string (e.g.,
+        - code [ref=e1474]: npub1...
+        - text: ). Returns 400 for invalid npubs.
+      - listitem [ref=e1475]: All feeds return up to 50 items.
+      - listitem [ref=e1476]:
+        - code [ref=e1477]: /feed/latest
+        - text: is recency-sorted.
+      - listitem [ref=e1478]:
+        - code [ref=e1479]: /feed/trending
+        - text: is trend-sorted.
+      - listitem [ref=e1480]:
+        - code [ref=e1481]: "/feed/tag/{hashtag}"
+        - text: and
+        - code [ref=e1482]: "/feed/category/{category}"
+        - text: support
+        - code [ref=e1483]: "?sort="
+        - text: (
+        - code [ref=e1484]: trending
+        - text: default) and
+        - code [ref=e1485]: "?platform="
+        - text: (for example,
+        - code [ref=e1486]: vine
+        - text: ).
+      - listitem [ref=e1487]: No authentication required.
+    - heading "Podcast Namespace Extensions" [level=3] [ref=e1488]
+    - paragraph [ref=e1489]: "Each feed includes:"
+    - list [ref=e1490]:
+      - listitem [ref=e1491]:
+        - code [ref=e1492]: <podcast:medium>video</podcast:medium>
+        - text: — identifies content type
+      - listitem [ref=e1493]:
+        - code [ref=e1494]: <atom:link rel="self">
+        - text: — canonical feed URL
+      - listitem [ref=e1495]:
+        - code [ref=e1496]: "<podcast:socialInteract uri=\"nostr:{naddr}\" protocol=\"nostr\">"
+        - text: — links items to Nostr events
+    - paragraph [ref=e1497]: "Per-item extensions:"
+    - list [ref=e1498]:
+      - listitem [ref=e1499]:
+        - code [ref=e1500]: <enclosure>
+        - text: — video URL with MIME type and file size
+      - listitem [ref=e1501]:
+        - code [ref=e1502]: <itunes:author>
+        - text: — creator display name
+      - listitem [ref=e1503]:
+        - code [ref=e1504]: <itunes:image>
+        - text: — video thumbnail
+      - listitem [ref=e1505]:
+        - code [ref=e1506]: <itunes:duration>
+        - text: — video duration (on hashtag/category feeds with full media metadata)
+      - listitem [ref=e1507]:
+        - code [ref=e1508]: <guid isPermaLink="false">
+        - text: — set to the video's d-tag (addressable event identifier)
+      - listitem [ref=e1509]:
+        - code [ref=e1510]: <link>
+        - text: —
+        - code [ref=e1511]: "https://divine.video/v/{naddr}"
+        - text: deep link
+    - paragraph [ref=e1512]:
+      - text: Creator feeds (
+      - code [ref=e1513]: "/feed/{npub}/videos"
+      - text: ") also include channel-level:"
+    - list [ref=e1514]:
+      - listitem [ref=e1515]:
+        - code [ref=e1516]: <itunes:author>
+        - text: and
+        - code [ref=e1517]: <itunes:image>
+        - text: from the creator's Nostr profile
+      - listitem [ref=e1518]:
+        - code [ref=e1519]: <podcast:guid>
+        - text: set to the creator's npub
+      - listitem [ref=e1520]:
+        - code [ref=e1521]: <image>
+        - text: RSS standard channel image from profile picture
+    - heading "Example Usage" [level=3] [ref=e1522]
+    - code [ref=e1524]: "# Latest videos feed curl https://relay.divine.video/feed/latest # Creator's videos (use their npub) curl https://relay.divine.video/feed/npub1..../videos # Hashtag feed curl https://relay.divine.video/feed/tag/nostr # Category feed curl https://relay.divine.video/feed/category/music"
+    - heading "Caching" [level=3] [ref=e1525]
+    - paragraph [ref=e1526]: "All feed responses include:"
+    - code [ref=e1528]: "Cache-Control: public, max-age=300, stale-while-revalidate=60"
+    - separator [ref=e1529]
+    - heading "Common Patterns" [level=2] [ref=e1530]
+    - heading "Pagination" [level=3] [ref=e1531]
+    - paragraph [ref=e1532]:
+      - strong [ref=e1533]: "Important:"
+      - text: "Different endpoints have different pagination styles:"
+    - paragraph [ref=e1534]:
+      - strong [ref=e1535]: Array endpoints
+      - text: (
+      - code [ref=e1536]: /api/videos
+      - text: ","
+      - code [ref=e1537]: /api/hashtags
+      - text: ") - Return plain arrays:"
+    - code [ref=e1539]: "// Option 1: Use `before` param with last item's created_at timestamp const videos = await fetch('/api/videos?limit=50').then(r => r.json()); // For next page, use last video's timestamp const lastTimestamp = Math.floor(new Date(videos[videos.length - 1].created_at).getTime() / 1000); const nextPage = await fetch(`/api/videos?limit=50&before=${lastTimestamp}`).then(r => r.json()); // Stop when you get fewer results than requested const hasMore = nextPage.length === 50;"
+    - paragraph [ref=e1540]:
+      - strong [ref=e1541]: Offset-based pagination
+      - text: (for
+      - code [ref=e1542]: /api/videos
+      - text: ","
+      - code [ref=e1543]: /api/search
+      - text: "):"
+    - code [ref=e1545]: "// Option 2: Use offset for precise paging (useful for search results) const page1 = await fetch('/api/search?q=nostr&limit=20&offset=0').then(r => r.json()); const page2 = await fetch('/api/search?q=nostr&limit=20&offset=20').then(r => r.json()); const page3 = await fetch('/api/search?q=nostr&limit=20&offset=40').then(r => r.json()); // Works for videos sorted by loops too const topVines = await fetch('/api/videos?sort=loops&platform=vine&limit=50&offset=100').then(r => r.json());"
+    - paragraph [ref=e1546]:
+      - strong [ref=e1547]: Paginated endpoints
+      - text: (
+      - code [ref=e1548]: /api/videos/events
+      - text: ","
+      - code [ref=e1549]: "/api/users/{pk}/feed"
+      - text: ") - Return objects with cursor:"
+    - code [ref=e1551]: "const response = await fetch('/api/videos/events?limit=50').then(r => r.json()); // { videos: [...], next_cursor: \"1700000000\", has_more: true } if (response.has_more) { const nextPage = await fetch(`/api/videos/events?limit=50&before=${response.next_cursor}`); }"
+    - 'heading "Hybrid Approach: Events via WebSocket, Stats via REST" [level=3] [ref=e1552]'
+    - code [ref=e1554]: "// Subscribe to new videos via WebSocket ws.send(JSON.stringify([\"REQ\", \"feed\", { kinds: [34236], limit: 50 }])); // Get engagement + view stats for displayed videos const ids = videos.map(v => v.id); const stats = await fetch('/api/videos/stats/bulk', { method: 'POST', body: JSON.stringify({ event_ids: ids }) });"
+    - heading "Publishing a Video" [level=3] [ref=e1555]
+    - code [ref=e1557]: "const event = { kind: 34236, created_at: Math.floor(Date.now() / 1000), tags: [ [\"d\", crypto.randomUUID()], [\"title\", \"My Video\"], [\"imeta\", \"url https://cdn.example.com/video.mp4\", \"m video/mp4\", \"image https://cdn.example.com/thumb.jpg\" ], [\"t\", \"nostr\"] ], content: \"Video description\" }; // Sign with nostr extension or private key const signedEvent = await window.nostr.signEvent(event); ws.send(JSON.stringify([\"EVENT\", signedEvent]));"
+    - heading "Posting a Comment (Top-Level)" [level=3] [ref=e1558]
+    - code [ref=e1560]: "const comment = { kind: 1111, created_at: Math.floor(Date.now() / 1000), tags: [ [\"E\", videoId], // Root video (always the video) [\"K\", \"34236\"], // Root kind [\"P\", videoAuthorPubkey], // Root author [\"e\", videoId], // Parent = video for top-level [\"k\", \"34236\"], // Parent kind [\"p\", videoAuthorPubkey] // Parent author ], content: \"Great video!\" }; const signedComment = await window.nostr.signEvent(comment); ws.send(JSON.stringify([\"EVENT\", signedComment]));"
+    - heading "Replying to a Comment (Nested)" [level=3] [ref=e1561]
+    - code [ref=e1563]: "const reply = { kind: 1111, created_at: Math.floor(Date.now() / 1000), tags: [ [\"E\", videoId], // Root stays as the video [\"K\", \"34236\"], // Root kind stays as video kind [\"P\", videoAuthorPubkey], // Root author stays as video author [\"e\", parentCommentId], // Parent = the comment being replied to [\"k\", \"1111\"], // Parent kind = comment [\"p\", parentCommentAuthor] // Parent author = comment author ], content: \"I agree with your comment!\" }; const signedReply = await window.nostr.signEvent(reply); ws.send(JSON.stringify([\"EVENT\", signedReply]));"
+    - heading "Liking a Video" [level=3] [ref=e1564]
+    - code [ref=e1566]: "const reaction = { kind: 7, created_at: Math.floor(Date.now() / 1000), tags: [ [\"e\", videoId], [\"p\", videoAuthorPubkey], [\"k\", \"34236\"] ], content: \"+\" }; const signedReaction = await window.nostr.signEvent(reaction); ws.send(JSON.stringify([\"EVENT\", signedReaction]));"
+    - heading "Check if I Already Liked a Video" [level=3] [ref=e1567]
+    - code [ref=e1569]: "// Query for my reactions on this video ws.send(JSON.stringify([\"REQ\", \"my-reaction\", { kinds: [7], authors: [myPubkey], \"#e\": [videoId], limit: 1 }])); // If you get an event back, you've already reacted // If you only get EOSE with no events, you haven't"
+    - heading "Unlike a Video (Delete Reaction)" [level=3] [ref=e1570]
+    - code [ref=e1572]: "// First, find your reaction event ID (from the check above) const deletion = { kind: 5, created_at: Math.floor(Date.now() / 1000), tags: [ [\"e\", reactionEventId] // The ID of your kind 7 event ], content: \"\" }; const signedDeletion = await window.nostr.signEvent(deletion); ws.send(JSON.stringify([\"EVENT\", signedDeletion]));"
+    - heading "Updating a Video (Replaceable Events)" [level=3] [ref=e1573]
+    - paragraph [ref=e1574]:
+      - text: For parameterized replaceable events (kinds 30000-39999), publishing a new event with the
+      - strong [ref=e1575]:
+        - text: same
+        - code [ref=e1576]: d
+        - text: tag
+      - text: "replaces the old one:"
+    - code [ref=e1578]: "// Original video had d-tag \"my-video-id\" // To update it, publish new event with same d-tag: const updatedVideo = { kind: 34236, created_at: Math.floor(Date.now() / 1000), tags: [ [\"d\", \"my-video-id\"], // SAME d-tag = replacement [\"title\", \"Updated Title\"], [\"imeta\", \"url https://...\", \"image https://...\"], [\"t\", \"updated\"] ], content: \"New description\" }; // Sign and publish - relay automatically replaces the old event"
+    - heading "Follow a User" [level=3] [ref=e1579]
+    - paragraph [ref=e1580]: "Following requires a read-modify-write pattern on your kind 3 event:"
+    - code [ref=e1582]: "// 1. Fetch your current contact list ws.send(JSON.stringify([\"REQ\", \"my-follows\", { kinds: [3], authors: [myPubkey], limit: 1 }])); // 2. When you receive it, add the new follow ws.onmessage = (msg) => { const [type, subId, event] = JSON.parse(msg.data); if (type === 'EVENT' && subId === 'my-follows') { // Add new p tag to existing tags const newTags = [ ...event.tags, [\"p\", newFollowPubkey, \"wss://relay.divine.video\"] ]; // 3. Publish updated contact list const updatedContacts = { kind: 3, created_at: Math.floor(Date.now() / 1000), tags: newTags, content: event.content // Preserve relay list if any }; const signed = await window.nostr.signEvent(updatedContacts); ws.send(JSON.stringify([\"EVENT\", signed])); } };"
+    - heading "Unfollow a User" [level=3] [ref=e1583]
+    - paragraph [ref=e1584]: "Same pattern, but filter OUT the p tag:"
+    - code [ref=e1586]: const newTags = event.tags.filter( tag => !(tag[0] === 'p' && tag[1] === unfollowPubkey) );
+    - heading "Check if I'm Following Someone" [level=3] [ref=e1587]
+    - code [ref=e1589]: "// Option 1: Via REST API (check your following list) const following = await fetch(`/api/users/${myPubkey}/following`).then(r => r.json()); const isFollowing = following.following.includes(targetPubkey); // Option 2: Via WebSocket (fetch your kind 3 and check tags) ws.send(JSON.stringify([\"REQ\", \"my-follows\", { kinds: [3], authors: [myPubkey], limit: 1 }])); // Check if any p tag matches targetPubkey"
+    - heading "Check if Someone Follows Me" [level=3] [ref=e1590]
+    - code [ref=e1592]: "// Via REST API const followers = await fetch(`/api/users/${myPubkey}/followers`).then(r => r.json()); const followsMe = followers.followers.includes(targetPubkey); // Or check their kind 3 directly via WebSocket ws.send(JSON.stringify([\"REQ\", \"their-follows\", { kinds: [3], authors: [targetPubkey], limit: 1 }]));"
+    - heading "Get Video Feed with Author Profiles" [level=3] [ref=e1593]
+    - paragraph [ref=e1594]:
+      - text: Videos from
+      - code [ref=e1595]: /api/videos
+      - text: include
+      - code [ref=e1596]: pubkey
+      - text: "but not full profile. Batch-fetch profiles:"
+    - code [ref=e1598]: "// 1. Get videos const videos = await fetch('/api/videos?limit=20').then(r => r.json()); // 2. Collect unique author pubkeys const authorPubkeys = [...new Set(videos.map(v => v.pubkey))]; // 3. Batch fetch profiles const profiles = await fetch('/api/users/bulk', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ pubkeys: authorPubkeys }) }).then(r => r.json()); // 4. Create lookup map const profileMap = {}; profiles.users.forEach(u => profileMap[u.pubkey] = u.profile); // 5. Enrich videos with author info const enrichedVideos = videos.map(v => ({ ...v, author: profileMap[v.pubkey] || null }));"
+    - heading "Build Comment Thread Hierarchy" [level=3] [ref=e1599]
+    - paragraph [ref=e1600]:
+      - text: Comments have both root (
+      - code [ref=e1601]: E
+      - text: ) and parent (
+      - code [ref=e1602]: e
+      - text: ") tags. Build tree:"
+    - code [ref=e1604]: "// Fetch all comments on a video ws.send(JSON.stringify([\"REQ\", \"comments\", { kinds: [1111], \"#E\": [videoId] }])); // Collect comments, then build tree const comments = []; // Populate from EVENT messages function buildCommentTree(comments, videoId) { const byId = {}; const roots = []; // Index by ID comments.forEach(c => byId[c.id] = { ...c, replies: [] }); // Build hierarchy using lowercase 'e' tag (parent) comments.forEach(c => { const parentTag = c.tags.find(t => t[0] === 'e'); const parentId = parentTag ? parentTag[1] : null; if (parentId === videoId) { // Top-level comment roots.push(byId[c.id]); } else if (byId[parentId]) { // Reply to another comment byId[parentId].replies.push(byId[c.id]); } }); return roots; }"
+    - separator [ref=e1605]
+    - heading "Error Handling" [level=2] [ref=e1606]
+    - heading "WebSocket OK Message Prefixes" [level=3] [ref=e1607]
+    - list [ref=e1608]:
+      - listitem [ref=e1609]:
+        - code [ref=e1610]: "blocked:"
+        - text: "- Policy rejection (banned, rate limited, kind not allowed)"
+      - listitem [ref=e1611]:
+        - code [ref=e1612]: "invalid:"
+        - text: "- Structural issue (missing tags, bad signature)"
+    - heading "REST API Errors" [level=3] [ref=e1613]
+    - code [ref=e1615]: "{ \"error\": \"Video not found\" }"
+    - paragraph [ref=e1616]: "HTTP Status Codes:"
+    - list [ref=e1617]:
+      - listitem [ref=e1618]:
+        - code [ref=e1619]: "200"
+        - text: "- Success"
+      - listitem [ref=e1620]:
+        - code [ref=e1621]: "400"
+        - text: "- Bad request (missing params, validation error)"
+      - listitem [ref=e1622]:
+        - code [ref=e1623]: "401"
+        - text: "- Unauthorized (missing NIP-98 auth)"
+      - listitem [ref=e1624]:
+        - code [ref=e1625]: "403"
+        - text: "- Forbidden (wrong pubkey for protected endpoint)"
+      - listitem [ref=e1626]:
+        - code [ref=e1627]: "404"
+        - text: "- Not found"
+      - listitem [ref=e1628]:
+        - code [ref=e1629]: "500"
+        - text: "- Internal server error"
+    - separator [ref=e1630]
+    - heading "Rate Limits & Best Practices" [level=2] [ref=e1631]
+    - list [ref=e1632]:
+      - listitem [ref=e1633]:
+        - strong [ref=e1634]:
+          - text: Respect
+          - code [ref=e1635]: Cache-Control
+          - text: headers
+        - text: "- Caching varies by endpoint:"
+        - list [ref=e1636]:
+          - listitem [ref=e1637]:
+            - text: "Public list endpoints: 60 seconds ("
+            - code [ref=e1638]: public, max-age=60
+            - text: )
+          - listitem [ref=e1639]:
+            - text: "Stats endpoints: 30 seconds ("
+            - code [ref=e1640]: public, max-age=30
+            - text: )
+          - listitem [ref=e1641]:
+            - text: "Hashtag/leaderboard endpoints: 5 minutes ("
+            - code [ref=e1642]: public, max-age=300
+            - text: )
+          - listitem [ref=e1643]:
+            - text: "Authenticated endpoints: 30-60 seconds ("
+            - code [ref=e1644]: private, max-age=30
+            - text: or
+            - code [ref=e1645]: private, max-age=60
+            - text: )
+          - listitem [ref=e1646]:
+            - text: "Error responses: no cache ("
+            - code [ref=e1647]: no-store
+            - text: )
+      - listitem [ref=e1648]:
+        - strong [ref=e1649]: Use bulk endpoints
+        - text: "- Prefer"
+        - code [ref=e1650]: /api/videos/bulk
+        - text: over multiple single requests
+      - listitem [ref=e1651]:
+        - strong [ref=e1652]: Implement exponential backoff
+        - text: "- On 500 errors or rate limits"
+      - listitem [ref=e1653]:
+        - strong [ref=e1654]: Close WebSocket subscriptions
+        - text: "- Send CLOSE when done to free server resources"
+      - listitem [ref=e1655]:
+        - strong [ref=e1656]: Use pagination
+        - text: "- Don't request more than you need"
+      - listitem [ref=e1657]:
+        - strong [ref=e1658]: Verify signatures client-side
+        - text: "- Events from REST API are verifiable"
+    - heading "WebSocket Connection Lifecycle" [level=3] [ref=e1659]
+    - code [ref=e1661]: "const ws = new WebSocket('wss://relay.divine.video'); ws.onopen = () => { // Connection established - send subscriptions ws.send(JSON.stringify([\"REQ\", \"feed\", { kinds: [34236], limit: 50 }])); }; ws.onmessage = (msg) => { const data = JSON.parse(msg.data); const [type, ...rest] = data; switch (type) { case 'EVENT': const [subId, event] = rest; handleEvent(subId, event); break; case 'EOSE': // End of stored events - live events will follow break; case 'OK': const [eventId, success, message] = rest; handlePublishResult(eventId, success, message); break; case 'CLOSED': const [subId, reason] = rest; // Subscription was closed by relay break; } }; ws.onclose = () => { // Implement reconnection with exponential backoff setTimeout(() => reconnect(), 1000); }; // Clean up when done function cleanup() { ws.send(JSON.stringify([\"CLOSE\", \"feed\"])); ws.close(); }"
+    - separator [ref=e1662]
+    - heading "Authentication (NIP-98)" [level=2] [ref=e1663]
+    - paragraph [ref=e1664]: "Protected endpoints require NIP-98 HTTP auth. These endpoints are:"
+    - list [ref=e1665]:
+      - listitem [ref=e1666]:
+        - code [ref=e1667]: "GET /api/users/{pubkey}/notifications"
+        - text: "- View own notifications"
+      - listitem [ref=e1668]:
+        - code [ref=e1669]: "POST /api/users/{pubkey}/notifications/read"
+        - text: "- Mark notifications read"
+      - listitem [ref=e1670]:
+        - code [ref=e1671]: "GET /api/users/{pubkey}/analytics"
+        - text: "- View own creator analytics"
+      - listitem [ref=e1672]:
+        - code [ref=e1673]: "GET /api/users/{pubkey}/privacy"
+        - text: "- View own privacy settings"
+      - listitem [ref=e1674]:
+        - code [ref=e1675]: "PUT /api/users/{pubkey}/privacy"
+        - text: "- Update privacy settings"
+      - listitem [ref=e1676]:
+        - code [ref=e1677]: "DELETE /api/users/{pubkey}/privacy"
+        - text: "- Remove privacy settings (make account public)"
+      - listitem [ref=e1678]:
+        - code [ref=e1679]: "GET /api/access/{pubkey}"
+        - text: "- Check if you have access to view a user's content"
+      - listitem [ref=e1680]:
+        - code [ref=e1681]: GET /api/moderation/reports
+        - text: "- View moderation reports (admin only)"
+      - listitem [ref=e1682]:
+        - code [ref=e1683]: GET /api/moderation/labels
+        - text: "- View content labels (admin only)"
+      - listitem [ref=e1684]:
+        - code [ref=e1685]: GET /api/moderation/trusted-labelers
+        - text: "- List trusted labelers (admin only)"
+      - listitem [ref=e1686]:
+        - code [ref=e1687]: POST /api/moderation/trusted-labelers
+        - text: "- Add trusted labeler (admin only)"
+      - listitem [ref=e1688]:
+        - code [ref=e1689]: "DELETE /api/moderation/trusted-labelers/{pubkey}"
+        - text: "- Remove trusted labeler (admin only)"
+    - heading "Auth Header Format" [level=3] [ref=e1690]
+    - code [ref=e1692]: "Authorization: Nostr <base64-encoded-signed-event>"
+    - heading "Auth Event Structure (Kind 27235)" [level=3] [ref=e1693]
+    - code [ref=e1695]: "{ \"kind\": 27235, \"created_at\": <unix-timestamp-now>, \"tags\": [ [\"u\", \"https://relay.divine.video/api/users/{pubkey}/analytics?window=30d\"], [\"method\", \"GET\"] ], \"content\": \"\" }"
+    - heading "Required Tags" [level=3] [ref=e1696]
+    - table [ref=e1697]:
+      - rowgroup [ref=e1698]:
+        - row "Tag Required Description" [ref=e1699]:
+          - columnheader "Tag" [ref=e1700]
+          - columnheader "Required" [ref=e1701]
+          - columnheader "Description" [ref=e1702]
+      - rowgroup [ref=e1703]:
+        - row "u Always Full absolute URL including query parameters. Must exactly match the URL being requested (scheme + host + path + query string). Per NIP-98 spec." [ref=e1704]:
+          - cell "u" [ref=e1705]:
+            - code [ref=e1706]: u
+          - cell "Always" [ref=e1707]
+          - cell "Full absolute URL including query parameters. Must exactly match the URL being requested (scheme + host + path + query string). Per NIP-98 spec." [ref=e1708]:
+            - strong [ref=e1709]: Full absolute URL including query parameters.
+            - text: Must exactly match the URL being requested (scheme + host + path + query string). Per NIP-98 spec.
+        - 'row "method Always HTTP method: GET, POST, PUT, or DELETE" [ref=e1710]':
+          - cell "method" [ref=e1711]:
+            - code [ref=e1712]: method
+          - cell "Always" [ref=e1713]
+          - 'cell "HTTP method: GET, POST, PUT, or DELETE" [ref=e1714]':
+            - text: "HTTP method:"
+            - code [ref=e1715]: GET
+            - text: ","
+            - code [ref=e1716]: POST
+            - text: ","
+            - code [ref=e1717]: PUT
+            - text: ", or"
+            - code [ref=e1718]: DELETE
+        - row "payload POST/PUT only SHA256 hex hash of the raw request body bytes. Optional for GET/DELETE (no body)." [ref=e1719]:
+          - cell "payload" [ref=e1720]:
+            - code [ref=e1721]: payload
+          - cell "POST/PUT only" [ref=e1722]
+          - cell "SHA256 hex hash of the raw request body bytes. Optional for GET/DELETE (no body)." [ref=e1723]
+    - heading "Important Rules" [level=3] [ref=e1724]
+    - list [ref=e1725]:
+      - listitem [ref=e1726]:
+        - strong [ref=e1727]: URL must be exact
+        - text: ": The"
+        - code [ref=e1728]: u
+        - text: "tag must be the complete URL including query parameters. Example:"
+        - code [ref=e1729]: https://relay.divine.video/api/users/abc123.../analytics?window=30d
+        - text: — not just the path
+      - listitem [ref=e1730]:
+        - strong [ref=e1731]: Time window
+        - text: ": The"
+        - code [ref=e1732]: created_at
+        - text: must be within 60 seconds of the server's current time (10s clock skew allowed)
+      - listitem [ref=e1733]:
+        - strong [ref=e1734]: Pubkey match
+        - text: ": The event's"
+        - code [ref=e1735]: pubkey
+        - text: must match the
+        - code [ref=e1736]: "{pubkey}"
+        - text: in the URL path — you can only access your own data
+      - listitem [ref=e1737]:
+        - strong [ref=e1738]: Sign the event
+        - text: ": The event must have a valid Nostr signature from the keypair matching the pubkey"
+      - listitem [ref=e1739]:
+        - strong [ref=e1740]: Payload hash
+        - text: ": Only required for requests with a body (POST, PUT). For GET and DELETE, omit the"
+        - code [ref=e1741]: payload
+        - text: tag
+    - heading "Implementation Example" [level=3] [ref=e1742]
+    - code [ref=e1744]: "// Helper: build NIP-98 auth header async function buildNip98Auth(url, method, body = null) { const tags = [ [\"u\", url], // MUST include query params [\"method\", method] ]; // Add payload hash for requests with a body if (body) { const hash = await crypto.subtle.digest( 'SHA-256', new TextEncoder().encode(body) ); const hashHex = Array.from(new Uint8Array(hash)) .map(b => b.toString(16).padStart(2, '0')).join(''); tags.push([\"payload\", hashHex]); } const authEvent = { kind: 27235, created_at: Math.floor(Date.now() / 1000), tags, content: \"\" }; const signed = await window.nostr.signEvent(authEvent); return \"Nostr \" + btoa(JSON.stringify(signed)); } // GET analytics (note: query params included in signed URL) const analyticsUrl = `https://relay.divine.video/api/users/${myPubkey}/analytics?window=30d`; const authHeader = await buildNip98Auth(analyticsUrl, \"GET\"); const res = await fetch(analyticsUrl, { headers: { \"Authorization\": authHeader } }); // GET notifications const notifUrl = `https://relay.divine.video/api/users/${myPubkey}/notifications`; const res2 = await fetch(notifUrl, { headers: { \"Authorization\": await buildNip98Auth(notifUrl, \"GET\") } }); // POST mark notifications read (include payload hash) const readUrl = `https://relay.divine.video/api/users/${myPubkey}/notifications/read`; const body = JSON.stringify({ notification_ids: [\"id1\", \"id2\"] }); const res3 = await fetch(readUrl, { method: \"POST\", headers: { \"Authorization\": await buildNip98Auth(readUrl, \"POST\", body), \"Content-Type\": \"application/json\" }, body }); // PUT privacy settings (include payload hash) const privacyUrl = `https://relay.divine.video/api/users/${myPubkey}/privacy`; const privacyBody = JSON.stringify({ private: true }); const res4 = await fetch(privacyUrl, { method: \"PUT\", headers: { \"Authorization\": await buildNip98Auth(privacyUrl, \"PUT\", privacyBody), \"Content-Type\": \"application/json\" }, body: privacyBody });"
+    - heading "Common Auth Errors" [level=3] [ref=e1745]
+    - table [ref=e1746]:
+      - rowgroup [ref=e1747]:
+        - row "Status Error Likely Cause" [ref=e1748]:
+          - columnheader "Status" [ref=e1749]
+          - columnheader "Error" [ref=e1750]
+          - columnheader "Likely Cause" [ref=e1751]
+      - rowgroup [ref=e1752]:
+        - row "401 URL mismatch The u tag doesn't match the request URL. Check that query params are included and the hostname is correct." [ref=e1753]:
+          - cell "401" [ref=e1754]
+          - cell "URL mismatch" [ref=e1755]:
+            - code [ref=e1756]: URL mismatch
+          - cell "The u tag doesn't match the request URL. Check that query params are included and the hostname is correct." [ref=e1757]:
+            - text: The
+            - code [ref=e1758]: u
+            - text: tag doesn't match the request URL. Check that query params are included and the hostname is correct.
+        - row "401 event expired The created_at is more than 60 seconds old. Generate a fresh event for each request." [ref=e1759]:
+          - cell "401" [ref=e1760]
+          - cell "event expired" [ref=e1761]:
+            - code [ref=e1762]: event expired
+          - cell "The created_at is more than 60 seconds old. Generate a fresh event for each request." [ref=e1763]:
+            - text: The
+            - code [ref=e1764]: created_at
+            - text: is more than 60 seconds old. Generate a fresh event for each request.
+        - row "401 invalid signature The event signature doesn't verify. Ensure you're signing correctly." [ref=e1765]:
+          - cell "401" [ref=e1766]
+          - cell "invalid signature" [ref=e1767]:
+            - code [ref=e1768]: invalid signature
+          - cell "The event signature doesn't verify. Ensure you're signing correctly." [ref=e1769]
+        - row "401 missing 'method' tag The auth event is missing the [\"method\", \"GET\"] tag." [ref=e1770]:
+          - cell "401" [ref=e1771]
+          - cell "missing 'method' tag" [ref=e1772]:
+            - code [ref=e1773]: missing 'method' tag
+          - cell "The auth event is missing the [\"method\", \"GET\"] tag." [ref=e1774]:
+            - text: The auth event is missing the
+            - code [ref=e1775]: "[\"method\", \"GET\"]"
+            - text: tag.
+        - row "401 payload hash mismatch The payload tag doesn't match SHA256 of the actual body sent." [ref=e1776]:
+          - cell "401" [ref=e1777]
+          - cell "payload hash mismatch" [ref=e1778]:
+            - code [ref=e1779]: payload hash mismatch
+          - cell "The payload tag doesn't match SHA256 of the actual body sent." [ref=e1780]:
+            - text: The
+            - code [ref=e1781]: payload
+            - text: tag doesn't match SHA256 of the actual body sent.
+        - 'row "403 You can only view your own The auth event''s pubkey doesn''t match the {pubkey} in the URL path." [ref=e1782]':
+          - cell "403" [ref=e1783]
+          - cell "You can only view your own" [ref=e1784]:
+            - code [ref=e1785]: You can only view your own
+          - 'cell "The auth event''s pubkey doesn''t match the {pubkey} in the URL path." [ref=e1786]':
+            - text: The auth event's pubkey doesn't match the
+            - code [ref=e1787]: "{pubkey}"
+            - text: in the URL path.
+    - separator [ref=e1788]
+    - heading "Useful Queries" [level=2] [ref=e1789]
+    - heading "Get videos by a specific creator" [level=3] [ref=e1790]
+    - code [ref=e1792]: "GET /api/users/{pubkey}/videos?limit=50"
+    - heading "Get trending short-form videos" [level=3] [ref=e1793]
+    - code [ref=e1795]: GET /api/videos?sort=trending&kind=34236&limit=20
+    - heading "Search for videos about Bitcoin" [level=3] [ref=e1796]
+    - code [ref=e1798]: GET /api/search?q=bitcoin&limit=30
+    - heading "Get a user's home feed (personalized timeline)" [level=3] [ref=e1799]
+    - code [ref=e1801]: "GET /api/users/{pubkey}/feed?sort=recent&limit=50"
+    - heading "Get classic Vine archive videos" [level=3] [ref=e1802]
+    - code [ref=e1804]: GET /api/videos?platform=vine&sort=loops&limit=50
+    - heading "Check if specific videos exist" [level=3] [ref=e1805]
+    - code [ref=e1807]: "POST /api/videos/stats/bulk {\"event_ids\": [\"id1\", \"id2\", \"id3\"]}"
+    - heading "Get comments on a video (REST)" [level=3] [ref=e1808]
+    - code [ref=e1810]: "GET /api/videos/{id}/comments?sort=newest&limit=25"
+    - paragraph [ref=e1811]: Use REST when you need a simple paginated comment list with author metadata.
+    - heading "Subscribe to comments on a video (WebSocket)" [level=3] [ref=e1812]
+    - code [ref=e1814]: "[\"REQ\", \"comments\", { \"kinds\": [1111], \"#E\": [\"<video-event-id>\"] }]"
+    - paragraph [ref=e1815]:
+      - text: Use WebSocket when you need live updates or raw Nostr comment events. The
+      - code [ref=e1816]: "#E"
+      - text: (uppercase) tag matches all comments on a video regardless of nesting depth. Use
+      - code [ref=e1817]: "#e"
+      - text: (lowercase) to get direct replies to a specific comment.
+    - heading "Get reactions/comments on MY videos (notifications)" [level=3] [ref=e1818]
+    - paragraph [ref=e1819]:
+      - text: Subscribe to events that tag you in
+      - code [ref=e1820]: p
+      - text: ":"
+    - code [ref=e1822]: "[\"REQ\", \"notifications\", { \"kinds\": [7, 1111, 16], \"#p\": [\"<my-pubkey>\"], \"since\": <last-check-timestamp> }]"
+    - paragraph [ref=e1823]: "This gives you:"
+    - list [ref=e1824]:
+      - listitem [ref=e1825]:
+        - code [ref=e1826]: kind 7
+        - text: "- Reactions on your videos"
+      - listitem [ref=e1827]:
+        - code [ref=e1828]: kind 1111
+        - text: "- Comments on your videos"
+      - listitem [ref=e1829]:
+        - code [ref=e1830]: kind 16
+        - text: "- Reposts of your videos"
+    - paragraph [ref=e1831]:
+      - text: The
+      - code [ref=e1832]: "#p"
+      - text: filter matches because reactions/comments include a
+      - code [ref=e1833]: p
+      - text: tag pointing to the video author.
+    - separator [ref=e1834]
+    - heading "Content Moderation" [level=2] [ref=e1835]
+    - paragraph [ref=e1836]:
+      - text: FunnelCake includes a content moderation system based on NIP-32 (labels) and NIP-56 (reports). Content labels are automatically applied by the divine-moderation-service, which uses a VLM (Vision-Language Model) classifier to analyze video thumbnails and content. Trusted labelers can also tag content with labels like
+      - code [ref=e1837]: nsfw
+      - text: ", and those labels are used to filter content from public endpoints."
+    - heading "Trust And Safety Contract" [level=3] [ref=e1838]
+    - paragraph [ref=e1839]: "The current public contract is:"
+    - list [ref=e1840]:
+      - listitem [ref=e1841]:
+        - code [ref=e1842]: content_labels
+        - text: is a mixed-purpose field. It is not moderation-only.
+      - listitem [ref=e1843]:
+        - text: There is no separate
+        - code [ref=e1844]: moderation_labels
+        - text: field today.
+      - listitem [ref=e1845]:
+        - text: Clients that need a moderation-only view should derive it by intersecting
+        - code [ref=e1846]: content_labels
+        - text: with the published moderation vocabulary below.
+      - listitem [ref=e1847]:
+        - code [ref=e1848]: moderation_status
+        - text: ","
+        - code [ref=e1849]: ai_score
+        - text: ","
+        - code [ref=e1850]: ai_source
+        - text: ", and"
+        - code [ref=e1851]: ai_checked_at
+        - text: are moderation pipeline metadata. They do not replace a moderation-only label array.
+    - paragraph [ref=e1852]: "Live examples seen on production and staging include both moderation labels and discovery labels:"
+    - list [ref=e1853]:
+      - listitem [ref=e1854]:
+        - code [ref=e1855]: "[\"nudity\",\"sexual\",\"profanity\"]"
+      - listitem [ref=e1856]:
+        - code [ref=e1857]: "[\"activity:listening-to-music\",\"topic:gaming\",\"topic:music\"]"
+    - heading "Label Merge And Normalization" [level=3] [ref=e1858]
+    - paragraph [ref=e1859]:
+      - text: All video response objects include a
+      - code [ref=e1860]: content_labels
+      - text: "field (array of strings). The response merger currently:"
+    - list [ref=e1861]:
+      - listitem [ref=e1862]:
+        - text: Reads stored labels from the ClickHouse
+        - code [ref=e1863]: content_labels
+        - text: table.
+      - listitem [ref=e1864]:
+        - text: Merges raw NIP-32
+        - code [ref=e1865]: l
+        - text: tags from the video event itself.
+      - listitem [ref=e1866]:
+        - text: Merges raw kind
+        - code [ref=e1867]: "1985"
+        - text: label events.
+    - paragraph [ref=e1868]: "Normalization rules:"
+    - list [ref=e1869]:
+      - listitem [ref=e1870]:
+        - text: Language self-labels such as
+        - code [ref=e1871]: "[\"l\", \"en\", \"ISO-639-1\"]"
+        - text: are excluded.
+      - listitem [ref=e1872]:
+        - code [ref=e1873]: "[\"l\", \"music\", \"topic\"]"
+        - text: becomes
+        - code [ref=e1874]: topic:music
+        - text: .
+      - listitem [ref=e1875]:
+        - code [ref=e1876]: "[\"l\", \"nudity\", \"content-warning\"]"
+        - text: becomes
+        - code [ref=e1877]: nudity
+        - text: .
+      - listitem [ref=e1878]:
+        - text: Other namespaced labels are represented as
+        - code [ref=e1879]: namespace:value
+        - text: .
+      - listitem [ref=e1880]: Exact duplicate strings are removed. First-seen order is preserved.
+    - paragraph [ref=e1881]: There is no stronger precedence or conflict-resolution contract today beyond exact-string deduping. Clients should not assume semantic synonym handling.
+    - code [ref=e1883]: "{ \"id\": \"64-char-hex\", \"title\": \"Video Title\", \"content_labels\": [\"safe\"] }"
+    - paragraph [ref=e1884]:
+      - text: The field may be an empty array
+      - code [ref=e1885]: "[]"
+      - text: if the video has not yet been classified and has no applicable raw labels.
+    - heading "Stable Moderation Vocabulary" [level=3] [ref=e1886]
+    - paragraph [ref=e1887]:
+      - text: Use this subset of
+      - code [ref=e1888]: content_labels
+      - text: "for trust-and-safety decisions:"
+    - table [ref=e1889]:
+      - rowgroup [ref=e1890]:
+        - row "Class Labels Server behavior today Client guidance" [ref=e1891]:
+          - columnheader "Class" [ref=e1892]
+          - columnheader "Labels" [ref=e1893]
+          - columnheader "Server behavior today" [ref=e1894]
+          - columnheader "Client guidance" [ref=e1895]
+      - rowgroup [ref=e1896]:
+        - row "Always blocked illegal, csam Always hidden on public discovery/search surfaces. No opt-out. Treat as hard block." [ref=e1897]:
+          - cell "Always blocked" [ref=e1898]
+          - cell "illegal, csam" [ref=e1899]:
+            - code [ref=e1900]: illegal
+            - text: ","
+            - code [ref=e1901]: csam
+          - cell "Always hidden on public discovery/search surfaces. No opt-out." [ref=e1902]
+          - cell "Treat as hard block." [ref=e1903]
+        - row "Default-hidden moderation nsfw, nudity, sexual, explicit, pornography, violence, graphic-violence, gore, drugs, spam, scam Hidden by default on public discovery/search surfaces. On /api/videos, returned when opted in via nsfw=show. Safe to map to hide or warn policies." [ref=e1904]:
+          - cell "Default-hidden moderation" [ref=e1905]
+          - cell "nsfw, nudity, sexual, explicit, pornography, violence, graphic-violence, gore, drugs, spam, scam" [ref=e1906]:
+            - code [ref=e1907]: nsfw
+            - text: ","
+            - code [ref=e1908]: nudity
+            - text: ","
+            - code [ref=e1909]: sexual
+            - text: ","
+            - code [ref=e1910]: explicit
+            - text: ","
+            - code [ref=e1911]: pornography
+            - text: ","
+            - code [ref=e1912]: violence
+            - text: ","
+            - code [ref=e1913]: graphic-violence
+            - text: ","
+            - code [ref=e1914]: gore
+            - text: ","
+            - code [ref=e1915]: drugs
+            - text: ","
+            - code [ref=e1916]: spam
+            - text: ","
+            - code [ref=e1917]: scam
+          - cell "Hidden by default on public discovery/search surfaces. On /api/videos, returned when opted in via nsfw=show." [ref=e1918]:
+            - text: Hidden by default on public discovery/search surfaces. On
+            - code [ref=e1919]: /api/videos
+            - text: ", returned when opted in via"
+            - code [ref=e1920]: nsfw=show
+            - text: .
+          - cell "Safe to map to hide or warn policies." [ref=e1921]
+        - row "Namespaced moderation any stored label in the content-warning namespace Treated as default-hidden by server-side set filtering when available in stored moderation data. Treat as moderation-relevant." [ref=e1922]:
+          - cell "Namespaced moderation" [ref=e1923]
+          - cell "any stored label in the content-warning namespace" [ref=e1924]:
+            - text: any stored label in the
+            - code [ref=e1925]: content-warning
+            - text: namespace
+          - cell "Treated as default-hidden by server-side set filtering when available in stored moderation data." [ref=e1926]
+          - cell "Treat as moderation-relevant." [ref=e1927]
+        - 'row "Not part of the stable hide taxonomy examples: safe, profanity, topic:*, activity:*, mood:*, object:*, setting:*, source/archive labels Not part of the documented default server hide contract unless separately documented. Use for discovery, ranking, or client-side warning policy as appropriate." [ref=e1928]':
+          - cell "Not part of the stable hide taxonomy" [ref=e1929]
+          - 'cell "examples: safe, profanity, topic:*, activity:*, mood:*, object:*, setting:*, source/archive labels" [ref=e1930]':
+            - text: "examples:"
+            - code [ref=e1931]: safe
+            - text: ","
+            - code [ref=e1932]: profanity
+            - text: ","
+            - code [ref=e1933]: topic:*
+            - text: ","
+            - code [ref=e1934]: activity:*
+            - text: ","
+            - code [ref=e1935]: mood:*
+            - text: ","
+            - code [ref=e1936]: object:*
+            - text: ","
+            - code [ref=e1937]: setting:*
+            - text: ", source/archive labels"
+          - cell "Not part of the documented default server hide contract unless separately documented." [ref=e1938]
+          - cell "Use for discovery, ranking, or client-side warning policy as appropriate." [ref=e1939]
+    - heading "Server-Side Filtering Contract" [level=3] [ref=e1940]
+    - paragraph [ref=e1941]: "Supported today:"
+    - list [ref=e1942]:
+      - listitem [ref=e1943]:
+        - code [ref=e1944]: /api/videos
+        - list [ref=e1945]:
+          - listitem [ref=e1946]:
+            - code [ref=e1947]: nsfw=show
+            - text: is the only documented opt-in for default-hidden moderation labels.
+          - listitem [ref=e1948]:
+            - code [ref=e1949]: label=
+            - text: is not moderation-only.
+          - listitem [ref=e1950]: Current positive-match behavior checks stored ClickHouse labels plus raw NIP-32 self-labels. It should not be treated as a full parity guarantee with every response-enriched label source.
+          - listitem [ref=e1951]:
+            - code [ref=e1952]: category=
+            - text: is shorthand for
+            - code [ref=e1953]: label=topic:<category>
+            - text: .
+      - listitem [ref=e1954]:
+        - code [ref=e1955]: /api/search
+        - list [ref=e1956]:
+          - listitem [ref=e1957]:
+            - text: Supports
+            - code [ref=e1958]: label=
+            - text: only.
+      - listitem [ref=e1959]:
+        - code [ref=e1960]: "/api/users/{pubkey}/recommendations"
+        - list [ref=e1961]:
+          - listitem [ref=e1962]: Does not expose safety override parameters today.
+    - paragraph [ref=e1963]: "Not yet a stable public contract:"
+    - list [ref=e1964]:
+      - listitem [ref=e1965]:
+        - text: There is no stable
+        - code [ref=e1966]: exclude_label
+        - text: ","
+        - code [ref=e1967]: exclude_moderation_labels
+        - text: ", or"
+        - code [ref=e1968]: content_safety
+        - text: parameter today.
+      - listitem [ref=e1969]: Clients should not depend on undocumented per-label hide controls on the relay.
+    - paragraph [ref=e1970]: "Not supported on these endpoints today:"
+    - list [ref=e1971]:
+      - listitem [ref=e1972]:
+        - code [ref=e1973]: /api/search
+        - text: does not expose
+        - code [ref=e1974]: nsfw=show
+        - text: ","
+        - code [ref=e1975]: content_safety
+        - text: ", or per-label hide parameters."
+      - listitem [ref=e1976]:
+        - code [ref=e1977]: "/api/users/{pubkey}/recommendations"
+        - text: does not expose
+        - code [ref=e1978]: nsfw=show
+        - text: ","
+        - code [ref=e1979]: content_safety
+        - text: ", or per-label hide parameters."
+      - listitem [ref=e1980]:
+        - code [ref=e1981]: "/api/users/{pubkey}/videos"
+        - text: returns
+        - code [ref=e1982]: content_labels
+        - text: ", but does not expose"
+        - code [ref=e1983]: nsfw
+        - text: ","
+        - code [ref=e1984]: content_safety
+        - text: ", or"
+        - code [ref=e1985]: exclude_label
+        - text: .
+      - listitem [ref=e1986]:
+        - code [ref=e1987]: "/api/users/{pubkey}/feed"
+        - text: returns
+        - code [ref=e1988]: content_labels
+        - text: ", but does not expose"
+        - code [ref=e1989]: nsfw
+        - text: ","
+        - code [ref=e1990]: content_safety
+        - text: ", or"
+        - code [ref=e1991]: exclude_label
+        - text: .
+    - heading "Relay vs Client Responsibilities" [level=3] [ref=e1992]
+    - list [ref=e1993]:
+      - listitem [ref=e1994]:
+        - text: Relay responsibility
+        - list [ref=e1995]:
+          - listitem [ref=e1996]:
+            - text: Always block
+            - code [ref=e1997]: illegal
+            - text: and
+            - code [ref=e1998]: csam
+            - text: .
+          - listitem [ref=e1999]: Hide the default-hidden moderation vocabulary by default on endpoints that expose server-side safety filtering.
+      - listitem [ref=e2000]:
+        - text: Client responsibility
+        - list [ref=e2001]:
+          - listitem [ref=e2002]:
+            - text: Treat
+            - code [ref=e2003]: content_labels
+            - text: as mixed-purpose by design.
+          - listitem [ref=e2004]: Use the published moderation subset above for trust-and-safety UI.
+          - listitem [ref=e2005]: Apply warning, blur, confirmation, or additional hide logic for returned content based on product policy.
+          - listitem [ref=e2006]:
+            - text: Do not infer moderation meaning from discovery labels like
+            - code [ref=e2007]: topic:*
+            - text: or
+            - code [ref=e2008]: activity:*
+            - text: .
+    - heading "Endpoint Parity Caveat" [level=3] [ref=e2009]
+    - paragraph [ref=e2010]: The API code uses the same label-enrichment path for list rows, single-video stats, per-user videos, and feed rows. However, deployment parity still needs to be validated per environment.
+    - paragraph [ref=e2011]:
+      - text: "As of March 9, 2026, staging still showed a concrete gap: videos visible via"
+      - code [ref=e2012]: /api/videos?sort=recent&nsfw=show
+      - text: could still return
+      - code [ref=e2013]: "404"
+      - text: from
+      - code [ref=e2014]: "/api/videos/{id}"
+      - text: for the same full event IDs. Treat staging list-vs-single parity as best-effort until that host is refreshed.
+    - heading "NSFW Filtering" [level=3] [ref=e2015]
+    - paragraph [ref=e2016]:
+      - text: By default, public discovery endpoints exclude the default-hidden moderation vocabulary. On
+      - code [ref=e2017]: /api/videos
+      - text: ", the documented opt-in is"
+      - code [ref=e2018]: nsfw=show
+      - text: ":"
+    - code [ref=e2020]: GET /api/videos?nsfw=show
+    - heading "Moderation Endpoints" [level=3] [ref=e2021]
+    - paragraph [ref=e2022]: All moderation endpoints require NIP-98 authentication with an admin pubkey. These are for platform administration, not regular users.
+    - heading "GET /api/moderation/reports" [level=4] [ref=e2023]
+    - paragraph [ref=e2024]: Get aggregated moderation reports (Kind 1984 report events).
+    - paragraph [ref=e2025]:
+      - strong [ref=e2026]: "Query:"
+      - code [ref=e2027]: limit
+      - text: (1-100, default 50),
+      - code [ref=e2028]: offset
+      - text: (default 0)
+    - paragraph [ref=e2029]:
+      - strong [ref=e2030]: "Response:"
+    - code [ref=e2032]: "{ \"reports\": [ { \"target_event_id\": \"64-char-hex\", \"report_count\": 5, \"unique_reporters\": 3, \"latest_report_at\": \"2026-02-24T10:30:00Z\", \"report_types\": [\"spam\", \"nsfw\"] } ], \"total\": 100, \"offset\": 0, \"limit\": 50 }"
+    - heading "GET /api/moderation/labels" [level=4] [ref=e2033]
+    - paragraph [ref=e2034]: Get content labels applied by the VLM classifier and trusted labelers.
+    - paragraph [ref=e2035]:
+      - strong [ref=e2036]: "Query Parameters:"
+    - table [ref=e2037]:
+      - rowgroup [ref=e2038]:
+        - row "Param Type Description" [ref=e2039]:
+          - columnheader "Param" [ref=e2040]
+          - columnheader "Type" [ref=e2041]
+          - columnheader "Description" [ref=e2042]
+      - rowgroup [ref=e2043]:
+        - row "limit number Max results (1-100, default 50)" [ref=e2044]:
+          - cell "limit" [ref=e2045]:
+            - code [ref=e2046]: limit
+          - cell "number" [ref=e2047]
+          - cell "Max results (1-100, default 50)" [ref=e2048]
+        - row "offset number Pagination offset (default 0)" [ref=e2049]:
+          - cell "offset" [ref=e2050]:
+            - code [ref=e2051]: offset
+          - cell "number" [ref=e2052]
+          - cell "Pagination offset (default 0)" [ref=e2053]
+        - row "label string Filter by specific label value (e.g. nsfw, safe, violence)" [ref=e2054]:
+          - cell "label" [ref=e2055]:
+            - code [ref=e2056]: label
+          - cell "string" [ref=e2057]
+          - cell "Filter by specific label value (e.g. nsfw, safe, violence)" [ref=e2058]:
+            - text: Filter by specific label value (e.g.
+            - code [ref=e2059]: nsfw
+            - text: ","
+            - code [ref=e2060]: safe
+            - text: ","
+            - code [ref=e2061]: violence
+            - text: )
+    - paragraph [ref=e2062]:
+      - strong [ref=e2063]: "Response:"
+    - code [ref=e2065]: "{ \"labels\": [ { \"target_event_id\": \"64-char-hex\", \"label_value\": \"nsfw\", \"label_namespace\": \"com.example.labeler\", \"labeler_pubkey\": \"64-char-hex\", \"labeled_at\": \"2026-02-24T10:30:00Z\" } ], \"total\": 50, \"offset\": 0, \"limit\": 50 }"
+    - heading "GET /api/moderation/trusted-labelers" [level=4] [ref=e2066]
+    - paragraph [ref=e2067]: Get the list of trusted labelers whose labels affect content filtering.
+    - paragraph [ref=e2068]:
+      - strong [ref=e2069]: "Response:"
+    - code [ref=e2071]: "{ \"labelers\": [ { \"pubkey\": \"64-char-hex\", \"added_at\": \"2026-02-24T10:30:00Z\", \"reason\": \"Divine official moderator\" } ] }"
+    - heading "POST /api/moderation/trusted-labelers" [level=4] [ref=e2072]
+    - paragraph [ref=e2073]: Add a trusted labeler.
+    - paragraph [ref=e2074]:
+      - strong [ref=e2075]: "Request:"
+    - code [ref=e2077]: "{ \"pubkey\": \"64-char-hex\", \"reason\": \"Trusted community moderator\" }"
+    - paragraph [ref=e2078]:
+      - strong [ref=e2079]: "Response:"
+      - code [ref=e2080]: 200 OK
+      - text: (empty body)
+    - 'heading "DELETE /api/moderation/trusted-labelers/{pubkey}" [level=4] [ref=e2081]'
+    - paragraph [ref=e2082]: Remove a trusted labeler.
+    - paragraph [ref=e2083]:
+      - strong [ref=e2084]: "Response:"
+      - code [ref=e2085]: 200 OK
+      - text: (empty body)
+    - separator [ref=e2086]
+    - heading "Relay Information (NIP-11)" [level=2] [ref=e2087]
+    - paragraph [ref=e2088]:
+      - text: Discover relay capabilities by fetching the root URL with
+      - code [ref=e2089]: "Accept: application/nostr+json"
+      - text: ":"
+    - code [ref=e2091]: "curl -H \"Accept: application/nostr+json\" https://relay.divine.video/"
+    - paragraph [ref=e2092]:
+      - strong [ref=e2093]: "Response:"
+    - code [ref=e2095]: "{ \"name\": \"Divine Video Relay\", \"description\": \"Video-focused Nostr relay\", \"pubkey\": \"relay-admin-pubkey\", \"contact\": \"admin@divine.video\", \"supported_nips\": [1, 9, 11, 22, 25, 33, 40, 45, 50, 51, 71], \"software\": \"funnelcake\", \"version\": \"0.1.0\", \"limitation\": { \"max_content_length\": 102400, \"max_subscriptions\": 20, \"max_filters\": 10, \"max_event_tags\": 2000, \"max_message_length\": 131072 } }"
+    - separator [ref=e2096]
+    - heading "Private Accounts" [level=2] [ref=e2097]
+    - paragraph [ref=e2098]: FunnelCake supports private accounts. When a user makes their account private, their video content is hidden from public queries. Only approved viewers can access private content.
+    - heading "How Private Accounts Affect Queries" [level=3] [ref=e2099]
+    - list [ref=e2100]:
+      - listitem [ref=e2101]:
+        - strong [ref=e2102]: Public video endpoints
+        - text: (
+        - code [ref=e2103]: /api/videos
+        - text: ","
+        - code [ref=e2104]: /api/search
+        - text: ","
+        - code [ref=e2105]: /api/hashtags/trending
+        - text: ","
+        - code [ref=e2106]: /api/leaderboard/*
+        - text: ","
+        - code [ref=e2107]: "/api/users/{pubkey}/feed"
+        - text: "): Videos from private accounts are"
+        - strong [ref=e2108]: excluded
+        - text: from results
+      - listitem [ref=e2109]:
+        - strong [ref=e2110]: User profile endpoint
+        - text: (
+        - code [ref=e2111]: "/api/users/{pubkey}"
+        - text: "): Still returns the profile. Client apps should check and display a \"Private Account\" indicator"
+      - listitem [ref=e2112]:
+        - strong [ref=e2113]: User videos/collabs
+        - text: (
+        - code [ref=e2114]: "/api/users/{pubkey}/videos"
+        - text: ","
+        - code [ref=e2115]: "/api/users/{pubkey}/collabs"
+        - text: "): Returns empty for private accounts"
+      - listitem [ref=e2116]:
+        - strong [ref=e2117]: Direct video lookup
+        - text: (
+        - code [ref=e2118]: "/api/videos/{id}"
+        - text: "): If you have the event ID, you can still access the video (privacy is about discovery, not direct access)"
+    - heading "Privacy Management Endpoints" [level=3] [ref=e2119]
+    - paragraph [ref=e2120]: All privacy management endpoints require NIP-98 authentication. Users can only manage their own privacy settings.
+    - heading "Get Privacy Settings" [level=4] [ref=e2121]
+    - code [ref=e2123]: "GET /api/users/{pubkey}/privacy Authorization: Nostr <base64-encoded-signed-event>"
+    - paragraph [ref=e2124]: "Response:"
+    - code [ref=e2126]: "{ \"pubkey\": \"abc123...\", \"is_private\": true, \"approved_viewers\": [\"viewer_pubkey_1\", \"viewer_pubkey_2\"] }"
+    - paragraph [ref=e2127]:
+      - text: If no privacy settings exist, returns
+      - code [ref=e2128]: "is_private: false"
+      - text: with empty
+      - code [ref=e2129]: approved_viewers
+      - text: .
+    - heading "Update Privacy Settings" [level=4] [ref=e2130]
+    - code [ref=e2132]: "PUT /api/users/{pubkey}/privacy Authorization: Nostr <base64-encoded-signed-event> Content-Type: application/json { \"is_private\": true, \"approved_viewers\": [\"viewer_pubkey_1\", \"viewer_pubkey_2\"] }"
+    - paragraph [ref=e2133]:
+      - strong [ref=e2134]: "Important:"
+      - text: This is a full replacement -- send the complete list of approved viewers each time. Going private takes effect immediately.
+    - heading "Delete Privacy Settings" [level=4] [ref=e2135]
+    - code [ref=e2137]: "DELETE /api/users/{pubkey}/privacy Authorization: Nostr <base64-encoded-signed-event>"
+    - paragraph [ref=e2138]: Makes the account public and removes all privacy settings.
+    - heading "Check Access" [level=4] [ref=e2139]
+    - code [ref=e2141]: "GET /api/access/{pubkey} Authorization: Nostr <base64-encoded-signed-event>"
+    - paragraph [ref=e2142]: "Response:"
+    - code [ref=e2144]: "{ \"pubkey\": \"abc123...\", \"has_access\": true }"
+    - paragraph [ref=e2145]: Returns whether the authenticated viewer has access to the target user's content. Useful for Blossom integration and client apps.
+    - heading "WebSocket Relay (NIP-42)" [level=3] [ref=e2146]
+    - paragraph [ref=e2147]: "The relay supports NIP-42 authentication. On connection, the relay sends an AUTH challenge:"
+    - code [ref=e2149]: "[\"AUTH\", \"<challenge-string>\"]"
+    - paragraph [ref=e2150]: "Clients authenticate by sending a signed event:"
+    - code [ref=e2152]: "[\"AUTH\", { \"kind\": 22242, \"tags\": [ [\"relay\", \"wss://relay.divine.video\"], [\"challenge\", \"<challenge-string>\"] ], \"content\": \"\", ...signed event fields }]"
+    - paragraph [ref=e2153]: After authentication, REQ queries will include content from private accounts that the authenticated user is approved to view.
+    - separator [ref=e2154]
+    - heading "API Documentation Endpoints" [level=2] [ref=e2155]
+    - paragraph [ref=e2156]: "Interactive documentation is available at:"
+    - table [ref=e2157]:
+      - rowgroup [ref=e2158]:
+        - row "Endpoint Description" [ref=e2159]:
+          - columnheader "Endpoint" [ref=e2160]
+          - columnheader "Description" [ref=e2161]
+      - rowgroup [ref=e2162]:
+        - row "/docs Documentation landing page with links to all resources" [ref=e2163]:
+          - cell "/docs" [ref=e2164]:
+            - code [ref=e2165]: /docs
+          - cell "Documentation landing page with links to all resources" [ref=e2166]
+        - row "/docs/llm-guide This LLM API guide rendered as HTML" [ref=e2167]:
+          - cell "/docs/llm-guide" [ref=e2168]:
+            - code [ref=e2169]: /docs/llm-guide
+          - cell "This LLM API guide rendered as HTML" [ref=e2170]
+        - row "/swagger-ui Interactive OpenAPI/Swagger UI with live request testing" [ref=e2171]:
+          - cell "/swagger-ui" [ref=e2172]:
+            - code [ref=e2173]: /swagger-ui
+          - cell "Interactive OpenAPI/Swagger UI with live request testing" [ref=e2174]
+        - row "/openapi.json Raw OpenAPI 3.0 JSON specification" [ref=e2175]:
+          - cell "/openapi.json" [ref=e2176]:
+            - code [ref=e2177]: /openapi.json
+          - cell "Raw OpenAPI 3.0 JSON specification" [ref=e2178]
+    - paragraph [ref=e2179]:
+      - strong [ref=e2180]: "Production URLs:"
+    - list [ref=e2181]:
+      - listitem [ref=e2182]:
+        - code [ref=e2183]: https://relay.divine.video/docs
+      - listitem [ref=e2184]:
+        - code [ref=e2185]: https://relay.divine.video/swagger-ui
+    - paragraph [ref=e2186]:
+      - strong [ref=e2187]: "Staging URLs:"
+    - list [ref=e2188]:
+      - listitem [ref=e2189]:
+        - code [ref=e2190]: https://relay.staging.divine.video/docs
+      - listitem [ref=e2191]:
+        - code [ref=e2192]: https://relay.staging.divine.video/swagger-ui

--- a/scripts/downgrade-classic-vines-to-age-restricted.mjs
+++ b/scripts/downgrade-classic-vines-to-age-restricted.mjs
@@ -1,0 +1,518 @@
+#!/usr/bin/env node
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Discovers legacy Vine imports and downgrades eligible machine-applied moderation to AGE_RESTRICTED
+// ABOUTME: Skips rows with human review signals and supports preview/execute operational runs
+
+import fs from 'fs';
+import path from 'path';
+import { extractMediaShaFromEvent } from '../src/validation.mjs';
+import { isOriginalVine, parseVideoEventMetadata } from '../src/nostr/relay-client.mjs';
+
+const DEFAULT_RELAY_URL = 'wss://relay.divine.video';
+const DEFAULT_WORKER_URL = 'https://moderation-api.divine.video';
+const DEFAULT_ADMIN_ORIGIN = 'https://moderation.admin.divine.video';
+const DEFAULT_BATCH_SIZE = 100;
+const DEFAULT_CONCURRENCY = 5;
+const CHECKPOINT_FILE = '.classic-vine-age-restricted-checkpoint.json';
+const REPORT_FILE = '.classic-vine-age-restricted-report.json';
+const DOWNGRADE_REASON = 'classic-vine-downgrade: machine-applied legacy Vine restriction downgraded to age-restricted';
+const DOWNGRADE_SOURCE = 'classic-vine-downgrade-script';
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function readJsonFile(filePath) {
+  const text = fs.readFileSync(filePath, 'utf8');
+  return JSON.parse(text);
+}
+
+function writeJsonFile(filePath, value) {
+  fs.writeFileSync(filePath, JSON.stringify(value, null, 2));
+}
+
+function getApiToken(options = {}) {
+  return options.apiToken || process.env.MODERATION_API_TOKEN || process.env.SERVICE_API_TOKEN || null;
+}
+
+function getAdminOrigin(options = {}) {
+  return options.adminOrigin || process.env.MODERATION_ADMIN_ORIGIN || null;
+}
+
+function getCfAccessCookie(options = {}) {
+  return options.cfAccessCookie || process.env.CF_ACCESS_COOKIE || null;
+}
+
+function parseUnixTimestamp(value) {
+  if (value == null) return null;
+  const parsed = Number.parseInt(String(value), 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function getArgValue(args, flag) {
+  const index = args.indexOf(flag);
+  if (index === -1 || index === args.length - 1) return null;
+  return args[index + 1];
+}
+
+function hasAdminSessionAuth(options = {}) {
+  return Boolean(options.adminOrigin && options.cfAccessCookie);
+}
+
+export function buildAgeRestrictedUpdate(sha256) {
+  return {
+    sha256,
+    action: 'AGE_RESTRICTED',
+    reason: DOWNGRADE_REASON,
+    source: DOWNGRADE_SOURCE
+  };
+}
+
+export function classifyDecisionForDowngrade(decision) {
+  if (!decision) {
+    return { eligible: false, reason: 'no-decision' };
+  }
+
+  if (decision.reviewed_by) {
+    return { eligible: false, reason: 'human-reviewed' };
+  }
+
+  if (decision.review_notes) {
+    return { eligible: false, reason: 'review-notes-present' };
+  }
+
+  if (decision.action === 'SAFE') {
+    return { eligible: false, reason: 'already-safe' };
+  }
+
+  if (decision.action === 'AGE_RESTRICTED') {
+    return { eligible: false, reason: 'already-age-restricted' };
+  }
+
+  return { eligible: true, reason: 'eligible-machine-restriction' };
+}
+
+export function extractClassicVineCandidateFromEvent(event) {
+  const sha256 = extractMediaShaFromEvent(event);
+  if (!sha256) return null;
+
+  const nostrContext = parseVideoEventMetadata(event);
+  if (!isOriginalVine(nostrContext)) return null;
+
+  return {
+    sha256,
+    eventId: event?.id || null,
+    nostrContext
+  };
+}
+
+export function parseArgs(argv = process.argv.slice(2)) {
+  const mode = argv.includes('--execute') ? 'execute' : 'preview';
+  const relayUrl = getArgValue(argv, '--relay') || DEFAULT_RELAY_URL;
+  const workerUrl = getArgValue(argv, '--worker') || DEFAULT_WORKER_URL;
+  const apiToken = getArgValue(argv, '--token') || getApiToken();
+  const adminOrigin = getArgValue(argv, '--admin-origin') || getAdminOrigin();
+  const cfAccessCookie = getArgValue(argv, '--cf-access-cookie') || getCfAccessCookie();
+  const inputPath = getArgValue(argv, '--input');
+  const checkpointPath = getArgValue(argv, '--checkpoint') || CHECKPOINT_FILE;
+  const reportPath = getArgValue(argv, '--report') || REPORT_FILE;
+  const batchSize = Number.parseInt(getArgValue(argv, '--batch-size') || String(DEFAULT_BATCH_SIZE), 10);
+  const concurrency = Number.parseInt(getArgValue(argv, '--concurrency') || String(DEFAULT_CONCURRENCY), 10);
+  const maxTotal = parseUnixTimestamp(getArgValue(argv, '--max-total'));
+  const since = parseUnixTimestamp(getArgValue(argv, '--since'));
+  const until = parseUnixTimestamp(getArgValue(argv, '--until'));
+  const resume = !argv.includes('--no-resume');
+
+  return {
+    mode,
+    relayUrl,
+    workerUrl,
+    apiToken,
+    adminOrigin: adminOrigin ? adminOrigin.replace(/\/$/, '') : null,
+    cfAccessCookie,
+    inputPath,
+    checkpointPath,
+    reportPath,
+    batchSize: Number.isFinite(batchSize) && batchSize > 0 ? batchSize : DEFAULT_BATCH_SIZE,
+    concurrency: Number.isFinite(concurrency) && concurrency > 0 ? concurrency : DEFAULT_CONCURRENCY,
+    maxTotal: Number.isFinite(maxTotal) && maxTotal > 0 ? maxTotal : null,
+    since,
+    until,
+    resume
+  };
+}
+
+export function loadCheckpoint(checkpointPath) {
+  try {
+    if (!checkpointPath || !fs.existsSync(checkpointPath)) return null;
+    return readJsonFile(checkpointPath);
+  } catch (error) {
+    console.error('[DOWNGRADE] Failed to load checkpoint:', error.message);
+    return null;
+  }
+}
+
+export function saveCheckpoint(checkpointPath, checkpoint) {
+  try {
+    if (!checkpointPath) return;
+    writeJsonFile(checkpointPath, checkpoint);
+  } catch (error) {
+    console.error('[DOWNGRADE] Failed to save checkpoint:', error.message);
+  }
+}
+
+function buildRequestHeaders(options = {}) {
+  if (hasAdminSessionAuth(options)) {
+    return {
+      'Cookie': `CF_Authorization=${options.cfAccessCookie}`,
+      'Content-Type': 'application/json'
+    };
+  }
+
+  return {
+    'Authorization': `Bearer ${options.apiToken}`,
+    'Content-Type': 'application/json'
+  };
+}
+
+function buildDecisionLookupUrl(sha256, options = {}) {
+  if (hasAdminSessionAuth(options)) {
+    return `${options.adminOrigin || DEFAULT_ADMIN_ORIGIN}/admin/api/video/${sha256}`;
+  }
+
+  return `${options.workerUrl}/api/v1/decisions/${sha256}`;
+}
+
+function buildAgeRestrictedUpdateRequest(sha256, options = {}) {
+  if (hasAdminSessionAuth(options)) {
+    return {
+      method: 'POST',
+      headers: buildRequestHeaders(options),
+      body: JSON.stringify({
+        action: 'AGE_RESTRICTED',
+        reason: DOWNGRADE_REASON
+      })
+    };
+  }
+
+  return {
+    method: 'POST',
+    headers: buildRequestHeaders(options),
+    body: JSON.stringify(buildAgeRestrictedUpdate(sha256))
+  };
+}
+
+async function fetchRelayEvents(relayUrl, options = {}, deps = {}) {
+  const WebSocketImpl = deps.WebSocket || globalThis.WebSocket;
+  if (!WebSocketImpl) {
+    throw new Error('Global WebSocket implementation not available in this Node runtime');
+  }
+
+  const { limit = DEFAULT_BATCH_SIZE, since = null, until = null } = options;
+
+  return new Promise((resolve, reject) => {
+    const events = [];
+    let ws;
+    const timeout = setTimeout(() => {
+      try {
+        if (ws) ws.close();
+      } catch {}
+      reject(new Error('WebSocket timeout'));
+    }, 30000);
+
+    try {
+      ws = new WebSocketImpl(relayUrl);
+
+      const addHandler = ws.addEventListener
+        ? (type, handler) => ws.addEventListener(type, handler)
+        : (type, handler) => ws.on(type, handler);
+
+      addHandler('open', () => {
+        const subscriptionId = Math.random().toString(36).slice(2);
+        const filter = { kinds: [34236], limit };
+        if (since != null) filter.since = since;
+        if (until != null) filter.until = until;
+        ws.send(JSON.stringify(['REQ', subscriptionId, filter]));
+
+        addHandler('message', (message) => {
+          const raw = typeof message?.data === 'string' ? message.data : message?.toString?.() || '';
+          try {
+            const payload = JSON.parse(raw);
+            if (payload[0] === 'EVENT' && payload[1] === subscriptionId) {
+              events.push(payload[2]);
+            }
+            if (payload[0] === 'EOSE' && payload[1] === subscriptionId) {
+              clearTimeout(timeout);
+              try { ws.close(); } catch {}
+              resolve(events);
+            }
+          } catch (error) {
+            console.error('[DOWNGRADE] Failed to parse relay message:', error.message);
+          }
+        });
+      });
+
+      addHandler('error', (error) => {
+        clearTimeout(timeout);
+        reject(error instanceof Error ? error : new Error('WebSocket error'));
+      });
+    } catch (error) {
+      clearTimeout(timeout);
+      reject(error);
+    }
+  });
+}
+
+function dedupeCandidates(candidates) {
+  const bySha = new Map();
+  for (const candidate of candidates) {
+    if (!candidate?.sha256) continue;
+    if (!bySha.has(candidate.sha256)) {
+      bySha.set(candidate.sha256, candidate);
+    }
+  }
+  return [...bySha.values()];
+}
+
+function loadCandidatesFromInput(inputPath) {
+  const resolvedPath = path.resolve(inputPath);
+  const parsed = readJsonFile(resolvedPath);
+  const rawItems = Array.isArray(parsed)
+    ? parsed
+    : Array.isArray(parsed?.videos)
+      ? parsed.videos
+      : Array.isArray(parsed?.sha256s)
+        ? parsed.sha256s.map((sha256) => ({ sha256 }))
+        : [];
+
+  return rawItems.map((item) => {
+    if (typeof item === 'string') {
+      return { sha256: item.toLowerCase(), eventId: null, nostrContext: null };
+    }
+    return {
+      sha256: typeof item.sha256 === 'string' ? item.sha256.toLowerCase() : null,
+      eventId: item.eventId || null,
+      nostrContext: item.nostrContext || null
+    };
+  }).filter((item) => item.sha256);
+}
+
+async function fetchDecision(sha256, options = {}, deps = {}) {
+  const fetchImpl = deps.fetch || globalThis.fetch;
+  const response = await fetchImpl(buildDecisionLookupUrl(sha256, options), {
+    headers: buildRequestHeaders(options)
+  });
+
+  if (response.status === 404) {
+    return null;
+  }
+
+  if (!response.ok) {
+    throw new Error(`Decision lookup failed for ${sha256}: HTTP ${response.status} ${await response.text()}`);
+  }
+
+  const payload = await response.json();
+  return hasAdminSessionAuth(options) ? payload?.video || null : payload;
+}
+
+async function updateDecisionToAgeRestricted(sha256, options = {}, deps = {}) {
+  const fetchImpl = deps.fetch || globalThis.fetch;
+  const updateUrl = hasAdminSessionAuth(options)
+    ? `${options.adminOrigin || DEFAULT_ADMIN_ORIGIN}/admin/api/moderate/${sha256}`
+    : `${options.workerUrl}/api/v1/moderate`;
+  const response = await fetchImpl(updateUrl, buildAgeRestrictedUpdateRequest(sha256, options));
+
+  if (!response.ok) {
+    throw new Error(`Moderation update failed for ${sha256}: HTTP ${response.status} ${await response.text()}`);
+  }
+
+  return response.json();
+}
+
+function buildInitialStats() {
+  return {
+    discovered: 0,
+    eligible: 0,
+    updated: 0,
+    skippedHumanReviewed: 0,
+    skippedReviewNotes: 0,
+    skippedSafe: 0,
+    skippedAlreadyAgeRestricted: 0,
+    skippedNoDecision: 0,
+    skippedNotVine: 0,
+    failed: 0
+  };
+}
+
+function recordSkip(stats, reason) {
+  switch (reason) {
+    case 'human-reviewed':
+      stats.skippedHumanReviewed++;
+      break;
+    case 'review-notes-present':
+      stats.skippedReviewNotes++;
+      break;
+    case 'already-safe':
+      stats.skippedSafe++;
+      break;
+    case 'already-age-restricted':
+      stats.skippedAlreadyAgeRestricted++;
+      break;
+    case 'no-decision':
+      stats.skippedNoDecision++;
+      break;
+    case 'not-vine':
+      stats.skippedNotVine++;
+      break;
+    default:
+      break;
+  }
+}
+
+async function discoverCandidates(options, deps = {}) {
+  if (options.inputPath) {
+    return dedupeCandidates(loadCandidatesFromInput(options.inputPath));
+  }
+
+  const allCandidates = [];
+  let currentUntil = options.until;
+
+  while (true) {
+    const events = await fetchRelayEvents(options.relayUrl, {
+      limit: options.batchSize,
+      since: options.since,
+      until: currentUntil
+    }, deps);
+
+    if (events.length === 0) {
+      break;
+    }
+
+    for (const event of events) {
+      const candidate = extractClassicVineCandidateFromEvent(event);
+      if (candidate) {
+        allCandidates.push(candidate);
+      }
+    }
+
+    const oldestCreatedAt = events.reduce((oldest, event) => {
+      if (!Number.isFinite(event?.created_at)) return oldest;
+      return oldest == null ? event.created_at : Math.min(oldest, event.created_at);
+    }, null);
+
+    if (oldestCreatedAt == null) {
+      break;
+    }
+
+    currentUntil = oldestCreatedAt - 1;
+    if (options.since != null && currentUntil < options.since) {
+      break;
+    }
+    if (events.length < options.batchSize) {
+      break;
+    }
+    if (options.maxTotal && allCandidates.length >= options.maxTotal) {
+      break;
+    }
+  }
+
+  const candidates = dedupeCandidates(allCandidates);
+  return options.maxTotal ? candidates.slice(0, options.maxTotal) : candidates;
+}
+
+export async function runClassicVineAgeRestrictionDowngrade(options = {}, deps = {}) {
+  if (Boolean(options.adminOrigin) !== Boolean(options.cfAccessCookie)) {
+    throw new Error('Admin session mode requires both adminOrigin and cfAccessCookie.');
+  }
+
+  if (!options.apiToken && !hasAdminSessionAuth(options)) {
+    throw new Error('Missing auth. Set SERVICE_API_TOKEN or MODERATION_API_TOKEN, or pass --token. For admin-session mode, pass --admin-origin and --cf-access-cookie.');
+  }
+
+  const stats = buildInitialStats();
+  const report = {
+    mode: options.mode,
+    relay: options.relayUrl,
+    worker: options.workerUrl,
+    startedAt: new Date().toISOString(),
+    results: []
+  };
+
+  const discoverCandidatesImpl = deps.discoverCandidates || discoverCandidates;
+  const candidates = await discoverCandidatesImpl(options, deps);
+  stats.discovered = candidates.length;
+
+  for (let index = 0; index < candidates.length; index++) {
+    const candidate = candidates[index];
+    const decision = await fetchDecision(candidate.sha256, options, deps);
+    const classification = classifyDecisionForDowngrade(decision);
+
+    if (!classification.eligible) {
+      recordSkip(stats, classification.reason);
+      report.results.push({
+        sha256: candidate.sha256,
+        eventId: candidate.eventId,
+        result: classification.reason
+      });
+      continue;
+    }
+
+    stats.eligible++;
+
+    if (options.mode === 'preview') {
+      report.results.push({
+        sha256: candidate.sha256,
+        eventId: candidate.eventId,
+        result: 'eligible'
+      });
+      continue;
+    }
+
+    try {
+      const response = await updateDecisionToAgeRestricted(candidate.sha256, options, deps);
+      stats.updated++;
+      report.results.push({
+        sha256: candidate.sha256,
+        eventId: candidate.eventId,
+        result: 'updated',
+        response
+      });
+    } catch (error) {
+      stats.failed++;
+      report.results.push({
+        sha256: candidate.sha256,
+        eventId: candidate.eventId,
+        result: 'failed',
+        error: error.message
+      });
+    }
+
+    if (options.concurrency > 0 && index + 1 < candidates.length) {
+      await sleep(100);
+    }
+  }
+
+  report.finishedAt = new Date().toISOString();
+  report.stats = stats;
+  return report;
+}
+
+async function main() {
+  const options = parseArgs();
+  const report = await runClassicVineAgeRestrictionDowngrade(options);
+  writeJsonFile(options.reportPath, report);
+  console.log(JSON.stringify({
+    mode: options.mode,
+    stats: report.stats,
+    reportPath: options.reportPath
+  }, null, 2));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error('[DOWNGRADE] Fatal error:', error);
+    process.exit(1);
+  });
+}

--- a/scripts/downgrade-classic-vines-to-age-restricted.test.mjs
+++ b/scripts/downgrade-classic-vines-to-age-restricted.test.mjs
@@ -1,0 +1,330 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Tests for classic Vine downgrade script helpers
+// ABOUTME: Verifies legacy Vine candidate extraction and conservative eligibility filtering
+
+import { describe, expect, it } from 'vitest';
+import {
+  buildAgeRestrictedUpdate,
+  classifyDecisionForDowngrade,
+  extractClassicVineCandidateFromEvent,
+  runClassicVineAgeRestrictionDowngrade
+} from './downgrade-classic-vines-to-age-restricted.mjs';
+
+describe('extractClassicVineCandidateFromEvent', () => {
+  it('extracts a candidate from a legacy Vine event using x/imeta x media hash', () => {
+    const sha256 = 'a'.repeat(64);
+    const event = {
+      id: 'b'.repeat(64),
+      content: '',
+      created_at: 1465948644,
+      tags: [
+        ['d', 'legacy-vine-id'],
+        ['x', sha256],
+        ['imeta', `url https://media.divine.video/${sha256}`, 'm video/mp4', `x ${sha256}`],
+        ['platform', 'vine'],
+        ['client', 'vine-archive-importer'],
+        ['r', 'https://vine.co/v/legacy-vine-id'],
+        ['published_at', '1465948644']
+      ]
+    };
+
+    expect(extractClassicVineCandidateFromEvent(event)).toEqual({
+      sha256,
+      eventId: event.id,
+      nostrContext: expect.objectContaining({
+        platform: 'vine',
+        client: 'vine-archive-importer',
+        sourceUrl: 'https://vine.co/v/legacy-vine-id',
+        publishedAt: 1465948644
+      })
+    });
+  });
+
+  it('returns null for non-Vine events', () => {
+    const event = {
+      id: 'b'.repeat(64),
+      content: '',
+      created_at: 1700000000,
+      tags: [
+        ['d', 'not-vine'],
+        ['x', 'a'.repeat(64)],
+        ['platform', 'divine']
+      ]
+    };
+
+    expect(extractClassicVineCandidateFromEvent(event)).toBeNull();
+  });
+});
+
+describe('classifyDecisionForDowngrade', () => {
+  it('marks machine-applied non-SAFE rows as eligible', () => {
+    const decision = {
+      sha256: 'a'.repeat(64),
+      action: 'PERMANENT_BAN',
+      reviewed_by: null,
+      review_notes: null
+    };
+
+    expect(classifyDecisionForDowngrade(decision)).toEqual({
+      eligible: true,
+      reason: 'eligible-machine-restriction'
+    });
+  });
+
+  it('skips rows with reviewed_by set', () => {
+    expect(classifyDecisionForDowngrade({
+      sha256: 'a'.repeat(64),
+      action: 'QUARANTINE',
+      reviewed_by: 'admin',
+      review_notes: null
+    })).toEqual({
+      eligible: false,
+      reason: 'human-reviewed'
+    });
+  });
+
+  it('skips rows with review_notes set', () => {
+    expect(classifyDecisionForDowngrade({
+      sha256: 'a'.repeat(64),
+      action: 'AGE_RESTRICTED',
+      reviewed_by: null,
+      review_notes: 'manual T&S action'
+    })).toEqual({
+      eligible: false,
+      reason: 'review-notes-present'
+    });
+  });
+
+  it('skips SAFE rows', () => {
+    expect(classifyDecisionForDowngrade({
+      sha256: 'a'.repeat(64),
+      action: 'SAFE',
+      reviewed_by: null,
+      review_notes: null
+    })).toEqual({
+      eligible: false,
+      reason: 'already-safe'
+    });
+  });
+
+  it('skips rows already age-restricted', () => {
+    expect(classifyDecisionForDowngrade({
+      sha256: 'a'.repeat(64),
+      action: 'AGE_RESTRICTED',
+      reviewed_by: null,
+      review_notes: null
+    })).toEqual({
+      eligible: false,
+      reason: 'already-age-restricted'
+    });
+  });
+
+  it('skips missing rows', () => {
+    expect(classifyDecisionForDowngrade(null)).toEqual({
+      eligible: false,
+      reason: 'no-decision'
+    });
+  });
+});
+
+describe('buildAgeRestrictedUpdate', () => {
+  it('builds the expected moderation update payload', () => {
+    const sha256 = 'a'.repeat(64);
+    expect(buildAgeRestrictedUpdate(sha256)).toEqual({
+      sha256,
+      action: 'AGE_RESTRICTED',
+      reason: 'classic-vine-downgrade: machine-applied legacy Vine restriction downgraded to age-restricted',
+      source: 'classic-vine-downgrade-script'
+    });
+  });
+});
+
+describe('runClassicVineAgeRestrictionDowngrade', () => {
+  it('reports eligible rows in preview mode without updating them', async () => {
+    const sha256 = 'a'.repeat(64);
+
+    const report = await runClassicVineAgeRestrictionDowngrade({
+      mode: 'preview',
+      apiToken: 'token',
+      relayUrl: 'wss://relay.example',
+      workerUrl: 'https://worker.example'
+    }, {
+      discoverCandidates: async () => [{ sha256, eventId: 'b'.repeat(64) }],
+      fetch: async () => ({
+        ok: true,
+        json: async () => ({
+          sha256,
+          action: 'PERMANENT_BAN',
+          reviewed_by: null,
+          review_notes: null
+        })
+      })
+    });
+
+    expect(report.stats.eligible).toBe(1);
+    expect(report.stats.updated).toBe(0);
+    expect(report.results).toEqual([
+      {
+        sha256,
+        eventId: 'b'.repeat(64),
+        result: 'eligible'
+      }
+    ]);
+  });
+
+  it('updates eligible rows in execute mode', async () => {
+    const sha256 = 'a'.repeat(64);
+    let updateCalls = 0;
+
+    const report = await runClassicVineAgeRestrictionDowngrade({
+      mode: 'execute',
+      apiToken: 'token',
+      relayUrl: 'wss://relay.example',
+      workerUrl: 'https://worker.example'
+    }, {
+      discoverCandidates: async () => [{ sha256, eventId: 'b'.repeat(64) }],
+      fetch: async (url, init = {}) => {
+        if (String(url).includes('/api/v1/decisions/')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              sha256,
+              action: 'QUARANTINE',
+              reviewed_by: null,
+              review_notes: null
+            })
+          };
+        }
+
+        updateCalls++;
+        expect(JSON.parse(init.body)).toEqual(buildAgeRestrictedUpdate(sha256));
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ success: true, sha256, action: 'AGE_RESTRICTED' })
+        };
+      }
+    });
+
+    expect(updateCalls).toBe(1);
+    expect(report.stats.updated).toBe(1);
+    expect(report.results[0]).toEqual({
+      sha256,
+      eventId: 'b'.repeat(64),
+      result: 'updated',
+      response: { success: true, sha256, action: 'AGE_RESTRICTED' }
+    });
+  });
+
+  it('uses admin lookup endpoints in preview mode when an admin session is provided', async () => {
+    const sha256 = 'a'.repeat(64);
+    const requests = [];
+
+    const report = await runClassicVineAgeRestrictionDowngrade({
+      mode: 'preview',
+      relayUrl: 'wss://relay.example',
+      workerUrl: 'https://worker.example',
+      adminOrigin: 'https://moderation.admin.divine.video',
+      cfAccessCookie: 'cf-cookie'
+    }, {
+      discoverCandidates: async () => [{ sha256, eventId: 'b'.repeat(64) }],
+      fetch: async (url, init = {}) => {
+        requests.push({ url: String(url), init });
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            video: {
+              sha256,
+              action: 'PERMANENT_BAN',
+              reviewed_by: null,
+              review_notes: null
+            }
+          })
+        };
+      }
+    });
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]).toEqual({
+      url: `https://moderation.admin.divine.video/admin/api/video/${sha256}`,
+      init: {
+        headers: {
+          'Cookie': 'CF_Authorization=cf-cookie',
+          'Content-Type': 'application/json'
+        }
+      }
+    });
+    expect(report.stats.eligible).toBe(1);
+    expect(report.results[0]).toEqual({
+      sha256,
+      eventId: 'b'.repeat(64),
+      result: 'eligible'
+    });
+  });
+
+  it('uses admin moderate endpoints in execute mode when an admin session is provided', async () => {
+    const sha256 = 'a'.repeat(64);
+    const requests = [];
+
+    const report = await runClassicVineAgeRestrictionDowngrade({
+      mode: 'execute',
+      relayUrl: 'wss://relay.example',
+      workerUrl: 'https://worker.example',
+      adminOrigin: 'https://moderation.admin.divine.video',
+      cfAccessCookie: 'cf-cookie'
+    }, {
+      discoverCandidates: async () => [{ sha256, eventId: 'b'.repeat(64) }],
+      fetch: async (url, init = {}) => {
+        requests.push({ url: String(url), init });
+
+        if (String(url).includes('/admin/api/video/')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              video: {
+                sha256,
+                action: 'QUARANTINE',
+                reviewed_by: null,
+                review_notes: null
+              }
+            })
+          };
+        }
+
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ success: true, sha256, action: 'AGE_RESTRICTED' })
+        };
+      }
+    });
+
+    expect(requests).toHaveLength(2);
+    expect(requests[1]).toEqual({
+      url: `https://moderation.admin.divine.video/admin/api/moderate/${sha256}`,
+      init: {
+        method: 'POST',
+        headers: {
+          'Cookie': 'CF_Authorization=cf-cookie',
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          action: 'AGE_RESTRICTED',
+          reason: 'classic-vine-downgrade: machine-applied legacy Vine restriction downgraded to age-restricted'
+        })
+      }
+    });
+    expect(report.stats.updated).toBe(1);
+    expect(report.results[0]).toEqual({
+      sha256,
+      eventId: 'b'.repeat(64),
+      result: 'updated',
+      response: { success: true, sha256, action: 'AGE_RESTRICTED' }
+    });
+  });
+});

--- a/scripts/export-for-safeguard-eval.mjs
+++ b/scripts/export-for-safeguard-eval.mjs
@@ -1,0 +1,163 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Export recent moderation decisions + VLM classifier data as JSONL
+// ABOUTME: for offline evaluation against a gpt-oss-safeguard policy prompt.
+//
+// Read-only. Hits the admin API endpoints (/api/v1/decisions + /api/v1/classifier/:sha256)
+// and writes one JSON object per line to stdout or --out. Feed the output to a local
+// Ollama/vLLM/Colab safeguard run, then diff the model's action vs. the `action` field.
+//
+// Usage:
+//   node scripts/export-for-safeguard-eval.mjs \
+//     --worker https://moderation.admin.divine.video \
+//     --token $MODERATION_API_TOKEN \
+//     --limit 200 \
+//     --out tmp/safeguard-eval-set.jsonl
+//
+// Optional filters:
+//   --action QUARANTINE       only include rows with this action (repeatable)
+//   --since 2026-03-01        ISO date; skip rows moderated earlier
+//   --require-vlm             drop rows with no VLM classifier data in KV
+
+import fs from 'fs';
+import process from 'process';
+
+function parseArgs(argv) {
+  const args = { actions: [], limit: 200, requireVlm: false };
+  for (let i = 2; i < argv.length; i++) {
+    const flag = argv[i];
+    const next = argv[i + 1];
+    switch (flag) {
+      case '--worker': args.worker = next; i++; break;
+      case '--token': args.token = next; i++; break;
+      case '--limit': args.limit = Number(next); i++; break;
+      case '--action': args.actions.push(next); i++; break;
+      case '--since': args.since = next; i++; break;
+      case '--out': args.out = next; i++; break;
+      case '--require-vlm': args.requireVlm = true; break;
+      case '--help':
+      case '-h':
+        console.log(`See header comment in ${import.meta.url} for usage.`);
+        process.exit(0);
+    }
+  }
+  args.worker = args.worker || process.env.MODERATION_WORKER_URL;
+  args.token = args.token || process.env.MODERATION_API_TOKEN || process.env.SERVICE_API_TOKEN;
+  if (!args.worker) throw new Error('Missing --worker or MODERATION_WORKER_URL');
+  if (!args.token) throw new Error('Missing --token or MODERATION_API_TOKEN');
+  return args;
+}
+
+async function apiGet(path, { worker, token }) {
+  const res = await fetch(`${worker}${path}`, {
+    headers: { Authorization: `Bearer ${token}` }
+  });
+  if (!res.ok) throw new Error(`GET ${path} → HTTP ${res.status}`);
+  return res.json();
+}
+
+async function fetchDecisions({ worker, token, limit, actions, since }) {
+  const pageSize = 100;
+  const all = [];
+  let cursor = null;
+  while (all.length < limit) {
+    const qs = new URLSearchParams({ limit: String(pageSize) });
+    if (cursor) qs.set('cursor', cursor);
+    const page = await apiGet(`/api/v1/decisions?${qs}`, { worker, token });
+    const rows = page.decisions || page.results || page.items || page;
+    if (!Array.isArray(rows) || rows.length === 0) break;
+    for (const row of rows) {
+      if (actions.length && !actions.includes(row.action)) continue;
+      if (since && row.moderated_at && row.moderated_at < since) continue;
+      all.push(row);
+      if (all.length >= limit) break;
+    }
+    cursor = page.next_cursor || page.nextCursor || null;
+    if (!cursor) break;
+  }
+  return all.slice(0, limit);
+}
+
+async function fetchClassifier(sha256, ctx) {
+  try {
+    const payload = await apiGet(`/api/v1/classifier/${sha256}`, ctx);
+    return payload?.classifier_data || null;
+  } catch {
+    return null;
+  }
+}
+
+function toEvalRecord(decision, classifier) {
+  const scores = safeParse(decision.scores);
+  const categories = safeParse(decision.categories);
+  const vlm = classifier || {};
+  return {
+    sha256: decision.sha256,
+    ground_truth: {
+      action: decision.action,
+      reviewed_by: decision.reviewed_by || null,
+      reviewed_at: decision.reviewed_at || null,
+      review_notes: decision.review_notes || null
+    },
+    content: {
+      title: decision.title || null,
+      author: decision.author || null,
+      uploaded_by: decision.uploaded_by || null,
+      published_at: decision.published_at || null,
+      event_id: decision.event_id || null,
+      content_url: decision.content_url || null
+    },
+    signals: {
+      provider: decision.provider || null,
+      categories,
+      scores,
+      moderated_at: decision.moderated_at || null
+    },
+    vlm: {
+      description: vlm.description || null,
+      topics: vlm.topics || [],
+      setting: vlm.setting || null,
+      objects: vlm.objects || [],
+      activities: vlm.activities || [],
+      mood: vlm.mood || null,
+      top_categories: vlm.topCategories || vlm.top_categories || [],
+      top_settings: vlm.topSettings || vlm.top_settings || [],
+      top_objects: vlm.topObjects || vlm.top_objects || []
+    }
+  };
+}
+
+function safeParse(val) {
+  if (val == null) return null;
+  if (typeof val !== 'string') return val;
+  try { return JSON.parse(val); } catch { return val; }
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const ctx = { worker: args.worker, token: args.token };
+
+  console.error(`[EXPORT] fetching up to ${args.limit} decisions from ${args.worker}`);
+  const decisions = await fetchDecisions({ ...ctx, limit: args.limit, actions: args.actions, since: args.since });
+  console.error(`[EXPORT] got ${decisions.length} decisions, fetching VLM data...`);
+
+  const out = args.out ? fs.createWriteStream(args.out) : process.stdout;
+  let written = 0;
+  let skippedNoVlm = 0;
+  for (const dec of decisions) {
+    const classifier = await fetchClassifier(dec.sha256, ctx);
+    if (args.requireVlm && !classifier) { skippedNoVlm++; continue; }
+    const record = toEvalRecord(dec, classifier);
+    out.write(JSON.stringify(record) + '\n');
+    written++;
+  }
+
+  if (args.out) out.end();
+  console.error(`[EXPORT] wrote ${written} records${skippedNoVlm ? ` (skipped ${skippedNoVlm} missing VLM)` : ''}`);
+}
+
+main().catch((err) => {
+  console.error('[EXPORT] failed:', err.message);
+  process.exit(1);
+});

--- a/search-snapshot.md
+++ b/search-snapshot.md
@@ -1,0 +1,19 @@
+- generic [ref=e2]:
+  - region "Notifications (F8)":
+    - list
+  - region "Notifications alt+T"
+  - complementary [ref=e3]:
+    - button "Go to home" [ref=e5] [cursor=pointer]:
+      - img "Divine" [ref=e6]
+    - generic [ref=e7]:
+      - navigation [ref=e8]
+      - generic [ref=e146]
+      - button "RSS Feeds" [ref=e23] [cursor=pointer]
+      - button "Dark mode" [ref=e32] [cursor=pointer]
+      - 'button "Language: English" [ref=e39] [cursor=pointer]'
+      - button "Log in" [ref=e47] [cursor=pointer]
+      - generic [ref=e49]
+  - main [ref=e67]:
+    - main [ref=e69]:
+      - generic [ref=e70]
+      - generic [ref=e81]

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -18,7 +18,6 @@ import dashboardHTML from './admin/dashboard.html';
 import swipeReviewHTML from './admin/swipe-review.html';
 import messagesHTML from './admin/messages.html';
 import { initReportsTable, addReport } from './reports.mjs';
-import { initOffenderTable, updateUploaderStats, getUploaderStats } from './offender-tracker.mjs';
 import { initUploaderEnforcementTable, getUploaderEnforcement, setUploaderEnforcement, applyUploaderEnforcementToResult } from './uploader-enforcement.mjs';
 import { formatForStorage, formatForGorse, formatForFunnelcake } from './classification/pipeline.mjs';
 import { topicsToLabels, topicsToWeightedFeatures } from './classification/topic-extractor.mjs';
@@ -504,14 +503,10 @@ async function enrichAdminLookupVideo(video, env) {
   }
 
   if (enriched.uploaded_by) {
-    const [uploaderStats, uploaderEnforcement] = await Promise.all([
-      getUploaderStats(env.BLOSSOM_DB, enriched.uploaded_by).catch(() => null),
-      getUploaderEnforcement(env.BLOSSOM_DB, enriched.uploaded_by).catch(() => null)
-    ]);
+    const uploaderEnforcement = await getUploaderEnforcement(env.BLOSSOM_DB, enriched.uploaded_by).catch(() => null);
 
     enriched = {
       ...enriched,
-      uploaderStats,
       uploaderEnforcement: uploaderEnforcement || {
         pubkey: enriched.uploaded_by,
         approval_required: false,
@@ -931,8 +926,6 @@ export default {
       return hostMismatchResponse(requestId, hostname, url.pathname, expectedHost);
     }
 
-    // Ensure offender tracking table exists (idempotent)
-    await initOffenderTable(env.BLOSSOM_DB);
     await initUploaderEnforcementTable(env.BLOSSOM_DB);
 
     // Ensure reports table exists
@@ -3682,15 +3675,6 @@ async function runMigration() {
         console.log(`[MODERATION] Step 8: Handling result (action=${result.action})`);
         await handleModerationResult(result, env);
         console.log(`[MODERATION] Step 9: Result handled`);
-
-        // Update uploader stats for repeat offender tracking
-        if (result.uploadedBy) {
-          try {
-            await updateUploaderStats(env.BLOSSOM_DB, result.uploadedBy, result.action);
-          } catch (statsErr) {
-            console.error(`[MODERATION] Failed to update uploader stats:`, statsErr.message);
-          }
-        }
 
         // Acknowledge successful processing
         message.ack();

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -23,6 +23,7 @@ import { formatForStorage, formatForGorse, formatForFunnelcake } from './classif
 import { topicsToLabels, topicsToWeightedFeatures } from './classification/topic-extractor.mjs';
 import { getKVThresholds, setKVThresholds, DEFAULT_THRESHOLDS } from './moderation/classifier.mjs';
 import { isValidSha256, isValidLookupIdentifier, isValidPubkey, parseMaybeJson, getEventTagValue, parseImetaParams, extractShaFromUrl, extractMediaShaFromEvent } from './validation.mjs';
+import { parseRetryAfterSeconds } from './http-utils.mjs';
 import { parseVttText } from './moderation/text-classifier.mjs';
 import { notifyAtprotoLabeler } from './atproto/label-webhook.mjs';
 import { buildDownstreamPublishContext } from './moderation/downstream-publishing.mjs';
@@ -313,15 +314,39 @@ function getAdminTranscriptProxyUrl(sha256) {
 async function fetchTranscriptAsset(sha256, env) {
   const sourceUrl = getTranscriptSourceUrl(sha256, env);
   const response = await fetch(sourceUrl);
+  const subtitleUrl = getAdminTranscriptProxyUrl(sha256);
 
   if (response.status === 404) {
     return {
       found: false,
+      pending: false,
       sha256,
       sourceUrl,
-      subtitleUrl: getAdminTranscriptProxyUrl(sha256),
+      subtitleUrl,
       vttContent: null,
       transcriptText: ''
+    };
+  }
+
+  if (response.status === 202) {
+    let pendingBody = null;
+    try {
+      pendingBody = await response.json();
+    } catch {
+      pendingBody = null;
+    }
+
+    return {
+      found: false,
+      pending: true,
+      sha256,
+      sourceUrl,
+      subtitleUrl,
+      vttContent: null,
+      transcriptText: '',
+      retryAfterSeconds: parseRetryAfterSeconds(response.headers.get('Retry-After')),
+      pendingStatus: typeof pendingBody?.status === 'string' ? pendingBody.status : null,
+      pendingMessage: typeof pendingBody?.message === 'string' ? pendingBody.message : null
     };
   }
 
@@ -332,9 +357,10 @@ async function fetchTranscriptAsset(sha256, env) {
   const vttContent = await response.text();
   return {
     found: true,
+    pending: false,
     sha256,
     sourceUrl,
-    subtitleUrl: getAdminTranscriptProxyUrl(sha256),
+    subtitleUrl,
     vttContent,
     transcriptText: parseVttText(vttContent).trim()
   };
@@ -516,6 +542,93 @@ async function enrichAdminLookupVideo(video, env) {
   }
 
   return enriched;
+}
+
+const UPLOADER_HISTORY_ACTIONS = ['SAFE', 'REVIEW', 'QUARANTINE', 'AGE_RESTRICTED', 'PERMANENT_BAN'];
+
+function extractReasonFromRow(row) {
+  if (row.review_notes) return row.review_notes;
+  if (row.raw_response) {
+    try {
+      const raw = typeof row.raw_response === 'string' ? JSON.parse(row.raw_response) : row.raw_response;
+      if (raw && typeof raw === 'object') {
+        if (typeof raw.reason === 'string' && raw.reason.trim()) return raw.reason;
+        if (Array.isArray(raw.categories) && raw.categories.length > 0) return raw.categories.join(', ');
+      }
+    } catch {}
+  }
+  return null;
+}
+
+async function resolveProfileWithTimeout(pubkey, env, timeoutMs = 250) {
+  if (env.SKIP_PROFILE_RESOLUTION === 'true') return null;
+  try {
+    const { resolveProfile } = await import('./nostr/profile-resolver.mjs');
+    return await Promise.race([
+      resolveProfile(pubkey, env).catch(() => null),
+      new Promise((resolve) => setTimeout(() => resolve(null), timeoutMs))
+    ]);
+  } catch {
+    return null;
+  }
+}
+
+async function buildUploaderHistory(pubkey, env) {
+  const db = env.BLOSSOM_DB;
+  const actionBreakdown = Object.fromEntries(UPLOADER_HISTORY_ACTIONS.map((action) => [action, 0]));
+
+  const [totalsRow, breakdownRows, recentRows, dmRow, aiRow, enforcement, profile] = await Promise.all([
+    db.prepare(
+      `SELECT COUNT(*) AS videos, MIN(moderated_at) AS firstSeen, MAX(moderated_at) AS lastSeen
+       FROM moderation_results WHERE uploaded_by = ?`
+    ).bind(pubkey).first().catch(() => null),
+    db.prepare(
+      `SELECT action, COUNT(*) AS count FROM moderation_results WHERE uploaded_by = ? GROUP BY action`
+    ).bind(pubkey).all().catch(() => ({ results: [] })),
+    db.prepare(
+      `SELECT sha256, action, moderated_at, review_notes, raw_response
+       FROM moderation_results
+       WHERE uploaded_by = ? AND action IN ('REVIEW','QUARANTINE','AGE_RESTRICTED','PERMANENT_BAN')
+       ORDER BY moderated_at DESC LIMIT 10`
+    ).bind(pubkey).all().catch(() => ({ results: [] })),
+    db.prepare(
+      `SELECT COUNT(*) AS dmCount FROM dm_log WHERE sender_pubkey = ? OR recipient_pubkey = ?`
+    ).bind(pubkey, pubkey).first().catch(() => null),
+    db.prepare(
+      `SELECT COUNT(*) AS aiFlaggedCount FROM moderation_results
+       WHERE uploaded_by = ? AND (categories LIKE '%ai_generated%' OR categories LIKE '%deepfake%')`
+    ).bind(pubkey).first().catch(() => null),
+    getUploaderEnforcement(db, pubkey).catch(() => null),
+    resolveProfileWithTimeout(pubkey, env)
+  ]);
+
+  for (const row of (breakdownRows?.results || [])) {
+    if (row?.action && actionBreakdown[row.action] !== undefined) {
+      actionBreakdown[row.action] = Number(row.count) || 0;
+    }
+  }
+
+  const recentFlagged = (recentRows?.results || []).map((row) => ({
+    sha256: row.sha256,
+    action: row.action,
+    processedAt: row.moderated_at,
+    reason: extractReasonFromRow(row)
+  }));
+
+  return {
+    pubkey,
+    profile: profile || null,
+    totals: {
+      videos: Number(totalsRow?.videos) || 0,
+      firstSeen: totalsRow?.firstSeen || null,
+      lastSeen: totalsRow?.lastSeen || null
+    },
+    actionBreakdown,
+    recentFlagged,
+    aiFlaggedCount: Number(aiRow?.aiFlaggedCount) || 0,
+    dmCount: Number(dmRow?.dmCount) || 0,
+    enforcement: enforcement || null
+  };
 }
 
 async function getAdminLookupVideo(identifier, env, options = {}) {
@@ -2028,6 +2141,27 @@ export default {
 
       try {
         const transcript = await fetchTranscriptAsset(sha256, env);
+        if (transcript.pending) {
+          const headers = { ...JSON_HEADERS };
+          if (transcript.retryAfterSeconds !== null) {
+            headers['Retry-After'] = String(transcript.retryAfterSeconds);
+          }
+
+          return new Response(JSON.stringify({
+            sha256,
+            found: false,
+            pending: true,
+            subtitleUrl: transcript.subtitleUrl,
+            sourceUrl: transcript.sourceUrl,
+            retryAfterSeconds: transcript.retryAfterSeconds,
+            status: transcript.pendingStatus,
+            message: transcript.pendingMessage
+          }), {
+            status: 202,
+            headers
+          });
+        }
+
         if (!transcript.found) {
           return new Response(JSON.stringify({
             sha256,
@@ -2340,6 +2474,27 @@ export default {
 
       try {
         const transcript = await fetchTranscriptAsset(sha256, env);
+        if (transcript.pending) {
+          const headers = { ...JSON_HEADERS };
+          if (transcript.retryAfterSeconds !== null) {
+            headers['Retry-After'] = String(transcript.retryAfterSeconds);
+          }
+
+          return new Response(JSON.stringify({
+            sha256,
+            found: false,
+            pending: true,
+            subtitleUrl: transcript.subtitleUrl,
+            sourceUrl: transcript.sourceUrl,
+            retryAfterSeconds: transcript.retryAfterSeconds,
+            status: transcript.pendingStatus,
+            message: transcript.pendingMessage
+          }), {
+            status: 202,
+            headers
+          });
+        }
+
         if (!transcript.found || !transcript.vttContent) {
           return new Response('Transcript not found', { status: 404 });
         }
@@ -2837,6 +2992,29 @@ async function runMigration() {
         return new Response(JSON.stringify({ error: 'No realness verification found' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
       }
       return new Response(JSON.stringify(result), { headers: { 'Content-Type': 'application/json' } });
+    }
+
+    if (url.pathname.startsWith('/admin/api/uploader/')
+        && request.method === 'GET'
+        && !url.pathname.endsWith('/enforcement')) {
+      const authError = await requireAuth(request, env);
+      if (authError) return authError;
+
+      const parts = url.pathname.split('/');
+      const pubkey = parts[4];
+      if (!pubkey || parts.length !== 5) {
+        return jsonResponse(400, { error: 'pubkey required' });
+      }
+
+      try {
+        const body = await buildUploaderHistory(pubkey, env);
+        return new Response(JSON.stringify(body), {
+          headers: { 'Content-Type': 'application/json' }
+        });
+      } catch (err) {
+        console.error('[UPLOADER-HISTORY] Error:', err);
+        return jsonResponse(500, { error: err.message });
+      }
     }
 
     if (url.pathname === '/admin/api/classic-vines/rollback' && request.method === 'POST') {

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -17,15 +17,13 @@ import { hexToBytes, bytesToHex } from '@noble/hashes/utils';
 import dashboardHTML from './admin/dashboard.html';
 import swipeReviewHTML from './admin/swipe-review.html';
 import messagesHTML from './admin/messages.html';
-import { buildCreatorContext } from './admin/creator-context.mjs';
-import { buildProvenance } from './admin/provenance.mjs';
 import { initReportsTable, addReport } from './reports.mjs';
+import { initOffenderTable, updateUploaderStats, getUploaderStats } from './offender-tracker.mjs';
 import { initUploaderEnforcementTable, getUploaderEnforcement, setUploaderEnforcement, applyUploaderEnforcementToResult } from './uploader-enforcement.mjs';
 import { formatForStorage, formatForGorse, formatForFunnelcake } from './classification/pipeline.mjs';
 import { topicsToLabels, topicsToWeightedFeatures } from './classification/topic-extractor.mjs';
 import { getKVThresholds, setKVThresholds, DEFAULT_THRESHOLDS } from './moderation/classifier.mjs';
 import { isValidSha256, isValidLookupIdentifier, isValidPubkey, parseMaybeJson, getEventTagValue, parseImetaParams, extractShaFromUrl, extractMediaShaFromEvent } from './validation.mjs';
-import { parseRetryAfterSeconds } from './http-utils.mjs';
 import { parseVttText } from './moderation/text-classifier.mjs';
 import { notifyAtprotoLabeler } from './atproto/label-webhook.mjs';
 import { buildDownstreamPublishContext } from './moderation/downstream-publishing.mjs';
@@ -53,35 +51,7 @@ const CATEGORY_TO_LABEL = {
 const ADMIN_HOSTNAME = 'moderation.admin.divine.video';
 const API_HOSTNAME = 'moderation-api.divine.video';
 const DEFAULT_RELAY_ADMIN_URL = 'https://relay.admin.divine.video';
-const DEFAULT_DIVINE_API_BASE_URL = 'https://api.divine.video';
-const DEFAULT_LEGACY_FUNNELCAKE_BASE_URL = 'https://relay.divine.video';
 const JSON_HEADERS = { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' };
-
-// ETags for admin HTML pages — computed once at module load, change only on deploy.
-// Allows browsers to cache the HTML but revalidate on every request (304 if unchanged).
-const HTML_ETAGS = {
-  dashboard: `"${hashCode(dashboardHTML)}"`,
-  review: `"${hashCode(swipeReviewHTML)}"`,
-  messages: `"${hashCode(messagesHTML)}"`,
-};
-
-function hashCode(str) {
-  let hash = 0;
-  for (let i = 0; i < str.length; i++) {
-    hash = ((hash << 5) - hash + str.charCodeAt(i)) | 0;
-  }
-  return hash.toString(36);
-}
-
-function serveHTML(html, etag, request) {
-  if (request.headers.get('If-None-Match') === etag) {
-    return new Response(null, { status: 304, headers: { 'ETag': etag } });
-  }
-  return new Response(html, {
-    headers: { 'Content-Type': 'text/html', 'Cache-Control': 'no-cache', 'ETag': etag }
-  });
-}
-
 const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]']);
 
 /**
@@ -180,73 +150,6 @@ function hostMismatchResponse(requestId, hostname, pathname, expectedHost) {
   return jsonError(`Not found on ${hostname}. Use https://${expectedHost}${pathname}`, 404);
 }
 
-function isPresentValue(value) {
-  return value !== null && value !== undefined && value !== '';
-}
-
-function pickFirstPresentValue(...values) {
-  for (const value of values) {
-    if (isPresentValue(value)) {
-      return value;
-    }
-  }
-  return null;
-}
-
-function mergePresentFields(primary = {}, fallback = {}) {
-  const merged = { ...(fallback || {}) };
-  for (const [key, value] of Object.entries(primary || {})) {
-    if (isPresentValue(value)) {
-      merged[key] = value;
-    }
-  }
-  return Object.keys(merged).length > 0 ? merged : null;
-}
-
-function getDivineApiBaseUrl(env) {
-  return env.DIVINE_API_BASE_URL || DEFAULT_DIVINE_API_BASE_URL;
-}
-
-function getLegacyFunnelcakeBaseUrl(env) {
-  return env.FUNNELCAKE_API_BASE_URL || DEFAULT_LEGACY_FUNNELCAKE_BASE_URL;
-}
-
-function buildAdminNostrContext({
-  event = null,
-  metadata = null,
-  authorFallback = null,
-  pubkey = null,
-  eventId = null,
-  stableId = null
-} = {}) {
-  const resolvedPubkey = pickFirstPresentValue(pubkey, event?.pubkey);
-  const resolvedEventId = pickFirstPresentValue(eventId, event?.id, metadata?.eventId);
-  const resolvedStableId = pickFirstPresentValue(stableId, metadata?.stableId);
-
-  return {
-    title: pickFirstPresentValue(metadata?.title),
-    author: pickFirstPresentValue(metadata?.author, authorFallback),
-    client: pickFirstPresentValue(metadata?.client),
-    content: pickFirstPresentValue(metadata?.content, event?.content),
-    pubkey: resolvedPubkey ? `${resolvedPubkey.substring(0, 16)}...` : null,
-    eventId: resolvedEventId,
-    platform: pickFirstPresentValue(metadata?.platform),
-    loops: metadata?.loops ?? null,
-    likes: metadata?.likes ?? null,
-    comments: metadata?.comments ?? null,
-    url: pickFirstPresentValue(metadata?.url),
-    sourceUrl: pickFirstPresentValue(metadata?.sourceUrl),
-    publishedAt: metadata?.publishedAt ?? null,
-    archivedAt: metadata?.archivedAt ?? null,
-    importedAt: metadata?.importedAt ?? null,
-    vineHashId: pickFirstPresentValue(metadata?.vineHashId),
-    vineUserId: pickFirstPresentValue(metadata?.vineUserId),
-    proofmode: metadata?.proofmode ?? null,
-    createdAt: metadata?.createdAt ?? event?.created_at ?? null,
-    stableId: resolvedStableId
-  };
-}
-
 function buildFunnelcakeVideoLookup(eventResponse, identifier) {
   if (!eventResponse?.event) {
     return null;
@@ -264,836 +167,98 @@ function buildFunnelcakeVideoLookup(eventResponse, identifier) {
 
   return {
     eventId: event.id,
-    event_id: event.id,
     stableId,
     lookupId: identifier,
     mediaSha,
     videoUrl,
-    content_url: videoUrl,
     thumbnailUrl,
     uploadedBy: event.pubkey || null,
-    author: metadata.author || stats.author_name || null,
-    title: metadata.title || null,
-    published_at: metadata.publishedAt || null,
-    createdAt: event.created_at ? new Date(event.created_at * 1000).toISOString() : null,
-    nostrContext: buildAdminNostrContext({
-      event,
-      metadata,
-      authorFallback: stats.author_name || null,
-      stableId
-    }),
-    publisherProfile: {
-      display_name: stats.author_name || null,
-      picture: stats.author_avatar || null
+    createdAt: event.created_at || null,
+    nostrContext: {
+      title: metadata.title || null,
+      author: metadata.author || stats.author_name || null,
+      client: metadata.client || null,
+      content: metadata.content || event.content || null,
+      url: videoUrl || null,
+      publishedAt: metadata.publishedAt || null,
+      pubkey: event.pubkey ? `${event.pubkey.substring(0, 16)}...` : null,
+      eventId: event.id,
+      platform: metadata.platform || null
     },
     divineUrl: `https://divine.video/video/${encodeURIComponent(stableId)}`
   };
 }
 
-function parseOptionalInteger(value) {
-  if (value === null || value === undefined || value === '') {
-    return null;
-  }
-
-  if (typeof value === 'number') {
-    return Number.isFinite(value) ? value : null;
-  }
-
-  if (typeof value === 'string' && /^\d+$/.test(value)) {
-    const parsed = Number.parseInt(value, 10);
-    return Number.isFinite(parsed) ? parsed : null;
-  }
-
-  return value;
-}
-
-function parseOptionalString(value) {
-  return typeof value === 'string' && value.length > 0 ? value : null;
-}
-
-function parseOptionalObject(value) {
-  return value && typeof value === 'object' && !Array.isArray(value) ? value : null;
-}
-
-function parseStoredAdminSnapshot(rawResponse) {
-  const parsed = parseMaybeJson(rawResponse, null);
-  const root = parseOptionalObject(parsed);
-  const snapshot = mergePresentFields(
-    parseOptionalObject(root?.nostrSnapshot) || {},
-    parseOptionalObject(root?.nostrContext) || {}
-  ) || root;
-
-  if (!snapshot) {
-    return null;
-  }
-
-  const uploadedBy = [
-    root?.uploadedBy,
-    root?.uploaded_by,
-    snapshot?.uploadedBy,
-    snapshot?.uploaded_by,
-    root?.pubkey,
-    snapshot?.pubkey
-  ].find((candidate) => isValidPubkey(candidate)) || null;
-
-  const parsedSnapshot = {
-    uploadedBy,
-    title: parseOptionalString(root?.title ?? snapshot.title),
-    author: parseOptionalString(root?.author ?? snapshot.author),
-    eventId: parseOptionalString(
-      root?.nostrEventId
-      ?? root?.nostr_event_id
-      ?? root?.eventId
-      ?? root?.event_id
-      ?? snapshot.eventId
-      ?? snapshot.event_id
-    ),
-    contentUrl: parseOptionalString(
-      root?.contentUrl
-      ?? root?.content_url
-      ?? snapshot.url
-      ?? snapshot.contentUrl
-      ?? snapshot.content_url
-    ),
-    sourceUrl: parseOptionalString(root?.sourceUrl ?? root?.source_url ?? snapshot.sourceUrl ?? snapshot.source_url),
-    platform: parseOptionalString(root?.platform ?? snapshot.platform),
-    client: parseOptionalString(root?.client ?? snapshot.client),
-    publishedAt: parseOptionalInteger(root?.publishedAt ?? root?.published_at ?? snapshot.publishedAt ?? snapshot.published_at),
-    archivedAt: parseOptionalString(root?.archivedAt ?? root?.archived_at ?? snapshot.archivedAt ?? snapshot.archived_at),
-    importedAt: parseOptionalInteger(root?.importedAt ?? root?.imported_at ?? snapshot.importedAt ?? snapshot.imported_at),
-    vineHashId: parseOptionalString(root?.vineHashId ?? root?.vine_hash_id ?? snapshot.vineHashId ?? snapshot.vine_hash_id),
-    vineUserId: parseOptionalString(root?.vineUserId ?? root?.vine_user_id ?? snapshot.vineUserId ?? snapshot.vine_user_id),
-    stableId: parseOptionalString(snapshot.stableId ?? snapshot.stable_id ?? snapshot.dTag ?? snapshot.d_tag),
-    content: parseOptionalString(root?.content ?? snapshot.content ?? snapshot.summary ?? snapshot.contentText ?? snapshot.content_text),
-    createdAt: parseOptionalInteger(root?.createdAt ?? root?.created_at ?? snapshot.createdAt ?? snapshot.created_at),
-    proofmode: parseOptionalObject(root?.proofmode ?? snapshot.proofmode)
-  };
-
-  return Object.values(parsedSnapshot).some((value) => value !== null) ? parsedSnapshot : null;
-}
-
-function extractStableIdFromDivineUrl(divineUrl) {
-  if (!isPresentValue(divineUrl) || typeof divineUrl !== 'string') {
-    return null;
-  }
-
-  try {
-    const url = new URL(divineUrl);
-    const segments = url.pathname.split('/').filter(Boolean);
-    if (segments.length >= 2 && segments[0] === 'video') {
-      return decodeURIComponent(segments[1]) || null;
-    }
-  } catch {
-    return null;
-  }
-
-  return null;
-}
-
-function buildStoredNostrContext(row, uploadedBy = null, options = {}) {
-  const {
-    includePubkey = true,
-    title = null,
-    author = null,
-    url = null,
-    sourceUrl = null,
-    platform = null,
-    client = null,
-    publishedAt = null,
-    archivedAt = null,
-    importedAt = null,
-    vineHashId = null,
-    vineUserId = null,
-    eventId = null,
-    createdAt = null,
-    stableId = null,
-    content = null,
-    proofmode = null
-  } = options;
+function buildStoredLookupMetadata(row) {
   if (!row) {
-    return null;
+    return {
+      eventId: null,
+      divineUrl: null,
+      nostrContext: null
+    };
   }
 
-  const metadata = {
-    title: pickFirstPresentValue(row.title, title),
-    author: pickFirstPresentValue(row.author, author),
-    platform: pickFirstPresentValue(platform),
-    client: pickFirstPresentValue(client),
-    loops: null,
-    likes: null,
-    comments: null,
-    url: pickFirstPresentValue(row.content_url, url),
-    sourceUrl: pickFirstPresentValue(sourceUrl),
-    publishedAt: pickFirstPresentValue(parseOptionalInteger(row.published_at), publishedAt),
-    archivedAt: pickFirstPresentValue(archivedAt),
-    importedAt: pickFirstPresentValue(importedAt),
-    vineHashId: pickFirstPresentValue(vineHashId),
-    vineUserId: pickFirstPresentValue(vineUserId),
-    content: parseOptionalString(content),
-    eventId: pickFirstPresentValue(row.event_id, eventId),
-    createdAt: pickFirstPresentValue(createdAt),
-    stableId: parseOptionalString(stableId),
-    proofmode: parseOptionalObject(proofmode)
-  };
-
-  const hasStoredMetadata = Object.values(metadata).some((value) => value !== null);
-
-  if (includePubkey && uploadedBy) {
-    metadata.pubkey = `${uploadedBy.substring(0, 16)}...`;
-  }
-
-  return hasStoredMetadata ? metadata : null;
-}
-
-async function fetchFunnelcakeLookupVideo(identifier, env) {
-  const bases = [getDivineApiBaseUrl(env), getLegacyFunnelcakeBaseUrl(env)];
-  let lastError = null;
-
-  for (const baseUrl of [...new Set(bases.filter(Boolean))]) {
-    try {
-      const response = await fetch(`${baseUrl}/api/videos/${encodeURIComponent(identifier)}`, {
-        headers: {
-          'Accept': 'application/json'
-        }
-      });
-
-      if (response.status === 404) {
-        continue;
-      }
-
-      if (!response.ok) {
-        lastError = new Error(`Funnelcake lookup failed with HTTP ${response.status}`);
-        continue;
-      }
-
-      return buildFunnelcakeVideoLookup(await response.json(), identifier);
-    } catch (error) {
-      lastError = error;
-    }
-  }
-
-  if (lastError) {
-    throw lastError;
-  }
-
-  return null;
-}
-
-async function fetchStoredVideoMetadata(sha256, env) {
-  try {
-    return await env.BLOSSOM_DB.prepare(`
-      SELECT sha256, video_guid, current_status, current_hls_url, current_thumbnail_url, current_mp4_url, uploaded_by, uploaded_at
-      FROM video_metadata
-      WHERE sha256 = ?
-    `).bind(sha256).first();
-  } catch {
-    return null;
-  }
-}
-
-async function fetchLatestWebhookEvent(sha256, env) {
-  try {
-    return await env.BLOSSOM_DB.prepare(`
-      SELECT sha256, video_guid, hls_url, mp4_url, thumbnail_url, received_at, status_name
-      FROM bunny_webhook_events e1
-      WHERE e1.sha256 = ?
-        AND received_at = (
-          SELECT MAX(received_at) FROM bunny_webhook_events e2 WHERE e2.sha256 = e1.sha256
-        )
-      LIMIT 1
-    `).bind(sha256).first();
-  } catch {
-    return null;
-  }
-}
-
-async function fetchStoredRelayVideo(sha256, env) {
-  if (!sha256) {
-    return null;
-  }
-
-  try {
-    return await env.BLOSSOM_DB.prepare(`
-      SELECT sha256, event_id, stable_id, pubkey, title, content, summary, video_url, thumbnail_url,
-             published_at, created_at, author_name, author_avatar, raw_json, synced_at, source_updated_at
-      FROM relay_videos
-      WHERE sha256 = ?
-    `).bind(sha256).first();
-  } catch {
-    return null;
-  }
-}
-
-async function fetchStoredRelayCreator(pubkey, env) {
-  if (!pubkey) {
-    return null;
-  }
-
-  try {
-    return await env.BLOSSOM_DB.prepare(`
-      SELECT pubkey, display_name, username, avatar_url, bio, website, nip05,
-             follower_count, following_count, video_count, event_count,
-             first_activity, last_activity, raw_json, synced_at
-      FROM relay_creators
-      WHERE pubkey = ?
-    `).bind(pubkey).first();
-  } catch {
-    return null;
-  }
-}
-
-function buildStoredRelayPublisherProfile(creatorRow = null, relayVideoRow = null) {
-  if (!creatorRow && !relayVideoRow) {
-    return null;
-  }
-
-  return {
-    display_name: pickFirstPresentValue(creatorRow?.display_name, relayVideoRow?.author_name),
-    name: pickFirstPresentValue(creatorRow?.username),
-    picture: pickFirstPresentValue(creatorRow?.avatar_url, relayVideoRow?.author_avatar),
-    about: pickFirstPresentValue(creatorRow?.bio),
-    website: pickFirstPresentValue(creatorRow?.website),
-    nip05: pickFirstPresentValue(creatorRow?.nip05)
-  };
-}
-
-function buildStoredRelayVideo(relayVideoRow = null, relayCreatorRow = null) {
-  if (!relayVideoRow) {
-    return null;
-  }
-
-  const uploadedBy = pickFirstPresentValue(relayVideoRow.pubkey, relayCreatorRow?.pubkey);
-  const eventId = pickFirstPresentValue(relayVideoRow.event_id);
-  const stableId = pickFirstPresentValue(relayVideoRow.stable_id);
-  const title = pickFirstPresentValue(relayVideoRow.title);
-  const author = pickFirstPresentValue(relayVideoRow.author_name, relayCreatorRow?.display_name, relayCreatorRow?.username);
-  const contentUrl = pickFirstPresentValue(relayVideoRow.video_url);
-  const publishedAt = pickFirstPresentValue(relayVideoRow.published_at);
-  const content = pickFirstPresentValue(relayVideoRow.content, relayVideoRow.summary);
-
-  return {
-    uploaded_by: uploadedBy,
-    title,
-    author,
-    content_url: contentUrl,
-    content_text: content,
-    published_at: publishedAt,
-    stableId,
-    event_id: eventId,
-    eventId,
-    divineUrl: stableId
-      ? `https://divine.video/video/${encodeURIComponent(stableId)}`
-      : (eventId ? `https://divine.video/video/${encodeURIComponent(eventId)}` : null),
-    cdnUrl: contentUrl,
-    thumbnailUrl: pickFirstPresentValue(relayVideoRow.thumbnail_url),
-    publisherProfile: buildStoredRelayPublisherProfile(relayCreatorRow, relayVideoRow),
-    nostrContext: buildAdminNostrContext({
-      pubkey: uploadedBy,
-      eventId,
-      stableId,
-      metadata: {
-        title,
-        author,
-        content,
-        url: contentUrl,
-        publishedAt,
-        createdAt: pickFirstPresentValue(relayVideoRow.created_at),
-        stableId,
-        eventId
-      }
-    })
-  };
-}
-
-function mergeStoredRelayCreatorContext(existingContext = null, relayCreatorRow = null, pubkey = null) {
-  if (!relayCreatorRow || !pubkey) {
-    return existingContext;
-  }
-
-  return {
-    name: pickFirstPresentValue(relayCreatorRow.display_name, relayCreatorRow.username, existingContext?.name),
-    pubkey,
-    profileUrl: existingContext?.profileUrl || `https://divine.video/profile/${pubkey}`,
-    avatarUrl: pickFirstPresentValue(relayCreatorRow.avatar_url, existingContext?.avatarUrl),
-    stats: existingContext?.stats || null,
-    social: {
-      videoCount: relayCreatorRow.video_count ?? existingContext?.social?.videoCount ?? null,
-      totalEvents: relayCreatorRow.event_count ?? existingContext?.social?.totalEvents ?? null,
-      followerCount: relayCreatorRow.follower_count ?? existingContext?.social?.followerCount ?? null,
-      followingCount: relayCreatorRow.following_count ?? existingContext?.social?.followingCount ?? null,
-      firstActivity: relayCreatorRow.first_activity ?? existingContext?.social?.firstActivity ?? null,
-      lastActivity: relayCreatorRow.last_activity ?? existingContext?.social?.lastActivity ?? null
-    },
-    enforcement: existingContext?.enforcement || {
-      pubkey,
-      approvalRequired: false,
-      relayBanned: false
-    }
-  };
-}
-
-function buildStoredAdminFallbackRow(baseRow = {}, storedSnapshot = null, videoMetadataRow = null, webhookEventRow = null) {
-  return {
-    title: pickFirstPresentValue(baseRow?.title, storedSnapshot?.title),
-    author: pickFirstPresentValue(baseRow?.author, storedSnapshot?.author),
-    event_id: pickFirstPresentValue(baseRow?.event_id, storedSnapshot?.eventId),
-    content_url: pickFirstPresentValue(
-      baseRow?.content_url,
-      storedSnapshot?.contentUrl,
-      videoMetadataRow?.current_mp4_url,
-      webhookEventRow?.mp4_url,
-      videoMetadataRow?.current_hls_url,
-      webhookEventRow?.hls_url
-    ),
-    published_at: pickFirstPresentValue(baseRow?.published_at, storedSnapshot?.publishedAt)
-  };
-}
-
-function normalizePersistedTimestampValue(value) {
-  const parsedInteger = parseOptionalInteger(value);
-  if (parsedInteger !== null) {
-    return parsedInteger;
-  }
-
-  return parseOptionalString(value);
-}
-
-function buildStoredModeratedVideo(baseRow = {}, storedSnapshot = null, videoMetadataRow = null, webhookEventRow = null, cdnUrl = null) {
-  const fallbackRow = buildStoredAdminFallbackRow(baseRow, storedSnapshot, videoMetadataRow, webhookEventRow);
-  const uploadedBy = pickFirstPresentValue(
-    baseRow?.uploaded_by,
-    storedSnapshot?.uploadedBy,
-    videoMetadataRow?.uploaded_by
+  const eventId = row.event_id || null;
+  const publishedAt = row.published_at ? parseInt(row.published_at, 10) : null;
+  const hasStoredContext = Boolean(
+    row.title || row.author || row.content_url || eventId || row.uploaded_by || publishedAt
   );
-  const eventId = fallbackRow.event_id || null;
-  const persistedContentUrl = fallbackRow.content_url || null;
-  const persistedPublishedAt = fallbackRow.published_at || null;
-  const persistedNostrContext = buildStoredNostrContext(fallbackRow, uploadedBy, {
-    title: storedSnapshot?.title || null,
-    author: storedSnapshot?.author || null,
-    url: storedSnapshot?.contentUrl || null,
-    sourceUrl: storedSnapshot?.sourceUrl || null,
-    platform: storedSnapshot?.platform || null,
-    client: storedSnapshot?.client || null,
-    publishedAt: storedSnapshot?.publishedAt || null,
-    archivedAt: storedSnapshot?.archivedAt || null,
-    importedAt: storedSnapshot?.importedAt || null,
-    vineHashId: storedSnapshot?.vineHashId || null,
-    vineUserId: storedSnapshot?.vineUserId || null,
-    eventId: storedSnapshot?.eventId || null,
-    createdAt: storedSnapshot?.createdAt || null,
-    includePubkey: true,
-    stableId: storedSnapshot?.stableId || null,
-    content: storedSnapshot?.content || null,
-    proofmode: storedSnapshot?.proofmode || null
+
+  return {
+    eventId,
+    divineUrl: eventId ? `https://divine.video/video/${encodeURIComponent(eventId)}` : null,
+    nostrContext: hasStoredContext ? {
+      title: row.title || null,
+      author: row.author || null,
+      client: null,
+      content: null,
+      url: row.content_url || null,
+      publishedAt: Number.isFinite(publishedAt) ? publishedAt : null,
+      pubkey: row.uploaded_by ? `${row.uploaded_by.substring(0, 16)}...` : null,
+      eventId,
+      platform: null
+    } : null
+  };
+}
+
+function buildAdminNostrMetadata(metadata = {}, extras = {}) {
+  return {
+    title: metadata.title || null,
+    author: metadata.author || null,
+    platform: metadata.platform || null,
+    client: metadata.client || null,
+    loops: metadata.loops ?? null,
+    likes: metadata.likes ?? null,
+    comments: metadata.comments ?? null,
+    url: metadata.url || null,
+    sourceUrl: metadata.sourceUrl || null,
+    publishedAt: metadata.publishedAt ?? null,
+    archivedAt: metadata.archivedAt ?? null,
+    importedAt: metadata.importedAt ?? null,
+    vineHashId: metadata.vineHashId ?? null,
+    vineUserId: metadata.vineUserId ?? null,
+    content: metadata.content || null,
+    eventId: metadata.eventId || null,
+    createdAt: extras.createdAt ?? metadata.createdAt ?? null
+  };
+}
+
+async function fetchFunnelcakeLookupVideo(identifier) {
+  const response = await fetch(`https://relay.divine.video/api/videos/${encodeURIComponent(identifier)}`, {
+    headers: {
+      'Accept': 'application/json'
+    }
   });
 
-  return {
-    uploaded_by: uploadedBy,
-    title: fallbackRow.title || null,
-    author: fallbackRow.author || null,
-    content_url: persistedContentUrl,
-    content_text: storedSnapshot?.content || null,
-    published_at: persistedPublishedAt,
-    stableId: storedSnapshot?.stableId || null,
-    event_id: eventId,
-    eventId,
-    divineUrl: storedSnapshot?.stableId
-      ? `https://divine.video/video/${encodeURIComponent(storedSnapshot.stableId)}`
-      : (eventId ? `https://divine.video/video/${encodeURIComponent(eventId)}` : null),
-    nostrContext: persistedNostrContext,
-    cdnUrl: cdnUrl || persistedContentUrl || videoMetadataRow?.current_mp4_url || webhookEventRow?.mp4_url || null
-  };
-}
-
-function buildResolvedAdminRawResponse(existingRawResponse, video) {
-  const existingRoot = parseOptionalObject(parseMaybeJson(existingRawResponse, {})) || {};
-  const existingNostrContext = parseOptionalObject(existingRoot?.nostrContext) || {};
-  const existingSnapshot = mergePresentFields(
-    parseOptionalObject(existingRoot?.nostrSnapshot) || {},
-    existingNostrContext
-  ) || {};
-
-  const uploadedBy = pickFirstPresentValue(video?.uploaded_by);
-  const title = pickFirstPresentValue(video?.title, video?.nostrContext?.title);
-  const author = pickFirstPresentValue(video?.author, video?.nostrContext?.author);
-  const eventId = pickFirstPresentValue(video?.eventId, video?.event_id, video?.nostrContext?.eventId);
-  const contentUrl = pickFirstPresentValue(video?.content_url, video?.nostrContext?.url, video?.cdnUrl);
-  const publishedAt = normalizePersistedTimestampValue(pickFirstPresentValue(video?.published_at, video?.nostrContext?.publishedAt));
-  const snapshot = mergePresentFields(existingSnapshot, {
-    title,
-    author,
-    eventId,
-    url: contentUrl,
-    contentUrl,
-    sourceUrl: pickFirstPresentValue(video?.nostrContext?.sourceUrl),
-    publishedAt,
-    platform: pickFirstPresentValue(video?.nostrContext?.platform),
-    client: pickFirstPresentValue(video?.nostrContext?.client),
-    archivedAt: pickFirstPresentValue(video?.nostrContext?.archivedAt),
-    importedAt: pickFirstPresentValue(video?.nostrContext?.importedAt),
-    vineHashId: pickFirstPresentValue(video?.nostrContext?.vineHashId),
-    vineUserId: pickFirstPresentValue(video?.nostrContext?.vineUserId),
-    stableId: pickFirstPresentValue(video?.stableId, video?.nostrContext?.stableId, extractStableIdFromDivineUrl(video?.divineUrl)),
-    content: pickFirstPresentValue(video?.content_text, video?.nostrContext?.content),
-    createdAt: normalizePersistedTimestampValue(video?.nostrContext?.createdAt),
-    proofmode: parseOptionalObject(video?.nostrContext?.proofmode)
-  }) || null;
-
-  const mergedRoot = {
-    ...existingRoot,
-    uploadedBy: pickFirstPresentValue(uploadedBy, existingRoot?.uploadedBy, existingRoot?.uploaded_by),
-    title: pickFirstPresentValue(title, existingRoot?.title),
-    author: pickFirstPresentValue(author, existingRoot?.author),
-    nostrEventId: pickFirstPresentValue(eventId, existingRoot?.nostrEventId, existingRoot?.nostr_event_id, existingRoot?.eventId, existingRoot?.event_id),
-    contentUrl: pickFirstPresentValue(contentUrl, existingRoot?.contentUrl, existingRoot?.content_url),
-    publishedAt: pickFirstPresentValue(publishedAt, existingRoot?.publishedAt, existingRoot?.published_at),
-    nostrSnapshot: snapshot,
-    nostrContext: mergePresentFields(existingNostrContext, snapshot || {})
-  };
-
-  return JSON.stringify(mergedRoot);
-}
-
-function buildRelayVideoMirrorRecord(sha256, video) {
-  if (!sha256 || !video) {
+  if (response.status === 404) {
     return null;
   }
 
-  const eventId = pickFirstPresentValue(video.eventId, video.event_id, video.nostrContext?.eventId);
-  const stableId = pickFirstPresentValue(video.stableId, video.nostrContext?.stableId, extractStableIdFromDivineUrl(video.divineUrl));
-  const pubkey = pickFirstPresentValue(video.uploaded_by);
-  const title = pickFirstPresentValue(video.title, video.nostrContext?.title);
-  const content = pickFirstPresentValue(video.content_text, video.nostrContext?.content);
-  const summary = pickFirstPresentValue(video.nostrContext?.summary);
-  const videoUrl = pickFirstPresentValue(video.content_url, video.nostrContext?.url, video.cdnUrl);
-  const thumbnailUrl = pickFirstPresentValue(video.thumbnailUrl);
-  const publishedAt = normalizePersistedTimestampValue(pickFirstPresentValue(video.published_at, video.nostrContext?.publishedAt));
-  const createdAt = normalizePersistedTimestampValue(pickFirstPresentValue(video.nostrContext?.createdAt));
-  const authorName = pickFirstPresentValue(video.author, video.nostrContext?.author);
-  const authorAvatar = pickFirstPresentValue(video.publisherProfile?.picture, video.creatorContext?.avatarUrl);
-  const syncedAt = new Date().toISOString();
-
-  const hasUsefulData = [
-    eventId,
-    stableId,
-    pubkey,
-    title,
-    content,
-    videoUrl,
-    authorName
-  ].some((value) => isPresentValue(value));
-
-  if (!hasUsefulData) {
-    return null;
+  if (!response.ok) {
+    throw new Error(`Funnelcake lookup failed with HTTP ${response.status}`);
   }
 
-  return {
-    sha256,
-    event_id: eventId,
-    stable_id: stableId,
-    pubkey,
-    title,
-    content,
-    summary,
-    video_url: videoUrl,
-    thumbnail_url: thumbnailUrl,
-    published_at: publishedAt,
-    created_at: createdAt,
-    author_name: authorName,
-    author_avatar: authorAvatar,
-    raw_json: JSON.stringify({
-      sha256,
-      eventId,
-      stableId,
-      pubkey,
-      title,
-      content,
-      summary,
-      videoUrl,
-      thumbnailUrl,
-      publishedAt,
-      createdAt,
-      authorName,
-      authorAvatar,
-      publisherProfile: video.publisherProfile || null
-    }),
-    synced_at: syncedAt,
-    source_updated_at: null
-  };
-}
-
-function buildRelayCreatorMirrorRecord(pubkey, video) {
-  if (!pubkey || !video) {
-    return null;
-  }
-
-  const displayName = pickFirstPresentValue(video.publisherProfile?.display_name, video.creatorContext?.name, video.author);
-  const username = pickFirstPresentValue(video.publisherProfile?.name);
-  const avatarUrl = pickFirstPresentValue(video.publisherProfile?.picture, video.creatorContext?.avatarUrl);
-  const bio = pickFirstPresentValue(video.publisherProfile?.about);
-  const website = pickFirstPresentValue(video.publisherProfile?.website);
-  const nip05 = pickFirstPresentValue(video.publisherProfile?.nip05);
-  const social = video.creatorContext?.social || {};
-  const syncedAt = new Date().toISOString();
-
-  const hasUsefulData = [
-    displayName,
-    username,
-    avatarUrl,
-    social.followerCount,
-    social.videoCount
-  ].some((value) => isPresentValue(value));
-
-  if (!hasUsefulData) {
-    return null;
-  }
-
-  return {
-    pubkey,
-    display_name: displayName,
-    username,
-    avatar_url: avatarUrl,
-    bio,
-    website,
-    nip05,
-    follower_count: social.followerCount ?? null,
-    following_count: social.followingCount ?? null,
-    video_count: social.videoCount ?? null,
-    event_count: social.totalEvents ?? null,
-    first_activity: social.firstActivity ?? null,
-    last_activity: social.lastActivity ?? null,
-    raw_json: JSON.stringify({
-      pubkey,
-      displayName,
-      username,
-      avatarUrl,
-      bio,
-      website,
-      nip05,
-      social
-    }),
-    synced_at: syncedAt
-  };
-}
-
-async function persistRelayMirrorContext(sha256, video, env) {
-  if (!sha256 || !video) {
-    return false;
-  }
-
-  let wrote = false;
-  const relayVideo = buildRelayVideoMirrorRecord(sha256, video);
-  if (relayVideo) {
-    await env.BLOSSOM_DB.prepare(`
-      INSERT INTO relay_videos (
-        sha256, event_id, stable_id, pubkey, title, content, summary, video_url, thumbnail_url,
-        published_at, created_at, author_name, author_avatar, raw_json, synced_at, source_updated_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-      ON CONFLICT(sha256) DO UPDATE SET
-        event_id = excluded.event_id,
-        stable_id = excluded.stable_id,
-        pubkey = excluded.pubkey,
-        title = excluded.title,
-        content = excluded.content,
-        summary = excluded.summary,
-        video_url = excluded.video_url,
-        thumbnail_url = excluded.thumbnail_url,
-        published_at = excluded.published_at,
-        created_at = excluded.created_at,
-        author_name = excluded.author_name,
-        author_avatar = excluded.author_avatar,
-        raw_json = excluded.raw_json,
-        synced_at = excluded.synced_at,
-        source_updated_at = excluded.source_updated_at
-    `).bind(
-      relayVideo.sha256,
-      relayVideo.event_id,
-      relayVideo.stable_id,
-      relayVideo.pubkey,
-      relayVideo.title,
-      relayVideo.content,
-      relayVideo.summary,
-      relayVideo.video_url,
-      relayVideo.thumbnail_url,
-      relayVideo.published_at,
-      relayVideo.created_at,
-      relayVideo.author_name,
-      relayVideo.author_avatar,
-      relayVideo.raw_json,
-      relayVideo.synced_at,
-      relayVideo.source_updated_at
-    ).run();
-    wrote = true;
-  }
-
-  const pubkey = pickFirstPresentValue(video.uploaded_by, relayVideo?.pubkey);
-  const relayCreator = buildRelayCreatorMirrorRecord(pubkey, video);
-  if (relayCreator) {
-    await env.BLOSSOM_DB.prepare(`
-      INSERT INTO relay_creators (
-        pubkey, display_name, username, avatar_url, bio, website, nip05,
-        follower_count, following_count, video_count, event_count,
-        first_activity, last_activity, raw_json, synced_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-      ON CONFLICT(pubkey) DO UPDATE SET
-        display_name = excluded.display_name,
-        username = excluded.username,
-        avatar_url = excluded.avatar_url,
-        bio = excluded.bio,
-        website = excluded.website,
-        nip05 = excluded.nip05,
-        follower_count = excluded.follower_count,
-        following_count = excluded.following_count,
-        video_count = excluded.video_count,
-        event_count = excluded.event_count,
-        first_activity = excluded.first_activity,
-        last_activity = excluded.last_activity,
-        raw_json = excluded.raw_json,
-        synced_at = excluded.synced_at
-    `).bind(
-      relayCreator.pubkey,
-      relayCreator.display_name,
-      relayCreator.username,
-      relayCreator.avatar_url,
-      relayCreator.bio,
-      relayCreator.website,
-      relayCreator.nip05,
-      relayCreator.follower_count,
-      relayCreator.following_count,
-      relayCreator.video_count,
-      relayCreator.event_count,
-      relayCreator.first_activity,
-      relayCreator.last_activity,
-      relayCreator.raw_json,
-      relayCreator.synced_at
-    ).run();
-    wrote = true;
-  }
-
-  return wrote;
-}
-
-async function persistResolvedAdminContext(sha256, video, env, existingRow = null) {
-  if (!sha256 || !video || !existingRow) {
-    return false;
-  }
-
-  const nextValues = {
-    uploaded_by: pickFirstPresentValue(video.uploaded_by),
-    title: pickFirstPresentValue(video.title, video.nostrContext?.title),
-    author: pickFirstPresentValue(video.author, video.nostrContext?.author),
-    event_id: pickFirstPresentValue(video.eventId, video.event_id, video.nostrContext?.eventId),
-    content_url: pickFirstPresentValue(video.content_url, video.nostrContext?.url, video.cdnUrl),
-    published_at: normalizePersistedTimestampValue(pickFirstPresentValue(video.published_at, video.nostrContext?.publishedAt))
-  };
-
-  const currentSnapshot = parseStoredAdminSnapshot(existingRow.raw_response);
-  const currentValues = {
-    uploaded_by: pickFirstPresentValue(existingRow.uploaded_by, currentSnapshot?.uploadedBy),
-    title: pickFirstPresentValue(existingRow.title, currentSnapshot?.title),
-    author: pickFirstPresentValue(existingRow.author, currentSnapshot?.author),
-    event_id: pickFirstPresentValue(existingRow.event_id, currentSnapshot?.eventId),
-    content_url: pickFirstPresentValue(existingRow.content_url, currentSnapshot?.contentUrl),
-    published_at: normalizePersistedTimestampValue(pickFirstPresentValue(existingRow.published_at, currentSnapshot?.publishedAt))
-  };
-
-  const nextRawResponse = buildResolvedAdminRawResponse(existingRow.raw_response, video);
-  const hasScalarChange = Object.entries(nextValues).some(([key, value]) => value !== null && String(value) !== String(currentValues[key] ?? ''));
-  const hasRawResponseChange = nextRawResponse !== (existingRow.raw_response ?? null);
-
-  if (!hasScalarChange && !hasRawResponseChange) {
-    return false;
-  }
-
-  await env.BLOSSOM_DB.prepare(`
-    UPDATE moderation_results
-    SET uploaded_by = COALESCE(?, uploaded_by),
-        title = COALESCE(?, title),
-        author = COALESCE(?, author),
-        event_id = COALESCE(?, event_id),
-        content_url = COALESCE(?, content_url),
-        published_at = COALESCE(?, published_at),
-        raw_response = COALESCE(?, raw_response)
-    WHERE sha256 = ?
-  `).bind(
-    nextValues.uploaded_by,
-    nextValues.title,
-    nextValues.author,
-    nextValues.event_id,
-    nextValues.content_url,
-    nextValues.published_at,
-    nextRawResponse,
-    sha256
-  ).run();
-
-  return true;
-}
-
-function needsAdminContextRepair(row) {
-  return [
-    row?.uploaded_by,
-    row?.title,
-    row?.author,
-    row?.event_id,
-    row?.content_url,
-    row?.published_at
-  ].some((value) => !isPresentValue(value));
-}
-
-function buildAdminContextStatus(video) {
-  const nostrContext = video?.nostrContext || {};
-  const hasPublisher = Boolean(pickFirstPresentValue(
-    video?.publisherProfile?.display_name,
-    video?.uploaded_by,
-    video?.author,
-    nostrContext.author,
-    nostrContext.pubkey
-  ));
-  const hasPostIdentity = Boolean(pickFirstPresentValue(
-    video?.title,
-    video?.content_text,
-    nostrContext.title,
-    nostrContext.content,
-    video?.eventId,
-    video?.event_id,
-    video?.stableId,
-    nostrContext.eventId,
-    nostrContext.stableId
-  ));
-  const hasMetadataSignals = Boolean(pickFirstPresentValue(
-    nostrContext.sourceUrl,
-    nostrContext.platform,
-    nostrContext.client,
-    nostrContext.publishedAt,
-    nostrContext.archivedAt,
-    nostrContext.importedAt,
-    nostrContext.vineHashId,
-    nostrContext.vineUserId
-  ));
-  const hasSpecificContentUrl = Boolean(
-    isPresentValue(video?.content_url)
-    && video.content_url !== video.cdnUrl
-  );
-
-  if (!hasPublisher && !hasPostIdentity && !hasMetadataSignals && !hasSpecificContentUrl) {
-    return {
-      state: 'orphaned',
-      reason: 'legacy_moderation_row_without_context'
-    };
-  }
-
-  if (!hasPublisher || !hasPostIdentity) {
-    return {
-      state: 'partial',
-      reason: 'partial_context_available'
-    };
-  }
-
-  return {
-    state: 'resolved',
-    reason: null
-  };
+  return buildFunnelcakeVideoLookup(await response.json(), identifier);
 }
 
 function mergeLookupMetadata(baseVideo, funnelcakeVideo) {
@@ -1101,53 +266,23 @@ function mergeLookupMetadata(baseVideo, funnelcakeVideo) {
     return baseVideo;
   }
 
+  const baseNostrContext = Object.fromEntries(
+    Object.entries(baseVideo.nostrContext || {}).filter(([, value]) => value !== null && value !== undefined)
+  );
+
   return {
     ...baseVideo,
-    eventId: pickFirstPresentValue(funnelcakeVideo.eventId, funnelcakeVideo.event_id, baseVideo.eventId, baseVideo.event_id),
-    event_id: pickFirstPresentValue(funnelcakeVideo.event_id, funnelcakeVideo.eventId, baseVideo.event_id, baseVideo.eventId),
-    stableId: pickFirstPresentValue(funnelcakeVideo.stableId, baseVideo.stableId, extractStableIdFromDivineUrl(baseVideo.divineUrl)),
-    cdnUrl: pickFirstPresentValue(funnelcakeVideo.videoUrl, funnelcakeVideo.content_url, baseVideo.cdnUrl, baseVideo.content_url),
-    content_url: pickFirstPresentValue(funnelcakeVideo.content_url, funnelcakeVideo.videoUrl, baseVideo.content_url, baseVideo.cdnUrl),
-    thumbnailUrl: pickFirstPresentValue(funnelcakeVideo.thumbnailUrl, baseVideo.thumbnailUrl),
-    uploaded_by: pickFirstPresentValue(funnelcakeVideo.uploadedBy, funnelcakeVideo.uploaded_by, baseVideo.uploaded_by),
-    divineUrl: pickFirstPresentValue(funnelcakeVideo.divineUrl, baseVideo.divineUrl),
-    lookupId: pickFirstPresentValue(funnelcakeVideo.lookupId, baseVideo.lookupId),
-    title: pickFirstPresentValue(funnelcakeVideo.title, baseVideo.title, baseVideo.nostrContext?.title),
-    author: pickFirstPresentValue(funnelcakeVideo.author, baseVideo.author, baseVideo.nostrContext?.author),
-    published_at: pickFirstPresentValue(
-      funnelcakeVideo.published_at,
-      funnelcakeVideo.publishedAt,
-      funnelcakeVideo.nostrContext?.publishedAt,
-      baseVideo.published_at,
-      baseVideo.nostrContext?.publishedAt
-    ),
-    publisherProfile: mergePresentFields(funnelcakeVideo.publisherProfile, baseVideo.publisherProfile),
-    nostrContext: mergePresentFields(funnelcakeVideo.nostrContext || {}, baseVideo.nostrContext || {})
+    cdnUrl: funnelcakeVideo.videoUrl || baseVideo.cdnUrl || null,
+    thumbnailUrl: baseVideo.thumbnailUrl || funnelcakeVideo.thumbnailUrl || null,
+    uploaded_by: baseVideo.uploaded_by || funnelcakeVideo.uploadedBy || null,
+    eventId: baseVideo.eventId || funnelcakeVideo.eventId || null,
+    divineUrl: funnelcakeVideo.divineUrl || baseVideo.divineUrl,
+    lookupId: funnelcakeVideo.lookupId || baseVideo.lookupId,
+    nostrContext: {
+      ...(funnelcakeVideo.nostrContext || {}),
+      ...baseNostrContext
+    }
   };
-}
-
-async function fetchDivineApiUserProfiles(pubkeys, env) {
-  const uniquePubkeys = [...new Set((pubkeys || []).filter((pubkey) => typeof pubkey === 'string' && pubkey.length === 64))];
-  if (uniquePubkeys.length === 0) {
-    return {};
-  }
-
-  const response = await fetch(`${getDivineApiBaseUrl(env)}/api/users/bulk`, {
-    method: 'POST',
-    headers: {
-      'Accept': 'application/json',
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({ pubkeys: uniquePubkeys })
-  });
-
-  if (!response.ok) {
-    throw new Error(`User bulk lookup failed with HTTP ${response.status}`);
-  }
-
-  const data = await response.json();
-  const users = Array.isArray(data?.users) ? data.users : [];
-  return Object.fromEntries(users.map((user) => [user.pubkey, user.profile || null]));
 }
 
 function getRelayAdminUrl(env) {
@@ -1179,39 +314,15 @@ function getAdminTranscriptProxyUrl(sha256) {
 async function fetchTranscriptAsset(sha256, env) {
   const sourceUrl = getTranscriptSourceUrl(sha256, env);
   const response = await fetch(sourceUrl);
-  const subtitleUrl = getAdminTranscriptProxyUrl(sha256);
 
   if (response.status === 404) {
     return {
       found: false,
-      pending: false,
       sha256,
       sourceUrl,
-      subtitleUrl,
+      subtitleUrl: getAdminTranscriptProxyUrl(sha256),
       vttContent: null,
       transcriptText: ''
-    };
-  }
-
-  if (response.status === 202) {
-    let pendingBody = null;
-    try {
-      pendingBody = await response.json();
-    } catch {
-      pendingBody = null;
-    }
-
-    return {
-      found: false,
-      pending: true,
-      sha256,
-      sourceUrl,
-      subtitleUrl,
-      vttContent: null,
-      transcriptText: '',
-      retryAfterSeconds: parseRetryAfterSeconds(response.headers.get('Retry-After')),
-      pendingStatus: typeof pendingBody?.status === 'string' ? pendingBody.status : null,
-      pendingMessage: typeof pendingBody?.message === 'string' ? pendingBody.message : null
     };
   }
 
@@ -1222,55 +333,12 @@ async function fetchTranscriptAsset(sha256, env) {
   const vttContent = await response.text();
   return {
     found: true,
-    pending: false,
     sha256,
     sourceUrl,
-    subtitleUrl,
+    subtitleUrl: getAdminTranscriptProxyUrl(sha256),
     vttContent,
     transcriptText: parseVttText(vttContent).trim()
   };
-}
-
-function appendAbsoluteUrlCandidate(candidates, seen, value) {
-  if (!isPresentValue(value) || typeof value !== 'string') {
-    return;
-  }
-
-  if (!/^https?:\/\//i.test(value)) {
-    return;
-  }
-
-  if (seen.has(value)) {
-    return;
-  }
-
-  seen.add(value);
-  candidates.push(value);
-}
-
-async function getStoredAdminVideoSourceUrls(sha256, env) {
-  const candidates = [];
-  const seen = new Set();
-
-  try {
-    const kvModeration = parseMaybeJson(await env.MODERATION_KV.get(`moderation:${sha256}`), null);
-    appendAbsoluteUrlCandidate(candidates, seen, kvModeration?.cdnUrl);
-  } catch {
-    // Ignore KV lookup failures and continue with D1 fallback.
-  }
-
-  try {
-    const row = await env.BLOSSOM_DB.prepare(`
-      SELECT content_url
-      FROM moderation_results
-      WHERE sha256 = ?
-    `).bind(sha256).first();
-    appendAbsoluteUrlCandidate(candidates, seen, row?.content_url);
-  } catch {
-    // Ignore D1 lookup failures and keep the proxy behavior best-effort.
-  }
-
-  return candidates;
 }
 
 async function callRelayAdminAction(env, payload) {
@@ -1374,18 +442,28 @@ async function deleteEventFromRelayBySha256(sha256, env, source = 'unknown', rea
 
 async function fetchLookupNostrContext(hash, env) {
   try {
-    const video = await fetchFunnelcakeLookupVideo(hash, env);
-    if (!video) {
+    const event = await fetchNostrEventBySha256(hash, ['wss://relay.divine.video'], env);
+    if (!event) {
       return null;
     }
 
+    const metadata = parseVideoEventMetadata(event) || {};
+    const tags = event.tags || [];
+    const stableId = getEventTagValue(tags, 'd') || event.id || hash;
+
     return {
-      eventId: video.eventId || null,
-      uploadedBy: video.uploaded_by || video.uploadedBy || null,
-      divineUrl: video.divineUrl || null,
-      stableId: video.stableId || null,
-      publisherProfile: video.publisherProfile || null,
-      nostrContext: video.nostrContext || null
+      eventId: event.id,
+      uploadedBy: event.pubkey || null,
+      divineUrl: `https://divine.video/video/${encodeURIComponent(stableId)}`,
+      nostrContext: {
+        title: metadata.title || null,
+        author: metadata.author || null,
+        client: metadata.client || null,
+        content: metadata.content || event.content || null,
+        pubkey: event.pubkey ? `${event.pubkey.substring(0, 16)}...` : null,
+        eventId: event.id,
+        platform: metadata.platform || null
+      }
     };
   } catch (error) {
     console.error(`[ADMIN] Failed to fetch Nostr context for ${hash}:`, error.message);
@@ -1393,307 +471,56 @@ async function fetchLookupNostrContext(hash, env) {
   }
 }
 
-function buildLookupCandidates(identifier, video) {
-  const candidates = [];
-  const seen = new Set();
-  const append = (value) => {
-    if (!isPresentValue(value)) {
-      return;
-    }
-    const normalized = String(value);
-    if (seen.has(normalized)) {
-      return;
-    }
-    seen.add(normalized);
-    candidates.push(normalized);
-  };
-
-  append(video?.eventId);
-  append(video?.event_id);
-  append(video?.stableId);
-  append(video?.stable_id);
-  append(extractStableIdFromDivineUrl(video?.divineUrl));
-  append(video?.lookupId);
-  append(identifier);
-  append(video?.sha256);
-
-  return candidates;
-}
-
-async function fetchRelayFirstAdminContext(identifier, video, env, options = {}) {
-  const { hydrateProfiles = true } = options;
-  const candidates = buildLookupCandidates(identifier, video);
-  for (const candidate of candidates) {
-    try {
-      const relayVideo = await fetchFunnelcakeLookupVideo(candidate, env);
-      if (!relayVideo) {
-        continue;
-      }
-
-      if (hydrateProfiles && relayVideo.uploadedBy) {
-        try {
-          const profiles = await fetchDivineApiUserProfiles([relayVideo.uploadedBy], env);
-          relayVideo.publisherProfile = mergePresentFields(
-            profiles[relayVideo.uploadedBy] || {},
-            relayVideo.publisherProfile || {}
-          );
-        } catch (error) {
-          console.warn(`[ADMIN] Failed to fetch relay user profile for ${relayVideo.uploadedBy}: ${error.message}`);
-        }
-      }
-
-      return relayVideo;
-    } catch (error) {
-      console.warn(`[ADMIN] Relay-first lookup failed for ${candidate}: ${error.message}`);
-    }
-  }
-
-  return null;
-}
-
-async function repairStoredAdminContextRow(row, env) {
-  if (!row?.sha256) {
-    return { repaired: false, video: null };
-  }
-
-  const storedSnapshot = parseStoredAdminSnapshot(row.raw_response);
-  const storedVideo = buildStoredModeratedVideo(row, storedSnapshot);
-  const relayVideo = await fetchRelayFirstAdminContext(row.sha256, {
-    ...row,
-    ...storedVideo
-  }, env, { hydrateProfiles: false });
-
-  if (!relayVideo) {
-    return {
-      repaired: false,
-      video: storedVideo
-    };
-  }
-
-  const repairedVideo = mergeLookupMetadata({
-    sha256: row.sha256,
-    ...storedVideo
-  }, relayVideo);
-  repairedVideo.nostrContext = mergePresentFields(repairedVideo.nostrContext || {}, {
-    title: repairedVideo.title,
-    author: repairedVideo.author,
-    content: pickFirstPresentValue(repairedVideo.nostrContext?.content, repairedVideo.content_text),
-    url: repairedVideo.content_url,
-    publishedAt: repairedVideo.published_at,
-    eventId: repairedVideo.eventId,
-    stableId: repairedVideo.stableId
-  });
-
-  const repaired = await persistResolvedAdminContext(row.sha256, repairedVideo, env, row);
-  return {
-    repaired,
-    video: repairedVideo
-  };
-}
-
-async function getUploaderStatsRow(db, pubkey) {
-  if (!pubkey) {
-    return null;
-  }
-
-  try {
-    return await db.prepare(`
-      SELECT pubkey, total_scanned, flagged_count, banned_count, restricted_count, review_count, last_flagged_at, risk_level
-      FROM uploader_stats
-      WHERE pubkey = ?
-    `).bind(pubkey).first();
-  } catch {
-    return null;
-  }
-}
-
-async function enrichAdminLookupVideo(video, env, identifierOrOptions = null, maybeOptions = {}) {
+async function enrichAdminLookupVideo(video, env) {
   if (!video) {
     return null;
   }
 
-  const identifier = typeof identifierOrOptions === 'string' ? identifierOrOptions : null;
-  const options = typeof identifierOrOptions === 'object' && identifierOrOptions !== null && !Array.isArray(identifierOrOptions)
-    ? identifierOrOptions
-    : maybeOptions;
-  const { remoteCreator = true, allowRelayLookup = true } = options;
-
   let enriched = { ...video };
-  const relayFirstContext = allowRelayLookup
-    ? await fetchRelayFirstAdminContext(identifier, enriched, env)
-    : null;
-  if (relayFirstContext) {
-    enriched = mergeLookupMetadata(enriched, relayFirstContext);
-  }
 
-  const needsNostrEnrichment = allowRelayLookup && !relayFirstContext && enriched.sha256 && (
-    !enriched.eventId
-    || !enriched.divineUrl
-    || !enriched.nostrContext
-    || !enriched.nostrContext.content
-    || !enriched.nostrContext.sourceUrl
-    || !enriched.nostrContext.platform
-    || !enriched.nostrContext.client
-    || !enriched.nostrContext.publishedAt
-  );
+  if (enriched.sha256 && (!enriched.eventId || !enriched.divineUrl || !enriched.nostrContext)) {
+    const funnelcakeVideo = await fetchFunnelcakeLookupVideo(enriched.lookupId || enriched.eventId || enriched.sha256).catch((error) => {
+      console.error(`[ADMIN] Failed to fetch relay context for ${enriched.sha256}:`, error.message);
+      return null;
+    });
 
-  if (needsNostrEnrichment) {
-    const nostrContext = await fetchLookupNostrContext(enriched.sha256, env);
-    if (nostrContext) {
-      enriched = {
-        ...enriched,
-        eventId: enriched.eventId || nostrContext.eventId,
-        stableId: enriched.stableId || nostrContext.stableId || extractStableIdFromDivineUrl(enriched.divineUrl),
-        divineUrl: enriched.divineUrl || nostrContext.divineUrl,
-        publisherProfile: mergePresentFields(enriched.publisherProfile || {}, nostrContext.publisherProfile || {}),
-        nostrContext: mergePresentFields(enriched.nostrContext || {}, nostrContext.nostrContext || {}),
-        uploaded_by: enriched.uploaded_by || nostrContext.uploadedBy || null
-      };
+    if (funnelcakeVideo) {
+      enriched = mergeLookupMetadata(enriched, funnelcakeVideo);
+    } else {
+      const nostrContext = await fetchLookupNostrContext(enriched.sha256, env);
+      if (nostrContext) {
+        enriched = {
+          ...enriched,
+          eventId: enriched.eventId || nostrContext.eventId,
+          divineUrl: enriched.divineUrl || nostrContext.divineUrl,
+          nostrContext: {
+            ...(nostrContext.nostrContext || {}),
+            ...(enriched.nostrContext || {})
+          },
+          uploaded_by: enriched.uploaded_by || nostrContext.uploadedBy || null
+        };
+      }
     }
   }
 
-  enriched.title = pickFirstPresentValue(enriched.title, enriched.nostrContext?.title);
-  enriched.author = pickFirstPresentValue(enriched.author, enriched.nostrContext?.author);
-  enriched.content_url = pickFirstPresentValue(enriched.content_url, enriched.cdnUrl, enriched.nostrContext?.url);
-  enriched.published_at = pickFirstPresentValue(enriched.published_at, enriched.nostrContext?.publishedAt);
-  enriched.event_id = pickFirstPresentValue(enriched.event_id, enriched.eventId, enriched.nostrContext?.eventId);
-  enriched.eventId = pickFirstPresentValue(enriched.eventId, enriched.event_id, enriched.nostrContext?.eventId);
-  enriched.stableId = pickFirstPresentValue(enriched.stableId, enriched.nostrContext?.stableId, extractStableIdFromDivineUrl(enriched.divineUrl));
-  enriched.divineUrl = pickFirstPresentValue(
-    enriched.divineUrl,
-    enriched.stableId ? `https://divine.video/video/${encodeURIComponent(enriched.stableId)}` : null,
-    enriched.eventId ? `https://divine.video/video/${encodeURIComponent(enriched.eventId)}` : null
-  );
-
-  enriched.nostrContext = mergePresentFields(enriched.nostrContext || {}, {
-    title: enriched.title,
-    author: enriched.author,
-    content: pickFirstPresentValue(enriched.nostrContext?.content, enriched.content_text),
-    url: enriched.content_url,
-    publishedAt: enriched.published_at,
-    eventId: enriched.eventId,
-    stableId: enriched.stableId
-  });
-
   if (enriched.uploaded_by) {
-    const uploaderStats = await getUploaderStatsRow(env.BLOSSOM_DB, enriched.uploaded_by);
-    const uploaderEnforcement = await getUploaderEnforcement(env.BLOSSOM_DB, enriched.uploaded_by).catch(() => null);
+    const [uploaderStats, uploaderEnforcement] = await Promise.all([
+      getUploaderStats(env.BLOSSOM_DB, enriched.uploaded_by).catch(() => null),
+      getUploaderEnforcement(env.BLOSSOM_DB, enriched.uploaded_by).catch(() => null)
+    ]);
 
     enriched = {
       ...enriched,
+      uploaderStats,
       uploaderEnforcement: uploaderEnforcement || {
         pubkey: enriched.uploaded_by,
         approval_required: false,
         relay_banned: false
-      },
-      creatorContext: await buildCreatorContext({
-        pubkey: enriched.uploaded_by,
-        uploaderStats,
-        uploaderEnforcement
-      }, {
-        includeRemote: remoteCreator
-      })
+      }
     };
   }
 
-  enriched = {
-    ...enriched,
-    provenance: buildProvenance({
-      nostrContext: enriched.nostrContext,
-      receivedAt: enriched.receivedAt || enriched.moderated_at || null
-    }),
-    contextStatus: buildAdminContextStatus(enriched)
-  };
-
   return enriched;
-}
-
-const UPLOADER_HISTORY_ACTIONS = ['SAFE', 'REVIEW', 'QUARANTINE', 'AGE_RESTRICTED', 'PERMANENT_BAN'];
-
-function extractReasonFromRow(row) {
-  if (row.review_notes) return row.review_notes;
-  if (row.raw_response) {
-    try {
-      const raw = typeof row.raw_response === 'string' ? JSON.parse(row.raw_response) : row.raw_response;
-      if (raw && typeof raw === 'object') {
-        if (typeof raw.reason === 'string' && raw.reason.trim()) return raw.reason;
-        if (Array.isArray(raw.categories) && raw.categories.length > 0) return raw.categories.join(', ');
-      }
-    } catch { /* ignore JSON parse errors */ }
-  }
-  return null;
-}
-
-async function resolveProfileWithTimeout(pubkey, env, timeoutMs = 250) {
-  if (env.SKIP_PROFILE_RESOLUTION === 'true') return null;
-  try {
-    const { resolveProfile } = await import('./nostr/profile-resolver.mjs');
-    return await Promise.race([
-      resolveProfile(pubkey, env).catch(() => null),
-      new Promise((resolve) => setTimeout(() => resolve(null), timeoutMs))
-    ]);
-  } catch {
-    return null;
-  }
-}
-
-async function buildUploaderHistory(pubkey, env) {
-  const db = env.BLOSSOM_DB;
-
-  const actionBreakdown = Object.fromEntries(UPLOADER_HISTORY_ACTIONS.map((a) => [a, 0]));
-
-  const [totalsRow, breakdownRows, recentRows, dmRow, aiRow, enforcement, profile] = await Promise.all([
-    db.prepare(
-      `SELECT COUNT(*) AS videos, MIN(moderated_at) AS firstSeen, MAX(moderated_at) AS lastSeen
-       FROM moderation_results WHERE uploaded_by = ?`
-    ).bind(pubkey).first().catch(() => null),
-    db.prepare(
-      `SELECT action, COUNT(*) AS count FROM moderation_results WHERE uploaded_by = ? GROUP BY action`
-    ).bind(pubkey).all().catch(() => ({ results: [] })),
-    db.prepare(
-      `SELECT sha256, action, moderated_at, review_notes, raw_response
-       FROM moderation_results
-       WHERE uploaded_by = ? AND action IN ('REVIEW','QUARANTINE','AGE_RESTRICTED','PERMANENT_BAN')
-       ORDER BY moderated_at DESC LIMIT 10`
-    ).bind(pubkey).all().catch(() => ({ results: [] })),
-    db.prepare(
-      `SELECT COUNT(*) AS dmCount FROM dm_log WHERE sender_pubkey = ? OR recipient_pubkey = ?`
-    ).bind(pubkey, pubkey).first().catch(() => null),
-    db.prepare(
-      `SELECT COUNT(*) AS aiFlaggedCount FROM moderation_results
-       WHERE uploaded_by = ? AND (categories LIKE '%ai_generated%' OR categories LIKE '%deepfake%')`
-    ).bind(pubkey).first().catch(() => null),
-    getUploaderEnforcement(db, pubkey).catch(() => null),
-    resolveProfileWithTimeout(pubkey, env)
-  ]);
-
-  for (const row of (breakdownRows?.results || [])) {
-    if (row && row.action && actionBreakdown[row.action] !== undefined) {
-      actionBreakdown[row.action] = Number(row.count) || 0;
-    }
-  }
-
-  const recentFlagged = (recentRows?.results || []).map((row) => ({
-    sha256: row.sha256,
-    action: row.action,
-    processedAt: row.moderated_at,
-    reason: extractReasonFromRow(row)
-  }));
-
-  return {
-    pubkey,
-    profile: profile || null,
-    totals: {
-      videos: Number(totalsRow?.videos) || 0,
-      firstSeen: totalsRow?.firstSeen || null,
-      lastSeen: totalsRow?.lastSeen || null
-    },
-    actionBreakdown,
-    recentFlagged,
-    aiFlaggedCount: Number(aiRow?.aiFlaggedCount) || 0,
-    dmCount: Number(dmRow?.dmCount) || 0,
-    enforcement: enforcement || null
-  };
 }
 
 async function getAdminLookupVideo(identifier, env, options = {}) {
@@ -1701,14 +528,8 @@ async function getAdminLookupVideo(identifier, env, options = {}) {
   const hash = isValidSha256(identifier) ? identifier.toLowerCase() : null;
   const cdnUrl = `https://${env.CDN_DOMAIN || 'media.divine.video'}/${hash}`;
   if (hash) {
-    const [videoMetadataRow, webhookEventRow, relayVideoRow] = await Promise.all([
-      fetchStoredVideoMetadata(hash, env),
-      fetchLatestWebhookEvent(hash, env),
-      fetchStoredRelayVideo(hash, env)
-    ]);
     const moderatedRow = await env.BLOSSOM_DB.prepare(`
-      SELECT sha256, action, provider, scores, categories, raw_response, moderated_at, reviewed_by, reviewed_at, review_notes, uploaded_by,
-             title, author, event_id, content_url, published_at
+      SELECT sha256, action, provider, scores, categories, moderated_at, reviewed_by, reviewed_at, review_notes, uploaded_by
       FROM moderation_results
       WHERE sha256 = ?
     `).bind(hash).first();
@@ -1718,22 +539,8 @@ async function getAdminLookupVideo(identifier, env, options = {}) {
 
     if (moderatedRow || kvModeration) {
       const moderatedAt = kvModeration?.moderated_at || moderatedRow?.moderated_at || null;
-      const storedSnapshot = parseStoredAdminSnapshot(moderatedRow?.raw_response);
-      const relayCreatorRow = await fetchStoredRelayCreator(
-        pickFirstPresentValue(relayVideoRow?.pubkey, moderatedRow?.uploaded_by, storedSnapshot?.uploadedBy, videoMetadataRow?.uploaded_by),
-        env
-      );
-      const storedVideo = mergeLookupMetadata(
-        buildStoredModeratedVideo(
-          moderatedRow,
-          storedSnapshot,
-          videoMetadataRow,
-          webhookEventRow,
-          kvModeration?.cdnUrl || cdnUrl
-        ),
-        buildStoredRelayVideo(relayVideoRow, relayCreatorRow)
-      );
-      const video = await enrichAdminLookupVideo({
+      const storedLookup = buildStoredLookupMetadata(moderatedRow);
+      return enrichAdminLookupVideo({
         sha256: hash,
         action: kvModeration?.action || moderatedRow?.action || 'REVIEW',
         provider: kvModeration?.provider || moderatedRow?.provider || null,
@@ -1743,34 +550,18 @@ async function getAdminLookupVideo(identifier, env, options = {}) {
         moderated_at: moderatedAt,
         reviewed_by: moderatedRow?.reviewed_by || kvModeration?.reviewedBy || kvModeration?.overriddenBy || null,
         reviewed_at: moderatedRow?.reviewed_at || null,
-        uploaded_by: pickFirstPresentValue(storedVideo.uploaded_by, kvModeration?.uploadedBy),
+        uploaded_by: moderatedRow?.uploaded_by || kvModeration?.uploadedBy || null,
+        eventId: storedLookup.eventId,
+        divineUrl: storedLookup.divineUrl,
+        nostrContext: storedLookup.nostrContext,
         reason: kvModeration?.reason || moderatedRow?.review_notes || null,
         manualOverride: Boolean(kvModeration?.manualOverride),
         overriddenAt: kvModeration?.overriddenAt || moderatedRow?.reviewed_at || null,
         previousAction: kvModeration?.previousAction || null,
         detailedCategories: parseMaybeJson(kvModeration?.detailedCategories, null),
         categoryVerifications: parseMaybeJson(kvModeration?.categoryVerifications, {}) || {},
-        ...storedVideo
-      }, env, identifier, {
-        allowRelayLookup: !relayVideoRow,
-        remoteCreator: !relayCreatorRow
-      });
-
-      if (relayCreatorRow && video.uploaded_by) {
-        video.publisherProfile = mergePresentFields(
-          buildStoredRelayPublisherProfile(relayCreatorRow, relayVideoRow),
-          video.publisherProfile || {}
-        );
-        video.creatorContext = mergeStoredRelayCreatorContext(video.creatorContext, relayCreatorRow, video.uploaded_by);
-      }
-
-      await persistRelayMirrorContext(hash, video, env);
-
-      if (moderatedRow) {
-        await persistResolvedAdminContext(hash, video, env, moderatedRow);
-      }
-
-      return video;
+        cdnUrl: kvModeration?.cdnUrl || cdnUrl
+      }, env);
     }
 
     const untriagedRow = await env.BLOSSOM_DB.prepare(`
@@ -1788,30 +579,25 @@ async function getAdminLookupVideo(identifier, env, options = {}) {
       let eventId = null;
       let divineUrl = null;
       let uploaderPubkey = null;
-      let stableId = null;
-      if (relayVideoRow) {
-        const relayCreatorRow = await fetchStoredRelayCreator(
-          pickFirstPresentValue(relayVideoRow?.pubkey, videoMetadataRow?.uploaded_by),
-          env
-        );
-        const mirroredVideo = buildStoredRelayVideo(relayVideoRow, relayCreatorRow);
-        nostrContext = mirroredVideo?.nostrContext || null;
-        eventId = mirroredVideo?.eventId || null;
-        divineUrl = mirroredVideo?.divineUrl || null;
-        uploaderPubkey = mirroredVideo?.uploaded_by || null;
-        stableId = mirroredVideo?.stableId || null;
-      } else {
-        try {
-          const video = await fetchFunnelcakeLookupVideo(hash, env);
-          if (video) {
-            eventId = video.eventId || null;
-            divineUrl = video.divineUrl || null;
-            uploaderPubkey = video.uploaded_by || video.uploadedBy || null;
-            nostrContext = video.nostrContext || null;
-          }
-        } catch (error) {
-          console.error(`[ADMIN] Failed to fetch Nostr context for ${hash}:`, error.message);
+      try {
+        const event = await fetchNostrEventBySha256(hash, ['wss://relay.divine.video'], env);
+        if (event) {
+          const metadata = parseVideoEventMetadata(event);
+          const stableId = getEventTagValue(event.tags || [], 'd') || event.id || hash;
+          eventId = event.id;
+          divineUrl = `https://divine.video/video/${encodeURIComponent(stableId)}`;
+          uploaderPubkey = event.pubkey || null;
+          nostrContext = {
+            title: metadata?.title || null,
+            author: metadata?.author || null,
+            client: metadata?.client || null,
+            content: metadata?.content || event.content || null,
+            pubkey: event.pubkey ? `${event.pubkey.substring(0, 16)}...` : null,
+            eventId
+          };
         }
+      } catch (error) {
+        console.error(`[ADMIN] Failed to fetch Nostr context for ${hash}:`, error.message);
       }
 
       return enrichAdminLookupVideo({
@@ -1825,12 +611,9 @@ async function getAdminLookupVideo(identifier, env, options = {}) {
         cdnUrl,
         nostrContext,
         eventId,
-        stableId,
         divineUrl,
         uploaded_by: uploaderPubkey
-      }, env, identifier, {
-        allowRelayLookup: !relayVideoRow
-      });
+      }, env);
     }
   }
 
@@ -1838,7 +621,7 @@ async function getAdminLookupVideo(identifier, env, options = {}) {
     return null;
   }
 
-  const funnelcakeVideo = await fetchFunnelcakeLookupVideo(identifier, env);
+  const funnelcakeVideo = await fetchFunnelcakeLookupVideo(identifier);
   if (!funnelcakeVideo) {
     return null;
   }
@@ -1848,7 +631,7 @@ async function getAdminLookupVideo(identifier, env, options = {}) {
       allowFunnelcakeFallback: false
     });
     if (resolvedByMediaSha) {
-      return enrichAdminLookupVideo(mergeLookupMetadata(resolvedByMediaSha, funnelcakeVideo), env, identifier);
+      return enrichAdminLookupVideo(mergeLookupMetadata(resolvedByMediaSha, funnelcakeVideo), env);
     }
   }
 
@@ -1858,7 +641,7 @@ async function getAdminLookupVideo(identifier, env, options = {}) {
 
   return enrichAdminLookupVideo({
     sha256: funnelcakeVideo.mediaSha,
-    receivedAt: funnelcakeVideo.createdAt,
+    receivedAt: funnelcakeVideo.createdAt ? new Date(funnelcakeVideo.createdAt * 1000).toISOString() : null,
     status: 'UNTRIAGED',
     cdnUrl: funnelcakeVideo.videoUrl || `https://${env.CDN_DOMAIN || 'media.divine.video'}/${funnelcakeVideo.mediaSha}`,
     thumbnailUrl: funnelcakeVideo.thumbnailUrl,
@@ -1867,7 +650,99 @@ async function getAdminLookupVideo(identifier, env, options = {}) {
     divineUrl: funnelcakeVideo.divineUrl,
     lookupId: funnelcakeVideo.lookupId,
     eventId: funnelcakeVideo.eventId
-  }, env, identifier);
+  }, env);
+}
+
+function appendAdminPlaybackCandidate(candidates, seenUrls, url, source) {
+  if (typeof url !== 'string' || !url.trim()) {
+    return;
+  }
+
+  try {
+    const normalizedUrl = new URL(url).toString();
+    if (seenUrls.has(normalizedUrl)) {
+      return;
+    }
+    seenUrls.add(normalizedUrl);
+    candidates.push({ url: normalizedUrl, source });
+  } catch {
+    // Ignore malformed URLs stored in metadata and continue through other candidates.
+  }
+}
+
+async function getStoredAdminPlaybackCandidates(sha256, env) {
+  const [moderatedRow, untriagedRow, kvModerationRaw] = await Promise.all([
+    env.BLOSSOM_DB.prepare(`
+      SELECT content_url
+      FROM moderation_results
+      WHERE sha256 = ?
+    `).bind(sha256).first(),
+    env.BLOSSOM_DB.prepare(`
+      SELECT mp4_url, hls_url
+      FROM bunny_webhook_events e1
+      WHERE e1.sha256 = ?
+        AND received_at = (
+          SELECT MAX(received_at) FROM bunny_webhook_events e2 WHERE e2.sha256 = e1.sha256
+        )
+      LIMIT 1
+    `).bind(sha256).first(),
+    env.MODERATION_KV.get(`moderation:${sha256}`)
+  ]);
+
+  const kvModeration = parseMaybeJson(kvModerationRaw, null);
+  const candidates = [];
+  const seenUrls = new Set();
+
+  appendAdminPlaybackCandidate(candidates, seenUrls, moderatedRow?.content_url, 'stored-content-url');
+  appendAdminPlaybackCandidate(candidates, seenUrls, kvModeration?.cdnUrl, 'stored-cdn-url');
+  appendAdminPlaybackCandidate(candidates, seenUrls, untriagedRow?.mp4_url, 'bunny-mp4-url');
+  appendAdminPlaybackCandidate(candidates, seenUrls, untriagedRow?.hls_url, 'bunny-hls-url');
+
+  return candidates;
+}
+
+function buildAdminVideoProxyRequestInit(request, extraHeaders = {}) {
+  const headers = new Headers(extraHeaders);
+  for (const headerName of ['Range', 'If-Range']) {
+    const value = request.headers.get(headerName);
+    if (value) {
+      headers.set(headerName, value);
+    }
+  }
+
+  return {
+    method: request.method === 'HEAD' ? 'HEAD' : 'GET',
+    headers
+  };
+}
+
+function createAdminVideoProxyResponse(upstreamResponse, proxySource, extraHeaders = {}) {
+  const headers = new Headers({
+    'Cache-Control': 'private, no-store',
+    'X-Admin-Proxy': proxySource
+  });
+
+  for (const headerName of ['Content-Type', 'Content-Length', 'Content-Range', 'Accept-Ranges', 'ETag', 'Last-Modified']) {
+    const value = upstreamResponse.headers.get(headerName);
+    if (value) {
+      headers.set(headerName, value);
+    }
+  }
+
+  if (!headers.has('Content-Type')) {
+    headers.set('Content-Type', 'video/mp4');
+  }
+
+  for (const [headerName, value] of Object.entries(extraHeaders)) {
+    if (value) {
+      headers.set(headerName, value);
+    }
+  }
+
+  return new Response(upstreamResponse.body, {
+    status: upstreamResponse.status,
+    headers
+  });
 }
 
 async function handleLegacyScan(request, env) {
@@ -2056,6 +931,8 @@ export default {
       return hostMismatchResponse(requestId, hostname, url.pathname, expectedHost);
     }
 
+    // Ensure offender tracking table exists (idempotent)
+    await initOffenderTable(env.BLOSSOM_DB);
     await initUploaderEnforcementTable(env.BLOSSOM_DB);
 
     // Ensure reports table exists
@@ -2100,7 +977,9 @@ export default {
         return authError;
       }
 
-      return serveHTML(dashboardHTML, HTML_ETAGS.dashboard, request);
+      return new Response(dashboardHTML, {
+        headers: { 'Content-Type': 'text/html' }
+      });
     }
 
     if (url.pathname === '/admin/review') {
@@ -2110,14 +989,18 @@ export default {
         return authError;
       }
 
-      return serveHTML(swipeReviewHTML, HTML_ETAGS.review, request);
+      return new Response(swipeReviewHTML, {
+        headers: { 'Content-Type': 'text/html' }
+      });
     }
 
     if (url.pathname === '/admin/messages') {
       const authError = await requireAuth(request, env);
       if (authError) return authError;
 
-      return serveHTML(messagesHTML, HTML_ETAGS.messages, request);
+      return new Response(messagesHTML, {
+        headers: { 'Content-Type': 'text/html' }
+      });
     }
 
     if (url.pathname === '/admin/api/videos') {
@@ -2162,7 +1045,7 @@ export default {
 
       // Query D1 with pagination
       const query = `
-        SELECT sha256, action, provider, scores, categories, moderated_at, reviewed_by, reviewed_at, uploaded_by, title, author, event_id, content_url, published_at
+        SELECT sha256, action, provider, scores, categories, moderated_at, reviewed_by, reviewed_at, uploaded_by
         FROM moderation_results
         ${whereClause}
         ORDER BY moderated_at ${orderDirection}
@@ -2185,21 +1068,31 @@ export default {
         moderated_at: row.moderated_at,
         reviewed_by: row.reviewed_by,
         reviewed_at: row.reviewed_at,
-        uploaded_by: row.uploaded_by || null,
-        title: row.title || null,
-        author: row.author || null,
-        event_id: row.event_id || null,
-        content_url: row.content_url || null,
-        published_at: row.published_at || null
+        uploaded_by: row.uploaded_by || null
       }));
 
-      // Classifier summaries fetched client-side via /admin/api/classifier/{sha256}
-      const videos = await Promise.all(videoRows.map((row) => enrichAdminLookupVideo(
-        row,
-        env,
-        row.event_id || row.sha256,
-        { remoteCreator: false, allowRelayLookup: false }
-      )));
+      // Reuse the existing relay-aware per-item lookup so dashboard cards can render
+      // publisher/post metadata immediately instead of starting from an "unknown" state.
+      const videos = await Promise.all(videoRows.map(async (video) => {
+        try {
+          const enriched = await getAdminLookupVideo(video.sha256, env);
+          if (!enriched) {
+            return video;
+          }
+
+          return {
+            ...video,
+            uploaded_by: enriched.uploaded_by || video.uploaded_by || null,
+            eventId: enriched.eventId || null,
+            divineUrl: enriched.divineUrl || null,
+            lookupId: enriched.lookupId || null,
+            nostrContext: enriched.nostrContext || null
+          };
+        } catch (error) {
+          console.error(`[${requestId}] Failed to enrich dashboard row ${video.sha256}:`, error.message);
+          return video;
+        }
+      }));
 
       console.log(`[${requestId}] Returning ${videos.length} videos in ${Date.now() - startTime}ms`);
       return new Response(JSON.stringify({
@@ -2211,60 +1104,6 @@ export default {
       }), {
         headers: JSON_HEADERS
       });
-    }
-
-    if (
-      url.pathname === '/admin/api/backfill-review-context' &&
-      (request.method === 'POST' || request.method === 'GET')
-    ) {
-      const authError = await requireAuth(request, env);
-      if (authError) {
-        return authError;
-      }
-
-      const limit = Math.min(parseInt(url.searchParams.get('limit') || '50', 10), 100);
-      const scanLimit = Math.max(limit * 3, limit);
-
-      try {
-        const result = await env.BLOSSOM_DB.prepare(`
-          SELECT sha256, action, provider, scores, categories, raw_response, moderated_at, reviewed_by, reviewed_at,
-                 uploaded_by, title, author, event_id, content_url, published_at
-          FROM moderation_results
-          ORDER BY moderated_at DESC
-          LIMIT ? OFFSET ?
-        `).bind(scanLimit, 0).all();
-
-        const rows = (result.results || [])
-          .filter((row) => row.action === 'REVIEW' && needsAdminContextRepair(row))
-          .slice(0, limit);
-
-        const repairs = [];
-        let repaired = 0;
-
-        for (const row of rows) {
-          const repairResult = await repairStoredAdminContextRow(row, env);
-          const status = repairResult.repaired ? 'repaired' : 'skipped';
-          if (repairResult.repaired) {
-            repaired += 1;
-          }
-          repairs.push({ sha256: row.sha256, status });
-        }
-
-        return new Response(JSON.stringify({
-          scanned: rows.length,
-          repaired,
-          skipped: rows.length - repaired,
-          repairs
-        }), {
-          headers: JSON_HEADERS
-        });
-      } catch (error) {
-        console.error('[ADMIN] Failed review context backfill:', error);
-        return new Response(JSON.stringify({ error: error.message }), {
-          status: 500,
-          headers: JSON_HEADERS
-        });
-      }
     }
 
     // Get real stats for dashboard
@@ -2413,13 +1252,17 @@ export default {
         // Fetch Nostr context in parallel for all unmoderated videos
         const nostrPromises = unmoderatedRows.map(async (row) => {
           try {
-            const video = await fetchFunnelcakeLookupVideo(row.sha256, env);
-            if (video) {
+            const event = await fetchNostrEventBySha256(row.sha256, ['wss://relay.divine.video'], env);
+            if (event) {
+              const metadata = parseVideoEventMetadata(event);
               return {
                 sha256: row.sha256,
-                eventId: video.eventId || null,
-                nostrContext: video.nostrContext || null,
-                pubkey: video.uploaded_by || video.uploadedBy || null
+                eventId: event.id,
+                title: metadata?.title || null,
+                author: metadata?.author || null,
+                client: metadata?.client || null,
+                content: metadata?.content || event.content || null,
+                pubkey: event.pubkey || null
               };
             }
           } catch (e) {
@@ -2445,16 +1288,15 @@ export default {
             cdnUrl: `https://${env.CDN_DOMAIN}/${row.sha256}`,
             eventId: nostr.eventId || null,
             uploaded_by: nostr.pubkey || null,
-            nostrContext: nostr.nostrContext || null
+            nostrContext: {
+              title: nostr.title,
+              author: nostr.author,
+              client: nostr.client,
+              content: nostr.content,
+              pubkey: nostr.pubkey ? nostr.pubkey.substring(0, 16) + '...' : null
+            }
           };
         });
-
-        const enrichedVideos = await Promise.all(videos.map((video) => enrichAdminLookupVideo(
-          video,
-          env,
-          video.eventId || video.sha256,
-          { remoteCreator: false, allowRelayLookup: false }
-        )));
 
         // Get total count of untriaged (same logic - latest status not deleted/error)
         const countResult = await env.BLOSSOM_DB.prepare(`
@@ -2470,7 +1312,7 @@ export default {
         `).first();
 
         return new Response(JSON.stringify({
-          videos: enrichedVideos,
+          videos,
           total: countResult?.total || 0,
           offset,
           limit,
@@ -3083,52 +1925,53 @@ export default {
           FROM moderation_results
           WHERE sha256 = ?
         `).bind(sha256).first();
-        const [videoMetadataRow, webhookEventRow, rawModerationRow] = await Promise.all([
-          fetchStoredVideoMetadata(sha256, env),
-          fetchLatestWebhookEvent(sha256, env),
-          env.BLOSSOM_DB.prepare(`SELECT raw_response FROM moderation_results WHERE sha256 = ?`).bind(sha256).first().catch(() => null)
-        ]);
-        const storedSnapshot = parseStoredAdminSnapshot(rawModerationRow?.raw_response);
-        const fallbackRow = buildStoredAdminFallbackRow(storedRow, storedSnapshot, videoMetadataRow, webhookEventRow);
-        const storedMetadata = buildStoredNostrContext(fallbackRow, pickFirstPresentValue(
-          storedRow?.uploaded_by,
-          storedSnapshot?.uploadedBy,
-          videoMetadataRow?.uploaded_by
-        ), {
-          includePubkey: false,
-          title: storedSnapshot?.title || null,
-          author: storedSnapshot?.author || null,
-          url: storedSnapshot?.contentUrl || null,
-          sourceUrl: storedSnapshot?.sourceUrl || null,
-          platform: storedSnapshot?.platform || null,
-          client: storedSnapshot?.client || null,
-          publishedAt: storedSnapshot?.publishedAt || null,
-          archivedAt: storedSnapshot?.archivedAt || null,
-          importedAt: storedSnapshot?.importedAt || null,
-          vineHashId: storedSnapshot?.vineHashId || null,
-          vineUserId: storedSnapshot?.vineUserId || null,
-          eventId: storedSnapshot?.eventId || null,
-          createdAt: storedSnapshot?.createdAt || null,
-          stableId: storedSnapshot?.stableId || null,
-          content: storedSnapshot?.content || null,
-          proofmode: storedSnapshot?.proofmode || null
-        });
+        const storedLookup = buildStoredLookupMetadata(storedRow);
 
-        if (storedMetadata) {
-          return new Response(JSON.stringify({ found: true, metadata: storedMetadata }), {
+        if (storedLookup.nostrContext) {
+          return new Response(JSON.stringify({
+            found: true,
+            metadata: buildAdminNostrMetadata(storedLookup.nostrContext)
+          }), {
             headers: { 'Content-Type': 'application/json' }
           });
         }
 
-        const video = await fetchFunnelcakeLookupVideo(sha256, env);
-        if (!video?.nostrContext) {
+        const funnelcakeVideo = await fetchFunnelcakeLookupVideo(sha256).catch((error) => {
+          console.error(`[ADMIN] Failed to fetch relay context for ${sha256}:`, error.message);
+          return null;
+        });
+
+        if (funnelcakeVideo?.nostrContext) {
+          return new Response(JSON.stringify({
+            found: true,
+            metadata: buildAdminNostrMetadata(funnelcakeVideo.nostrContext, {
+              createdAt: funnelcakeVideo.createdAt
+            })
+          }), {
+            headers: { 'Content-Type': 'application/json' }
+          });
+        }
+
+        const event = await fetchNostrEventBySha256(sha256, ['wss://relay.divine.video'], env);
+        if (!event) {
           return new Response(JSON.stringify({ found: false }), {
             headers: { 'Content-Type': 'application/json' }
           });
         }
 
-        const { pubkey: _ignoredPubkey, ...metadata } = video.nostrContext;
-        return new Response(JSON.stringify({ found: true, metadata }), {
+        const metadata = parseVideoEventMetadata(event) || {};
+        const eventId = event.id || null;
+
+        return new Response(JSON.stringify({
+          found: true,
+          metadata: buildAdminNostrMetadata({
+            ...metadata,
+            content: metadata.content || event.content || null,
+            eventId
+          }, {
+            createdAt: event.created_at || null
+          })
+        }), {
           headers: { 'Content-Type': 'application/json' }
         });
       } catch (error) {
@@ -3192,27 +2035,6 @@ export default {
 
       try {
         const transcript = await fetchTranscriptAsset(sha256, env);
-        if (transcript.pending) {
-          const headers = { ...JSON_HEADERS };
-          if (transcript.retryAfterSeconds !== null) {
-            headers['Retry-After'] = String(transcript.retryAfterSeconds);
-          }
-
-          return new Response(JSON.stringify({
-            sha256,
-            found: false,
-            pending: true,
-            subtitleUrl: transcript.subtitleUrl,
-            sourceUrl: transcript.sourceUrl,
-            retryAfterSeconds: transcript.retryAfterSeconds,
-            status: transcript.pendingStatus,
-            message: transcript.pendingMessage
-          }), {
-            status: 202,
-            headers
-          });
-        }
-
         if (!transcript.found) {
           return new Response(JSON.stringify({
             sha256,
@@ -3420,68 +2242,34 @@ export default {
         return new Response('Unauthorized', { status: 401 });
       }
 
-      const sha256 = url.pathname.split('/')[3].replace('.mp4', '');
-      const cdnUrl = `https://${env.CDN_DOMAIN}/${sha256}`;
-      const adminBypassUrl = `https://${env.CDN_DOMAIN}/admin/api/blob/${sha256}/content`;
+      const sha256 = url.pathname.split('/')[3].replace(/\.mp4$/i, '').toLowerCase();
+      const cdnDomain = env.CDN_DOMAIN || 'media.divine.video';
+      const cdnUrl = `https://${cdnDomain}/${sha256}`;
+      const adminBypassUrl = `https://${cdnDomain}/admin/api/blob/${sha256}/content`;
 
       const BROWSER_PLAYABLE_TYPES = new Set(['video/mp4', 'video/webm', 'video/ogg']);
 
-      // Forward range-related request headers to upstream so that <video>
-      // byte-range playback works end-to-end. Upstream 206 responses must be
-      // preserved along with Content-Range / Accept-Ranges / Content-Length
-      // so the browser player accepts the partial content.
-      const FORWARDED_RANGE_REQUEST_HEADERS = ['Range', 'If-Range', 'If-None-Match', 'If-Modified-Since'];
-      const buildUpstreamHeaders = (extraHeaders = {}) => {
-        const headers = { ...extraHeaders };
-        for (const name of FORWARDED_RANGE_REQUEST_HEADERS) {
-          const value = request.headers.get(name);
-          if (value) headers[name] = value;
-        }
-        return headers;
-      };
-      const passthroughResponseHeaders = (upstream, baseHeaders) => {
-        const headers = { ...baseHeaders };
-        const passthrough = ['Content-Range', 'Accept-Ranges', 'Content-Length', 'ETag', 'Last-Modified'];
-        for (const name of passthrough) {
-          const value = upstream.headers.get(name);
-          if (value) headers[name] = value;
-        }
-        return headers;
-      };
-
       try {
+        const upstreamRequestInit = buildAdminVideoProxyRequestInit(request);
+
         // CDN fetch (unauthenticated) — works for SAFE/unmoderated content
-        const cdnResponse = await fetch(cdnUrl, { headers: buildUpstreamHeaders() });
-        if (cdnResponse.ok || cdnResponse.status === 206) {
+        const cdnResponse = await fetch(cdnUrl, upstreamRequestInit);
+        if (cdnResponse.ok) {
           const contentType = cdnResponse.headers.get('Content-Type') || 'video/mp4';
 
           // If the format is browser-playable, serve directly
           if (BROWSER_PLAYABLE_TYPES.has(contentType)) {
             console.log(`[ADMIN] Serving video from CDN: ${sha256}`);
-            return new Response(cdnResponse.body, {
-              status: cdnResponse.status,
-              headers: passthroughResponseHeaders(cdnResponse, {
-                'Content-Type': contentType,
-                'Cache-Control': 'private, no-store',
-                'X-Admin-Proxy': 'cdn'
-              })
-            });
+            return createAdminVideoProxyResponse(cdnResponse, 'cdn');
           }
 
           // Non-browser format (e.g. video/3gpp, video/x-matroska) — try transcoded 720p MP4 from Blossom
           console.log(`[ADMIN] CDN returned non-playable ${contentType}, trying transcoded 720p for ${sha256}`);
-          const transcodeUrl = `https://${env.CDN_DOMAIN}/${sha256}/720p.mp4`;
-          const transcodeResponse = await fetch(transcodeUrl, { headers: buildUpstreamHeaders() });
-          if (transcodeResponse.ok || transcodeResponse.status === 206) {
+          const transcodeUrl = `https://${cdnDomain}/${sha256}/720p.mp4`;
+          const transcodeResponse = await fetch(transcodeUrl, upstreamRequestInit);
+          if (transcodeResponse.ok) {
             console.log(`[ADMIN] Serving transcoded 720p MP4 for ${sha256}`);
-            return new Response(transcodeResponse.body, {
-              status: transcodeResponse.status,
-              headers: passthroughResponseHeaders(transcodeResponse, {
-                'Content-Type': transcodeResponse.headers.get('Content-Type') || 'video/mp4',
-                'Cache-Control': 'private, no-store',
-                'X-Admin-Proxy': 'cdn-transcode'
-              })
-            });
+            return createAdminVideoProxyResponse(transcodeResponse, 'cdn-transcode');
           }
           console.warn(`[ADMIN] Transcoded 720p not available (${transcodeResponse.status}) for ${sha256}`);
         }
@@ -3490,50 +2278,40 @@ export default {
         // Fall back to admin bypass endpoint which serves regardless of moderation status
         if (env.BLOSSOM_WEBHOOK_SECRET) {
           console.log(`[ADMIN] CDN returned ${cdnResponse.status}, trying admin bypass for ${sha256}`);
-          const bypassHeaders = buildUpstreamHeaders({
-            'Authorization': `Bearer ${env.BLOSSOM_WEBHOOK_SECRET}`
-          });
-          const bypassResponse = await fetch(adminBypassUrl, { headers: bypassHeaders });
-          if (bypassResponse.ok || bypassResponse.status === 206) {
+          const bypassResponse = await fetch(
+            adminBypassUrl,
+            buildAdminVideoProxyRequestInit(request, {
+              'Authorization': `Bearer ${env.BLOSSOM_WEBHOOK_SECRET}`
+            })
+          );
+          if (bypassResponse.ok) {
             console.log(`[ADMIN] Serving video from admin bypass: ${sha256}`);
             const moderationStatus = bypassResponse.headers.get('X-Moderation-Status');
-            return new Response(bypassResponse.body, {
-              status: bypassResponse.status,
-              headers: passthroughResponseHeaders(bypassResponse, {
-                'Content-Type': bypassResponse.headers.get('Content-Type') || 'video/mp4',
-                'Cache-Control': 'private, no-store',
-                'X-Admin-Proxy': 'blossom-admin',
-                ...(moderationStatus && { 'X-Moderation-Status': moderationStatus }),
-              })
+            return createAdminVideoProxyResponse(bypassResponse, 'blossom-admin', {
+              'X-Moderation-Status': moderationStatus
             });
           }
           console.error(`[ADMIN] Admin bypass returned ${bypassResponse.status} for ${sha256}`);
         }
 
-        const storedSourceUrls = await getStoredAdminVideoSourceUrls(sha256, env);
-        for (const sourceUrl of storedSourceUrls) {
-          console.log(`[ADMIN] Trying stored content URL for ${sha256}: ${sourceUrl}`);
-          const storedSourceResponse = await fetch(sourceUrl, { headers: buildUpstreamHeaders() });
-          if (!(storedSourceResponse.ok || storedSourceResponse.status === 206)) {
-            console.warn(`[ADMIN] Stored content URL returned ${storedSourceResponse.status} for ${sha256}`);
+        const storedPlaybackCandidates = await getStoredAdminPlaybackCandidates(sha256, env);
+        for (const candidate of storedPlaybackCandidates) {
+          if (candidate.url === cdnUrl || candidate.url === adminBypassUrl) {
             continue;
           }
 
-          const contentType = storedSourceResponse.headers.get('Content-Type') || 'video/mp4';
-          if (!BROWSER_PLAYABLE_TYPES.has(contentType)) {
-            console.warn(`[ADMIN] Stored content URL returned non-playable ${contentType} for ${sha256}`);
-            continue;
-          }
+          try {
+            const fallbackResponse = await fetch(candidate.url, upstreamRequestInit);
+            if (!fallbackResponse.ok) {
+              console.warn(`[ADMIN] Stored playback candidate ${candidate.source} returned ${fallbackResponse.status} for ${sha256}`);
+              continue;
+            }
 
-          console.log(`[ADMIN] Serving video from stored content URL: ${sha256}`);
-          return new Response(storedSourceResponse.body, {
-            status: storedSourceResponse.status,
-            headers: passthroughResponseHeaders(storedSourceResponse, {
-              'Content-Type': contentType,
-              'Cache-Control': 'private, no-store',
-              'X-Admin-Proxy': 'stored-content-url'
-            })
-          });
+            console.log(`[ADMIN] Serving video from ${candidate.source}: ${sha256}`);
+            return createAdminVideoProxyResponse(fallbackResponse, candidate.source);
+          } catch (candidateError) {
+            console.warn(`[ADMIN] Stored playback candidate ${candidate.source} failed for ${sha256}: ${candidateError.message}`);
+          }
         }
 
         return new Response(JSON.stringify({
@@ -3569,29 +2347,6 @@ export default {
 
       try {
         const transcript = await fetchTranscriptAsset(sha256, env);
-        if (transcript.pending) {
-          const headers = {
-            ...JSON_HEADERS
-          };
-          if (transcript.retryAfterSeconds !== null) {
-            headers['Retry-After'] = String(transcript.retryAfterSeconds);
-          }
-
-          return new Response(JSON.stringify({
-            sha256,
-            found: false,
-            pending: true,
-            subtitleUrl: transcript.subtitleUrl,
-            sourceUrl: transcript.sourceUrl,
-            retryAfterSeconds: transcript.retryAfterSeconds,
-            status: transcript.pendingStatus,
-            message: transcript.pendingMessage
-          }), {
-            status: 202,
-            headers
-          });
-        }
-
         if (!transcript.found || !transcript.vttContent) {
           return new Response('Transcript not found', { status: 404 });
         }
@@ -4091,34 +2846,6 @@ async function runMigration() {
       return new Response(JSON.stringify(result), { headers: { 'Content-Type': 'application/json' } });
     }
 
-    // Admin API: Per-uploader history + aggregate stats for dashboard cards.
-    // On-demand aggregates from moderation_results + dm_log + uploader_enforcement.
-    // Deliberately NOT backed by a denormalized table (see
-    // docs/superpowers/plans/2026-04-13-uploader-history-stats-plan.md — prior
-    // uploader_stats table caused drift, per commit e9179dc).
-    if (url.pathname.startsWith('/admin/api/uploader/')
-        && request.method === 'GET'
-        && !url.pathname.endsWith('/enforcement')) {
-      const authError = await requireAuth(request, env);
-      if (authError) return authError;
-
-      const parts = url.pathname.split('/');
-      const pubkey = parts[4];
-      if (!pubkey || parts.length !== 5) {
-        return jsonResponse(400, { error: 'pubkey required' });
-      }
-
-      try {
-        const body = await buildUploaderHistory(pubkey, env);
-        return new Response(JSON.stringify(body), {
-          headers: { 'Content-Type': 'application/json' }
-        });
-      } catch (err) {
-        console.error('[UPLOADER-HISTORY] Error:', err);
-        return jsonResponse(500, { error: err.message });
-      }
-    }
-
     if (url.pathname === '/admin/api/classic-vines/rollback' && request.method === 'POST') {
       const authError = await requireAuth(request, env);
       if (authError) return authError;
@@ -4315,31 +3042,24 @@ async function runMigration() {
           });
         }
 
-        // Update or insert moderation result.
-        // reviewed_by is set to the source because /api/v1/moderate is called by human
-        // operators (relay-manager UI, external tools) — not by the AI pipeline.
-        // Without this, relay-manager bans land in the AI Flagged human-review queue.
-        const reviewedBy = source || 'external-api';
-        const now = new Date().toISOString();
+        // Update or insert moderation result
         await env.BLOSSOM_DB.prepare(`
-          INSERT INTO moderation_results (sha256, action, provider, scores, categories, moderated_at, reviewed_by, reviewed_at)
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+          INSERT INTO moderation_results (sha256, action, provider, scores, categories, moderated_at)
+          VALUES (?, ?, ?, ?, ?, ?)
           ON CONFLICT(sha256) DO UPDATE SET
             action = excluded.action,
             provider = excluded.provider,
             review_notes = ?,
-            reviewed_by = excluded.reviewed_by,
-            reviewed_at = excluded.reviewed_at
+            reviewed_at = ?
         `).bind(
           sha256,
           action.toUpperCase(),
-          reviewedBy,
+          source || 'external-api',
           JSON.stringify({}),
           JSON.stringify([reason || action.toLowerCase()]),
-          now,
-          reviewedBy,
-          now,
-          reason || null
+          new Date().toISOString(),
+          reason || null,
+          new Date().toISOString()
         ).run();
 
         console.log(`[API] Moderation updated: ${sha256} -> ${action} by ${source || 'external-api'} (auth: ${authSource})`);
@@ -4910,13 +3630,7 @@ async function runMigration() {
           result.provider || 'unknown',
           JSON.stringify(result.scores || {}),
           JSON.stringify(result.categories || []),
-          JSON.stringify({
-            ...(result.rawResponse || {}),
-            nostrSnapshot: {
-              stableId: result.nostrContext?.stableId || null,
-              content: result.nostrContext?.content || null
-            }
-          }),
+          JSON.stringify(result.rawResponse || {}),
           new Date().toISOString(),
           result.uploadedBy || null,
           result.nostrContext?.title || null,
@@ -4968,6 +3682,15 @@ async function runMigration() {
         console.log(`[MODERATION] Step 8: Handling result (action=${result.action})`);
         await handleModerationResult(result, env);
         console.log(`[MODERATION] Step 9: Result handled`);
+
+        // Update uploader stats for repeat offender tracking
+        if (result.uploadedBy) {
+          try {
+            await updateUploaderStats(env.BLOSSOM_DB, result.uploadedBy, result.action);
+          } catch (statsErr) {
+            console.error(`[MODERATION] Failed to update uploader stats:`, statsErr.message);
+          }
+        }
 
         // Acknowledge successful processing
         message.ack();

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -9,15 +9,7 @@ import worker from './index.mjs';
 
 const SHA256 = 'a'.repeat(64);
 
-function createDbMock({
-  moderationResults = new Map(),
-  webhookEvents = new Map(),
-  videoMetadata = new Map(),
-  relayVideos = new Map(),
-  relayCreators = new Map(),
-  uploaderEnforcements = new Map(),
-  uploaderStats = new Map(),
-} = {}) {
+function createDbMock({ moderationResults = new Map(), moderationListRows = [], webhookEvents = new Map() } = {}) {
   return {
     prepare(sql) {
       let bindings = [];
@@ -28,98 +20,6 @@ function createDbMock({
           return this;
         },
         async run() {
-          if (sql.includes('UPDATE moderation_results') && sql.includes('WHERE sha256 = ?')) {
-            const [uploaded_by, title, author, event_id, content_url, published_at, raw_response, sha256] = bindings;
-            const existing = moderationResults.get(sha256) || { sha256 };
-            moderationResults.set(sha256, {
-              ...existing,
-              uploaded_by,
-              title,
-              author,
-              event_id,
-              content_url,
-              published_at,
-              raw_response
-            });
-          }
-          if (sql.includes('INSERT INTO relay_videos')) {
-            const [
-              sha256,
-              event_id,
-              stable_id,
-              pubkey,
-              title,
-              content,
-              summary,
-              video_url,
-              thumbnail_url,
-              published_at,
-              created_at,
-              author_name,
-              author_avatar,
-              raw_json,
-              synced_at,
-              source_updated_at
-            ] = bindings;
-            const existing = relayVideos.get(sha256) || { sha256 };
-            relayVideos.set(sha256, {
-              ...existing,
-              sha256,
-              event_id,
-              stable_id,
-              pubkey,
-              title,
-              content,
-              summary,
-              video_url,
-              thumbnail_url,
-              published_at,
-              created_at,
-              author_name,
-              author_avatar,
-              raw_json,
-              synced_at,
-              source_updated_at
-            });
-          }
-          if (sql.includes('INSERT INTO relay_creators')) {
-            const [
-              pubkey,
-              display_name,
-              username,
-              avatar_url,
-              bio,
-              website,
-              nip05,
-              follower_count,
-              following_count,
-              video_count,
-              event_count,
-              first_activity,
-              last_activity,
-              raw_json,
-              synced_at
-            ] = bindings;
-            const existing = relayCreators.get(pubkey) || { pubkey };
-            relayCreators.set(pubkey, {
-              ...existing,
-              pubkey,
-              display_name,
-              username,
-              avatar_url,
-              bio,
-              website,
-              nip05,
-              follower_count,
-              following_count,
-              video_count,
-              event_count,
-              first_activity,
-              last_activity,
-              raw_json,
-              synced_at
-            });
-          }
           return { success: true };
         },
         async first() {
@@ -129,57 +29,11 @@ function createDbMock({
           if (sql.includes('FROM bunny_webhook_events')) {
             return webhookEvents.get(bindings[0]) ?? null;
           }
-          if (sql.includes('FROM video_metadata')) {
-            return videoMetadata.get(bindings[0]) ?? null;
-          }
-          if (sql.includes('FROM relay_videos')) {
-            return relayVideos.get(bindings[0]) ?? null;
-          }
-          if (sql.includes('FROM relay_creators')) {
-            return relayCreators.get(bindings[0]) ?? null;
-          }
-          if (sql.includes('FROM uploader_enforcement')) {
-            return uploaderEnforcements.get(bindings[0]) ?? null;
-          }
-          if (sql.includes('FROM uploader_stats')) {
-            return uploaderStats.get(bindings[0]) ?? null;
-          }
           return null;
         },
         async all() {
-          if (sql.includes('COUNT(*) as total FROM moderation_results')) {
-            return { results: [{ total: moderationResults.size }] };
-          }
-          if (sql.includes('FROM moderation_results')) {
-            let results = Array.from(moderationResults.values());
-
-            if (sql.includes("reviewed_by IS NULL")) {
-              results = results.filter((row) => row.reviewed_by == null);
-            }
-
-            if (sql.includes("action IN ('REVIEW', 'AGE_RESTRICTED', 'PERMANENT_BAN')")) {
-              const allowed = new Set(['REVIEW', 'AGE_RESTRICTED', 'PERMANENT_BAN']);
-              results = results.filter((row) => allowed.has(row.action));
-            }
-
-            if (sql.includes("action IN ('AGE_RESTRICTED', 'PERMANENT_BAN')")) {
-              const allowed = new Set(['AGE_RESTRICTED', 'PERMANENT_BAN']);
-              results = results.filter((row) => allowed.has(row.action));
-            }
-
-            if (sql.includes('moderated_at >= ?')) {
-              const since = bindings[0];
-              results = results.filter((row) => row.moderated_at >= since);
-            }
-
-            const limit = bindings[bindings.length - 2];
-            const offset = bindings[bindings.length - 1];
-            results = results
-              .sort((a, b) => a.moderated_at.localeCompare(b.moderated_at))
-              .reverse()
-              .slice(offset, offset + limit);
-
-            return { results };
+          if (sql.includes('FROM moderation_results') && sql.includes('ORDER BY moderated_at')) {
+            return { results: moderationListRows };
           }
           return { results: [] };
         }
@@ -401,227 +255,45 @@ describe('HTTP hostname routing', () => {
 });
 
 describe('Admin video lookup', () => {
-  it('returns quick review queue rows with persisted metadata fields', async () => {
+  it('returns a moderated video and merges KV override fields', async () => {
     const env = createEnv({
       BLOSSOM_DB: createDbMock({
         moderationResults: new Map([[SHA256, {
           sha256: SHA256,
           action: 'REVIEW',
           provider: 'hiveai',
-          scores: JSON.stringify({ ai_generated: 0.9 }),
-          categories: JSON.stringify(['ai_generated']),
-          moderated_at: '2026-03-11T00:00:00.000Z',
-          reviewed_by: null,
-          reviewed_at: null,
-          uploaded_by: 'f'.repeat(64),
-          title: 'Airport dance',
-          author: 'Creator Name',
-          event_id: 'e'.repeat(64),
-          content_url: 'https://media.divine.video/airport-dance.mp4',
-          published_at: '2026-03-10T12:00:00.000Z'
-        }]])
-      })
-    });
-
-    const response = await worker.fetch(
-      new Request('https://moderation.admin.divine.video/admin/api/videos?action=FLAGGED&limit=100', {
-        headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
-      }),
-      env
-    );
-
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toMatchObject({
-      videos: [{
-        sha256: SHA256,
-        title: 'Airport dance',
-        author: 'Creator Name',
-        event_id: 'e'.repeat(64),
-        content_url: 'https://media.divine.video/airport-dance.mp4',
-        published_at: '2026-03-10T12:00:00.000Z'
-      }]
-    });
-  });
-
-  it('returns a moderated video and merges KV override fields', async () => {
-    const pubkey = 'f'.repeat(64);
-    const eventId = 'e'.repeat(64);
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = async (url) => {
-      if (String(url) === `https://api.divine.video/api/videos/${eventId}`) {
-        return new Response('not found', { status: 404 });
-      }
-
-      if (String(url) === `https://api.divine.video/api/users/${pubkey}`) {
-        return new Response(JSON.stringify({
-          pubkey,
-          profile: {
-            display_name: 'Alice',
-            name: 'alice',
-            picture: 'https://cdn.example.com/alice.png',
-          },
-          social: {
-            follower_count: 100,
-            following_count: 20,
-          },
-          stats: {
-            video_count: 12,
-            total_events: 88,
-            first_activity: '2019-01-01T00:00:00.000Z',
-            last_activity: '2026-04-14T00:00:00.000Z',
-          },
-          engagement: {}
-        }), {
-          headers: { 'Content-Type': 'application/json' }
-        });
-      }
-
-      if (String(url) === `https://api.divine.video/api/users/${pubkey}/social`) {
-        return new Response(JSON.stringify({
-          follower_count: 100,
-          following_count: 20,
-        }), {
-          headers: { 'Content-Type': 'application/json' }
-        });
-      }
-
-      throw new Error(`Unexpected fetch: ${url}`);
-    };
-
-    try {
-      const env = createEnv({
-        BLOSSOM_DB: createDbMock({
-          moderationResults: new Map([[SHA256, {
-            sha256: SHA256,
-            action: 'REVIEW',
-            provider: 'hiveai',
-            scores: JSON.stringify({ nudity: 0.4 }),
-            categories: JSON.stringify(['nudity']),
-            moderated_at: '2026-03-07T00:00:00.000Z',
-            reviewed_by: 'admin',
-            reviewed_at: '2026-03-07T01:00:00.000Z',
-            review_notes: 'legacy note',
-            uploaded_by: pubkey,
-            title: 'Imported clip',
-            author: 'Alice',
-            event_id: eventId,
-            content_url: `https://blossom.primal.net/${SHA256}.mp4`,
-            published_at: 1408579200
-          }]]),
-          uploaderStats: new Map([[pubkey, {
-            pubkey,
-            total_scanned: 5,
-            flagged_count: 2,
-            banned_count: 0,
-            restricted_count: 1,
-            review_count: 1,
-            last_flagged_at: '2026-03-10T00:00:00.000Z',
-            risk_level: 'elevated'
-          }]]),
-          uploaderEnforcements: new Map([[pubkey, {
-            pubkey,
-            approval_required: 0,
-            relay_banned: 1
-          }]])
-        }),
-        MODERATION_KV: {
-          async get(key) {
-            if (key === `moderation:${SHA256}`) {
-              return JSON.stringify({
-                action: 'AGE_RESTRICTED',
-                cdnUrl: `https://blossom.primal.net/${SHA256}.mp4`,
-                scores: { nudity: 0.91, ai_generated: 0.2 },
-                manualOverride: true,
-                previousAction: 'REVIEW',
-                overriddenAt: 1741305600000,
-                reason: 'Manual override'
-              });
-            }
-            return null;
-          },
-          async put() {},
-          async delete() {},
-          async list() { return { keys: [], list_complete: true, cursor: null }; }
-        }
-      });
-
-      const response = await worker.fetch(
-        new Request(`https://moderation.admin.divine.video/admin/api/video/${SHA256}`, {
-          headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
-        }),
-        env
-      );
-
-      expect(response.status).toBe(200);
-      await expect(response.json()).resolves.toMatchObject({
-        video: {
-          sha256: SHA256,
-          action: 'AGE_RESTRICTED',
-          cdnUrl: `https://blossom.primal.net/${SHA256}.mp4`,
-          manualOverride: true,
-          previousAction: 'REVIEW',
-          reason: 'Manual override',
-          scores: {
-            nudity: 0.91
-          },
-          nostrContext: {
-            title: 'Imported clip',
-            author: 'Alice',
-            url: `https://blossom.primal.net/${SHA256}.mp4`,
-            publishedAt: 1408579200
-          },
-          eventId,
-          divineUrl: `https://divine.video/video/${eventId}`,
-          creatorContext: {
-            name: 'Alice',
-            stats: {
-              totalScanned: 5
-            },
-            social: {
-              followerCount: 100
-            },
-            enforcement: {
-              relayBanned: true
-            }
-          },
-          provenance: {
-            status: 'pre_2022_legacy',
-            dateSource: 'published_at',
-            isPre2022: true,
-            reasons: expect.arrayContaining(['published_at:2014-08-21T00:00:00.000Z'])
-          }
-        }
-      });
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  it('returns provenance in admin video list payloads', async () => {
-    const pubkey = '1'.repeat(64);
-    const env = createEnv({
-      BLOSSOM_DB: createDbMock({
-        moderationResults: new Map([[SHA256, {
-          sha256: SHA256,
-          action: 'AGE_RESTRICTED',
-          provider: 'hiveai',
-          scores: JSON.stringify({ ai_generated: 0.92 }),
-          categories: JSON.stringify(['ai_generated']),
+          scores: JSON.stringify({ nudity: 0.4 }),
+          categories: JSON.stringify(['nudity']),
           moderated_at: '2026-03-07T00:00:00.000Z',
-          reviewed_by: null,
-          reviewed_at: null,
-          uploaded_by: pubkey,
-          title: 'Old archive upload',
-          author: 'Archivist',
-          event_id: '2'.repeat(64),
-          content_url: `https://blossom.primal.net/${SHA256}.mp4`,
-          published_at: 1514678400
+          reviewed_by: 'admin',
+          reviewed_at: '2026-03-07T01:00:00.000Z',
+          review_notes: 'legacy note',
+          uploaded_by: 'npub123'
         }]])
-      })
+      }),
+      MODERATION_KV: {
+        async get(key) {
+          if (key === `moderation:${SHA256}`) {
+            return JSON.stringify({
+              action: 'AGE_RESTRICTED',
+              cdnUrl: `https://blossom.primal.net/${SHA256}.mp4`,
+              scores: { nudity: 0.91, ai_generated: 0.2 },
+              manualOverride: true,
+              previousAction: 'REVIEW',
+              overriddenAt: 1741305600000,
+              reason: 'Manual override'
+            });
+          }
+          return null;
+        },
+        async put() {},
+        async delete() {},
+        async list() { return { keys: [], list_complete: true, cursor: null }; }
+      }
     });
 
     const response = await worker.fetch(
-      new Request('https://moderation.admin.divine.video/admin/api/videos?action=FLAGGED&limit=10', {
+      new Request(`https://moderation.admin.divine.video/admin/api/video/${SHA256}`, {
         headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
       }),
       env
@@ -629,16 +301,17 @@ describe('Admin video lookup', () => {
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toMatchObject({
-      videos: [
-        {
-          sha256: SHA256,
-          provenance: {
-            status: 'pre_2022_legacy',
-            dateSource: 'published_at',
-            isPre2022: true
-          }
+      video: {
+        sha256: SHA256,
+        action: 'AGE_RESTRICTED',
+        cdnUrl: `https://blossom.primal.net/${SHA256}.mp4`,
+        manualOverride: true,
+        previousAction: 'REVIEW',
+        reason: 'Manual override',
+        scores: {
+          nudity: 0.91
         }
-      ]
+      }
     });
   });
 
@@ -699,138 +372,6 @@ describe('Admin video lookup', () => {
     }
   });
 
-  it('prefers mirrored relay video and creator rows without upstream fetch', async () => {
-    const pubkey = 'f'.repeat(64);
-    const eventId = 'e'.repeat(64);
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = async (url) => {
-      throw new Error(`Unexpected fetch: ${url}`);
-    };
-
-    try {
-      const env = createEnv({
-        BLOSSOM_DB: createDbMock({
-          moderationResults: new Map([[SHA256, {
-            sha256: SHA256,
-            action: 'REVIEW',
-            provider: 'hiveai',
-            scores: JSON.stringify({ nudity: 0.4 }),
-            categories: JSON.stringify(['nudity']),
-            moderated_at: '2026-03-07T00:00:00.000Z',
-            reviewed_by: null,
-            reviewed_at: null,
-            uploaded_by: null,
-            title: null,
-            author: null,
-            event_id: null,
-            content_url: null,
-            published_at: null
-          }]]),
-          relayVideos: new Map([[SHA256, {
-            sha256: SHA256,
-            event_id: eventId,
-            stable_id: 'mirror-stable-id',
-            pubkey,
-            title: 'Mirrored title',
-            content: 'Mirrored content',
-            summary: 'Mirrored summary',
-            video_url: 'https://media.divine.video/mirrored.mp4',
-            thumbnail_url: 'https://media.divine.video/mirrored.jpg',
-            published_at: '2026-03-06T12:00:00.000Z',
-            created_at: '2026-03-06T11:00:00.000Z',
-            author_name: 'Mirror Author',
-            author_avatar: 'https://cdn.example.com/author.png',
-            raw_json: JSON.stringify({ id: eventId }),
-            synced_at: '2026-04-16T00:00:00.000Z',
-            source_updated_at: '2026-04-15T23:59:00.000Z'
-          }]]),
-          relayCreators: new Map([[pubkey, {
-            pubkey,
-            display_name: 'Mirror Creator',
-            username: 'mirror',
-            avatar_url: 'https://cdn.example.com/creator.png',
-            bio: 'Mirrored creator bio',
-            website: 'https://divine.video/profile/mirror',
-            nip05: 'mirror@divine.video',
-            follower_count: 123,
-            following_count: 45,
-            video_count: 67,
-            event_count: 89,
-            first_activity: '2020-01-01T00:00:00.000Z',
-            last_activity: '2026-04-15T00:00:00.000Z',
-            raw_json: JSON.stringify({ pubkey }),
-            synced_at: '2026-04-16T00:00:00.000Z'
-          }]]),
-          uploaderStats: new Map([[pubkey, {
-            pubkey,
-            total_scanned: 5,
-            flagged_count: 2,
-            banned_count: 0,
-            restricted_count: 1,
-            review_count: 1,
-            last_flagged_at: '2026-03-10T00:00:00.000Z',
-            risk_level: 'elevated'
-          }]]),
-          uploaderEnforcements: new Map([[pubkey, {
-            pubkey,
-            approval_required: 0,
-            relay_banned: 1
-          }]])
-        })
-      });
-
-      const response = await worker.fetch(
-        new Request(`https://moderation.admin.divine.video/admin/api/video/${SHA256}`, {
-          headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
-        }),
-        env
-      );
-
-      expect(response.status).toBe(200);
-      await expect(response.json()).resolves.toMatchObject({
-        video: {
-          sha256: SHA256,
-          title: 'Mirrored title',
-          author: 'Mirror Author',
-          uploaded_by: pubkey,
-          eventId,
-          stableId: 'mirror-stable-id',
-          divineUrl: 'https://divine.video/video/mirror-stable-id',
-          content_url: 'https://media.divine.video/mirrored.mp4',
-          nostrContext: {
-            title: 'Mirrored title',
-            author: 'Mirror Author',
-            content: 'Mirrored content',
-            url: 'https://media.divine.video/mirrored.mp4',
-            publishedAt: '2026-03-06T12:00:00.000Z',
-            eventId,
-            stableId: 'mirror-stable-id'
-          },
-          publisherProfile: {
-            display_name: 'Mirror Creator',
-            name: 'mirror',
-            picture: 'https://cdn.example.com/creator.png'
-          },
-          creatorContext: {
-            name: 'Mirror Creator',
-            avatarUrl: 'https://cdn.example.com/creator.png',
-            social: {
-              followerCount: 123,
-              followingCount: 45,
-              videoCount: 67,
-              totalEvents: 89
-            },
-            enforcement: {
-              relayBanned: true
-            }
-          }
-        }
-      });
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
   it('uses FunnelCake REST instead of WebSocket when moderated metadata is missing', async () => {
     const originalFetch = globalThis.fetch;
     const originalWebSocket = globalThis.WebSocket;
@@ -844,7 +385,7 @@ describe('Admin video lookup', () => {
 
     globalThis.fetch = async (url) => {
       restCalls.push(String(url));
-      if (String(url) === `https://api.divine.video/api/videos/${SHA256}`) {
+      if (String(url) === `https://relay.divine.video/api/videos/${SHA256}`) {
         return new Response(JSON.stringify({
           event: {
             id: 'd'.repeat(64),
@@ -863,49 +404,6 @@ describe('Admin video lookup', () => {
           stats: {
             author_name: 'REST author'
           }
-        }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' }
-        });
-      }
-
-      if (String(url) === 'https://api.divine.video/api/users/bulk') {
-        return new Response(JSON.stringify({
-          users: [{
-            pubkey: 'b'.repeat(64),
-            profile: {
-              display_name: 'REST display name',
-              picture: 'https://cdn.divine.video/rest-avatar.jpg'
-            }
-          }],
-          missing: []
-        }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' }
-        });
-      }
-
-      if (String(url) === `https://api.divine.video/api/users/${'b'.repeat(64)}`) {
-        return new Response(JSON.stringify({
-          pubkey: 'b'.repeat(64),
-          profile: {
-            display_name: 'REST display name',
-            picture: 'https://cdn.divine.video/rest-avatar.jpg'
-          },
-          stats: {
-            video_count: 3,
-            total_events: 11
-          }
-        }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' }
-        });
-      }
-
-      if (String(url) === `https://api.divine.video/api/users/${'b'.repeat(64)}/social`) {
-        return new Response(JSON.stringify({
-          follower_count: 7,
-          following_count: 2
         }), {
           status: 200,
           headers: { 'Content-Type': 'application/json' }
@@ -941,13 +439,8 @@ describe('Admin video lookup', () => {
       await expect(response.json()).resolves.toMatchObject({
         video: {
           sha256: SHA256,
-          uploaded_by: 'b'.repeat(64),
           eventId: 'd'.repeat(64),
           divineUrl: `https://divine.video/video/${SHA256}`,
-          publisherProfile: {
-            display_name: 'REST display name',
-            picture: 'https://cdn.divine.video/rest-avatar.jpg'
-          },
           nostrContext: {
             title: 'REST title',
             author: 'REST author',
@@ -958,62 +451,45 @@ describe('Admin video lookup', () => {
           }
         }
       });
-      expect(restCalls).toEqual([
-        `https://api.divine.video/api/videos/${SHA256}`,
-        'https://api.divine.video/api/users/bulk',
-        `https://api.divine.video/api/users/${'b'.repeat(64)}`,
-        `https://api.divine.video/api/users/${'b'.repeat(64)}/social`
-      ]);
+      expect(restCalls).toEqual([`https://relay.divine.video/api/videos/${SHA256}`]);
     } finally {
       globalThis.fetch = originalFetch;
       globalThis.WebSocket = originalWebSocket;
     }
   });
 
-  it('prefers api.divine.video context over stored metadata for moderated videos', async () => {
-    const eventId = '1'.repeat(64);
-    const uploaderPubkey = '9'.repeat(64);
+  it('returns mirrored relay context fields in the admin video list payload', async () => {
     const originalFetch = globalThis.fetch;
+    const originalWebSocket = globalThis.WebSocket;
+    const restCalls = [];
+
+    globalThis.WebSocket = class {
+      constructor() {
+        throw new Error('WebSocket should not be used for dashboard list metadata');
+      }
+    };
+
     globalThis.fetch = async (url) => {
-      if (String(url) === `https://api.divine.video/api/videos/${eventId}`) {
+      restCalls.push(String(url));
+      if (String(url) === `https://relay.divine.video/api/videos/${SHA256}`) {
         return new Response(JSON.stringify({
           event: {
-            id: eventId,
-            pubkey: uploaderPubkey,
-            created_at: 1773503656,
+            id: 'd'.repeat(64),
+            pubkey: 'b'.repeat(64),
+            created_at: 1700000000,
             kind: 34236,
             tags: [
-              ['d', 'relay-stable-id'],
-              ['title', 'Relay title'],
-              ['client', 'divine-web'],
-              ['platform', 'vine'],
-              ['published_at', '1773503656'],
-              ['imeta', `url https://cdn.divine.video/${SHA256}.mp4`, `x ${SHA256}`, 'image https://cdn.divine.video/thumb.jpg']
+              ['d', SHA256],
+              ['title', 'REST title'],
+              ['published_at', '1389756506'],
+              ['imeta', 'url https://media.divine.video/rest-content.mp4', `x ${SHA256}`]
             ],
-            content: 'Relay description',
-            sig: 'd'.repeat(128)
+            content: 'REST description',
+            sig: 'e'.repeat(128)
           },
           stats: {
-            author_name: 'Relay Author',
-            author_avatar: 'https://cdn.divine.video/avatar.jpg'
+            author_name: 'REST author'
           }
-        }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' }
-        });
-      }
-
-      if (String(url) === 'https://api.divine.video/api/users/bulk') {
-        return new Response(JSON.stringify({
-          users: [{
-            pubkey: uploaderPubkey,
-            profile: {
-              display_name: 'Relay Display Name',
-              picture: 'https://cdn.divine.video/avatar.jpg',
-              nip05: 'relay@example.com'
-            }
-          }],
-          missing: []
         }), {
           status: 200,
           headers: { 'Content-Type': 'application/json' }
@@ -1024,302 +500,51 @@ describe('Admin video lookup', () => {
     };
 
     try {
+      const moderationRow = {
+        sha256: SHA256,
+        action: 'REVIEW',
+        provider: 'hiveai',
+        scores: JSON.stringify({ nudity: 0.4 }),
+        categories: JSON.stringify(['nudity']),
+        moderated_at: '2026-03-07T00:00:00.000Z',
+        reviewed_by: null,
+        reviewed_at: null,
+        uploaded_by: null
+      };
+
       const response = await worker.fetch(
-        new Request(`https://moderation.admin.divine.video/admin/api/video/${SHA256}`, {
+        new Request('https://moderation.admin.divine.video/admin/api/videos', {
           headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
         }),
         createEnv({
           BLOSSOM_DB: createDbMock({
-            moderationResults: new Map([[SHA256, {
-              sha256: SHA256,
-              action: 'REVIEW',
-              provider: 'hiveai',
-              scores: JSON.stringify({ nudity: 0.82 }),
-              categories: JSON.stringify(['nudity']),
-              moderated_at: '2026-03-07T00:00:00.000Z',
-              reviewed_by: null,
-              reviewed_at: null,
-              review_notes: 'legacy note',
-              uploaded_by: 'f'.repeat(64),
-              title: 'Stored title',
-              author: 'Stored author',
-              event_id: eventId,
-              content_url: 'https://media.divine.video/stored.mp4',
-              published_at: '2026-03-06T00:00:00.000Z'
-            }]])
+            moderationResults: new Map([[SHA256, moderationRow]]),
+            moderationListRows: [moderationRow]
           })
         })
       );
 
       expect(response.status).toBe(200);
       await expect(response.json()).resolves.toMatchObject({
-        video: {
+        videos: [{
           sha256: SHA256,
-          uploaded_by: uploaderPubkey,
-          eventId,
-          divineUrl: 'https://divine.video/video/relay-stable-id',
-          title: 'Relay title',
-          author: 'Relay Author',
-          content_url: `https://cdn.divine.video/${SHA256}.mp4`,
+          uploaded_by: 'b'.repeat(64),
+          eventId: 'd'.repeat(64),
+          divineUrl: `https://divine.video/video/${SHA256}`,
           nostrContext: {
-            title: 'Relay title',
-            author: 'Relay Author',
-            content: 'Relay description',
-            client: 'divine-web',
-            platform: 'vine',
-            url: `https://cdn.divine.video/${SHA256}.mp4`
+            title: 'REST title',
+            author: 'REST author',
+            url: 'https://media.divine.video/rest-content.mp4',
+            publishedAt: 1389756506,
+            content: 'REST description',
+            eventId: 'd'.repeat(64)
           }
-        }
+        }]
       });
+      expect(restCalls).toEqual([`https://relay.divine.video/api/videos/${SHA256}`]);
     } finally {
       globalThis.fetch = originalFetch;
-    }
-  });
-
-  it('falls back to stored admin metadata when api.divine.video lookup misses', async () => {
-    const eventId = '2'.repeat(64);
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = async (url) => {
-      if (String(url) === `https://api.divine.video/api/videos/${eventId}`) {
-        return new Response('not found', { status: 404 });
-      }
-      throw new Error(`Unexpected fetch: ${url}`);
-    };
-
-    try {
-      const response = await worker.fetch(
-        new Request(`https://moderation.admin.divine.video/admin/api/video/${SHA256}`, {
-          headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
-        }),
-        createEnv({
-          BLOSSOM_DB: createDbMock({
-            moderationResults: new Map([[SHA256, {
-              sha256: SHA256,
-              action: 'REVIEW',
-              provider: 'hiveai',
-              scores: JSON.stringify({ nudity: 0.82 }),
-              categories: JSON.stringify(['nudity']),
-              moderated_at: '2026-03-07T00:00:00.000Z',
-              reviewed_by: null,
-              reviewed_at: null,
-              review_notes: 'legacy note',
-              uploaded_by: 'f'.repeat(64),
-              title: 'Stored title',
-              author: 'Stored author',
-              event_id: eventId,
-              content_url: 'https://media.divine.video/stored.mp4',
-              published_at: '2026-03-06T00:00:00.000Z'
-            }]])
-          })
-        })
-      );
-
-      expect(response.status).toBe(200);
-      await expect(response.json()).resolves.toMatchObject({
-        video: {
-          sha256: SHA256,
-          uploaded_by: 'f'.repeat(64),
-          eventId,
-          title: 'Stored title',
-          author: 'Stored author',
-          content_url: 'https://media.divine.video/stored.mp4',
-          nostrContext: {
-            title: 'Stored title',
-            author: 'Stored author',
-            url: 'https://media.divine.video/stored.mp4',
-            publishedAt: '2026-03-06T00:00:00.000Z'
-          }
-        }
-      });
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  it('uses stored stable post id from raw_response snapshot when event_id is missing', async () => {
-    const stableId = 'relay-stable-id';
-    const uploaderPubkey = '9'.repeat(64);
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = async (url) => {
-      if (String(url) === `https://api.divine.video/api/videos/${stableId}`) {
-        return new Response(JSON.stringify({
-          event: {
-            id: '3'.repeat(64),
-            pubkey: uploaderPubkey,
-            created_at: 1773503656,
-            kind: 34236,
-            tags: [
-              ['d', stableId],
-              ['title', 'Stable relay title'],
-              ['published_at', '1773503656'],
-              ['imeta', `url https://cdn.divine.video/${SHA256}.mp4`, `x ${SHA256}`]
-            ],
-            content: 'Stable relay description',
-            sig: 'd'.repeat(128)
-          },
-          stats: {
-            author_name: 'Stable Relay Author',
-            author_avatar: 'https://cdn.divine.video/avatar.jpg'
-          }
-        }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' }
-        });
-      }
-
-      if (String(url) === 'https://api.divine.video/api/users/bulk') {
-        return new Response(JSON.stringify({
-          users: [{
-            pubkey: uploaderPubkey,
-            profile: {
-              display_name: 'Stable Relay Display Name',
-              picture: 'https://cdn.divine.video/avatar.jpg'
-            }
-          }],
-          missing: []
-        }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' }
-        });
-      }
-
-      throw new Error(`Unexpected fetch: ${url}`);
-    };
-
-    try {
-      const response = await worker.fetch(
-        new Request(`https://moderation.admin.divine.video/admin/api/video/${SHA256}`, {
-          headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
-        }),
-        createEnv({
-          BLOSSOM_DB: createDbMock({
-            moderationResults: new Map([[SHA256, {
-              sha256: SHA256,
-              action: 'REVIEW',
-              provider: 'hiveai',
-              scores: JSON.stringify({ nudity: 0.82 }),
-              categories: JSON.stringify(['nudity']),
-              raw_response: JSON.stringify({
-                nostrSnapshot: {
-                  stableId,
-                  content: 'Stored snapshot body'
-                }
-              }),
-              moderated_at: '2026-03-07T00:00:00.000Z',
-              reviewed_by: null,
-              reviewed_at: null,
-              uploaded_by: 'f'.repeat(64),
-              title: null,
-              author: null,
-              event_id: null,
-              content_url: 'https://media.divine.video/stored.mp4',
-              published_at: null
-            }]])
-          })
-        })
-      );
-
-      expect(response.status).toBe(200);
-      await expect(response.json()).resolves.toMatchObject({
-        video: {
-          sha256: SHA256,
-          uploaded_by: uploaderPubkey,
-          divineUrl: 'https://divine.video/video/relay-stable-id',
-          title: 'Stable relay title',
-          author: 'Stable Relay Author',
-          content_url: `https://cdn.divine.video/${SHA256}.mp4`,
-          nostrContext: {
-            title: 'Stable relay title',
-            author: 'Stable Relay Author',
-            content: 'Stable relay description',
-            url: `https://cdn.divine.video/${SHA256}.mp4`
-          }
-        }
-      });
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  it('falls back to summary tag when relay event content is empty', async () => {
-    const eventId = '4'.repeat(64);
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = async (url) => {
-      if (String(url) === `https://api.divine.video/api/videos/${eventId}`) {
-        return new Response(JSON.stringify({
-          event: {
-            id: eventId,
-            pubkey: '6'.repeat(64),
-            created_at: 1773503656,
-            kind: 34236,
-            tags: [
-              ['d', 'summary-stable-id'],
-              ['title', 'Summary title'],
-              ['summary', 'Summary body text'],
-              ['published_at', '1773503656'],
-              ['imeta', `url https://cdn.divine.video/${SHA256}.mp4`, `x ${SHA256}`]
-            ],
-            content: '',
-            sig: 'd'.repeat(128)
-          },
-          stats: {
-            author_name: 'Summary Author'
-          }
-        }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' }
-        });
-      }
-
-      if (String(url) === 'https://api.divine.video/api/users/bulk') {
-        return new Response(JSON.stringify({ users: [], missing: ['6'.repeat(64)] }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' }
-        });
-      }
-
-      throw new Error(`Unexpected fetch: ${url}`);
-    };
-
-    try {
-      const response = await worker.fetch(
-        new Request(`https://moderation.admin.divine.video/admin/api/video/${SHA256}`, {
-          headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
-        }),
-        createEnv({
-          BLOSSOM_DB: createDbMock({
-            moderationResults: new Map([[SHA256, {
-              sha256: SHA256,
-              action: 'REVIEW',
-              provider: 'hiveai',
-              scores: JSON.stringify({ nudity: 0.82 }),
-              categories: JSON.stringify(['nudity']),
-              moderated_at: '2026-03-07T00:00:00.000Z',
-              reviewed_by: null,
-              reviewed_at: null,
-              uploaded_by: 'f'.repeat(64),
-              title: null,
-              author: null,
-              event_id: eventId,
-              content_url: null,
-              published_at: null
-            }]])
-          })
-        })
-      );
-
-      expect(response.status).toBe(200);
-      await expect(response.json()).resolves.toMatchObject({
-        video: {
-          title: 'Summary title',
-          author: 'Summary Author',
-          nostrContext: {
-            content: 'Summary body text'
-          }
-        }
-      });
-    } finally {
-      globalThis.fetch = originalFetch;
+      globalThis.WebSocket = originalWebSocket;
     }
   });
 
@@ -1501,45 +726,6 @@ describe('Admin video lookup', () => {
     });
   });
 
-  it('includes uploader identity keys (nostrContext, eventId, uploaded_by, divineUrl) for moderated rows', async () => {
-    const env = createEnv({
-      BLOSSOM_DB: createDbMock({
-        moderationResults: new Map([[SHA256, {
-          sha256: SHA256,
-          action: 'REVIEW',
-          provider: 'hiveai',
-          scores: JSON.stringify({ nudity: 0.2 }),
-          categories: JSON.stringify([]),
-          moderated_at: '2026-04-01T00:00:00.000Z',
-          uploaded_by: 'c'.repeat(64),
-          title: 'Clip title',
-          author: 'Alice',
-          event_id: '2'.repeat(64),
-          content_url: 'https://media.divine.video/clip.mp4',
-          published_at: '2026-04-01T00:00:00.000Z'
-        }]])
-      })
-    });
-
-    const response = await worker.fetch(
-      new Request(`https://moderation.admin.divine.video/admin/api/video/${SHA256}`, {
-        headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
-      }),
-      env
-    );
-
-    expect(response.status).toBe(200);
-    const body = await response.json();
-    expect(body.video).toHaveProperty('nostrContext');
-    expect(body.video).toHaveProperty('eventId');
-    expect(body.video).toHaveProperty('uploaded_by');
-    expect(body.video).toHaveProperty('divineUrl');
-    expect(body.video.uploaded_by).toBe('c'.repeat(64));
-    expect(body.video.eventId).toBe('2'.repeat(64));
-    expect(body.video.divineUrl).toBe(`https://divine.video/video/${'2'.repeat(64)}`);
-    expect(body.video.nostrContext).toMatchObject({ title: 'Clip title', author: 'Alice' });
-  });
-
   it('returns 404 when the lookup identifier is unknown', async () => {
     const originalFetch = globalThis.fetch;
     globalThis.fetch = async () => new Response('not found', { status: 404 });
@@ -1556,641 +742,6 @@ describe('Admin video lookup', () => {
       await expect(response.json()).resolves.toEqual({
         error: 'Video not found',
         identifier: SHA256
-      });
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  it('recovers legacy context from raw_response and video_metadata when persisted columns are empty', async () => {
-    const uploaderPubkey = 'd'.repeat(64);
-    const eventId = 'e'.repeat(64);
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = async (url) => {
-      throw new Error(`Unexpected fetch: ${url}`);
-    };
-
-    try {
-      const response = await worker.fetch(
-        new Request(`https://moderation.admin.divine.video/admin/api/video/${SHA256}`, {
-          headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
-        }),
-        createEnv({
-          BLOSSOM_DB: createDbMock({
-            moderationResults: new Map([[SHA256, {
-              sha256: SHA256,
-              action: 'REVIEW',
-              provider: 'hiveai',
-              scores: JSON.stringify({ nudity: 0.71 }),
-              categories: JSON.stringify(['nudity']),
-              raw_response: JSON.stringify({
-                uploadedBy: uploaderPubkey,
-                nostrEventId: eventId,
-                nostrContext: {
-                  title: 'Legacy title',
-                  author: 'Legacy author',
-                  content: 'Legacy description',
-                  publishedAt: 1389756506,
-                  sourceUrl: 'https://vine.co/v/abc123',
-                  platform: 'vine',
-                  client: 'vine-archive-importer'
-                }
-              }),
-              moderated_at: '2026-02-17T20:32:58.616Z',
-              reviewed_by: null,
-              reviewed_at: null,
-              uploaded_by: null,
-              title: null,
-              author: null,
-              event_id: null,
-              content_url: null,
-              published_at: null
-            }]]),
-            videoMetadata: new Map([[SHA256, {
-              sha256: SHA256,
-              uploaded_by: uploaderPubkey,
-              current_status: 'ready',
-              current_mp4_url: 'https://media.divine.video/legacy.mp4',
-              current_hls_url: 'https://media.divine.video/legacy.m3u8'
-            }]])
-          })
-        })
-      );
-
-      expect(response.status).toBe(200);
-      await expect(response.json()).resolves.toMatchObject({
-        video: {
-          sha256: SHA256,
-          uploaded_by: uploaderPubkey,
-          title: 'Legacy title',
-          author: 'Legacy author',
-          eventId,
-          divineUrl: `https://divine.video/video/${eventId}`,
-          content_url: 'https://media.divine.video/legacy.mp4',
-          nostrContext: {
-            title: 'Legacy title',
-            author: 'Legacy author',
-            content: 'Legacy description',
-            url: 'https://media.divine.video/legacy.mp4',
-            sourceUrl: 'https://vine.co/v/abc123',
-            publishedAt: 1389756506,
-            eventId,
-            platform: 'vine',
-            client: 'vine-archive-importer',
-            pubkey: `${uploaderPubkey.substring(0, 16)}...`
-          }
-        }
-      });
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  it('marks unrecoverable legacy moderation rows as orphaned context', async () => {
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = async (url) => {
-      if (String(url) === `https://api.divine.video/api/videos/${SHA256}`) {
-        return new Response('not found', { status: 404 });
-      }
-      if (String(url) === `https://relay.divine.video/api/videos/${SHA256}`) {
-        return new Response('not found', { status: 404 });
-      }
-      throw new Error(`Unexpected fetch: ${url}`);
-    };
-
-    try {
-      const response = await worker.fetch(
-        new Request(`https://moderation.admin.divine.video/admin/api/video/${SHA256}`, {
-          headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
-        }),
-        createEnv({
-          BLOSSOM_DB: createDbMock({
-            moderationResults: new Map([[SHA256, {
-              sha256: SHA256,
-              action: 'REVIEW',
-              provider: 'hiveai',
-              scores: JSON.stringify({ nudity: 0.93 }),
-              categories: JSON.stringify(['nudity']),
-              raw_response: '{}',
-              moderated_at: '2026-02-17T20:32:58.616Z',
-              reviewed_by: null,
-              reviewed_at: null,
-              uploaded_by: null,
-              title: null,
-              author: null,
-              event_id: null,
-              content_url: null,
-              published_at: null
-            }]])
-          })
-        })
-      );
-
-      expect(response.status).toBe(200);
-      await expect(response.json()).resolves.toMatchObject({
-        video: {
-          sha256: SHA256,
-          contextStatus: {
-            state: 'orphaned',
-            reason: 'legacy_moderation_row_without_context'
-          }
-        }
-      });
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  it('caches relay-resolved admin context into moderation_results during lookup', async () => {
-    const eventId = 'f'.repeat(64);
-    const uploaderPubkey = 'b'.repeat(64);
-    const moderationResults = new Map([[SHA256, {
-      sha256: SHA256,
-      action: 'REVIEW',
-      provider: 'hiveai',
-      scores: JSON.stringify({ nudity: 0.91 }),
-      categories: JSON.stringify(['nudity']),
-      raw_response: '{}',
-      moderated_at: '2026-02-17T20:32:58.616Z',
-      reviewed_by: null,
-      reviewed_at: null,
-      uploaded_by: null,
-      title: null,
-      author: null,
-      event_id: null,
-      content_url: null,
-      published_at: null
-    }]]);
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = async (url) => {
-      if (String(url) === `https://api.divine.video/api/videos/${SHA256}`) {
-        return new Response(JSON.stringify({
-          event: {
-            id: eventId,
-            pubkey: uploaderPubkey,
-            created_at: 1700000000,
-            kind: 34236,
-            tags: [
-              ['d', 'cacheable-stable-id'],
-              ['title', 'Cached title'],
-              ['published_at', '1389756506'],
-              ['imeta', 'url https://media.divine.video/cached-content.mp4', `x ${SHA256}`]
-            ],
-            content: 'Cached body text',
-            sig: 'e'.repeat(128)
-          },
-          stats: {
-            author_name: 'Cached author',
-            author_avatar: 'https://cdn.divine.video/avatar.jpg'
-          }
-        }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' }
-        });
-      }
-
-      throw new Error(`Unexpected fetch: ${url}`);
-    };
-
-    try {
-      const env = createEnv({
-        BLOSSOM_DB: createDbMock({ moderationResults })
-      });
-
-      const response = await worker.fetch(
-        new Request(`https://moderation.admin.divine.video/admin/api/video/${SHA256}`, {
-          headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
-        }),
-        env
-      );
-
-      expect(response.status).toBe(200);
-      await expect(response.json()).resolves.toMatchObject({
-        video: {
-          sha256: SHA256,
-          uploaded_by: uploaderPubkey,
-          title: 'Cached title',
-          author: 'Cached author',
-          eventId,
-          content_url: 'https://media.divine.video/cached-content.mp4'
-        }
-      });
-
-      expect(moderationResults.get(SHA256)).toMatchObject({
-        uploaded_by: uploaderPubkey,
-        title: 'Cached title',
-        author: 'Cached author',
-        event_id: eventId,
-        content_url: 'https://media.divine.video/cached-content.mp4',
-        published_at: 1389756506
-      });
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  it('writes through relay mirror tables during admin lookup cache miss', async () => {
-    const eventId = 'f'.repeat(64);
-    const uploaderPubkey = 'b'.repeat(64);
-    const moderationResults = new Map([[SHA256, {
-      sha256: SHA256,
-      action: 'REVIEW',
-      provider: 'hiveai',
-      scores: JSON.stringify({ nudity: 0.91 }),
-      categories: JSON.stringify(['nudity']),
-      raw_response: '{}',
-      moderated_at: '2026-02-17T20:32:58.616Z',
-      reviewed_by: null,
-      reviewed_at: null,
-      uploaded_by: null,
-      title: null,
-      author: null,
-      event_id: null,
-      content_url: null,
-      published_at: null
-    }]]);
-    const relayVideos = new Map();
-    const relayCreators = new Map();
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = async (url, init = {}) => {
-      if (String(url) === `https://api.divine.video/api/videos/${SHA256}`) {
-        return new Response(JSON.stringify({
-          event: {
-            id: eventId,
-            pubkey: uploaderPubkey,
-            created_at: 1700000000,
-            kind: 34236,
-            tags: [
-              ['d', 'cacheable-stable-id'],
-              ['title', 'Cached title'],
-              ['published_at', '1389756506'],
-              ['imeta', 'url https://media.divine.video/cached-content.mp4', `x ${SHA256}`]
-            ],
-            content: 'Cached body text',
-            sig: 'e'.repeat(128)
-          },
-          stats: {
-            author_name: 'Cached author',
-            author_avatar: 'https://cdn.divine.video/avatar.jpg'
-          }
-        }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' }
-        });
-      }
-      if (String(url) === 'https://api.divine.video/api/users/bulk') {
-        expect(init.method).toBe('POST');
-        return new Response(JSON.stringify({
-          users: [{
-            pubkey: uploaderPubkey,
-            profile: {
-              display_name: 'Bulk cached creator',
-              name: 'bulk-cached',
-              picture: 'https://cdn.divine.video/bulk-avatar.jpg'
-            }
-          }]
-        }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' }
-        });
-      }
-      if (String(url) === `https://api.divine.video/api/users/${uploaderPubkey}`) {
-        return new Response(JSON.stringify({
-          pubkey: uploaderPubkey,
-          profile: {
-            display_name: 'Creator profile name',
-            name: 'creator-handle',
-            picture: 'https://cdn.divine.video/profile-avatar.jpg'
-          },
-          stats: {
-            video_count: 12,
-            total_events: 88,
-            first_activity: '2019-01-01T00:00:00.000Z',
-            last_activity: '2026-04-14T00:00:00.000Z'
-          },
-          social: {
-            follower_count: 100,
-            following_count: 20
-          }
-        }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' }
-        });
-      }
-      if (String(url) === `https://api.divine.video/api/users/${uploaderPubkey}/social`) {
-        return new Response(JSON.stringify({
-          follower_count: 100,
-          following_count: 20
-        }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' }
-        });
-      }
-
-      throw new Error(`Unexpected fetch: ${url}`);
-    };
-
-    try {
-      const env = createEnv({
-        BLOSSOM_DB: createDbMock({ moderationResults, relayVideos, relayCreators })
-      });
-
-      const response = await worker.fetch(
-        new Request(`https://moderation.admin.divine.video/admin/api/video/${SHA256}`, {
-          headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
-        }),
-        env
-      );
-
-      expect(response.status).toBe(200);
-      await expect(response.json()).resolves.toMatchObject({
-        video: {
-          sha256: SHA256,
-          uploaded_by: uploaderPubkey,
-          title: 'Cached title',
-          author: 'Cached author',
-          eventId,
-          content_url: 'https://media.divine.video/cached-content.mp4'
-        }
-      });
-
-      expect(relayVideos.get(SHA256)).toMatchObject({
-        sha256: SHA256,
-        event_id: eventId,
-        stable_id: 'cacheable-stable-id',
-        pubkey: uploaderPubkey,
-        title: 'Cached title',
-        content: 'Cached body text',
-        video_url: 'https://media.divine.video/cached-content.mp4',
-        author_name: 'Cached author'
-      });
-
-      expect(relayCreators.get(uploaderPubkey)).toMatchObject({
-        pubkey: uploaderPubkey,
-        display_name: 'Bulk cached creator',
-        username: 'bulk-cached',
-        avatar_url: 'https://cdn.divine.video/bulk-avatar.jpg',
-        follower_count: 100,
-        following_count: 20,
-        video_count: 12,
-        event_count: 88
-      });
-
-      expect(moderationResults.get(SHA256)).toMatchObject({
-        uploaded_by: uploaderPubkey,
-        title: 'Cached title',
-        author: 'Cached author',
-        event_id: eventId,
-        content_url: 'https://media.divine.video/cached-content.mp4',
-        published_at: 1389756506
-      });
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-});
-
-describe('Quick review HTML', () => {
-  it('serves metadata-first quick review sections', async () => {
-    const response = await worker.fetch(
-      new Request('https://moderation.admin.divine.video/admin/review', {
-        headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
-      }),
-      createEnv()
-    );
-
-    expect(response.status).toBe(200);
-    const html = await response.text();
-    expect(html).toContain('review-primary-layout');
-    expect(html).toContain('Publisher');
-    expect(html).toContain('Post Context');
-    expect(html).toContain('Timeline');
-    expect(html).toContain('Technical Metadata');
-  });
-
-  it('includes labeled timestamps and full-context field wiring', async () => {
-    const response = await worker.fetch(
-      new Request('https://moderation.admin.divine.video/admin/review', {
-        headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
-      }),
-      createEnv()
-    );
-
-    expect(response.status).toBe(200);
-    const html = await response.text();
-    expect(html).toContain('Published');
-    expect(html).toContain('Received');
-    expect(html).toContain('Moderated');
-    expect(html).toContain('Reviewed');
-    expect(html).toContain('published_at');
-    expect(html).toContain('content_url');
-    expect(html).toContain('event_id');
-  });
-
-  it('includes publisher profile wiring for quick review metadata rendering', async () => {
-    const response = await worker.fetch(
-      new Request('https://moderation.admin.divine.video/admin/review', {
-        headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
-      }),
-      createEnv()
-    );
-
-    expect(response.status).toBe(200);
-    const html = await response.text();
-    expect(html).toContain('publisherProfile');
-    expect(html).toContain('display_name');
-  });
-
-  it('uses neutral empty-state copy instead of internal fallback labels', async () => {
-    const response = await worker.fetch(
-      new Request('https://moderation.admin.divine.video/admin/review', {
-        headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
-      }),
-      createEnv()
-    );
-
-    expect(response.status).toBe(200);
-    const html = await response.text();
-    expect(html).not.toContain('legacy_moderation_row_without_context');
-    expect(html).not.toContain('Legacy moderation row');
-    expect(html).not.toContain('Unknown provenance');
-    expect(html).not.toContain('Unknown Creator');
-    expect(html).toContain('Post details unavailable');
-    expect(html).toContain('Creator details unavailable');
-  });
-});
-
-describe('Admin context backfill', () => {
-  it('repairs sparse review rows via admin context backfill endpoint', async () => {
-    const sparseSha = '1'.repeat(64);
-    const repairedEventId = '2'.repeat(64);
-    const repairedPubkey = '3'.repeat(64);
-    const moderationResults = new Map([[sparseSha, {
-      sha256: sparseSha,
-      action: 'REVIEW',
-      provider: 'hiveai',
-      scores: JSON.stringify({ nudity: 0.84 }),
-      categories: JSON.stringify(['nudity']),
-      raw_response: '{}',
-      moderated_at: '2026-02-17T20:32:58.616Z',
-      reviewed_by: null,
-      reviewed_at: null,
-      uploaded_by: null,
-      title: null,
-      author: null,
-      event_id: null,
-      content_url: null,
-      published_at: null
-    }]]);
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = async (url) => {
-      if (String(url) === `https://api.divine.video/api/videos/${sparseSha}`) {
-        return new Response(JSON.stringify({
-          event: {
-            id: repairedEventId,
-            pubkey: repairedPubkey,
-            created_at: 1700000100,
-            kind: 34236,
-            tags: [
-              ['d', 'repaired-stable-id'],
-              ['title', 'Repaired title'],
-              ['published_at', '1389756507'],
-              ['imeta', `url https://media.divine.video/${sparseSha}.mp4`, `x ${sparseSha}`]
-            ],
-            content: 'Recovered by backfill',
-            sig: 'e'.repeat(128)
-          },
-          stats: {
-            author_name: 'Repaired author'
-          }
-        }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' }
-        });
-      }
-
-      throw new Error(`Unexpected fetch: ${url}`);
-    };
-
-    try {
-      const env = createEnv({
-        BLOSSOM_DB: createDbMock({ moderationResults })
-      });
-
-      const response = await worker.fetch(
-        new Request('https://moderation.admin.divine.video/admin/api/backfill-review-context?limit=10', {
-          method: 'POST',
-          headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
-        }),
-        env
-      );
-
-      expect(response.status).toBe(200);
-      await expect(response.json()).resolves.toMatchObject({
-        scanned: 1,
-        repaired: 1,
-        skipped: 0,
-        repairs: [{
-          sha256: sparseSha,
-          status: 'repaired'
-        }]
-      });
-
-      expect(moderationResults.get(sparseSha)).toMatchObject({
-        uploaded_by: repairedPubkey,
-        title: 'Repaired title',
-        author: 'Repaired author',
-        event_id: repairedEventId,
-        content_url: `https://media.divine.video/${sparseSha}.mp4`,
-        published_at: 1389756507
-      });
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  it('supports GET for admin context backfill endpoint', async () => {
-    const sparseSha = 'c'.repeat(64);
-    const repairedPubkey = 'f'.repeat(64);
-    const repairedEventId = 'g'.repeat(64);
-    const moderationResults = new Map([[sparseSha, {
-      sha256: sparseSha,
-      action: 'REVIEW',
-      provider: 'hiveai',
-      scores: '{}',
-      categories: '[]',
-      raw_response: '{}',
-      moderated_at: '2026-04-15T00:00:00.000Z',
-      reviewed_by: null,
-      reviewed_at: null,
-      uploaded_by: null,
-      title: null,
-      author: null,
-      event_id: null,
-      content_url: null,
-      published_at: null
-    }]]);
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = async (url) => {
-      if (String(url) === `https://api.divine.video/api/videos/${sparseSha}`) {
-        return new Response(JSON.stringify({
-          event: {
-            id: repairedEventId,
-            pubkey: repairedPubkey,
-            created_at: 1700000200,
-            kind: 34236,
-            tags: [
-              ['d', 'repaired-stable-id-get'],
-              ['title', 'Recovered title via GET'],
-              ['published_at', '1389756607'],
-              ['imeta', `url https://media.divine.video/${sparseSha}.mp4`, `x ${sparseSha}`]
-            ],
-            content: 'Recovered by GET backfill',
-            sig: 'h'.repeat(128)
-          },
-          stats: {
-            author_name: 'Recovered author via GET'
-          }
-        }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' }
-        });
-      }
-
-      throw new Error(`Unexpected fetch: ${url}`);
-    };
-
-    try {
-      const env = createEnv({
-        BLOSSOM_DB: createDbMock({ moderationResults })
-      });
-
-      const response = await worker.fetch(
-        new Request('https://moderation.admin.divine.video/admin/api/backfill-review-context?limit=10', {
-          method: 'GET',
-          headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
-        }),
-        env
-      );
-
-      expect(response.status).toBe(200);
-      await expect(response.json()).resolves.toMatchObject({
-        scanned: 1,
-        repaired: 1,
-        skipped: 0,
-        repairs: [{
-          sha256: sparseSha,
-          status: 'repaired'
-        }]
-      });
-
-      expect(moderationResults.get(sparseSha)).toMatchObject({
-        uploaded_by: repairedPubkey,
-        title: 'Recovered title via GET',
-        author: 'Recovered author via GET',
-        event_id: repairedEventId,
-        content_url: `https://media.divine.video/${sparseSha}.mp4`,
-        published_at: 1389756607
       });
     } finally {
       globalThis.fetch = originalFetch;
@@ -2252,9 +803,7 @@ describe('Admin nostr context lookup', () => {
           vineUserId: null,
           content: null,
           eventId: 'c'.repeat(64),
-          stableId: null,
-          createdAt: null,
-          proofmode: null
+          createdAt: null
         }
       });
     } finally {
@@ -2275,10 +824,6 @@ describe('Admin nostr context lookup', () => {
 
     globalThis.fetch = async (url) => {
       restCalls.push(String(url));
-      if (String(url) === `https://api.divine.video/api/videos/${SHA256}`) {
-        return new Response('not found', { status: 404 });
-      }
-
       if (String(url) === `https://relay.divine.video/api/videos/${SHA256}`) {
         return new Response(JSON.stringify({
           event: {
@@ -2333,17 +878,12 @@ describe('Admin nostr context lookup', () => {
           importedAt: null,
           vineHashId: null,
           vineUserId: null,
-          proofmode: null,
           content: 'REST description',
           eventId: 'd'.repeat(64),
-          stableId: SHA256,
           createdAt: 1700000000
         }
       });
-      expect(restCalls).toEqual([
-        `https://api.divine.video/api/videos/${SHA256}`,
-        `https://relay.divine.video/api/videos/${SHA256}`
-      ]);
+      expect(restCalls).toEqual([`https://relay.divine.video/api/videos/${SHA256}`]);
     } finally {
       globalThis.fetch = originalFetch;
       globalThis.WebSocket = originalWebSocket;
@@ -2545,6 +1085,49 @@ describe('admin video proxy format fallback', () => {
     }
   });
 
+  it('preserves byte-range streaming headers for browser playback', async () => {
+    const originalFetch = globalThis.fetch;
+    let receivedRange = null;
+
+    globalThis.fetch = async (url, init = {}) => {
+      if (String(url) === `https://media.divine.video/${SHA256}`) {
+        receivedRange = init.headers?.get?.('Range') || init.headers?.Range || null;
+        return new Response('partial-mp4-bytes', {
+          status: 206,
+          headers: {
+            'Content-Type': 'video/mp4',
+            'Content-Range': 'bytes 0-1023/4096',
+            'Accept-Ranges': 'bytes',
+            'Content-Length': '1024'
+          }
+        });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    };
+
+    try {
+      const response = await worker.fetch(
+        new Request(`https://moderation.admin.divine.video/admin/video/${SHA256}.mp4`, {
+          headers: {
+            'Cf-Access-Authenticated-User-Email': 'mod@divine.video',
+            'Range': 'bytes=0-1023'
+          }
+        }),
+        createEnv()
+      );
+
+      expect(receivedRange).toBe('bytes=0-1023');
+      expect(response.status).toBe(206);
+      expect(response.headers.get('Content-Type')).toBe('video/mp4');
+      expect(response.headers.get('Content-Range')).toBe('bytes 0-1023/4096');
+      expect(response.headers.get('Accept-Ranges')).toBe('bytes');
+      expect(response.headers.get('Content-Length')).toBe('1024');
+      expect(response.headers.get('X-Admin-Proxy')).toBe('cdn');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it('falls back to transcoded 720p MP4 when CDN returns video/3gpp', async () => {
     const originalFetch = globalThis.fetch;
     const fetchedUrls = [];
@@ -2618,18 +1201,17 @@ describe('admin video proxy format fallback', () => {
     }
   });
 
-  it('falls back to stored moderation content_url when CDN and admin bypass miss', async () => {
+  it('falls back to stored moderation content URL when CDN fetch fails and admin bypass is unavailable', async () => {
     const originalFetch = globalThis.fetch;
-    const storedUrl = 'https://blossom.primal.net/imported-video.mp4';
-    const fetchedUrls = [];
+    const fetchCalls = [];
 
     globalThis.fetch = async (url) => {
-      fetchedUrls.push(String(url));
+      fetchCalls.push(String(url));
       if (String(url) === `https://media.divine.video/${SHA256}`) {
         return new Response('not found', { status: 404 });
       }
-      if (String(url) === storedUrl) {
-        return new Response('stored-source-bytes', {
+      if (String(url) === 'https://archive.example.com/original-vine.mp4') {
+        return new Response('archive-bytes', {
           status: 200,
           headers: { 'Content-Type': 'video/mp4' }
         });
@@ -2648,13 +1230,10 @@ describe('admin video proxy format fallback', () => {
               sha256: SHA256,
               action: 'REVIEW',
               provider: 'hiveai',
-              scores: JSON.stringify({ nudity: 0.4 }),
+              scores: JSON.stringify({ nudity: 0.92 }),
               categories: JSON.stringify(['nudity']),
               moderated_at: '2026-03-07T00:00:00.000Z',
-              reviewed_by: null,
-              reviewed_at: null,
-              uploaded_by: 'b'.repeat(64),
-              content_url: storedUrl
+              content_url: 'https://archive.example.com/original-vine.mp4'
             }]])
           })
         })
@@ -2663,9 +1242,9 @@ describe('admin video proxy format fallback', () => {
       expect(response.status).toBe(200);
       expect(response.headers.get('Content-Type')).toBe('video/mp4');
       expect(response.headers.get('X-Admin-Proxy')).toBe('stored-content-url');
-      expect(fetchedUrls).toEqual([
+      expect(fetchCalls).toEqual([
         `https://media.divine.video/${SHA256}`,
-        storedUrl
+        'https://archive.example.com/original-vine.mp4'
       ]);
     } finally {
       globalThis.fetch = originalFetch;
@@ -2701,155 +1280,6 @@ describe('admin video proxy format fallback', () => {
       expect(response.status).toBe(200);
       expect(response.headers.get('Content-Type')).toBe('video/mp4');
       expect(response.headers.get('X-Admin-Proxy')).toBe('cdn-transcode');
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-});
-
-describe('admin video proxy range forwarding', () => {
-  it('forwards Range header to CDN and returns 206 with Content-Range', async () => {
-    const originalFetch = globalThis.fetch;
-    let receivedInit = null;
-    globalThis.fetch = async (url, init) => {
-      if (String(url) === `https://media.divine.video/${SHA256}`) {
-        receivedInit = init;
-        return new Response('partial-bytes', {
-          status: 206,
-          headers: {
-            'Content-Type': 'video/mp4',
-            'Content-Range': 'bytes 0-1023/5000000',
-            'Accept-Ranges': 'bytes',
-            'Content-Length': '1024'
-          }
-        });
-      }
-      throw new Error(`Unexpected fetch: ${url}`);
-    };
-
-    try {
-      const response = await worker.fetch(
-        new Request(`https://moderation.admin.divine.video/admin/video/${SHA256}.mp4`, {
-          headers: {
-            'Cf-Access-Authenticated-User-Email': 'mod@divine.video',
-            'Range': 'bytes=0-1023'
-          }
-        }),
-        createEnv()
-      );
-
-      expect(response.status).toBe(206);
-      expect(response.headers.get('Content-Range')).toBe('bytes 0-1023/5000000');
-      expect(response.headers.get('Accept-Ranges')).toBe('bytes');
-      expect(response.headers.get('Content-Length')).toBe('1024');
-      expect(response.headers.get('X-Admin-Proxy')).toBe('cdn');
-
-      const upstreamHeaders = new Headers(receivedInit?.headers || {});
-      expect(upstreamHeaders.get('Range')).toBe('bytes=0-1023');
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  it('forwards Range header to admin bypass branch and returns 206', async () => {
-    const originalFetch = globalThis.fetch;
-    let bypassInit = null;
-    globalThis.fetch = async (url, init) => {
-      if (String(url) === `https://media.divine.video/${SHA256}`) {
-        return new Response('nope', { status: 404 });
-      }
-      if (String(url) === `https://media.divine.video/admin/api/blob/${SHA256}/content`) {
-        bypassInit = init;
-        return new Response('partial-bytes', {
-          status: 206,
-          headers: {
-            'Content-Type': 'video/mp4',
-            'Content-Range': 'bytes 0-1023/5000000',
-            'Accept-Ranges': 'bytes',
-            'Content-Length': '1024'
-          }
-        });
-      }
-      throw new Error(`Unexpected fetch: ${url}`);
-    };
-
-    try {
-      const response = await worker.fetch(
-        new Request(`https://moderation.admin.divine.video/admin/video/${SHA256}.mp4`, {
-          headers: {
-            'Cf-Access-Authenticated-User-Email': 'mod@divine.video',
-            'Range': 'bytes=0-1023'
-          }
-        }),
-        createEnv({ BLOSSOM_WEBHOOK_SECRET: 'test-secret' })
-      );
-
-      expect(response.status).toBe(206);
-      expect(response.headers.get('Content-Range')).toBe('bytes 0-1023/5000000');
-      expect(response.headers.get('Accept-Ranges')).toBe('bytes');
-      expect(response.headers.get('Content-Length')).toBe('1024');
-      expect(response.headers.get('X-Admin-Proxy')).toBe('blossom-admin');
-
-      const upstreamHeaders = new Headers(bypassInit?.headers || {});
-      expect(upstreamHeaders.get('Range')).toBe('bytes=0-1023');
-      expect(upstreamHeaders.get('Authorization')).toBe('Bearer test-secret');
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  it('serves 200 from CDN when no Range header is present', async () => {
-    const originalFetch = globalThis.fetch;
-    let receivedInit = null;
-    globalThis.fetch = async (url, init) => {
-      if (String(url) === `https://media.divine.video/${SHA256}`) {
-        receivedInit = init;
-        return new Response('full-bytes', {
-          status: 200,
-          headers: { 'Content-Type': 'video/mp4' }
-        });
-      }
-      throw new Error(`Unexpected fetch: ${url}`);
-    };
-
-    try {
-      const response = await worker.fetch(
-        new Request(`https://moderation.admin.divine.video/admin/video/${SHA256}.mp4`, {
-          headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
-        }),
-        createEnv()
-      );
-
-      expect(response.status).toBe(200);
-      expect(response.headers.get('X-Admin-Proxy')).toBe('cdn');
-      const upstreamHeaders = new Headers(receivedInit?.headers || {});
-      expect(upstreamHeaders.get('Range')).toBeNull();
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  it('returns 404 when CDN and admin bypass both miss', async () => {
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = async (url) => {
-      if (String(url) === `https://media.divine.video/${SHA256}`) {
-        return new Response('nope', { status: 404 });
-      }
-      if (String(url) === `https://media.divine.video/admin/api/blob/${SHA256}/content`) {
-        return new Response('nope', { status: 404 });
-      }
-      throw new Error(`Unexpected fetch: ${url}`);
-    };
-
-    try {
-      const response = await worker.fetch(
-        new Request(`https://moderation.admin.divine.video/admin/video/${SHA256}.mp4`, {
-          headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
-        }),
-        createEnv({ BLOSSOM_WEBHOOK_SECRET: 'test-secret' })
-      );
-
-      expect(response.status).toBe(404);
     } finally {
       globalThis.fetch = originalFetch;
     }
@@ -3051,68 +1481,6 @@ describe('notifyBlossom integration via admin moderate endpoint', () => {
       expect(data.success).toBe(false);
       expect(data.blossom_notified).toBe(false);
       expect(data.action).toBe('AGE_RESTRICTED');
-    } finally {
-      globalThis.fetch = origFetch;
-    }
-  });
-
-  it('sets reviewed_by to source on /api/v1/moderate', async () => {
-    const kvStore = new Map();
-    let capturedSql = null;
-    let capturedBindings = null;
-    const env = {
-      ALLOW_DEV_ACCESS: 'true',
-      SERVICE_API_TOKEN: 'test-service-token',
-      BLOSSOM_WEBHOOK_URL: 'https://mock-blossom.test/admin/moderate',
-      BLOSSOM_WEBHOOK_SECRET: 'test-webhook-secret',
-      BLOSSOM_DB: {
-        prepare(sql) {
-          let bindings = [];
-          return {
-            bind(...args) { bindings = args; return this; },
-            async run() {
-              capturedSql = sql;
-              capturedBindings = bindings;
-              return { success: true };
-            },
-            async first() { return null; },
-            async all() { return { results: [] }; },
-          };
-        },
-        async batch() { return []; },
-      },
-      MODERATION_KV: {
-        store: kvStore,
-        async get(key) { return kvStore.get(key) ?? null; },
-        async put(key, value) { kvStore.set(key, value); },
-        async delete(key) { kvStore.delete(key); },
-        async list() { return { keys: [], list_complete: true, cursor: null }; }
-      },
-      MODERATION_QUEUE: { async send() {} },
-    };
-
-    const origFetch = globalThis.fetch;
-    globalThis.fetch = async (url) => {
-      if (url === 'https://mock-blossom.test/admin/moderate') {
-        return new Response(JSON.stringify({ success: true }), { status: 200 });
-      }
-      return origFetch(url);
-    };
-
-    try {
-      const response = await worker.fetch(
-        new Request('https://moderation-api.divine.video/api/v1/moderate', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer test-service-token' },
-          body: JSON.stringify({ sha256: 'abc123', action: 'PERMANENT_BAN', source: 'relay-manager' }),
-        }),
-        env
-      );
-
-      expect(response.status).toBe(200);
-      expect(capturedSql).toContain('reviewed_by');
-      // reviewed_by binding should be 'relay-manager' (same as source)
-      expect(capturedBindings).toContain('relay-manager');
     } finally {
       globalThis.fetch = origFetch;
     }

--- a/src/moderation/classic-vine-rollback.test.mjs
+++ b/src/moderation/classic-vine-rollback.test.mjs
@@ -4,13 +4,20 @@
 // ABOUTME: Tests for classic Vine enforcement rollback helpers
 // ABOUTME: Verifies rollback candidate matching and enforcement rewrite semantics
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import {
   buildClassicVineRollbackUpdate,
   executeClassicVineRollback,
   getClassicVineRollbackKvKeys,
-  isClassicVineRollbackCandidate
+  isClassicVineRollbackCandidate,
+  runClassicVineRollback
 } from './classic-vine-rollback.mjs';
+
+const OriginalWebSocket = globalThis.WebSocket;
+
+afterEach(() => {
+  globalThis.WebSocket = OriginalWebSocket;
+});
 
 describe('isClassicVineRollbackCandidate', () => {
   it('accepts explicit Vine platform metadata', () => {
@@ -117,5 +124,76 @@ describe('executeClassicVineRollback', () => {
     expect(writes).toHaveLength(0);
     expect(result.alreadySafe).toBe(true);
     expect(result.blossomNotified).toBe(true);
+  });
+});
+
+describe('runClassicVineRollback', () => {
+  it('previews legacy Vine events discovered by x tag when d is a Vine ID', async () => {
+    const sha256 = 'a'.repeat(64);
+    const event = {
+      id: 'b'.repeat(64),
+      kind: 34236,
+      content: '',
+      created_at: 1465948644,
+      tags: [
+        ['d', 'legacy-vine-id'],
+        ['x', sha256],
+        ['imeta', `url https://media.divine.video/${sha256}`, 'm video/mp4', `x ${sha256}`],
+        ['platform', 'vine'],
+        ['client', 'vine-archive-importer'],
+        ['r', 'https://vine.co/v/legacy-vine-id'],
+        ['published_at', '1465948644']
+      ]
+    };
+
+    class FakeWebSocket {
+      constructor() {
+        this.listeners = {};
+        queueMicrotask(() => this.emit('open'));
+      }
+
+      addEventListener(type, handler) {
+        if (!this.listeners[type]) {
+          this.listeners[type] = [];
+        }
+        this.listeners[type].push(handler);
+      }
+
+      send(message) {
+        const [, subscriptionId, filter] = JSON.parse(message);
+        queueMicrotask(() => {
+          if (filter['#x']?.includes(sha256)) {
+            this.emit('message', { data: JSON.stringify(['EVENT', subscriptionId, event]) });
+          }
+          this.emit('message', { data: JSON.stringify(['EOSE', subscriptionId]) });
+        });
+      }
+
+      close() {
+        queueMicrotask(() => this.emit('close'));
+      }
+
+      emit(type, event = {}) {
+        for (const handler of this.listeners[type] || []) {
+          handler(event);
+        }
+      }
+    }
+
+    globalThis.WebSocket = FakeWebSocket;
+
+    const result = await runClassicVineRollback({
+      mode: 'preview',
+      source: 'sha-list',
+      sha256s: [sha256]
+    }, {});
+
+    expect(result.candidates).toEqual([
+      {
+        sha256,
+        reason: 'confirmed-classic-vine',
+        would_restore: true
+      }
+    ]);
   });
 });

--- a/src/moderation/classifier.mjs
+++ b/src/moderation/classifier.mjs
@@ -33,7 +33,7 @@ const DEFAULT_TEXT_PROFANITY_MEDIUM = 0.5;
 const PERMANENT_BAN_CATEGORIES = ['self_harm', 'offensive', 'ai_generated', 'deepfake'];
 
 // Categories that warrant age restriction
-const AGE_RESTRICTED_CATEGORIES = ['nudity', 'violence', 'gore', 'weapon', 'recreational_drug', 'alcohol', 'tobacco', 'gambling', 'destruction'];
+const AGE_RESTRICTED_CATEGORIES = ['violence', 'gore', 'weapon', 'recreational_drug', 'alcohol', 'tobacco', 'gambling', 'destruction'];
 
 // Categories that are informational only (lower threshold for review)
 const INFORMATIONAL_CATEGORIES = ['medical', 'money', 'military', 'text_profanity', 'qr_unsafe'];
@@ -142,6 +142,8 @@ export function classifyModerationResult(moderationData, env = {}) {
   // Default values for all categories
   const defaultScores = {
     nudity: 0,
+    sexual: 0,
+    porn: 0,
     violence: 0,
     ai_generated: 0,
     gore: 0,
@@ -169,6 +171,14 @@ export function classifyModerationResult(moderationData, env = {}) {
   // Load thresholds from env or use defaults
   const thresholds = {
     nudity: {
+      high: parseFloat(env.NSFW_THRESHOLD_HIGH || DEFAULT_NSFW_HIGH),
+      medium: parseFloat(env.NSFW_THRESHOLD_MEDIUM || DEFAULT_NSFW_MEDIUM)
+    },
+    sexual: {
+      high: parseFloat(env.NSFW_THRESHOLD_HIGH || DEFAULT_NSFW_HIGH),
+      medium: parseFloat(env.NSFW_THRESHOLD_MEDIUM || DEFAULT_NSFW_MEDIUM)
+    },
+    porn: {
       high: parseFloat(env.NSFW_THRESHOLD_HIGH || DEFAULT_NSFW_HIGH),
       medium: parseFloat(env.NSFW_THRESHOLD_MEDIUM || DEFAULT_NSFW_MEDIUM)
     },
@@ -245,6 +255,12 @@ export function classifyModerationResult(moderationData, env = {}) {
     category = 'extreme_gore';
     reason = 'Extreme gore content detected - immediate removal required';
   }
+  else if (scores.porn >= (thresholds.porn?.high || DEFAULT_NSFW_HIGH)) {
+    action = 'PERMANENT_BAN';
+    severity = 'critical';
+    category = 'porn';
+    reason = `Porn content detected (score: ${scores.porn.toFixed(2)}) - immediate removal required`;
+  }
   else if (scores.ai_generated >= (thresholds.ai_generated?.high || DEFAULT_AI_GENERATED_HIGH)) {
     action = 'QUARANTINE';
     severity = 'high';
@@ -271,6 +287,12 @@ export function classifyModerationResult(moderationData, env = {}) {
     severity = 'critical';
     category = 'threats';
     reason = `Threatening content detected in transcript (score: ${text_scores.threats.toFixed(2)}) - immediate removal required`;
+  }
+  else if (scores.sexual >= (thresholds.sexual?.high || DEFAULT_NSFW_HIGH)) {
+    action = 'AGE_RESTRICTED';
+    severity = 'high';
+    category = 'sexual';
+    reason = `Sexual content detected (score: ${scores.sexual.toFixed(2)}) - requires age verification`;
   }
   // Check for AGE_RESTRICTED categories
   else if (AGE_RESTRICTED_CATEGORIES.some(cat => {
@@ -341,6 +363,8 @@ export function classifyModerationResult(moderationData, env = {}) {
 function getCategoryLabel(category) {
   const labels = {
     nudity: 'Adult',
+    sexual: 'Sexual',
+    porn: 'Porn',
     violence: 'Violent',
     ai_generated: 'AI-generated',
     gore: 'Gore',

--- a/src/moderation/classifier.test.mjs
+++ b/src/moderation/classifier.test.mjs
@@ -24,8 +24,8 @@ describe('Moderation Classifier', () => {
   it('should classify medium scores as REVIEW', () => {
     const result = classifyModerationResult({
       maxScores: {
-        nudity: 0.65,
-        violence: 0.3
+        nudity: 0.1,
+        violence: 0.65
       }
     });
 
@@ -37,8 +37,8 @@ describe('Moderation Classifier', () => {
   it('should classify scores above quarantine threshold as QUARANTINE', () => {
     const result = classifyModerationResult({
       maxScores: {
-        nudity: 0.75,
-        violence: 0.3
+        nudity: 0.1,
+        violence: 0.75
       }
     });
 
@@ -47,17 +47,47 @@ describe('Moderation Classifier', () => {
     expect(result.reason).toContain('quarantined');
   });
 
-  it('should classify high nudity as AGE_RESTRICTED', () => {
+  it('keeps benign nudity SAFE when no explicit sexual signal is present', () => {
     const result = classifyModerationResult({
       maxScores: {
-        nudity: 0.85,
-        violence: 0.1
+        nudity: 0.92,
+        sexual: 0,
+        porn: 0
+      }
+    });
+
+    expect(result.action).toBe('SAFE');
+    expect(result.category).toBeNull();
+  });
+
+  it('should classify high sexual content as AGE_RESTRICTED', () => {
+    const result = classifyModerationResult({
+      maxScores: {
+        nudity: 0.1,
+        sexual: 0.85,
+        porn: 0
       }
     });
 
     expect(result.action).toBe('AGE_RESTRICTED');
     expect(result.severity).toBe('high');
-    expect(result.reason).toContain('Adult');
+    expect(result.category).toBe('sexual');
+    expect(result.reason).toContain('Sexual');
+  });
+
+  it('should classify high porn content as PERMANENT_BAN', () => {
+    const result = classifyModerationResult({
+      maxScores: {
+        nudity: 0.1,
+        sexual: 0.1,
+        porn: 0.9
+      }
+    });
+
+    expect(result.action).toBe('PERMANENT_BAN');
+    expect(result.severity).toBe('critical');
+    expect(result.category).toBe('porn');
+    expect(result.reason).toContain('Porn');
   });
 
   it('should classify high violence as AGE_RESTRICTED', () => {
@@ -84,8 +114,8 @@ describe('Moderation Classifier', () => {
     // Score 0.85: above default quarantine (0.7) but below env high (0.9) → QUARANTINE
     const result = classifyModerationResult({
       maxScores: {
-        nudity: 0.85,
-        violence: 0.1
+        nudity: 0.1,
+        sexual: 0.85
       }
     }, env);
 
@@ -100,8 +130,8 @@ describe('Moderation Classifier', () => {
     // Score 0.75: above default medium (0.6) but below custom quarantine (0.8) → REVIEW
     const result = classifyModerationResult({
       maxScores: {
-        nudity: 0.75,
-        violence: 0.1
+        nudity: 0.1,
+        sexual: 0.75
       }
     }, env);
 
@@ -111,8 +141,8 @@ describe('Moderation Classifier', () => {
   it('should use default thresholds when env not provided', () => {
     const result = classifyModerationResult({
       maxScores: {
-        nudity: 0.85,
-        violence: 0.1
+        nudity: 0.1,
+        sexual: 0.85
       }
     });
 
@@ -123,17 +153,21 @@ describe('Moderation Classifier', () => {
     const result = classifyModerationResult({
       maxScores: {
         nudity: 0.65,
+        sexual: 0.45,
+        porn: 0.2,
         violence: 0.45,
         ai_generated: 0.2
       }
     });
 
     expect(result.scores.nudity).toBe(0.65);
+    expect(result.scores.sexual).toBe(0.45);
+    expect(result.scores.porn).toBe(0.2);
     expect(result.scores.violence).toBe(0.45);
     expect(result.scores.ai_generated).toBe(0.2);
     expect(result.scores.gore).toBe(0);
     expect(result.scores.weapon).toBe(0);
-    expect(Object.keys(result.scores).length).toBe(18);
+    expect(Object.keys(result.scores).length).toBe(20);
   });
 
   it('should identify primary concern', () => {

--- a/src/moderation/pipeline.mjs
+++ b/src/moderation/pipeline.mjs
@@ -10,7 +10,6 @@ import { classifyText, parseVttText } from './text-classifier.mjs';
 import { fetchNostrEventBySha256, parseVideoEventMetadata, isOriginalVine, hasStrongOriginalVineEvidence } from '../nostr/relay-client.mjs';
 import { classifyVideo } from '../classification/pipeline.mjs';
 import { extractTopics } from '../classification/topic-extractor.mjs';
-import { getRetryAfterSecondsFromResponse } from '../http-utils.mjs';
 
 const ORIGINAL_VINE_SUPPRESSED_CATEGORIES = new Set(['ai_generated', 'deepfake']);
 const DOWNSTREAM_SIGNAL_THRESHOLD = 0.5;
@@ -31,6 +30,20 @@ function parseOptionalInteger(value) {
   }
 
   return null;
+}
+
+function getRetryAfterSeconds(response) {
+  if (typeof response?.headers?.get !== 'function') {
+    return null;
+  }
+
+  const value = response.headers.get('Retry-After');
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    return null;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : null;
 }
 
 function buildQueueMetadataNostrContext(metadata) {
@@ -174,12 +187,7 @@ export async function classifyVideoOnly(sha256, env, options = {}) {
         const vttUrl = `https://media.divine.video/${sha256}.vtt`;
         const vttResponse = await fetchFn(vttUrl);
         if (vttResponse.status === 202) {
-          // Transcript is still generating. We treat this as a terminal skip
-          // for this classification run — the moderation result persists
-          // without transcript text/topic analysis. A reprocess once the
-          // transcript lands is tracked separately (see follow-up issue); we
-          // do not block the pipeline waiting for Blossom here.
-          const retryAfterSeconds = getRetryAfterSecondsFromResponse(vttResponse);
+          const retryAfterSeconds = getRetryAfterSeconds(vttResponse);
           console.log(`[CLASSIFY-ONLY] VTT transcript for ${sha256} is still pending${retryAfterSeconds !== null ? ` (retry after ${retryAfterSeconds}s)` : ''}`);
           return null;
         }
@@ -342,11 +350,7 @@ export async function moderateVideo(videoData, env, fetchFn = fetch) {
     console.log(`[MODERATION] Fetching VTT transcript: ${vttUrl}`);
     const vttResponse = await fetchFn(vttUrl);
     if (vttResponse.status === 202) {
-      // Transcript is still generating. We proceed with video-only moderation
-      // and persist the result without transcript text/topic analysis.
-      // Reprocessing once the transcript lands is tracked separately (see
-      // follow-up issue); blocking the pipeline on Blossom is not acceptable.
-      const retryAfterSeconds = getRetryAfterSecondsFromResponse(vttResponse);
+      const retryAfterSeconds = getRetryAfterSeconds(vttResponse);
       console.log(`[MODERATION] VTT transcript for ${sha256} is still pending${retryAfterSeconds !== null ? ` (retry after ${retryAfterSeconds}s)` : ''} - skipping text analysis`);
     } else if (vttResponse.status === 404) {
       console.log(`[MODERATION] No VTT transcript found for ${sha256} (404) - skipping text analysis`);

--- a/src/moderation/pipeline.test.mjs
+++ b/src/moderation/pipeline.test.mjs
@@ -440,7 +440,7 @@ describe('Moderation Pipeline', () => {
   });
 
   it('keeps imported original vines SAFE while retaining raw AI scores', async () => {
-    const sha256 = 'i'.repeat(64);
+    const sha256 = 'c'.repeat(64);
     globalThis.WebSocket = createNostrLookupWebSocket({
       id: 'evt-original-vine',
       content: 'classic archive vine',
@@ -556,7 +556,7 @@ describe('Moderation Pipeline', () => {
   });
 
   it('keeps downstream moderation signals for original vines when non-AI scores are high', async () => {
-    const sha256 = 'j'.repeat(64);
+    const sha256 = 'd'.repeat(64);
     globalThis.WebSocket = createNostrLookupWebSocket({
       id: 'evt-original-vine-signals',
       content: 'classic archive vine',

--- a/src/moderation/pipeline.test.mjs
+++ b/src/moderation/pipeline.test.mjs
@@ -168,7 +168,7 @@ describe('Moderation Pipeline', () => {
     expect(result.topicProfile).toBeNull();
   });
 
-  it('retains downstream signals for Hive nudity classifications', async () => {
+  it('keeps benign Hive nudity SAFE while retaining downstream nudity signals', async () => {
     const mockFetch = vi.fn(async (url) => {
       if (typeof url === 'string' && url.endsWith('.vtt')) {
         return {
@@ -215,18 +215,16 @@ describe('Moderation Pipeline', () => {
     }, env, mockFetch);
 
     expect(result.provider).toBe('hiveai');
-    expect(result.action).toBe('AGE_RESTRICTED');
-    expect(result.category).toBe('nudity');
+    expect(result.action).toBe('SAFE');
     expect(result.scores.nudity).toBe(0.91);
+    expect(result.scores.sexual).toBe(0);
+    expect(result.scores.porn).toBe(0);
     expect(result.downstreamSignals?.hasSignals).toBe(true);
     expect(result.downstreamSignals?.scores?.nudity).toBe(0.91);
     expect(result.downstreamSignals?.primaryConcern).toBe('nudity');
-    expect(result.rawClassifierData?.allClassMaxScores?.yes_male_nudity).toBe(0.91);
-    expect(result.rawClassifierData?.allClassMaxScores?.yes_male_swimwear).toBe(0.88);
-    expect(result.rawClassifierData?.allClassMaxScores?.yes_male_underwear).toBe(0.83);
   });
 
-  it('maps Hive sexual display into the current nudity category', async () => {
+  it('should detect Hive sexual content and return AGE_RESTRICTED', async () => {
     const mockFetch = vi.fn(async (url) => {
       if (typeof url === 'string' && url.endsWith('.vtt')) {
         return {
@@ -273,10 +271,9 @@ describe('Moderation Pipeline', () => {
 
     expect(result.provider).toBe('hiveai');
     expect(result.action).toBe('AGE_RESTRICTED');
-    expect(result.category).toBe('nudity');
-    expect(result.scores.nudity).toBe(0.9);
-    expect(result.rawClassifierData?.allClassMaxScores?.yes_sexual_display).toBe(0.9);
-    expect(result.rawClassifierData?.allClassMaxScores?.yes_sex_toy).toBe(0.82);
+    expect(result.category).toBe('sexual');
+    expect(result.scores.sexual).toBe(0.9);
+    expect(result.scores.porn).toBe(0);
   });
 
   it('should detect borderline violence and return REVIEW', async () => {

--- a/src/moderation/providers/hiveai/normalizer.mjs
+++ b/src/moderation/providers/hiveai/normalizer.mjs
@@ -12,20 +12,20 @@ const MODERATION_CLASS_MAP = {
   // Nudity/Sexual
   'general_nsfw': 'nudity',
   'general_suggestive': 'nudity',
-  'yes_sexual_activity': 'nudity',
-  'yes_sexual_display': 'nudity',
   'yes_female_nudity': 'nudity',
   'yes_male_nudity': 'nudity',
   'yes_sheer_see-through': 'nudity',
-  'yes_sex_toy': 'nudity',
   'yes_male_underwear': 'nudity',
   'yes_female_underwear': 'nudity',
   'yes_female_swimwear': 'nudity',
   'yes_male_swimwear': 'nudity',
-  'animated_explicit_sexual_content': 'nudity',
   'animated_female_nudity': 'nudity',
   'animated_male_nudity': 'nudity',
   'animated_suggestive': 'nudity',
+  'yes_sexual_display': 'sexual',
+  'yes_sex_toy': 'sexual',
+  'yes_sexual_activity': 'porn',
+  'animated_explicit_sexual_content': 'porn',
 
   // Violence
   'yes_violence': 'violence',
@@ -112,6 +112,8 @@ function extractRawClassifierData(output, source) {
 function normalizeModerationResponse(moderationResult) {
   const scores = {
     nudity: 0,
+    sexual: 0,
+    porn: 0,
     violence: 0,
     gore: 0,
     offensive: 0,
@@ -171,7 +173,9 @@ function normalizeModerationResponse(moderationResult) {
     }
   }
 
-  console.log(`[HiveAI] Moderation scores - nudity: ${scores.nudity.toFixed(3)}, violence: ${scores.violence.toFixed(3)}, weapons: ${scores.weapons.toFixed(3)}`);
+  console.log(
+    `[HiveAI] Moderation scores - nudity: ${scores.nudity.toFixed(3)}, sexual: ${scores.sexual.toFixed(3)}, porn: ${scores.porn.toFixed(3)}, violence: ${scores.violence.toFixed(3)}, weapons: ${scores.weapons.toFixed(3)}`
+  );
 
   return { scores, details, flaggedFrames };
 }
@@ -307,6 +311,8 @@ export function normalizeHiveAIResponse(hiveResult) {
   // Initialize with all categories at 0
   const scores = {
     nudity: 0,
+    sexual: 0,
+    porn: 0,
     violence: 0,
     gore: 0,
     offensive: 0,

--- a/src/moderation/providers/hiveai/normalizer.test.mjs
+++ b/src/moderation/providers/hiveai/normalizer.test.mjs
@@ -121,6 +121,86 @@ describe('Hive.AI Response Normalizer', () => {
       expect(result.scores.nudity).toBe(0.92);
     });
 
+    it('treats male-coded swimwear and shirtless classes as label-only nudity', () => {
+      const hiveResponse = {
+        moderation: {
+          status: [{
+            response: {
+              output: [
+                {
+                  time: 0,
+                  classes: [
+                    { class: 'yes_male_nudity', score: 0.91 },
+                    { class: 'yes_male_swimwear', score: 0.88 },
+                    { class: 'yes_male_underwear', score: 0.83 }
+                  ]
+                }
+              ]
+            }
+          }]
+        },
+        aiDetection: null
+      };
+
+      const result = normalizeHiveAIResponse(hiveResponse);
+
+      expect(result.scores.nudity).toBe(0.91);
+      expect(result.scores.sexual).toBe(0);
+      expect(result.scores.porn).toBe(0);
+    });
+
+    it('maps sex-toy and sexual-display classes to warning-grade sexual content', () => {
+      const hiveResponse = {
+        moderation: {
+          status: [{
+            response: {
+              output: [
+                {
+                  time: 0,
+                  classes: [
+                    { class: 'yes_sexual_display', score: 0.9 },
+                    { class: 'yes_sex_toy', score: 0.82 }
+                  ]
+                }
+              ]
+            }
+          }]
+        },
+        aiDetection: null
+      };
+
+      const result = normalizeHiveAIResponse(hiveResponse);
+
+      expect(result.scores.sexual).toBe(0.9);
+      expect(result.scores.porn).toBe(0);
+    });
+
+    it('maps explicit sexual activity classes to ban-grade porn content', () => {
+      const hiveResponse = {
+        moderation: {
+          status: [{
+            response: {
+              output: [
+                {
+                  time: 0,
+                  classes: [
+                    { class: 'yes_sexual_activity', score: 0.94 },
+                    { class: 'animated_explicit_sexual_content', score: 0.97 }
+                  ]
+                }
+              ]
+            }
+          }]
+        },
+        aiDetection: null
+      };
+
+      const result = normalizeHiveAIResponse(hiveResponse);
+
+      expect(result.scores.sexual).toBe(0);
+      expect(result.scores.porn).toBe(0.97);
+    });
+
     it('should normalize violence and gore detection', () => {
       const hiveResponse = {
         moderation: {

--- a/src/moderation/providers/sightengine/adapter.mjs
+++ b/src/moderation/providers/sightengine/adapter.mjs
@@ -56,6 +56,8 @@ export class SightengineProvider extends BaseModerationProvider {
       const normalized = {
         scores: {
           nudity: rawResult.maxScores?.nudity || 0,
+          sexual: rawResult.maxScores?.sexual || 0,
+          porn: rawResult.maxScores?.porn || 0,
           violence: rawResult.maxScores?.violence || 0,
           gore: rawResult.maxScores?.gore || 0,
           offensive: rawResult.maxScores?.offensive || 0,

--- a/src/moderation/sightengine.mjs
+++ b/src/moderation/sightengine.mjs
@@ -73,6 +73,8 @@ function analyzeFrames(frames) {
   // Initialize max scores for all categories
   const maxScores = {
     nudity: 0,
+    sexual: 0,
+    porn: 0,
     violence: 0,
     ai_generated: 0,
     deepfake: 0,
@@ -123,25 +125,27 @@ function analyzeFrames(frames) {
 
     // NUDITY-2.1: Detailed adult content classification
     // Support both old format (raw/partial) and new format (detailed categories)
-    const nudityIntensity = Math.max(
+    const broadNudity = Math.max(
       frame.nudity?.raw || 0,  // Legacy support
       frame.nudity?.partial || 0,  // Legacy support
-      frame.nudity?.sexual_activity || 0,
-      frame.nudity?.sexual_display || 0,
-      frame.nudity?.erotica || 0,
-      frame.nudity?.very_suggestive || 0,
       frame.nudity?.suggestive || 0,
       frame.nudity?.mildly_suggestive || 0
     );
     const nuditySuggestive = Math.max(
       frame.nudity?.visibly_undressed || 0,
-      frame.nudity?.sextoy || 0,
-      frame.nudity?.suggestive_focus || 0,
-      frame.nudity?.suggestive_pose || 0,
       frame.nudity?.lingerie || 0,
       frame.nudity?.male_underwear || 0
     );
-    frameScores.nudity = Math.max(nudityIntensity, nuditySuggestive);
+    frameScores.nudity = Math.max(broadNudity, nuditySuggestive);
+    frameScores.sexual = Math.max(
+      frame.nudity?.sexual_display || 0,
+      frame.nudity?.erotica || 0,
+      frame.nudity?.very_suggestive || 0,
+      frame.nudity?.sextoy || 0,
+      frame.nudity?.suggestive_focus || 0,
+      frame.nudity?.suggestive_pose || 0
+    );
+    frameScores.porn = frame.nudity?.sexual_activity || 0;
     frameDetails.nudity = {
       sexual_activity: frame.nudity?.sexual_activity || 0,
       sexual_display: frame.nudity?.sexual_display || 0,
@@ -150,6 +154,8 @@ function analyzeFrames(frames) {
       suggestive: frame.nudity?.suggestive || 0,
       visibly_undressed: frame.nudity?.visibly_undressed || 0,
       sextoy: frame.nudity?.sextoy || 0,
+      suggestive_focus: frame.nudity?.suggestive_focus || 0,
+      suggestive_pose: frame.nudity?.suggestive_pose || 0,
       lingerie: frame.nudity?.lingerie || 0,
       male_underwear: frame.nudity?.male_underwear || 0
     };

--- a/src/moderation/sightengine.test.mjs
+++ b/src/moderation/sightengine.test.mjs
@@ -252,6 +252,8 @@ describe('Sightengine Integration', () => {
 
     // Verify all category scores are extracted
     expect(result.maxScores.nudity).toBe(0.1);
+    expect(result.maxScores.sexual).toBe(0);
+    expect(result.maxScores.porn).toBe(0.05);
     expect(result.maxScores.violence).toBe(0.2);
     expect(result.maxScores.gore).toBe(0.3);
     expect(result.maxScores.offensive).toBe(0.4);
@@ -267,6 +269,44 @@ describe('Sightengine Integration', () => {
     expect(result.maxScores.money).toBe(0.05);
     expect(result.maxScores.destruction).toBe(0.25);
     expect(result.maxScores.military).toBe(0.1);
+  });
+
+  it('should separate broad nudity from explicit sexual and porn signals', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        status: 'success',
+        data: {
+          frames: [
+            {
+              info: { position: 0 },
+              nudity: {
+                male_underwear: 0.6,
+                sexual_display: 0.81,
+                sextoy: 0.7,
+                sexual_activity: 0.93
+              }
+            }
+          ]
+        }
+      })
+    });
+
+    const env = {
+      SIGHTENGINE_API_USER: 'test-user',
+      SIGHTENGINE_API_SECRET: 'test-secret'
+    };
+
+    const result = await moderateVideoWithSightengine(
+      'https://cdn.divine.video/test.mp4',
+      {},
+      env,
+      mockFetch
+    );
+
+    expect(result.maxScores.nudity).toBe(0.6);
+    expect(result.maxScores.sexual).toBe(0.81);
+    expect(result.maxScores.porn).toBe(0.93);
   });
 
   it('should extract detailed subcategories for nudity', async () => {

--- a/src/moderation/vocabulary.mjs
+++ b/src/moderation/vocabulary.mjs
@@ -55,6 +55,8 @@ export function isCanonicalLabel(label) {
 export function classifierCategoryToLabels(category, scores) {
   const map = {
     nudity: ['nudity'],
+    sexual: ['sexual'],
+    porn: ['porn'],
     violence: ['violence'],
     gore: ['graphic-media'],
     offensive: ['hate'],

--- a/src/moderation/vocabulary.test.mjs
+++ b/src/moderation/vocabulary.test.mjs
@@ -110,6 +110,14 @@ describe('classifierCategoryToLabels', () => {
     expect(classifierCategoryToLabels('nudity')).toEqual(['nudity']);
   });
 
+  it('should map sexual to sexual', () => {
+    expect(classifierCategoryToLabels('sexual')).toEqual(['sexual']);
+  });
+
+  it('should map porn to porn', () => {
+    expect(classifierCategoryToLabels('porn')).toEqual(['porn']);
+  });
+
   it('should map gore to graphic-media', () => {
     expect(classifierCategoryToLabels('gore')).toEqual(['graphic-media']);
   });

--- a/src/nostr/relay-client.mjs
+++ b/src/nostr/relay-client.mjs
@@ -4,6 +4,8 @@
 // ABOUTME: Nostr relay WebSocket client for fetching event context
 // ABOUTME: Connects to relay.divine.video to get kind 34236 video events by SHA256
 
+import { extractMediaShaFromEvent } from '../validation.mjs';
+
 async function queryRelay(relayUrl, filter, env = {}, options = {}) {
   return new Promise((resolve, reject) => {
     let ws;
@@ -102,7 +104,8 @@ async function queryRelay(relayUrl, filter, env = {}, options = {}) {
 
 /**
  * Fetch Nostr event for a video SHA256 from relay.
- * The d-tag in kind 34236 video events contains the SHA256 hash directly.
+ * Legacy Vine imports use d=vine_id and expose the media hash via x/imeta x,
+ * while newer content may still use d=sha256.
  *
  * @param {string} sha256 - Video hash
  * @param {string[]} relays - Relay URLs to query
@@ -110,15 +113,30 @@ async function queryRelay(relayUrl, filter, env = {}, options = {}) {
  * @returns {Promise<Object|null>} Nostr event or null if not found
  */
 export async function fetchNostrEventBySha256(sha256, relays = ['wss://relay.divine.video'], env = {}) {
+  const normalizedSha256 = typeof sha256 === 'string' ? sha256.toLowerCase() : sha256;
+
   for (const relay of relays) {
     try {
-      const event = await queryRelay(relay, {
-        kinds: [34236],
-        '#d': [sha256],
-        limit: 1
-      }, env);
-      if (event) {
-        return event;
+      const xTagMatches = await queryRelay(relay, {
+        kinds: [34235, 34236],
+        '#x': [normalizedSha256],
+        limit: 10
+      }, env, { collectAll: true });
+
+      const xTagEvent = xTagMatches.find((event) => extractMediaShaFromEvent(event) === normalizedSha256);
+      if (xTagEvent) {
+        return xTagEvent;
+      }
+
+      const dTagMatches = await queryRelay(relay, {
+        kinds: [34235, 34236],
+        '#d': [normalizedSha256],
+        limit: 10
+      }, env, { collectAll: true });
+
+      const dTagEvent = dTagMatches.find((event) => extractMediaShaFromEvent(event) === normalizedSha256);
+      if (dTagEvent) {
+        return dTagEvent;
       }
     } catch (error) {
       console.error(`[NOSTR] Failed to fetch from ${relay}:`, error);
@@ -157,30 +175,6 @@ export async function fetchNostrVideoEventsByDTag(dTag, relays = ['wss://relay.d
 
   return [];
 }
-
-/**
- * Extract SHA256 from imeta tag parameters
- * imeta format: ["imeta", "url ...", "m video/mp4", "x <sha256>", "image ..."]
- */
-function extractSha256FromImeta(event) {
-  if (!event || !event.tags) return null;
-
-  for (const tag of event.tags) {
-    if (tag[0] === 'imeta') {
-      // Parse space-separated parameters in imeta tag
-      for (let i = 1; i < tag.length; i++) {
-        const param = tag[i];
-        // Look for "x <sha256>" parameter
-        if (param && param.startsWith('x ')) {
-          return param.substring(2).trim();
-        }
-      }
-    }
-  }
-
-  return null;
-}
-
 /**
  * Extract metadata from kind 34236 event tags
  */

--- a/src/nostr/relay-client.test.mjs
+++ b/src/nostr/relay-client.test.mjs
@@ -2,7 +2,13 @@
 // If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import { afterEach, describe, it, expect } from 'vitest';
-import { fetchNostrVideoEventsByDTag, parseVideoEventMetadata, isOriginalVine, hasStrongOriginalVineEvidence } from './relay-client.mjs';
+import {
+  fetchNostrEventBySha256,
+  fetchNostrVideoEventsByDTag,
+  parseVideoEventMetadata,
+  isOriginalVine,
+  hasStrongOriginalVineEvidence
+} from './relay-client.mjs';
 
 const OriginalWebSocket = globalThis.WebSocket;
 
@@ -277,5 +283,58 @@ describe('fetchNostrVideoEventsByDTag', () => {
 
     const events = await fetchNostrVideoEventsByDTag(sha256);
     expect(events).toEqual([versionA, versionB]);
+  });
+});
+
+describe('fetchNostrEventBySha256', () => {
+  it('finds legacy Vine events by x tag when d is the Vine ID', async () => {
+    const sha256 = 'a'.repeat(64);
+    const event = {
+      id: 'b'.repeat(64),
+      kind: 34236,
+      tags: [
+        ['d', 'legacy-vine-id'],
+        ['x', sha256],
+        ['imeta', `url https://media.divine.video/${sha256}`, 'm video/mp4', `x ${sha256}`]
+      ]
+    };
+
+    class FakeWebSocket {
+      constructor() {
+        this.listeners = {};
+        queueMicrotask(() => this.emit('open'));
+      }
+
+      addEventListener(type, handler) {
+        if (!this.listeners[type]) {
+          this.listeners[type] = [];
+        }
+        this.listeners[type].push(handler);
+      }
+
+      send(message) {
+        const [, subscriptionId, filter] = JSON.parse(message);
+        queueMicrotask(() => {
+          if (filter['#x']?.includes(sha256)) {
+            this.emit('message', { data: JSON.stringify(['EVENT', subscriptionId, event]) });
+          }
+          this.emit('message', { data: JSON.stringify(['EOSE', subscriptionId]) });
+        });
+      }
+
+      close() {
+        queueMicrotask(() => this.emit('close'));
+      }
+
+      emit(type, event = {}) {
+        for (const handler of this.listeners[type] || []) {
+          handler(event);
+        }
+      }
+    }
+
+    globalThis.WebSocket = FakeWebSocket;
+
+    await expect(fetchNostrEventBySha256(sha256)).resolves.toEqual(event);
   });
 });

--- a/src/nostr/relay-client.test.mjs
+++ b/src/nostr/relay-client.test.mjs
@@ -287,6 +287,56 @@ describe('fetchNostrVideoEventsByDTag', () => {
 });
 
 describe('fetchNostrEventBySha256', () => {
+  it('falls back to d tag when the media sha is stored directly there', async () => {
+    const sha256 = 'c'.repeat(64);
+    const event = {
+      id: 'd'.repeat(64),
+      kind: 34236,
+      tags: [
+        ['d', sha256],
+        ['platform', 'vine']
+      ]
+    };
+
+    class FakeWebSocket {
+      constructor() {
+        this.listeners = {};
+        queueMicrotask(() => this.emit('open'));
+      }
+
+      addEventListener(type, handler) {
+        if (!this.listeners[type]) {
+          this.listeners[type] = [];
+        }
+        this.listeners[type].push(handler);
+      }
+
+      send(message) {
+        const [, subscriptionId, filter] = JSON.parse(message);
+        queueMicrotask(() => {
+          if (filter['#d']?.includes(sha256)) {
+            this.emit('message', { data: JSON.stringify(['EVENT', subscriptionId, event]) });
+          }
+          this.emit('message', { data: JSON.stringify(['EOSE', subscriptionId]) });
+        });
+      }
+
+      close() {
+        queueMicrotask(() => this.emit('close'));
+      }
+
+      emit(type, event = {}) {
+        for (const handler of this.listeners[type] || []) {
+          handler(event);
+        }
+      }
+    }
+
+    globalThis.WebSocket = FakeWebSocket;
+
+    await expect(fetchNostrEventBySha256(sha256)).resolves.toEqual(event);
+  });
+
   it('finds legacy Vine events by x tag when d is the Vine ID', async () => {
     const sha256 = 'a'.repeat(64);
     const event = {

--- a/src/validation.mjs
+++ b/src/validation.mjs
@@ -78,6 +78,7 @@ export function extractMediaShaFromEvent(event) {
   const imeta = parseImetaParams(tags);
   return extractShaFromUrl(imeta.x)
     || extractShaFromUrl(getEventTagValue(tags, 'x'))
+    || extractShaFromUrl(getEventTagValue(tags, 'd'))
     || extractShaFromUrl(imeta.url)
     || extractShaFromUrl(getEventTagValue(tags, 'url'))
     || null;


### PR DESCRIPTION
## Summary
- improve admin video lookup, list enrichment, and Nostr context fallback behavior around relay-backed metadata
- add moderation tooling and tests for legacy vine handling, classifier/provider updates, and evaluation/export scripts
- include the supporting design/plan docs and relay guide snapshot used for the admin metadata work

## Test Plan
- [x] npx vitest run src/index.test.mjs -t "Admin video lookup|Admin nostr context lookup" --exclude='.worktrees/**' --exclude='.claude/**'
