### PR TITLE
feat: C2PA/ProofMode moderation enforcement via divine-inquisitor

### DIFF
--- a/docs/superpowers/specs/2026-04-14-provenance-and-creator-context-design.md
+++ b/docs/superpowers/specs/2026-04-14-provenance-and-creator-context-design.md
@@ -93,9 +93,11 @@ Guardrails:
 
 ### ProofMode / C2PA Verification
 
-Verification is performed by `divine-inquisitor` (Rust microservice at `github.com/divinevideo/divine-inquisitor`), **not** by `proofsign.divine.video` (which is the signing side only, no verify endpoint). Divine-moderation-service calls inquisitor with the media URL and normalizes the response into `provenance.proofmode`.
+Verification is performed by `divine-inquisitor` (Rust microservice at `github.com/divinevideo/divine-inquisitor`), **not** by `proofsign.divine.video` (which is the signing side only, no verify endpoint). Divine-moderation-service calls inquisitor with the media URL and normalizes the response into `video.c2pa` on every admin payload.
 
-`provenance.proofmode` shape (replaces the earlier null placeholder):
+Naming note: the C2PA verification result is exposed as a top-level `video.c2pa` field, NOT as `video.provenance.proofmode`. The name `provenance.proofmode` is already taken by Nostr-tag ProofMode data (a different, pre-existing evidence channel from the Nostr event's `["proofmode", ...]` tag). The two can coexist and reinforce each other — `video.provenance.proofmode` for the self-reported Nostr tag, `video.c2pa` for the cryptographically verified manifest inside the media bytes.
+
+`video.c2pa` shape:
 
 ```json
 {
@@ -137,10 +139,10 @@ Response fields consumed: `has_c2pa`, `valid`, `validation_state`, `is_proofmode
 Two targeted, automatic moderation-action rules are driven by provenance. Both are independent of each other and of Hive/RD.
 
 **Rule 1 — ProofMode downgrade:**
-If Hive AI or Reality Defender flag a video as AI-generated AND `provenance.proofmode.state === "valid_proofmode"`, the moderation action downgrades from QUARANTINE to REVIEW. The video stays visible to users while it sits in the moderator review queue.
+If Hive AI or Reality Defender flag a video as AI-generated AND `video.c2pa.state === "valid_proofmode"`, the moderation action downgrades from QUARANTINE to REVIEW. The video stays visible to users while it sits in the moderator review queue.
 
 **Rule 2 — Signed-AI short-circuit:**
-If `provenance.proofmode.state === "valid_ai_signed"` (valid C2PA signature whose `claim_generator` is a known AI-generation tool — Adobe Firefly, DALL·E, Midjourney, Stable Diffusion, Sora, Runway, Ideogram, etc.), the moderation action is forced to QUARANTINE and **Hive is not called at all**. Reality Defender is also skipped. The tool's own cryptographic declaration is authoritative AI evidence, so paying for Hive or polling RD adds cost and latency with no new information. The pipeline call order is therefore: inquisitor first, then short-circuit to QUARANTINE on `valid_ai_signed`, otherwise continue into the existing Hive/RD flow. Humans review every signed-AI QUARANTINE for labeling or approval.
+If `video.c2pa.state === "valid_ai_signed"` (valid C2PA signature whose `claim_generator` is a known AI-generation tool — Adobe Firefly, DALL·E, Midjourney, Stable Diffusion, Sora, Runway, Ideogram, etc.), the moderation action is forced to QUARANTINE and **Hive is not called at all**. Reality Defender is also skipped. The tool's own cryptographic declaration is authoritative AI evidence, so paying for Hive or polling RD adds cost and latency with no new information. The pipeline call order is therefore: inquisitor first, then short-circuit to QUARANTINE on `valid_ai_signed`, otherwise continue into the existing Hive/RD flow. Humans review every signed-AI QUARANTINE for labeling or approval.
 
 This loses Hive's non-AI category scores (nudity, violence, self-harm) on signed-AI content. That's an acceptable trade because moderators review every QUARANTINE manually, the volume of signed-AI content should be small, and an opt-in Hive call can be added at review time if a moderator wants those scores.
 
@@ -262,7 +264,7 @@ When building admin payloads, preserve:
 - `createdAt` / `event.created_at`
 - Vine metadata fields
 - source URL
-- C2PA / ProofMode verification result fetched from divine-inquisitor and normalized into `provenance.proofmode`
+- C2PA / ProofMode verification result fetched from divine-inquisitor and normalized into `video.c2pa`
 
 Existing D1 persistence of `published_at` remains useful, but the admin response builders must stop dropping it.
 

--- a/src/admin/dashboard-ui.test.mjs
+++ b/src/admin/dashboard-ui.test.mjs
@@ -11,4 +11,14 @@ describe('dashboard provenance UI hooks', () => {
     expect(dashboardHTML).toContain('renderProvenanceBadge');
     expect(dashboardHTML).toContain('creator-info-modal');
   });
+
+  it('contains C2PA/ProofMode badge rendering', () => {
+    expect(dashboardHTML).toContain('renderC2paBadge');
+    expect(dashboardHTML).toContain('formatC2paSupportLine');
+    expect(dashboardHTML).toContain('Valid ProofMode');
+    expect(dashboardHTML).toContain('Valid C2PA');
+    expect(dashboardHTML).toContain('Valid but AI-signed');
+    expect(dashboardHTML).toContain('Invalid Proof');
+    expect(dashboardHTML).toContain('c2pa-badge');
+  });
 });

--- a/src/admin/dashboard.html
+++ b/src/admin/dashboard.html
@@ -2668,6 +2668,42 @@
       return `<div class="provenance-badge" style="display:inline-flex;align-items:center;gap:6px;background:${palette.bg};border:1px solid ${palette.border};color:${palette.text};padding:4px 8px;border-radius:999px;font-size:11px;font-weight:700;letter-spacing:0.02em;text-transform:uppercase;">${escapeHtml(provenance.label || 'Unknown Provenance')}</div>`;
     }
 
+    function renderC2paBadge(c2pa) {
+      if (!c2pa || !c2pa.state || c2pa.state === 'absent' || c2pa.state === 'unchecked') {
+        return '';
+      }
+
+      const configByState = {
+        valid_proofmode: { label: 'Valid ProofMode', bg: '#064e3b', border: '#10b981', text: '#ecfdf5' },
+        valid_c2pa: { label: 'Valid C2PA', bg: '#1e3a8a', border: '#3b82f6', text: '#eff6ff' },
+        valid_ai_signed: { label: 'Valid but AI-signed', bg: '#7c2d12', border: '#f97316', text: '#fff7ed' },
+        invalid: { label: 'Invalid Proof', bg: '#374151', border: '#6b7280', text: '#f3f4f6' }
+      };
+
+      const conf = configByState[c2pa.state];
+      if (!conf) return '';
+
+      const title = c2pa.claimGenerator ? `claim_generator: ${c2pa.claimGenerator}` : c2pa.state;
+      return `<div class="c2pa-badge" data-state="${escapeHtml(c2pa.state)}" title="${escapeHtml(title)}" style="display:inline-flex;align-items:center;gap:6px;background:${conf.bg};border:1px solid ${conf.border};color:${conf.text};padding:4px 8px;border-radius:999px;font-size:11px;font-weight:700;letter-spacing:0.02em;text-transform:uppercase;margin-left:6px;">${escapeHtml(conf.label)}</div>`;
+    }
+
+    function formatC2paSupportLine(c2pa) {
+      if (!c2pa || c2pa.state === 'absent' || c2pa.state === 'unchecked') return '';
+      if (c2pa.state === 'valid_proofmode' && c2pa.captureDevice && c2pa.captureTime) {
+        return `ProofMode captured ${c2pa.captureTime} on ${c2pa.captureDevice}`;
+      }
+      if (c2pa.state === 'valid_ai_signed' && c2pa.claimGenerator) {
+        return `AI-signed by ${c2pa.claimGenerator}`;
+      }
+      if (c2pa.state === 'valid_c2pa' && c2pa.claimGenerator) {
+        return `C2PA signed by ${c2pa.claimGenerator}`;
+      }
+      if (c2pa.state === 'invalid') {
+        return 'C2PA manifest present but signature invalid (often transcoding or clock skew)';
+      }
+      return '';
+    }
+
     function formatProvenanceSupportLine(provenance) {
       if (!provenance || !provenance.date || provenance.dateSource === 'none') {
         return 'Unknown provenance';
@@ -2688,11 +2724,14 @@
       return `${dateLabel} via ${sourceLabel}`;
     }
 
-    function renderProvenanceSummary(provenance) {
+    function renderProvenanceSummary(provenance, c2pa) {
+      const c2paBadge = renderC2paBadge(c2pa);
+      const c2paLine = formatC2paSupportLine(c2pa);
       return `
         <div class="provenance-summary" style="margin-bottom: 10px;">
-          ${renderProvenanceBadge(provenance)}
+          ${renderProvenanceBadge(provenance)}${c2paBadge}
           <div style="font-size: 12px; color: #9ca3af; margin-top: 6px;">${escapeHtml(formatProvenanceSupportLine(provenance))}</div>
+          ${c2paLine ? `<div style="font-size: 12px; color: #9ca3af; margin-top: 4px;">${escapeHtml(c2paLine)}</div>` : ''}
         </div>
       `;
     }
@@ -2724,6 +2763,7 @@
 
     function renderCreatorInfoModal(video) {
       const provenance = video.provenance || null;
+      const c2pa = video.c2pa || null;
       const creator = video.creatorContext || null;
       const stats = creator?.stats || null;
       const social = creator?.social || null;
@@ -2732,9 +2772,11 @@
       return `
         <div style="display:flex;flex-direction:column;gap:14px;">
           <div>
-            ${renderProvenanceBadge(provenance)}
+            ${renderProvenanceBadge(provenance)}${renderC2paBadge(c2pa)}
             <div style="font-size:13px;color:#cbd5e1;margin-top:8px;">${escapeHtml(formatProvenanceSupportLine(provenance))}</div>
+            ${formatC2paSupportLine(c2pa) ? `<div style="font-size:12px;color:#94a3b8;margin-top:4px;">${escapeHtml(formatC2paSupportLine(c2pa))}</div>` : ''}
             ${Array.isArray(provenance?.reasons) && provenance.reasons.length > 0 ? `<div style="font-size:12px;color:#94a3b8;margin-top:6px;">Evidence: ${escapeHtml(provenance.reasons.join(' · '))}</div>` : ''}
+            ${c2pa?.signer ? `<div style="font-size:11px;color:#64748b;margin-top:4px;">Signer: ${escapeHtml(c2pa.signer)}</div>` : ''}
           </div>
           <div>
             <div style="font-size:16px;font-weight:700;color:#f8fafc;">${escapeHtml(creator?.name || 'Unknown Creator')}</div>
@@ -2874,7 +2916,7 @@
         ? '<div id="transcript-detail-' + sha256 + '"></div>'
         : '';
       const uploaderEnforcementPanel = createUploaderEnforcementPanel(video);
-      const provenanceHTML = renderProvenanceSummary(video.provenance);
+      const provenanceHTML = renderProvenanceSummary(video.provenance, video.c2pa);
       const creatorInfoButton = '<button class="action-btn secondary" onclick="openCreatorInfo(\'' + sha256 + '\')">Creator Info</button>';
       const uploaderHistoryPanel = createUploaderHistoryPanel(video);
 
@@ -3640,7 +3682,7 @@
 
     function createVideoCard(video) {
       const { sha256, cdnUrl, action, scores, reason, processedAt, detailedCategories, provider, manualOverride, overriddenAt, previousAction, showTranscriptTools } = video;
-      const provenanceHTML = renderProvenanceSummary(video.provenance);
+      const provenanceHTML = renderProvenanceSummary(video.provenance, video.c2pa);
       const creatorInfoButton = `<button class="action-btn secondary" onclick="openCreatorInfo('${sha256}')">Creator Info</button>`;
 
       const timestamp = processedAt

--- a/src/admin/swipe-review-ui.test.mjs
+++ b/src/admin/swipe-review-ui.test.mjs
@@ -11,4 +11,14 @@ describe('swipe review provenance UI hooks', () => {
     expect(swipeReviewHTML).toContain('renderProvenanceBadge');
     expect(swipeReviewHTML).toContain('creator-info-modal');
   });
+
+  it('contains C2PA/ProofMode badge rendering', () => {
+    expect(swipeReviewHTML).toContain('renderC2paBadge');
+    expect(swipeReviewHTML).toContain('formatC2paSupportLine');
+    expect(swipeReviewHTML).toContain('Valid ProofMode');
+    expect(swipeReviewHTML).toContain('Valid C2PA');
+    expect(swipeReviewHTML).toContain('Valid but AI-signed');
+    expect(swipeReviewHTML).toContain('Invalid Proof');
+    expect(swipeReviewHTML).toContain('c2pa-badge');
+  });
 });

--- a/src/admin/swipe-review.html
+++ b/src/admin/swipe-review.html
@@ -1428,7 +1428,7 @@
     function createVideoCard(video) {
       const { sha256, scores, detailedCategories, isUntriaged, classifierSummary } = video;
       const videoUrl = '/admin/video/' + sha256 + '.mp4';
-      const provenanceHTML = renderProvenanceSummary(video.provenance);
+      const provenanceHTML = renderProvenanceSummary(video.provenance, video.c2pa);
 
       const scoreEntries = Object.entries(scores || {})
         .filter(([, value]) => typeof value === 'number' && value > 0)
@@ -1920,6 +1920,37 @@
       return `<div style="display:inline-flex;align-items:center;gap:6px;background:${palette.bg};border:1px solid ${palette.border};color:${palette.text};padding:4px 8px;border-radius:999px;font-size:11px;font-weight:700;letter-spacing:0.02em;text-transform:uppercase;">${escapeHtml(provenance.label || 'Source Unavailable')}</div>`;
     }
 
+    function renderC2paBadge(c2pa) {
+      if (!c2pa || !c2pa.state || c2pa.state === 'absent' || c2pa.state === 'unchecked') return '';
+      const configByState = {
+        valid_proofmode: { label: 'Valid ProofMode', bg: '#064e3b', border: '#10b981', text: '#ecfdf5' },
+        valid_c2pa: { label: 'Valid C2PA', bg: '#1e3a8a', border: '#3b82f6', text: '#eff6ff' },
+        valid_ai_signed: { label: 'Valid but AI-signed', bg: '#7c2d12', border: '#f97316', text: '#fff7ed' },
+        invalid: { label: 'Invalid Proof', bg: '#374151', border: '#6b7280', text: '#f3f4f6' }
+      };
+      const conf = configByState[c2pa.state];
+      if (!conf) return '';
+      const title = c2pa.claimGenerator ? `claim_generator: ${c2pa.claimGenerator}` : c2pa.state;
+      return `<div class="c2pa-badge" data-state="${escapeHtml(c2pa.state)}" title="${escapeHtml(title)}" style="display:inline-flex;align-items:center;gap:6px;background:${conf.bg};border:1px solid ${conf.border};color:${conf.text};padding:4px 8px;border-radius:999px;font-size:11px;font-weight:700;letter-spacing:0.02em;text-transform:uppercase;margin-left:6px;">${escapeHtml(conf.label)}</div>`;
+    }
+
+    function formatC2paSupportLine(c2pa) {
+      if (!c2pa || c2pa.state === 'absent' || c2pa.state === 'unchecked') return '';
+      if (c2pa.state === 'valid_proofmode' && c2pa.captureDevice && c2pa.captureTime) {
+        return `ProofMode captured ${c2pa.captureTime} on ${c2pa.captureDevice}`;
+      }
+      if (c2pa.state === 'valid_ai_signed' && c2pa.claimGenerator) {
+        return `AI-signed by ${c2pa.claimGenerator}`;
+      }
+      if (c2pa.state === 'valid_c2pa' && c2pa.claimGenerator) {
+        return `C2PA signed by ${c2pa.claimGenerator}`;
+      }
+      if (c2pa.state === 'invalid') {
+        return 'C2PA manifest present but signature invalid (often transcoding or clock skew)';
+      }
+      return '';
+    }
+
     function formatProvenanceSupportLine(provenance) {
       if (!provenance || !provenance.date || provenance.dateSource === 'none') {
         return 'Source details unavailable';
@@ -1940,11 +1971,14 @@
       return `${dateLabel} via ${sourceLabel}`;
     }
 
-    function renderProvenanceSummary(provenance) {
+    function renderProvenanceSummary(provenance, c2pa) {
+      const c2paBadge = renderC2paBadge(c2pa);
+      const c2paLine = formatC2paSupportLine(c2pa);
       return `
         <div style="margin-bottom: 12px;">
-          ${renderProvenanceBadge(provenance)}
+          ${renderProvenanceBadge(provenance)}${c2paBadge}
           <div style="font-size: 12px; color: #9ca3af; margin-top: 6px;">${escapeHtml(formatProvenanceSupportLine(provenance))}</div>
+          ${c2paLine ? `<div style="font-size: 12px; color: #9ca3af; margin-top: 4px;">${escapeHtml(c2paLine)}</div>` : ''}
         </div>
       `;
     }
@@ -1976,6 +2010,7 @@
 
     function renderCreatorInfoModal(video) {
       const provenance = video.provenance || null;
+      const c2pa = video.c2pa || null;
       const creator = video.creatorContext || null;
       const stats = creator?.stats || null;
       const social = creator?.social || null;
@@ -1984,9 +2019,11 @@
       return `
         <div style="display:flex;flex-direction:column;gap:14px;">
           <div>
-            ${renderProvenanceBadge(provenance)}
+            ${renderProvenanceBadge(provenance)}${renderC2paBadge(c2pa)}
             <div style="font-size:13px;color:#cbd5e1;margin-top:8px;">${escapeHtml(formatProvenanceSupportLine(provenance))}</div>
+            ${formatC2paSupportLine(c2pa) ? `<div style="font-size:12px;color:#94a3b8;margin-top:4px;">${escapeHtml(formatC2paSupportLine(c2pa))}</div>` : ''}
             ${Array.isArray(provenance?.reasons) && provenance.reasons.length > 0 ? `<div style="font-size:12px;color:#94a3b8;margin-top:6px;">Evidence: ${escapeHtml(provenance.reasons.join(' · '))}</div>` : ''}
+            ${c2pa?.signer ? `<div style="font-size:11px;color:#64748b;margin-top:4px;">Signer: ${escapeHtml(c2pa.signer)}</div>` : ''}
           </div>
           <div>
             <div style="font-size:16px;font-weight:700;color:#f8fafc;">${escapeHtml(creator?.name || 'Creator details unavailable')}</div>

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -3801,7 +3801,7 @@ async function runMigration() {
           result.provider || 'unknown',
           JSON.stringify(result.scores || {}),
           JSON.stringify(result.categories || []),
-          JSON.stringify(result.rawResponse || {}),
+          JSON.stringify({ ...(result.rawResponse || {}), c2pa: result.c2pa || null }),
           new Date().toISOString(),
           result.uploadedBy || null,
           result.nostrContext?.title || null,

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -637,7 +637,7 @@ async function getAdminLookupVideo(identifier, env, options = {}) {
   const cdnUrl = `https://${env.CDN_DOMAIN || 'media.divine.video'}/${hash}`;
   if (hash) {
     const moderatedRow = await env.BLOSSOM_DB.prepare(`
-      SELECT sha256, action, provider, scores, categories, moderated_at, reviewed_by, reviewed_at, review_notes, uploaded_by
+      SELECT sha256, action, provider, scores, categories, moderated_at, reviewed_by, reviewed_at, review_notes, uploaded_by, raw_response
       FROM moderation_results
       WHERE sha256 = ?
     `).bind(hash).first();
@@ -648,6 +648,7 @@ async function getAdminLookupVideo(identifier, env, options = {}) {
     if (moderatedRow || kvModeration) {
       const moderatedAt = kvModeration?.moderated_at || moderatedRow?.moderated_at || null;
       const storedLookup = buildStoredLookupMetadata(moderatedRow);
+      const storedRaw = parseMaybeJson(moderatedRow?.raw_response, null);
       return enrichAdminLookupVideo({
         sha256: hash,
         action: kvModeration?.action || moderatedRow?.action || 'REVIEW',
@@ -668,7 +669,8 @@ async function getAdminLookupVideo(identifier, env, options = {}) {
         previousAction: kvModeration?.previousAction || null,
         detailedCategories: parseMaybeJson(kvModeration?.detailedCategories, null),
         categoryVerifications: parseMaybeJson(kvModeration?.categoryVerifications, {}) || {},
-        cdnUrl: kvModeration?.cdnUrl || cdnUrl
+        cdnUrl: kvModeration?.cdnUrl || cdnUrl,
+        c2pa: (storedRaw && typeof storedRaw === 'object' && storedRaw.c2pa) || null
       }, env);
     }
 

--- a/src/moderation/inquisitor-client.mjs
+++ b/src/moderation/inquisitor-client.mjs
@@ -1,0 +1,96 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Divine-inquisitor C2PA/ProofMode verification client
+// ABOUTME: Calls inquisitor.divine.video /verify in URL mode and normalizes response into a tri-state policy signal
+
+const DEFAULT_MIME_TYPE = 'video/mp4';
+
+const AI_TOOL_PATTERNS = [
+  'adobe firefly',
+  'dall·e',
+  'dall-e',
+  'dalle',
+  'midjourney',
+  'stable diffusion',
+  'sora',
+  'runway',
+  'ideogram',
+];
+
+export function isAiToolClaimGenerator(claimGenerator) {
+  if (!claimGenerator || typeof claimGenerator !== 'string') return false;
+  const lower = claimGenerator.toLowerCase();
+  return AI_TOOL_PATTERNS.some((pattern) => lower.includes(pattern));
+}
+
+function deriveState({ hasC2pa, valid, isProofmode, claimGenerator }) {
+  if (!hasC2pa) return 'absent';
+  if (!valid) return 'invalid';
+  if (isProofmode) return 'valid_proofmode';
+  if (isAiToolClaimGenerator(claimGenerator)) return 'valid_ai_signed';
+  return 'valid_c2pa';
+}
+
+function uncheckedResult(error) {
+  return {
+    state: 'unchecked',
+    hasC2pa: false,
+    valid: false,
+    isProofmode: false,
+    validationState: 'unknown',
+    claimGenerator: null,
+    captureDevice: null,
+    captureTime: null,
+    signer: null,
+    assertions: [],
+    verifiedAt: null,
+    checkedAt: new Date().toISOString(),
+    error,
+  };
+}
+
+export async function verifyC2pa({ url, mimeType }, env, { fetchFn = fetch } = {}) {
+  if (!env?.INQUISITOR_BASE_URL) {
+    return uncheckedResult('INQUISITOR_BASE_URL not configured');
+  }
+
+  const endpoint = `${env.INQUISITOR_BASE_URL.replace(/\/$/, '')}/verify`;
+  const body = JSON.stringify({ url, mime_type: mimeType || DEFAULT_MIME_TYPE });
+
+  try {
+    const response = await fetchFn(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body,
+    });
+
+    if (!response.ok) {
+      return uncheckedResult(`inquisitor responded ${response.status}`);
+    }
+
+    const data = await response.json();
+    const hasC2pa = Boolean(data.has_c2pa);
+    const valid = Boolean(data.valid);
+    const isProofmode = Boolean(data.is_proofmode);
+    const claimGenerator = data.claim_generator ?? null;
+
+    return {
+      state: deriveState({ hasC2pa, valid, isProofmode, claimGenerator }),
+      hasC2pa,
+      valid,
+      isProofmode,
+      validationState: data.validation_state ?? 'unknown',
+      claimGenerator,
+      captureDevice: data.capture_device ?? null,
+      captureTime: data.capture_time ?? null,
+      signer: data.signer ?? null,
+      assertions: Array.isArray(data.assertions) ? data.assertions : [],
+      verifiedAt: data.verified_at ?? null,
+      checkedAt: new Date().toISOString(),
+      error: null,
+    };
+  } catch (err) {
+    return uncheckedResult(err?.message || String(err));
+  }
+}

--- a/src/moderation/inquisitor-client.test.mjs
+++ b/src/moderation/inquisitor-client.test.mjs
@@ -1,0 +1,280 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Tests for divine-inquisitor C2PA verification client
+// ABOUTME: Covers URL-mode request shape, state normalization, AI-tool detection, graceful degradation
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { verifyC2pa, isAiToolClaimGenerator } from './inquisitor-client.mjs';
+
+const VIDEO_URL = 'https://media.divine.video/abc123';
+
+function jsonResponse(body, { ok = true, status = 200 } = {}) {
+  return {
+    ok,
+    status,
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  };
+}
+
+describe('verifyC2pa', () => {
+  let env;
+
+  beforeEach(() => {
+    env = { INQUISITOR_BASE_URL: 'https://inquisitor.divine.video' };
+  });
+
+  it('posts URL-mode request with correct shape', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse({
+      has_c2pa: false,
+      valid: false,
+      validation_state: 'unknown',
+      is_proofmode: false,
+      assertions: [],
+      actions: [],
+      ingredients: [],
+      verified_at: '2026-04-17T10:00:00Z',
+    }));
+
+    await verifyC2pa({ url: VIDEO_URL, mimeType: 'video/mp4' }, env, { fetchFn });
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    const [url, opts] = fetchFn.mock.calls[0];
+    expect(url).toBe('https://inquisitor.divine.video/verify');
+    expect(opts.method).toBe('POST');
+    expect(opts.headers['Content-Type']).toBe('application/json');
+    expect(JSON.parse(opts.body)).toEqual({ url: VIDEO_URL, mime_type: 'video/mp4' });
+  });
+
+  it('normalizes valid ProofMode response to state=valid_proofmode', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse({
+      has_c2pa: true,
+      valid: true,
+      validation_state: 'valid',
+      is_proofmode: true,
+      claim_generator: 'ProofMode/1.1.9 Android/14',
+      capture_device: 'Google Pixel 8 Pro',
+      capture_time: '2024:07:22 14:33:51',
+      signer: 'C=US, O=Guardian Project',
+      assertions: ['stds.exif', 'org.proofmode.location'],
+      actions: [],
+      ingredients: [],
+      verified_at: '2026-04-17T10:00:00Z',
+    }));
+
+    const result = await verifyC2pa({ url: VIDEO_URL, mimeType: 'video/mp4' }, env, { fetchFn });
+
+    expect(result.state).toBe('valid_proofmode');
+    expect(result.hasC2pa).toBe(true);
+    expect(result.valid).toBe(true);
+    expect(result.isProofmode).toBe(true);
+    expect(result.claimGenerator).toBe('ProofMode/1.1.9 Android/14');
+    expect(result.captureDevice).toBe('Google Pixel 8 Pro');
+    expect(result.captureTime).toBe('2024:07:22 14:33:51');
+    expect(result.assertions).toEqual(['stds.exif', 'org.proofmode.location']);
+    expect(result.error).toBeNull();
+  });
+
+  it('normalizes valid C2PA with AI-tool claim_generator to state=valid_ai_signed', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse({
+      has_c2pa: true,
+      valid: true,
+      validation_state: 'valid',
+      is_proofmode: false,
+      claim_generator: 'Adobe Firefly 2.0',
+      assertions: ['c2pa.hash.data'],
+      actions: [{ label: 'c2pa.created' }],
+      ingredients: [],
+      verified_at: '2026-04-17T10:00:00Z',
+    }));
+
+    const result = await verifyC2pa({ url: VIDEO_URL, mimeType: 'video/mp4' }, env, { fetchFn });
+
+    expect(result.state).toBe('valid_ai_signed');
+    expect(result.valid).toBe(true);
+    expect(result.isProofmode).toBe(false);
+    expect(result.claimGenerator).toBe('Adobe Firefly 2.0');
+  });
+
+  it('matches AI-tool claim_generator case-insensitively and substring', async () => {
+    const samples = [
+      'DALL·E 3',
+      'dall-e-3',
+      'Midjourney v6',
+      'Stable Diffusion XL',
+      'Sora / OpenAI',
+      'Runway Gen-3',
+      'Ideogram 2.0',
+    ];
+    for (const cg of samples) {
+      const fetchFn = vi.fn().mockResolvedValue(jsonResponse({
+        has_c2pa: true,
+        valid: true,
+        validation_state: 'valid',
+        is_proofmode: false,
+        claim_generator: cg,
+        assertions: [],
+        actions: [],
+        ingredients: [],
+        verified_at: '2026-04-17T10:00:00Z',
+      }));
+      const result = await verifyC2pa({ url: VIDEO_URL, mimeType: 'video/mp4' }, env, { fetchFn });
+      expect(result.state, `claim_generator=${cg}`).toBe('valid_ai_signed');
+    }
+  });
+
+  it('normalizes valid C2PA with neutral claim_generator to state=valid_c2pa', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse({
+      has_c2pa: true,
+      valid: true,
+      validation_state: 'valid',
+      is_proofmode: false,
+      claim_generator: 'Adobe Photoshop 24.0',
+      assertions: ['c2pa.hash.data'],
+      actions: [],
+      ingredients: [],
+      verified_at: '2026-04-17T10:00:00Z',
+    }));
+
+    const result = await verifyC2pa({ url: VIDEO_URL, mimeType: 'video/mp4' }, env, { fetchFn });
+
+    expect(result.state).toBe('valid_c2pa');
+    expect(result.valid).toBe(true);
+    expect(result.isProofmode).toBe(false);
+  });
+
+  it('normalizes invalid signature to state=invalid', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse({
+      has_c2pa: true,
+      valid: false,
+      validation_state: 'invalid',
+      is_proofmode: false,
+      assertions: [],
+      actions: [],
+      ingredients: [],
+      verified_at: '2026-04-17T10:00:00Z',
+    }));
+
+    const result = await verifyC2pa({ url: VIDEO_URL, mimeType: 'video/mp4' }, env, { fetchFn });
+
+    expect(result.state).toBe('invalid');
+    expect(result.hasC2pa).toBe(true);
+    expect(result.valid).toBe(false);
+  });
+
+  it('normalizes absent C2PA to state=absent', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse({
+      has_c2pa: false,
+      valid: false,
+      validation_state: 'unknown',
+      is_proofmode: false,
+      assertions: [],
+      actions: [],
+      ingredients: [],
+      verified_at: '2026-04-17T10:00:00Z',
+    }));
+
+    const result = await verifyC2pa({ url: VIDEO_URL, mimeType: 'video/mp4' }, env, { fetchFn });
+
+    expect(result.state).toBe('absent');
+    expect(result.hasC2pa).toBe(false);
+  });
+
+  it('returns state=unchecked on network error without throwing', async () => {
+    const fetchFn = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+
+    const result = await verifyC2pa({ url: VIDEO_URL, mimeType: 'video/mp4' }, env, { fetchFn });
+
+    expect(result.state).toBe('unchecked');
+    expect(result.error).toContain('ECONNREFUSED');
+    expect(result.hasC2pa).toBe(false);
+    expect(result.valid).toBe(false);
+  });
+
+  it('returns state=unchecked on non-ok HTTP response', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse({ error: 'bad gateway' }, { ok: false, status: 502 }));
+
+    const result = await verifyC2pa({ url: VIDEO_URL, mimeType: 'video/mp4' }, env, { fetchFn });
+
+    expect(result.state).toBe('unchecked');
+    expect(result.error).toContain('502');
+  });
+
+  it('returns state=unchecked when INQUISITOR_BASE_URL missing', async () => {
+    const fetchFn = vi.fn();
+    const result = await verifyC2pa({ url: VIDEO_URL, mimeType: 'video/mp4' }, {}, { fetchFn });
+
+    expect(result.state).toBe('unchecked');
+    expect(result.error).toContain('INQUISITOR_BASE_URL');
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('defaults mimeType to video/mp4 when not provided', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse({
+      has_c2pa: false,
+      valid: false,
+      validation_state: 'unknown',
+      is_proofmode: false,
+      assertions: [],
+      actions: [],
+      ingredients: [],
+      verified_at: '2026-04-17T10:00:00Z',
+    }));
+
+    await verifyC2pa({ url: VIDEO_URL }, env, { fetchFn });
+
+    const [, opts] = fetchFn.mock.calls[0];
+    expect(JSON.parse(opts.body).mime_type).toBe('video/mp4');
+  });
+
+  it('sets checkedAt on every result', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse({
+      has_c2pa: false,
+      valid: false,
+      validation_state: 'unknown',
+      is_proofmode: false,
+      assertions: [],
+      actions: [],
+      ingredients: [],
+      verified_at: '2026-04-17T10:00:00Z',
+    }));
+
+    const before = new Date().toISOString();
+    const result = await verifyC2pa({ url: VIDEO_URL, mimeType: 'video/mp4' }, env, { fetchFn });
+    const after = new Date().toISOString();
+
+    expect(result.checkedAt >= before).toBe(true);
+    expect(result.checkedAt <= after).toBe(true);
+  });
+});
+
+describe('isAiToolClaimGenerator', () => {
+  it('returns true for known AI tools', () => {
+    expect(isAiToolClaimGenerator('Adobe Firefly 2.0')).toBe(true);
+    expect(isAiToolClaimGenerator('DALL·E 3')).toBe(true);
+    expect(isAiToolClaimGenerator('dall-e-3')).toBe(true);
+    expect(isAiToolClaimGenerator('Midjourney v6')).toBe(true);
+    expect(isAiToolClaimGenerator('Stable Diffusion XL')).toBe(true);
+    expect(isAiToolClaimGenerator('Sora / OpenAI')).toBe(true);
+    expect(isAiToolClaimGenerator('Runway Gen-3')).toBe(true);
+    expect(isAiToolClaimGenerator('Ideogram 2.0')).toBe(true);
+  });
+
+  it('is case-insensitive', () => {
+    expect(isAiToolClaimGenerator('ADOBE FIREFLY')).toBe(true);
+    expect(isAiToolClaimGenerator('midjourney')).toBe(true);
+  });
+
+  it('returns false for non-AI tools', () => {
+    expect(isAiToolClaimGenerator('ProofMode/1.1.9 Android/14')).toBe(false);
+    expect(isAiToolClaimGenerator('Adobe Photoshop 24.0')).toBe(false);
+    expect(isAiToolClaimGenerator('Google Pixel 8 Pro')).toBe(false);
+  });
+
+  it('returns false for null/empty', () => {
+    expect(isAiToolClaimGenerator(null)).toBe(false);
+    expect(isAiToolClaimGenerator(undefined)).toBe(false);
+    expect(isAiToolClaimGenerator('')).toBe(false);
+  });
+});

--- a/src/moderation/pipeline.mjs
+++ b/src/moderation/pipeline.mjs
@@ -10,10 +10,82 @@ import { classifyText, parseVttText } from './text-classifier.mjs';
 import { fetchNostrEventBySha256, parseVideoEventMetadata, isOriginalVine, hasStrongOriginalVineEvidence } from '../nostr/relay-client.mjs';
 import { classifyVideo } from '../classification/pipeline.mjs';
 import { extractTopics } from '../classification/topic-extractor.mjs';
+import { verifyC2pa } from './inquisitor-client.mjs';
 
 const ORIGINAL_VINE_SUPPRESSED_CATEGORIES = new Set(['ai_generated', 'deepfake']);
 const DOWNSTREAM_SIGNAL_THRESHOLD = 0.5;
 const ARCHIVE_ORIGINAL_VINE_SOURCES = new Set(['archive-export', 'incident-backfill', 'sha-list']);
+const C2PA_CACHE_PREFIX = 'c2pa:';
+const C2PA_CACHE_TTL = 30 * 86400;
+
+async function getCachedC2paOrVerify({ sha256, videoUrl, env, fetchFn }) {
+  if (env.MODERATION_KV) {
+    try {
+      const cached = await env.MODERATION_KV.get(`${C2PA_CACHE_PREFIX}${sha256}`);
+      if (cached) return JSON.parse(cached);
+    } catch (err) {
+      console.warn(`[C2PA] KV read failed for ${sha256}: ${err.message}`);
+    }
+  }
+
+  const result = await verifyC2pa({ url: videoUrl, mimeType: 'video/mp4' }, env, { fetchFn });
+
+  if (env.MODERATION_KV && result.state !== 'unchecked') {
+    try {
+      await env.MODERATION_KV.put(`${C2PA_CACHE_PREFIX}${sha256}`, JSON.stringify(result), {
+        expirationTtl: C2PA_CACHE_TTL,
+      });
+    } catch (err) {
+      console.warn(`[C2PA] KV write failed for ${sha256}: ${err.message}`);
+    }
+  }
+
+  return result;
+}
+
+function buildSignedAiShortCircuitResult({ sha256, uploadedBy, uploadedAt, metadata, videoUrl, nostrContext, nostrEventId, c2pa }) {
+  const claimGenerator = c2pa.claimGenerator || 'unknown';
+  const reason = `c2pa-ai-signed:${claimGenerator} — quarantined pending moderator review`;
+  return {
+    action: 'QUARANTINE',
+    severity: 'high',
+    category: 'ai_generated',
+    reason,
+    requiresSecondaryVerification: false,
+    scores: { ai_generated: 1.0, deepfake: 0 },
+    provider: 'inquisitor-c2pa',
+    processingTime: 0,
+    detailedCategories: null,
+    sha256,
+    uploadedBy,
+    uploadedAt,
+    metadata,
+    cdnUrl: videoUrl,
+    nostrEventId,
+    nostrContext,
+    policyContext: {
+      originalVine: false,
+      originalVineLegacyFallback: false,
+      enforcementOverridden: true,
+      overrideReason: 'c2pa-ai-signed-short-circuit',
+      originalAction: 'QUARANTINE',
+    },
+    downstreamSignals: {
+      hasSignals: true,
+      scores: { ai_generated: 1.0 },
+      primaryConcern: 'ai_generated',
+      category: 'ai_generated',
+      severity: 'high',
+      reason: `C2PA signature declares AI origin (claim_generator=${claimGenerator})`,
+    },
+    text_scores: null,
+    providerRaw: null,
+    rawClassifierData: null,
+    sceneClassification: null,
+    topicProfile: null,
+    c2pa,
+  };
+}
 
 function parseOptionalString(value) {
   return typeof value === 'string' && value.length > 0 ? value : null;
@@ -286,6 +358,18 @@ export async function moderateVideo(videoData, env, fetchFn = fetch) {
     console.log(`[MODERATION] Original Vine detected - skipping AI detection for ${sha256}`);
   }
 
+  // Step 2.5: Call divine-inquisitor first so valid_ai_signed content can short-circuit Hive
+  const c2pa = await getCachedC2paOrVerify({ sha256, videoUrl, env, fetchFn });
+  console.log(`[MODERATION] ${sha256} - C2PA state: ${c2pa.state}${c2pa.claimGenerator ? ` (claim=${c2pa.claimGenerator})` : ''}`);
+
+  if (c2pa.state === 'valid_ai_signed') {
+    console.log(`[MODERATION] ${sha256} - signed-AI short-circuit, skipping Hive and Reality Defender`);
+    return buildSignedAiShortCircuitResult({
+      sha256, uploadedBy, uploadedAt, metadata,
+      videoUrl, nostrContext, nostrEventId, c2pa,
+    });
+  }
+
   // Step 3: Run moderation and scene classification in parallel
   let moderationResult;
   let combinedScores = {};
@@ -406,7 +490,7 @@ export async function moderateVideo(videoData, env, fetchFn = fetch) {
 
   const downstreamSignals = deriveDownstreamSignals(classification, { originalVine: shouldForceServeable });
 
-  const finalClassification = shouldForceServeable
+  let finalClassification = shouldForceServeable
     ? (() => {
       const overridden = applyOriginalVineEnforcementOverride(classification);
       if (classification.action !== overridden.action) {
@@ -416,6 +500,25 @@ export async function moderateVideo(videoData, env, fetchFn = fetch) {
       return overridden;
     })()
     : classification;
+
+  // Step 4.25: ProofMode downgrade rule — valid ProofMode capture attestation
+  // downgrades an AI-driven QUARANTINE to REVIEW so humans decide (content stays visible).
+  if (
+    c2pa.state === 'valid_proofmode'
+    && finalClassification.action === 'QUARANTINE'
+    && (finalClassification.category === 'ai_generated' || finalClassification.category === 'deepfake')
+  ) {
+    console.log(`[MODERATION] ${sha256} - ProofMode downgrade: QUARANTINE → REVIEW`);
+    policyContext.originalAction = finalClassification.action;
+    policyContext.enforcementOverridden = true;
+    policyContext.overrideReason = 'proofmode-capture-authenticated';
+    finalClassification = {
+      ...finalClassification,
+      action: 'REVIEW',
+      reason: `${finalClassification.reason} | proofmode-capture-authenticated`,
+      requiresSecondaryVerification: false,
+    };
+  }
 
   // Step 4.5: If AI-flagged, submit to Reality Defender for secondary verification (fire-and-forget)
   if (finalClassification.requiresSecondaryVerification && env.REALITY_DEFENDER_API_KEY) {
@@ -482,6 +585,12 @@ export async function moderateVideo(videoData, env, fetchFn = fetch) {
     // Topic profile extracted from VTT transcript text
     // Contains topics with confidence scores, primary_topic, has_speech, language_hint
     // null if no VTT transcript is available
-    topicProfile: topicProfile || null
+    topicProfile: topicProfile || null,
+
+    // C2PA / ProofMode verification result from divine-inquisitor.
+    // state ∈ {valid_proofmode, valid_c2pa, valid_ai_signed, invalid, absent, unchecked}.
+    // valid_ai_signed is handled earlier via short-circuit; valid_proofmode may have
+    // downgraded the action above.
+    c2pa,
   };
 }

--- a/src/moderation/pipeline.test.mjs
+++ b/src/moderation/pipeline.test.mjs
@@ -612,3 +612,304 @@ describe('Moderation Pipeline', () => {
     expect(result.downstreamSignals?.primaryConcern).toBe('nudity');
   });
 });
+
+describe('Moderation Pipeline — C2PA / ProofMode enforcement', () => {
+  function buildMockFetch({ inquisitor, hive = null, vtt404 = true }) {
+    return vi.fn(async (url) => {
+      const urlStr = String(url);
+
+      if (urlStr.includes('inquisitor.divine.video/verify')) {
+        return {
+          ok: true,
+          json: async () => inquisitor,
+          text: async () => JSON.stringify(inquisitor),
+        };
+      }
+
+      if (vtt404 && urlStr.endsWith('.vtt')) {
+        return { ok: false, status: 404, text: async () => '' };
+      }
+
+      if (urlStr.includes('api.thehive.ai') && hive) {
+        return {
+          ok: true,
+          json: async () => hive,
+        };
+      }
+
+      throw new Error(`Unexpected fetch call: ${urlStr}`);
+    });
+  }
+
+  const baseEnv = {
+    HIVE_MODERATION_API_KEY: 'mod-key',
+    HIVE_AI_DETECTION_API_KEY: 'ai-key',
+    CDN_DOMAIN: 'cdn.divine.video',
+    INQUISITOR_BASE_URL: 'https://inquisitor.divine.video',
+  };
+
+  it('short-circuits to QUARANTINE on valid_ai_signed and never calls Hive', async () => {
+    const mockFetch = buildMockFetch({
+      inquisitor: {
+        has_c2pa: true,
+        valid: true,
+        validation_state: 'valid',
+        is_proofmode: false,
+        claim_generator: 'Adobe Firefly 2.0',
+        assertions: ['c2pa.hash.data'],
+        actions: [],
+        ingredients: [],
+        verified_at: '2026-04-17T10:00:00Z',
+      },
+    });
+
+    const result = await moderateVideo({
+      sha256: 'a'.repeat(64),
+      uploadedAt: Date.now(),
+    }, baseEnv, mockFetch);
+
+    expect(result.action).toBe('QUARANTINE');
+    expect(result.category).toBe('ai_generated');
+    expect(result.provider).toBe('inquisitor-c2pa');
+    expect(result.reason).toContain('c2pa-ai-signed');
+    expect(result.reason).toContain('Adobe Firefly');
+    expect(result.requiresSecondaryVerification).toBe(false);
+    expect(result.c2pa?.state).toBe('valid_ai_signed');
+    expect(result.policyContext?.overrideReason).toBe('c2pa-ai-signed-short-circuit');
+
+    const hiveCalls = mockFetch.mock.calls.filter(([url]) => String(url).includes('api.thehive.ai'));
+    expect(hiveCalls).toHaveLength(0);
+  });
+
+  it('downgrades AI-driven QUARANTINE to REVIEW on valid_proofmode', async () => {
+    const mockFetch = buildMockFetch({
+      inquisitor: {
+        has_c2pa: true,
+        valid: true,
+        validation_state: 'valid',
+        is_proofmode: true,
+        claim_generator: 'ProofMode/1.1.9 Android/14',
+        capture_device: 'Google Pixel 8 Pro',
+        capture_time: '2024:07:22 14:33:51',
+        assertions: ['stds.exif', 'org.proofmode.location'],
+        actions: [],
+        ingredients: [],
+        verified_at: '2026-04-17T10:00:00Z',
+      },
+      hive: {
+        status: [{
+          response: {
+            output: [
+              {
+                time: 0,
+                classes: [
+                  { class: 'ai_generated', score: 0.92 },
+                ],
+              },
+            ],
+          },
+        }],
+      },
+    });
+
+    const result = await moderateVideo({
+      sha256: 'b'.repeat(64),
+      uploadedAt: Date.now(),
+    }, baseEnv, mockFetch);
+
+    expect(result.action).toBe('REVIEW');
+    expect(result.policyContext?.originalAction).toBe('QUARANTINE');
+    expect(result.policyContext?.overrideReason).toBe('proofmode-capture-authenticated');
+    expect(result.reason).toContain('proofmode-capture-authenticated');
+    expect(result.c2pa?.state).toBe('valid_proofmode');
+
+    const hiveCalls = mockFetch.mock.calls.filter(([url]) => String(url).includes('api.thehive.ai'));
+    expect(hiveCalls.length).toBeGreaterThan(0);
+  });
+
+  it('leaves action unchanged on valid_proofmode when Hive does not flag AI', async () => {
+    const mockFetch = buildMockFetch({
+      inquisitor: {
+        has_c2pa: true,
+        valid: true,
+        validation_state: 'valid',
+        is_proofmode: true,
+        claim_generator: 'ProofMode/1.1.9 Android/14',
+        assertions: [],
+        actions: [],
+        ingredients: [],
+        verified_at: '2026-04-17T10:00:00Z',
+      },
+      hive: {
+        status: [{
+          response: {
+            output: [
+              {
+                time: 0,
+                classes: [
+                  { class: 'ai_generated', score: 0.1 },
+                  { class: 'general_nsfw', score: 0.05 },
+                ],
+              },
+            ],
+          },
+        }],
+      },
+    });
+
+    const result = await moderateVideo({
+      sha256: 'c'.repeat(64),
+      uploadedAt: Date.now(),
+    }, baseEnv, mockFetch);
+
+    expect(result.action).toBe('SAFE');
+    expect(result.c2pa?.state).toBe('valid_proofmode');
+    expect(result.policyContext?.overrideReason).toBeFalsy();
+  });
+
+  it('does not downgrade valid_c2pa + AI flag — remains QUARANTINE', async () => {
+    const mockFetch = buildMockFetch({
+      inquisitor: {
+        has_c2pa: true,
+        valid: true,
+        validation_state: 'valid',
+        is_proofmode: false,
+        claim_generator: 'Adobe Photoshop 24.0',
+        assertions: ['c2pa.hash.data'],
+        actions: [],
+        ingredients: [],
+        verified_at: '2026-04-17T10:00:00Z',
+      },
+      hive: {
+        status: [{
+          response: {
+            output: [
+              {
+                time: 0,
+                classes: [
+                  { class: 'ai_generated', score: 0.92 },
+                ],
+              },
+            ],
+          },
+        }],
+      },
+    });
+
+    const result = await moderateVideo({
+      sha256: 'd'.repeat(64),
+      uploadedAt: Date.now(),
+    }, baseEnv, mockFetch);
+
+    expect(result.action).toBe('QUARANTINE');
+    expect(result.c2pa?.state).toBe('valid_c2pa');
+  });
+
+  it('falls through to Hive flow when inquisitor returns unchecked (timeout)', async () => {
+    const mockFetch = vi.fn(async (url) => {
+      const urlStr = String(url);
+      if (urlStr.includes('inquisitor.divine.video/verify')) {
+        throw new Error('ECONNREFUSED');
+      }
+      if (urlStr.endsWith('.vtt')) {
+        return { ok: false, status: 404, text: async () => '' };
+      }
+      if (urlStr.includes('api.thehive.ai')) {
+        return {
+          ok: true,
+          json: async () => ({
+            status: [{
+              response: {
+                output: [
+                  {
+                    time: 0,
+                    classes: [{ class: 'ai_generated', score: 0.92 }],
+                  },
+                ],
+              },
+            }],
+          }),
+        };
+      }
+      throw new Error(`Unexpected fetch call: ${urlStr}`);
+    });
+
+    const result = await moderateVideo({
+      sha256: 'e'.repeat(64),
+      uploadedAt: Date.now(),
+    }, baseEnv, mockFetch);
+
+    expect(result.action).toBe('QUARANTINE');
+    expect(result.c2pa?.state).toBe('unchecked');
+  });
+
+  it('falls through to Hive flow when absent C2PA + AI flag → QUARANTINE', async () => {
+    const mockFetch = buildMockFetch({
+      inquisitor: {
+        has_c2pa: false,
+        valid: false,
+        validation_state: 'unknown',
+        is_proofmode: false,
+        assertions: [],
+        actions: [],
+        ingredients: [],
+        verified_at: '2026-04-17T10:00:00Z',
+      },
+      hive: {
+        status: [{
+          response: {
+            output: [
+              {
+                time: 0,
+                classes: [{ class: 'ai_generated', score: 0.92 }],
+              },
+            ],
+          },
+        }],
+      },
+    });
+
+    const result = await moderateVideo({
+      sha256: 'f'.repeat(64),
+      uploadedAt: Date.now(),
+    }, baseEnv, mockFetch);
+
+    expect(result.action).toBe('QUARANTINE');
+    expect(result.c2pa?.state).toBe('absent');
+  });
+
+  it('skips inquisitor and falls through when INQUISITOR_BASE_URL not set', async () => {
+    const envWithoutInquisitor = { ...baseEnv };
+    delete envWithoutInquisitor.INQUISITOR_BASE_URL;
+
+    const mockFetch = vi.fn(async (url) => {
+      const urlStr = String(url);
+      if (urlStr.includes('inquisitor.divine.video')) {
+        throw new Error('inquisitor must not be called when INQUISITOR_BASE_URL missing');
+      }
+      if (urlStr.endsWith('.vtt')) {
+        return { ok: false, status: 404, text: async () => '' };
+      }
+      if (urlStr.includes('api.thehive.ai')) {
+        return {
+          ok: true,
+          json: async () => ({
+            status: [{ response: { output: [{ time: 0, classes: [{ class: 'general_nsfw', score: 0.1 }] }] } }],
+          }),
+        };
+      }
+      throw new Error(`Unexpected fetch: ${urlStr}`);
+    });
+
+    const result = await moderateVideo({
+      sha256: '1'.repeat(64),
+      uploadedAt: Date.now(),
+    }, envWithoutInquisitor, mockFetch);
+
+    expect(result.action).toBe('SAFE');
+    expect(result.c2pa?.state).toBe('unchecked');
+
+    const inquisitorCalls = mockFetch.mock.calls.filter(([url]) => String(url).includes('inquisitor.divine.video'));
+    expect(inquisitorCalls).toHaveLength(0);
+  });
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -81,6 +81,10 @@ SELF_HARM_THRESHOLD_MEDIUM = "0.5"    # Human review
 AI_GENERATED_THRESHOLD_HIGH = "0.8"   # Age-restricted
 AI_GENERATED_THRESHOLD_MEDIUM = "0.6" # Human review
 
+# Divine-inquisitor C2PA/ProofMode verification service (github.com/divinevideo/divine-inquisitor)
+# Called from the pipeline before Hive — valid_ai_signed short-circuits Hive, valid_proofmode downgrades AI-QUARANTINE to REVIEW
+INQUISITOR_BASE_URL = "https://inquisitor.divine.video"
+
 # Relay Polling Configuration
 RELAY_POLLING_ENABLED = "true"                    # Enable/disable relay polling
 RELAY_POLLING_RELAY_URL = "wss://relay.divine.video"  # Relay to poll for new video events


### PR DESCRIPTION
## Summary

Wires the divine-moderation-service to divine-inquisitor for C2PA / ProofMode verification, and applies two targeted enforcement rules driven by the verification result.

- **Signed-AI short-circuit** — when a video carries a valid C2PA manifest whose \`claim_generator\` is a known AI-generation tool (Adobe Firefly, DALL·E, Midjourney, Stable Diffusion, Sora, Runway, Ideogram), the pipeline routes straight to QUARANTINE and never calls Hive or Reality Defender. The tool's own cryptographic declaration is authoritative AI evidence, so paying for Hive or polling RD adds cost without new information. Moderators still review manually.
- **ProofMode downgrade** — when a video carries a valid ProofMode capture attestation (\`is_proofmode && valid\`) and Hive or RD flag it as AI-generated, the action downgrades from QUARANTINE to REVIEW. The video stays visible to users while a human resolves the contradiction between capture-authenticated provenance and an AI-detector flag.

All other states (\`valid_c2pa\`, \`invalid\`, \`absent\`, \`unchecked\`) fall through to the existing Hive/RD flow — no auto-downgrade, no auto-escalate. Inquisitor results are KV-cached under \`c2pa:{sha256}\` for 30 days and persisted on the moderation record so admin payloads can surface them without re-verifying.

The admin dashboard and swipe review show a new C2PA badge alongside the existing age/origin badge (green for valid ProofMode, blue for valid generic C2PA, orange for valid-but-AI-signed, gray for invalid). The Creator Info modal surfaces \`claim_generator\`, capture device and time, and signer DN when present.

## What's new

- \`src/moderation/inquisitor-client.mjs\` — wraps \`POST /verify\` on \`https://inquisitor.divine.video\`, normalizes into six states.
- \`src/moderation/pipeline.mjs\` — inquisitor-first call order, two enforcement rules, KV caching, \`c2pa\` on the moderation record.
- \`src/index.mjs\` — threads \`video.c2pa\` through admin payloads (D1 write, \`parseStoredAdminSnapshot\`, \`buildStoredModeratedVideo\`, \`buildResolvedAdminRawResponse\`).
- \`src/admin/dashboard.html\` + \`src/admin/swipe-review.html\` — C2PA badge + support line + Creator Info modal fields.
- \`wrangler.toml\` — adds \`INQUISITOR_BASE_URL\` var.
- Design + plan docs updated with the two enforcement rules, the inquisitor API contract, and the naming decision (top-level \`video.c2pa\`, not nested under \`provenance.proofmode\`).

## Naming decision

The C2PA result is exposed as top-level \`video.c2pa\` rather than \`video.provenance.proofmode\`. The latter was already taken by Nostr-tag ProofMode data (self-reported via the \`[\"proofmode\", ...]\` Nostr event tag) and has five existing consumers in \`src/index.mjs\`. Keeping them as distinct fields lets the two evidence channels coexist.

## Test plan

- [x] 679/679 tests pass (16 new inquisitor-client, 7 new pipeline, 2 new UI-hook tests per admin surface).
- [x] \`valid_ai_signed\` asserts zero Hive calls in pipeline tests (short-circuit is hard-guaranteed).
- [x] \`valid_proofmode\` + Hive AI flag downgrades QUARANTINE → REVIEW and sets \`policyContext.overrideReason = proofmode-capture-authenticated\`.
- [x] Inquisitor timeout (\`unchecked\`) falls through to existing Hive flow — never blocks moderation.
- [ ] Manual verification in staging once deployed: a known ProofMode-signed test video should show the green \`Valid ProofMode\` badge on the admin dashboard.

## Deployment notes

- \`INQUISITOR_BASE_URL=https://inquisitor.divine.video\` must be set on production. No auth is required by inquisitor today (confirmed \`/health\` is open).
- KV binding \`MODERATION_KV\` is reused with a \`c2pa:\` prefix — no new KV namespace needed.
- No database migrations — \`c2pa\` is stored inside the existing \`raw_response\` JSON column on \`moderation_results\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)