### PR TITLE
feat: visible-watermark detector for AI-generated video

### DIFF
--- a/CONTENT_MODERATION.md
+++ b/CONTENT_MODERATION.md
@@ -536,6 +536,51 @@ Track these metrics:
 - API costs
 - Manual review queue size
 
+## Visible-Watermark Detector (AI-generated video)
+
+Most consumer AI video generators stamp a small, visually distinctive mark in a
+fixed corner of every frame. A narrow CNN classifier on 15% corner crops is
+highly effective and runs inside the Worker via `onnxruntime-web`.
+
+Source files:
+
+- `src/moderation/logo_detector.mjs` — extracts TL/TR/BL/BR crops per frame and
+  runs the classifier. `loadModel()` / `runInference()` are stubs today; they
+  become real ONNX calls once `LOGO_DETECTOR_MODEL_URL` is set and the model is
+  trained.
+- `src/moderation/logo_aggregator.mjs` — majority vote across frames. A verdict
+  is emitted when ≥50% of frames flag the **same class in the same corner** at
+  confidence ≥0.7. One-off false positives are discarded by design.
+
+### Class → generator mapping
+
+| Class           | Generator                            | Typical mark                            |
+|-----------------|--------------------------------------|-----------------------------------------|
+| `clean`         | —                                    | No visible AI watermark                 |
+| `meta_sparkle`  | Meta Imagine / Movie Gen             | Four-point sparkle icon, lower-left     |
+| `openai_sora`   | OpenAI Sora                          | Moving Sora wordmark                    |
+| `google_veo`    | Google Veo                           | "Veo" text watermark                    |
+| `runway`        | Runway (Gen-2/Gen-3)                 | Corner Runway logo                      |
+| `kling`         | Kuaishou Kling                       | Corner Kling logo                       |
+| `pika`          | Pika Labs                            | Corner Pika logo                        |
+| `luma`          | Luma Dream Machine                   | Corner Luma logo                        |
+| `other_logo`    | Unknown generator / off-taxonomy     | Fallback bucket for novel marks         |
+
+### Meta signal caveat
+
+`meta_sparkle` is our **primary signal for Meta-generated video** until Meta's
+Video Seal invisible-watermark prefixes are published and decodable. Once Video
+Seal detection lands, Meta provenance should be confirmed via the invisible
+payload and the sparkle demoted to a secondary indicator — Meta may retire the
+visible mark on their side at any time.
+
+### Configuration
+
+- `LOGO_DETECTOR_MODEL_URL` (wrangler.toml `[vars]`) — HTTPS URL of the ONNX
+  model file. Empty string leaves the detector on its stub code path (all frames
+  return `clean` with confidence 1.0) so the pipeline runs without the model in
+  dev and in tests.
+
 ## Next Steps
 
 1. Start with basic hash checking

--- a/CONTENT_MODERATION.md
+++ b/CONTENT_MODERATION.md
@@ -548,9 +548,13 @@ Source files:
   runs the classifier. `loadModel()` / `runInference()` are stubs today; they
   become real ONNX calls once `LOGO_DETECTOR_MODEL_URL` is set and the model is
   trained.
-- `src/moderation/logo_aggregator.mjs` — majority vote across frames. A verdict
-  is emitted when ≥50% of frames flag the **same class in the same corner** at
-  confidence ≥0.7. One-off false positives are discarded by design.
+- `src/moderation/logo_aggregator.mjs` — two-pass majority vote across
+  frames. **Static pass** keyed on `(corner, class)` catches stationary corner
+  marks (Meta sparkle, Veo text, Runway/Kling/Pika/Luma). **Fallback pass**
+  keyed on class alone catches moving watermarks like Sora's wordmark whose
+  corner hops frame-to-frame. A verdict fires when ≥50% of frames flag the
+  same class at confidence ≥0.7. One-off false positives are discarded by
+  design; static matches are preferred over moving matches when both qualify.
 
 ### Class → generator mapping
 

--- a/docs/superpowers/plans/2026-04-17-divine-ai-detector-design.md
+++ b/docs/superpowers/plans/2026-04-17-divine-ai-detector-design.md
@@ -1,0 +1,247 @@
+# divine-ai-detector — design
+
+**Status:** design, not implementation. Bootstraps from logo detection (PR #97)
+but shaped so Hive and Reality Defender calls can be phased down as internal
+signals come online. No cutover in this design — design for the cutover.
+
+## Mission
+
+Run Divine's AI-content detection internally for the signals where internal
+inference is cheap and high-confidence; keep Hive and Reality Defender for the
+ambiguous long tail. Distill vendor verdicts into internal models over time so
+the long tail shrinks.
+
+Not: "rip out Hive/RD." That's the result if distillation works.
+
+## Scope
+
+**v0 (this quarter):** one signal, `watermark_visible`.
+Classifier: ONNX CNN on four 15% corner crops per frame → per-generator class.
+Classes are the ones already in `src/moderation/logo_detector.mjs`:
+`meta_sparkle`, `openai_sora`, `google_veo`, `runway`, `kling`, `pika`, `luma`,
+`other_logo`, `clean`.
+
+**v0.5 (when Meta publishes Video Seal prefix):** add `watermark_invisible`.
+Spec-defined decoder, no ML.
+
+**v1 (next quarter):** distilled `ai_generated` signal trained from N weeks of
+Hive verdicts.
+
+**v1.5:** `deepfake_face_swap` from public datasets (FaceForensics++, DFDC)
+fine-tuned on Divine traffic.
+
+**Out of scope, forever:** NSFW / violence / hate / self-harm. Those stay with
+Hive — different domain, different ethics, different liability.
+
+## API
+
+Service name: `divine-ai-detector`. Deployed next to `divine-inquisitor` on
+GKE, same ArgoCD umbrella, same secrets pattern.
+
+### `POST /detect`
+
+One endpoint, signal-oriented. Caller picks which signals to run; service
+returns one envelope per signal. Missing signal = not requested, not an error.
+
+```json
+Request:
+{
+  "url": "https://media.divine.video/<sha256>.mp4",
+  "mime_type": "video/mp4",
+  "sha256": "<sha256>",            // optional, used as cache key
+  "signals": ["watermark_visible"] // default: all enabled signals
+}
+
+Response:
+{
+  "sha256": "<sha256>",
+  "checked_at": "2026-04-17T...Z",
+  "duration_ms": 430,
+  "signals": {
+    "watermark_visible": {
+      "state": "detected",         // detected | absent | error | skipped
+      "class": "meta_sparkle",     // signal-specific payload below state
+      "confidence": 0.92,
+      "frames_flagged": 3,
+      "total_frames": 4,
+      "model": "logo-v1.2.0"
+    }
+  }
+}
+```
+
+**Why one envelope per signal, not one top-level verdict:** each signal has a
+different model, different confidence distribution, different update cadence.
+The moderation worker decides how to combine them into policy — we don't
+pretend we know the right fusion yet.
+
+**Why `state` before the payload:** uniform tri-state lets the moderation
+worker branch without knowing each signal's payload shape. `error` and
+`skipped` are first-class states — vendor-fallback logic needs to distinguish
+"no watermark found" from "we didn't run this" from "the model crashed."
+
+### `GET /healthz` / `GET /livez` / `GET /readyz` / `GET /metrics`
+
+Standard inquisitor shape. `readyz` only returns 200 after all active models
+have loaded, so K8s doesn't route traffic during warmup.
+
+## Signal taxonomy + vendor parity
+
+The moderation pipeline's existing AI-content logic keys on `ai_generated` and
+`deepfake` category scores (see `wrangler.toml` `AI_GENERATED_THRESHOLD_*`).
+Keep that contract — don't invent a parallel taxonomy.
+
+| Internal signal        | Policy category it feeds | Vendor parity           |
+|------------------------|--------------------------|-------------------------|
+| `watermark_visible`    | `ai_generated`           | Hive `ai_generated` score (strong, corner-specific) |
+| `watermark_invisible`  | `ai_generated`           | No vendor equivalent — ground truth when present |
+| `ai_generated`         | `ai_generated`           | Hive `ai_generated`, Reality Defender                 |
+| `deepfake_face_swap`   | `deepfake`               | Hive `deepfake`, Reality Defender                     |
+
+The pipeline receives per-signal results, converts them to a normalized
+`ai_generated` / `deepfake` score using per-signal weights, and then runs the
+existing threshold logic unchanged. This is the contract that lets us swap
+internal for vendor without changing the policy layer.
+
+## Cutover strategy — four modes, per signal
+
+Every signal moves through these modes independently. The mode is a config
+knob on the moderation worker, not on `divine-ai-detector`.
+
+1. **shadow** — moderation worker calls both vendor and internal, uses vendor
+   verdict, logs both + disagreement. No user impact. Goal: calibrate
+   thresholds, measure agreement rate.
+2. **gated** — internal verdict used only when `confidence >= GATE`. Below
+   gate, fall through to vendor. GATE tuned from shadow-mode data.
+3. **preferred** — internal verdict always used when `state != error`. Vendor
+   called only on `error` / `skipped`.
+4. **sole** — internal only. Vendor call removed. Only move a signal here
+   after sustained preferred-mode agreement > 95% vs. vendor and zero
+   regressions in human review.
+
+Each signal's current mode is a single env var on the worker:
+`AI_DETECTOR_MODE_WATERMARK_VISIBLE=shadow|gated|preferred|sole`.
+Default for every new signal is `shadow`. Cutover = flip a var, not a deploy.
+
+**Rollback:** flip the var back. No data migration, no schema change. Vendor
+code stays wired the whole time.
+
+## Training data capture
+
+The distillation play only works if we log everything now:
+
+- Every Hive + RD verdict already gets logged in D1 `moderation_results`. Good.
+- Add: every `divine-ai-detector` verdict logged in the same table, keyed by
+  `sha256` + `signal` + `model_version`.
+- Add: when a human moderator overrides an automated verdict, flag the
+  `sha256` + the override reason. This is the highest-signal training data we
+  have and it's essentially free.
+- Training pipeline (out of scope for v0, but keep the data shape clean
+  enough to feed it): export D1 slice → GCS → training job on Vertex AI or a
+  GCE spot node → upload new ONNX to GCS → bump `LOGO_DETECTOR_MODEL_URL` →
+  canary in shadow mode → roll to preferred.
+
+## Non-negotiable contracts
+
+These must not drift, or cutover becomes a migration instead of a config flip:
+
+1. **Signal names** are stable forever once published. Rename = new signal +
+   deprecation window on the old one.
+2. **`state` values** are stable: `detected | absent | error | skipped`. No
+   new values without a major version bump.
+3. **`confidence` is 0.0–1.0**, calibrated so 0.7 is the Hive-equivalent
+   moderate threshold and 0.8 is the Hive-equivalent high threshold. Models
+   that don't output calibrated probabilities get Platt-scaled at training
+   time, not at inference time.
+4. **`model` field is required** on every signal response so we can bisect
+   regressions by model version.
+5. **`duration_ms` is required** so the worker can enforce a timeout budget
+   and fall through to vendors under load.
+
+## Service architecture
+
+- **Runtime:** Rust + Axum, distroless, same shape as `divine-inquisitor`. ONNX
+  inference via `ort` crate (Rust bindings for ONNX Runtime). CPU-only to
+  start; add GPU node pool if/when a signal needs it.
+- **Models:** each signal has one active model. Models downloaded from GCS at
+  startup, pinned by SHA. Version + SHA logged to Prometheus.
+- **Frame extraction:** the service fetches the video (or accepts
+  pre-extracted frames — see open question), decodes N keyframes via
+  `ffmpeg` (present in the image, not in the binary), hands frames to each
+  signal's inference path. Frame count per call is a config knob per signal.
+- **Caching:** result cached in-memory by `sha256 + signal + model_version`
+  for `CACHE_TTL`. Not authoritative — the authoritative cache is D1 on the
+  moderation worker side. In-memory cache is for avoiding redundant
+  reinvocation within a burst.
+- **Resource footprint (starting point):** 2 replicas, 512Mi–2Gi memory, 500m–2
+  CPU, HPA on CPU. Tune after shadow-mode traffic.
+
+## Minimum file set — new repo (`divine-ai-detector`)
+
+```
+Dockerfile                       (multi-stage; distroless final; ffmpeg baked in)
+Cargo.toml                       (axum, ort, reqwest, serde, tracing, metrics)
+src/main.rs                      (wire routes + graceful shutdown)
+src/routes/detect.rs             (POST /detect — signal dispatch)
+src/routes/health.rs             (healthz / livez / readyz / metrics)
+src/signals/mod.rs               (Signal trait: fn detect(&self, frames) -> Envelope)
+src/signals/watermark_visible.rs (v0 implementation; port logo_detector.mjs logic)
+src/frames.rs                    (ffmpeg-cli frame extraction)
+src/model_store.rs               (GCS download + SHA pinning)
+tests/                           (integration tests against fixture videos)
+.github/workflows/ci.yml         (test → docker push → dispatch to IaC repo)
+README.md                        (API + runbook)
+```
+
+## Minimum file set — IaC PR (`divine-iac-coreconfig`)
+
+```
+k8s/applications/divine-ai-detector/base/
+  deployment.yaml                (2 replicas, readiness probe, prometheus scrape)
+  service.yaml
+  httproute.yaml                 (ai-detector.ENVIRONMENT.divine.video)
+  kustomization.yaml
+k8s/applications/divine-ai-detector/overlays/{poc,staging,production}/
+  kustomization.yaml             (image tag, replica count, hostname)
+k8s/argocd/apps/divine-ai-detector.yaml   (ApplicationSet)
+k8s/external-secrets/base/divine-ai-detector-secrets.yaml  (GCS SA, if needed)
+```
+
+## Worker-side changes (future PRs, not now)
+
+- Rename `LOGO_DETECTOR_MODEL_URL` → `AI_DETECTOR_BASE_URL` (HTTP client to the
+  new service, not a direct model URL).
+- Reshape `src/moderation/logo_detector.mjs` into `ai-detector-client.mjs` —
+  thin HTTP client over `POST /detect`, still returning per-signal verdicts.
+- `src/moderation/logo_aggregator.mjs` keeps its vote math; it becomes the
+  Worker-side fusion layer that combines multiple signals' `confidence` into a
+  single `ai_generated` score. Lives next to the policy code, which is where
+  threshold tuning belongs.
+- `AI_DETECTOR_MODE_*` env vars per signal for shadow/gated/preferred/sole.
+
+PR #97 can merge as-is (it's a self-contained stub with its own tests); the
+above worker-side rewiring is the first follow-up PR once `divine-ai-detector`
+is reachable in staging.
+
+## Open questions
+
+1. **Frame extraction — service or worker?** Simpler for the service to fetch
+   + decode. But extracting frames in divine-moderation-service (Cloudflare
+   Images? divine-cdn-worker?) keeps the AI detector stateless and lets the
+   same frames feed multiple calls (logo + Video Seal + generic classifier).
+   Lean: start with service-side extraction; factor out if we add ≥3 signals.
+2. **Vertex AI vs self-hosted training?** Out of scope now; decide when the
+   first distillation run is scheduled.
+3. **Do we deprecate `divine-realness`?** No — it becomes the vendor-wrapper
+   the moderation worker calls *as a fallback* after `divine-ai-detector`
+   errors or returns low-confidence. Its scope narrows; it doesn't go away.
+4. **Per-signal timeouts.** Each signal's time budget probably differs (logo
+   is fast, generic AI classifier is slower). Decide on default: global
+   budget, per-signal budget, or caller-provided.
+
+## Not in this design
+
+- Actually building any of the above. This is a design to align on before
+  bootstrapping the repo.
+- NSFW / violence / hate / self-harm internal inference. Those stay vendor.
+- Pricing model for selling this service externally. Internal tool.

--- a/src/moderation/logo_aggregator.mjs
+++ b/src/moderation/logo_aggregator.mjs
@@ -2,7 +2,7 @@
 // If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // ABOUTME: Aggregates per-frame logo detections into a single verdict
-// ABOUTME: Majority vote per (corner, class) at confidence>=0.7, triggers at >=50% frames
+// ABOUTME: Static pass: majority vote per (corner, class); fallback: class-only for moving watermarks
 
 const CONFIDENCE_FLOOR = 0.7;
 const FRAME_SHARE_THRESHOLD = 0.5;
@@ -17,6 +17,24 @@ function emptyResult(total_frames = 0) {
   };
 }
 
+function pickWinner(buckets, total_frames) {
+  let winner = null;
+  for (const [label, bucket] of buckets) {
+    const frames_flagged = bucket.frames.size;
+    if (frames_flagged / total_frames < FRAME_SHARE_THRESHOLD) continue;
+    const confidence =
+      bucket.confidences.reduce((a, b) => a + b, 0) / bucket.confidences.length;
+    if (
+      !winner ||
+      frames_flagged > winner.frames_flagged ||
+      (frames_flagged === winner.frames_flagged && confidence > winner.confidence)
+    ) {
+      winner = { label, class: bucket.class, confidence, frames_flagged };
+    }
+  }
+  return winner;
+}
+
 export function aggregateLogoDetections(detections) {
   if (!detections || detections.length === 0) {
     return emptyResult();
@@ -26,39 +44,45 @@ export function aggregateLogoDetections(detections) {
   for (const d of detections) frameIndices.add(d.frame_index);
   const total_frames = frameIndices.size;
 
-  // key = `${corner}|${class}` -> { frames: Set<frame_index>, confidences: number[] }
-  const votes = new Map();
+  // Static pass: key on (corner, class). Catches stationary corner logos
+  // (Meta sparkle, Veo text, Runway/Kling/Pika/Luma corner marks).
+  const staticVotes = new Map();
+  // Fallback pass: key on class alone. Catches moving watermarks (Sora
+  // wordmark) where a class-true flag hops corners across frames.
+  const movingVotes = new Map();
+
   for (const d of detections) {
     if (d.class === 'clean') continue;
     if (d.confidence < CONFIDENCE_FLOOR) continue;
-    const key = `${d.corner}|${d.class}`;
-    let bucket = votes.get(key);
-    if (!bucket) {
-      bucket = { frames: new Set(), confidences: [] };
-      votes.set(key, bucket);
+
+    const staticKey = `${d.corner}|${d.class}`;
+    let sBucket = staticVotes.get(staticKey);
+    if (!sBucket) {
+      sBucket = { class: d.class, frames: new Set(), confidences: [] };
+      staticVotes.set(staticKey, sBucket);
     }
-    if (!bucket.frames.has(d.frame_index)) {
-      bucket.frames.add(d.frame_index);
-      bucket.confidences.push(d.confidence);
+    if (!sBucket.frames.has(d.frame_index)) {
+      sBucket.frames.add(d.frame_index);
+      sBucket.confidences.push(d.confidence);
+    }
+
+    let mBucket = movingVotes.get(d.class);
+    if (!mBucket) {
+      mBucket = { class: d.class, frames: new Set(), confidences: [] };
+      movingVotes.set(d.class, mBucket);
+    }
+    if (!mBucket.frames.has(d.frame_index)) {
+      mBucket.frames.add(d.frame_index);
+      mBucket.confidences.push(d.confidence);
     }
   }
 
-  let winner = null;
-  for (const [key, bucket] of votes) {
-    const frames_flagged = bucket.frames.size;
-    const share = frames_flagged / total_frames;
-    if (share < FRAME_SHARE_THRESHOLD) continue;
-    const [, cls] = key.split('|');
-    const confidence =
-      bucket.confidences.reduce((a, b) => a + b, 0) / bucket.confidences.length;
-    if (
-      !winner ||
-      frames_flagged > winner.frames_flagged ||
-      (frames_flagged === winner.frames_flagged && confidence > winner.confidence)
-    ) {
-      winner = { class: cls, confidence, frames_flagged };
-    }
-  }
+  // Static pass wins by construction: a class-only bucket always has >= the
+  // frames of any single (corner, class) slice of it, so a static winner
+  // implies the moving winner of the same class would tie or beat on count.
+  // We prefer the static winner because it's a tighter, higher-signal match.
+  const winner = pickWinner(staticVotes, total_frames)
+    || pickWinner(movingVotes, total_frames);
 
   if (!winner) {
     return emptyResult(total_frames);

--- a/src/moderation/logo_aggregator.mjs
+++ b/src/moderation/logo_aggregator.mjs
@@ -1,0 +1,74 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Aggregates per-frame logo detections into a single verdict
+// ABOUTME: Majority vote per (corner, class) at confidence>=0.7, triggers at >=50% frames
+
+const CONFIDENCE_FLOOR = 0.7;
+const FRAME_SHARE_THRESHOLD = 0.5;
+
+function emptyResult(total_frames = 0) {
+  return {
+    detected: false,
+    class: null,
+    confidence: 0,
+    frames_flagged: 0,
+    total_frames
+  };
+}
+
+export function aggregateLogoDetections(detections) {
+  if (!detections || detections.length === 0) {
+    return emptyResult();
+  }
+
+  const frameIndices = new Set();
+  for (const d of detections) frameIndices.add(d.frame_index);
+  const total_frames = frameIndices.size;
+
+  // key = `${corner}|${class}` -> { frames: Set<frame_index>, confidences: number[] }
+  const votes = new Map();
+  for (const d of detections) {
+    if (d.class === 'clean') continue;
+    if (d.confidence < CONFIDENCE_FLOOR) continue;
+    const key = `${d.corner}|${d.class}`;
+    let bucket = votes.get(key);
+    if (!bucket) {
+      bucket = { frames: new Set(), confidences: [] };
+      votes.set(key, bucket);
+    }
+    if (!bucket.frames.has(d.frame_index)) {
+      bucket.frames.add(d.frame_index);
+      bucket.confidences.push(d.confidence);
+    }
+  }
+
+  let winner = null;
+  for (const [key, bucket] of votes) {
+    const frames_flagged = bucket.frames.size;
+    const share = frames_flagged / total_frames;
+    if (share < FRAME_SHARE_THRESHOLD) continue;
+    const [, cls] = key.split('|');
+    const confidence =
+      bucket.confidences.reduce((a, b) => a + b, 0) / bucket.confidences.length;
+    if (
+      !winner ||
+      frames_flagged > winner.frames_flagged ||
+      (frames_flagged === winner.frames_flagged && confidence > winner.confidence)
+    ) {
+      winner = { class: cls, confidence, frames_flagged };
+    }
+  }
+
+  if (!winner) {
+    return emptyResult(total_frames);
+  }
+
+  return {
+    detected: true,
+    class: winner.class,
+    confidence: winner.confidence,
+    frames_flagged: winner.frames_flagged,
+    total_frames
+  };
+}

--- a/src/moderation/logo_aggregator.test.mjs
+++ b/src/moderation/logo_aggregator.test.mjs
@@ -105,18 +105,52 @@ describe('aggregateLogoDetections', () => {
     expect(result.confidence).toBeCloseTo((0.9 + 0.85 + 0.8) / 3, 5);
   });
 
-  it('requires the flags to be in the same corner, not scattered across corners', () => {
+  it('detects moving watermarks that hop corners across frames (Sora case)', () => {
+    // Sora's wordmark moves; corner-agreement would miss this even though every
+    // frame flags openai_sora. Fallback class-only vote must catch it.
+    const detections = [
+      ...flagCorner(0, 'TL', 'openai_sora', 0.9),
+      ...flagCorner(1, 'TR', 'openai_sora', 0.88),
+      ...flagCorner(2, 'BL', 'openai_sora', 0.92),
+      ...flagCorner(3, 'BR', 'openai_sora', 0.85)
+    ];
+
+    const result = aggregateLogoDetections(detections);
+    expect(result.detected).toBe(true);
+    expect(result.class).toBe('openai_sora');
+    expect(result.frames_flagged).toBe(4);
+    expect(result.total_frames).toBe(4);
+  });
+
+  it('does not trigger when scattered frames flag different classes', () => {
     const detections = [
       ...flagCorner(0, 'TL', 'meta_sparkle', 0.9),
-      ...flagCorner(1, 'TR', 'meta_sparkle', 0.9),
-      ...flagCorner(2, 'BL', 'meta_sparkle', 0.9),
-      ...flagCorner(3, 'BR', 'meta_sparkle', 0.9)
+      ...flagCorner(1, 'TR', 'openai_sora', 0.9),
+      ...flagCorner(2, 'BL', 'google_veo', 0.9),
+      ...flagCorner(3, 'BR', 'runway', 0.9)
     ];
 
     const result = aggregateLogoDetections(detections);
     expect(result.detected).toBe(false);
     expect(result.class).toBeNull();
     expect(result.total_frames).toBe(4);
+  });
+
+  it('prefers a static (same-corner) verdict over a moving (scattered) one when both qualify', () => {
+    // 3/4 frames flag meta_sparkle in BL (static) AND 3/4 flag openai_sora scattered.
+    // The static corner-consistent winner should win — it's a stronger signal.
+    const detections = [
+      ...flagCorner(0, 'BL', 'meta_sparkle', 0.9),
+      ...flagCorner(1, 'BL', 'meta_sparkle', 0.9),
+      ...flagCorner(2, 'BL', 'meta_sparkle', 0.9),
+      ...flagCorner(0, 'TL', 'openai_sora', 0.95),
+      ...flagCorner(1, 'TR', 'openai_sora', 0.95),
+      ...flagCorner(2, 'BR', 'openai_sora', 0.95)
+    ];
+
+    const result = aggregateLogoDetections(detections);
+    expect(result.detected).toBe(true);
+    expect(result.class).toBe('meta_sparkle');
   });
 
   it('requires the flags to agree on a single class, not a mix', () => {
@@ -195,6 +229,23 @@ describe('aggregateLogoDetections', () => {
     expect(result.class).toBe('openai_sora');
     expect(result.frames_flagged).toBe(2);
     expect(result.confidence).toBeCloseTo(0.95, 5);
+  });
+
+  it('averages confidence only over flags that cleared the 0.7 floor', () => {
+    // Two frames at 0.9 trigger; the third frame's 0.65 is below floor and
+    // must not drag the reported confidence down to (0.9+0.9+0.65)/3.
+    const detections = [
+      ...flagCorner(0, 'BL', 'meta_sparkle', 0.9),
+      ...flagCorner(1, 'BL', 'meta_sparkle', 0.9),
+      ...flagCorner(2, 'BL', 'meta_sparkle', 0.65),
+      ...cleanFrame(3)
+    ];
+
+    const result = aggregateLogoDetections(detections);
+    expect(result.detected).toBe(true);
+    expect(result.class).toBe('meta_sparkle');
+    expect(result.frames_flagged).toBe(2);
+    expect(result.confidence).toBeCloseTo(0.9, 5);
   });
 
   it('counts each frame at most once per corner even with duplicate detections', () => {

--- a/src/moderation/logo_aggregator.test.mjs
+++ b/src/moderation/logo_aggregator.test.mjs
@@ -1,0 +1,213 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Tests for logo detection aggregation / majority vote across frames
+// ABOUTME: Covers clean, single false positive, consistent logo, mixed signals
+
+import { describe, it, expect } from 'vitest';
+import { aggregateLogoDetections } from './logo_aggregator.mjs';
+
+function cleanFrame(frameIndex) {
+  return ['TL', 'TR', 'BL', 'BR'].map((corner) => ({
+    frame_index: frameIndex,
+    corner,
+    class: 'clean',
+    confidence: 1.0
+  }));
+}
+
+function flagCorner(frameIndex, corner, cls, confidence) {
+  return ['TL', 'TR', 'BL', 'BR'].map((c) => ({
+    frame_index: frameIndex,
+    corner: c,
+    class: c === corner ? cls : 'clean',
+    confidence: c === corner ? confidence : 1.0
+  }));
+}
+
+describe('aggregateLogoDetections', () => {
+  it('returns undetected for an empty detection list', () => {
+    expect(aggregateLogoDetections([])).toEqual({
+      detected: false,
+      class: null,
+      confidence: 0,
+      frames_flagged: 0,
+      total_frames: 0
+    });
+  });
+
+  it('returns undetected for null input', () => {
+    expect(aggregateLogoDetections(null)).toEqual({
+      detected: false,
+      class: null,
+      confidence: 0,
+      frames_flagged: 0,
+      total_frames: 0
+    });
+  });
+
+  it('returns undetected when every frame is clean', () => {
+    const detections = [];
+    for (let i = 0; i < 5; i++) detections.push(...cleanFrame(i));
+
+    const result = aggregateLogoDetections(detections);
+    expect(result).toEqual({
+      detected: false,
+      class: null,
+      confidence: 0,
+      frames_flagged: 0,
+      total_frames: 5
+    });
+  });
+
+  it('ignores a single-frame false positive below the 50% threshold', () => {
+    const detections = [
+      ...flagCorner(0, 'BL', 'meta_sparkle', 0.95),
+      ...cleanFrame(1),
+      ...cleanFrame(2),
+      ...cleanFrame(3),
+      ...cleanFrame(4)
+    ];
+
+    const result = aggregateLogoDetections(detections);
+    expect(result.detected).toBe(false);
+    expect(result.class).toBeNull();
+    expect(result.total_frames).toBe(5);
+    expect(result.frames_flagged).toBe(0);
+  });
+
+  it('ignores flags below the 0.7 confidence floor', () => {
+    const detections = [];
+    for (let i = 0; i < 4; i++) {
+      detections.push(...flagCorner(i, 'BL', 'meta_sparkle', 0.65));
+    }
+
+    const result = aggregateLogoDetections(detections);
+    expect(result.detected).toBe(false);
+    expect(result.class).toBeNull();
+    expect(result.total_frames).toBe(4);
+    expect(result.frames_flagged).toBe(0);
+  });
+
+  it('triggers when a logo is flagged in the same corner on >=50% of frames at conf>=0.7', () => {
+    const detections = [
+      ...flagCorner(0, 'BL', 'meta_sparkle', 0.9),
+      ...flagCorner(1, 'BL', 'meta_sparkle', 0.85),
+      ...flagCorner(2, 'BL', 'meta_sparkle', 0.8),
+      ...cleanFrame(3)
+    ];
+
+    const result = aggregateLogoDetections(detections);
+    expect(result.detected).toBe(true);
+    expect(result.class).toBe('meta_sparkle');
+    expect(result.frames_flagged).toBe(3);
+    expect(result.total_frames).toBe(4);
+    expect(result.confidence).toBeCloseTo((0.9 + 0.85 + 0.8) / 3, 5);
+  });
+
+  it('requires the flags to be in the same corner, not scattered across corners', () => {
+    const detections = [
+      ...flagCorner(0, 'TL', 'meta_sparkle', 0.9),
+      ...flagCorner(1, 'TR', 'meta_sparkle', 0.9),
+      ...flagCorner(2, 'BL', 'meta_sparkle', 0.9),
+      ...flagCorner(3, 'BR', 'meta_sparkle', 0.9)
+    ];
+
+    const result = aggregateLogoDetections(detections);
+    expect(result.detected).toBe(false);
+    expect(result.class).toBeNull();
+    expect(result.total_frames).toBe(4);
+  });
+
+  it('requires the flags to agree on a single class, not a mix', () => {
+    const detections = [
+      ...flagCorner(0, 'BL', 'meta_sparkle', 0.9),
+      ...flagCorner(1, 'BL', 'openai_sora', 0.9),
+      ...flagCorner(2, 'BL', 'google_veo', 0.9),
+      ...flagCorner(3, 'BL', 'runway', 0.9)
+    ];
+
+    const result = aggregateLogoDetections(detections);
+    expect(result.detected).toBe(false);
+    expect(result.class).toBeNull();
+  });
+
+  it('triggers at exactly 50% frames flagged', () => {
+    const detections = [
+      ...flagCorner(0, 'BL', 'meta_sparkle', 0.9),
+      ...flagCorner(1, 'BL', 'meta_sparkle', 0.9),
+      ...cleanFrame(2),
+      ...cleanFrame(3)
+    ];
+
+    const result = aggregateLogoDetections(detections);
+    expect(result.detected).toBe(true);
+    expect(result.class).toBe('meta_sparkle');
+    expect(result.frames_flagged).toBe(2);
+    expect(result.total_frames).toBe(4);
+  });
+
+  it('picks the strongest vote when two classes both exceed the 50% threshold', () => {
+    const detections = [
+      ...flagCorner(0, 'BL', 'meta_sparkle', 0.9),
+      ...flagCorner(1, 'BL', 'meta_sparkle', 0.9),
+      ...flagCorner(2, 'BL', 'meta_sparkle', 0.9),
+      ...flagCorner(0, 'TR', 'openai_sora', 0.8),
+      ...flagCorner(1, 'TR', 'openai_sora', 0.8)
+    ];
+
+    const result = aggregateLogoDetections(detections);
+    expect(result.detected).toBe(true);
+    expect(result.class).toBe('meta_sparkle');
+    expect(result.frames_flagged).toBe(3);
+  });
+
+  it('prefers the later vote when it covers more frames than the running winner', () => {
+    // First-inserted (BL|meta_sparkle) wins 2/4; later (TR|openai_sora) wins 3/4.
+    const detections = [
+      ...flagCorner(0, 'BL', 'meta_sparkle', 0.9),
+      ...flagCorner(1, 'BL', 'meta_sparkle', 0.9),
+      ...flagCorner(0, 'TR', 'openai_sora', 0.8),
+      ...flagCorner(1, 'TR', 'openai_sora', 0.8),
+      ...flagCorner(2, 'TR', 'openai_sora', 0.8),
+      ...cleanFrame(3)
+    ];
+
+    const result = aggregateLogoDetections(detections);
+    expect(result.detected).toBe(true);
+    expect(result.class).toBe('openai_sora');
+    expect(result.frames_flagged).toBe(3);
+    expect(result.total_frames).toBe(4);
+  });
+
+  it('breaks ties on frame count using average confidence', () => {
+    // Both BL|meta_sparkle and TR|openai_sora flag 2 of 3 frames. TR has higher conf.
+    const detections = [
+      ...flagCorner(0, 'BL', 'meta_sparkle', 0.72),
+      ...flagCorner(1, 'BL', 'meta_sparkle', 0.72),
+      ...flagCorner(0, 'TR', 'openai_sora', 0.95),
+      ...flagCorner(1, 'TR', 'openai_sora', 0.95),
+      ...cleanFrame(2)
+    ];
+
+    const result = aggregateLogoDetections(detections);
+    expect(result.detected).toBe(true);
+    expect(result.class).toBe('openai_sora');
+    expect(result.frames_flagged).toBe(2);
+    expect(result.confidence).toBeCloseTo(0.95, 5);
+  });
+
+  it('counts each frame at most once per corner even with duplicate detections', () => {
+    const detections = [
+      ...flagCorner(0, 'BL', 'meta_sparkle', 0.9),
+      ...flagCorner(0, 'BL', 'meta_sparkle', 0.95),
+      ...flagCorner(1, 'BL', 'meta_sparkle', 0.9),
+      ...cleanFrame(2)
+    ];
+
+    const result = aggregateLogoDetections(detections);
+    expect(result.frames_flagged).toBe(2);
+    expect(result.total_frames).toBe(3);
+    expect(result.detected).toBe(true);
+  });
+});

--- a/src/moderation/logo_detector.mjs
+++ b/src/moderation/logo_detector.mjs
@@ -1,0 +1,62 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Visible-watermark detector for consumer AI video generators
+// ABOUTME: Crops four 15% corners per frame and runs a stub classifier per crop
+//
+// The actual ONNX model (Meta sparkle, Sora, Veo, Runway, Kling, Pika, Luma corner
+// logos) is loaded lazily via `loadModel()` + `runInference()`. Both are stubs
+// until the trained classifier is wired in through onnxruntime-web — tests drive
+// behaviour by injecting `options.infer`.
+
+export const LOGO_CLASSES = [
+  'clean',
+  'meta_sparkle',
+  'openai_sora',
+  'google_veo',
+  'runway',
+  'kling',
+  'pika',
+  'luma',
+  'other_logo'
+];
+
+export const CORNERS = ['TL', 'TR', 'BL', 'BR'];
+
+const CORNER_RATIO = 0.15;
+
+export async function loadModel(modelUrl) {
+  if (!modelUrl) {
+    return { modelUrl: null, ready: false };
+  }
+  return { modelUrl, ready: true };
+}
+
+export function cropCorner(frame, corner) {
+  if (!CORNERS.includes(corner)) {
+    throw new Error(`unknown corner: ${corner}`);
+  }
+  return { frame, corner, ratio: CORNER_RATIO };
+}
+
+export async function runInference(_crop, _model) {
+  return { class: 'clean', confidence: 1.0 };
+}
+
+export async function detectLogos(frames, options = {}) {
+  const { model = null, infer = runInference } = options;
+  const detections = [];
+  for (let frame_index = 0; frame_index < frames.length; frame_index++) {
+    for (const corner of CORNERS) {
+      const crop = cropCorner(frames[frame_index], corner);
+      const result = await infer(crop, model);
+      detections.push({
+        frame_index,
+        corner,
+        class: result.class,
+        confidence: result.confidence
+      });
+    }
+  }
+  return detections;
+}

--- a/src/moderation/logo_detector.mjs
+++ b/src/moderation/logo_detector.mjs
@@ -32,6 +32,11 @@ export async function loadModel(modelUrl) {
   return { modelUrl, ready: true };
 }
 
+export async function loadModelFromEnv(env) {
+  const url = env && env.LOGO_DETECTOR_MODEL_URL ? env.LOGO_DETECTOR_MODEL_URL : null;
+  return loadModel(url);
+}
+
 export function cropCorner(frame, corner) {
   if (!CORNERS.includes(corner)) {
     throw new Error(`unknown corner: ${corner}`);

--- a/src/moderation/logo_detector.test.mjs
+++ b/src/moderation/logo_detector.test.mjs
@@ -8,6 +8,7 @@ import { describe, it, expect } from 'vitest';
 import {
   detectLogos,
   loadModel,
+  loadModelFromEnv,
   runInference,
   cropCorner,
   LOGO_CLASSES,
@@ -45,6 +46,34 @@ describe('logo_detector - loadModel', () => {
 
   it('handles a missing model URL by returning a non-ready handle', async () => {
     const model = await loadModel(null);
+    expect(model.ready).toBe(false);
+    expect(model.modelUrl).toBeNull();
+  });
+});
+
+describe('logo_detector - loadModelFromEnv', () => {
+  it('loads the model from env.LOGO_DETECTOR_MODEL_URL', async () => {
+    const env = { LOGO_DETECTOR_MODEL_URL: 'https://models.divine.video/logo-v1.onnx' };
+    const model = await loadModelFromEnv(env);
+    expect(model).toEqual({
+      modelUrl: 'https://models.divine.video/logo-v1.onnx',
+      ready: true
+    });
+  });
+
+  it('returns a non-ready handle when the env var is empty', async () => {
+    const model = await loadModelFromEnv({ LOGO_DETECTOR_MODEL_URL: '' });
+    expect(model).toEqual({ modelUrl: null, ready: false });
+  });
+
+  it('returns a non-ready handle when the env var is missing entirely', async () => {
+    const model = await loadModelFromEnv({});
+    expect(model.ready).toBe(false);
+    expect(model.modelUrl).toBeNull();
+  });
+
+  it('returns a non-ready handle when env itself is null', async () => {
+    const model = await loadModelFromEnv(null);
     expect(model.ready).toBe(false);
     expect(model.modelUrl).toBeNull();
   });

--- a/src/moderation/logo_detector.test.mjs
+++ b/src/moderation/logo_detector.test.mjs
@@ -1,0 +1,148 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Tests for visible-watermark detector on AI-generated video
+// ABOUTME: Covers corner cropping, stub inference, and detection shape
+
+import { describe, it, expect } from 'vitest';
+import {
+  detectLogos,
+  loadModel,
+  runInference,
+  cropCorner,
+  LOGO_CLASSES,
+  CORNERS
+} from './logo_detector.mjs';
+
+describe('logo_detector - constants', () => {
+  it('exposes the nine classifier classes in a stable order', () => {
+    expect(LOGO_CLASSES).toEqual([
+      'clean',
+      'meta_sparkle',
+      'openai_sora',
+      'google_veo',
+      'runway',
+      'kling',
+      'pika',
+      'luma',
+      'other_logo'
+    ]);
+  });
+
+  it('exposes the four corners in TL, TR, BL, BR order', () => {
+    expect(CORNERS).toEqual(['TL', 'TR', 'BL', 'BR']);
+  });
+});
+
+describe('logo_detector - loadModel', () => {
+  it('returns a handle that records the provided model URL', async () => {
+    const model = await loadModel('https://example.com/model.onnx');
+    expect(model).toMatchObject({
+      modelUrl: 'https://example.com/model.onnx',
+      ready: true
+    });
+  });
+
+  it('handles a missing model URL by returning a non-ready handle', async () => {
+    const model = await loadModel(null);
+    expect(model.ready).toBe(false);
+    expect(model.modelUrl).toBeNull();
+  });
+});
+
+describe('logo_detector - cropCorner', () => {
+  it('returns a crop descriptor covering 15% of the frame', () => {
+    const frame = 'https://cdn/frame-0.jpg';
+    const crop = cropCorner(frame, 'TL');
+    expect(crop).toEqual({ frame, corner: 'TL', ratio: 0.15 });
+  });
+
+  it('rejects an unknown corner', () => {
+    expect(() => cropCorner('frame', 'XY')).toThrow(/unknown corner/i);
+  });
+});
+
+describe('logo_detector - runInference (stub)', () => {
+  it('returns clean/1.0 until an ONNX model is wired in', async () => {
+    const crop = { frame: 'f', corner: 'TL', ratio: 0.15 };
+    const result = await runInference(crop, null);
+    expect(result).toEqual({ class: 'clean', confidence: 1.0 });
+  });
+});
+
+describe('logo_detector - detectLogos', () => {
+  it('returns an empty array for no frames', async () => {
+    const detections = await detectLogos([]);
+    expect(detections).toEqual([]);
+  });
+
+  it('emits four detections per frame, one per corner, in TL/TR/BL/BR order', async () => {
+    const frames = ['frame-a', 'frame-b'];
+    const detections = await detectLogos(frames);
+
+    expect(detections).toHaveLength(8);
+    expect(detections.map((d) => d.corner)).toEqual([
+      'TL', 'TR', 'BL', 'BR',
+      'TL', 'TR', 'BL', 'BR'
+    ]);
+    expect(detections.map((d) => d.frame_index)).toEqual([0, 0, 0, 0, 1, 1, 1, 1]);
+  });
+
+  it('returns detections with the expected shape', async () => {
+    const detections = await detectLogos(['frame']);
+    for (const d of detections) {
+      expect(d).toEqual({
+        frame_index: expect.any(Number),
+        corner: expect.stringMatching(/^(TL|TR|BL|BR)$/),
+        class: expect.any(String),
+        confidence: expect.any(Number)
+      });
+    }
+  });
+
+  it('uses the stub inference by default and reports every crop as clean', async () => {
+    const detections = await detectLogos(['frame-0', 'frame-1', 'frame-2']);
+    for (const d of detections) {
+      expect(d.class).toBe('clean');
+      expect(d.confidence).toBe(1.0);
+    }
+  });
+
+  it('supports injecting an alternate inference function for future ONNX swap', async () => {
+    const infer = async (crop) => {
+      if (crop.corner === 'BL') return { class: 'meta_sparkle', confidence: 0.92 };
+      return { class: 'clean', confidence: 1.0 };
+    };
+
+    const detections = await detectLogos(['frame'], { infer });
+    const bl = detections.find((d) => d.corner === 'BL');
+    expect(bl.class).toBe('meta_sparkle');
+    expect(bl.confidence).toBe(0.92);
+  });
+
+  it('passes both frame and corner descriptor into the inference function', async () => {
+    const calls = [];
+    const infer = async (crop, model) => {
+      calls.push({ ...crop, model });
+      return { class: 'clean', confidence: 1.0 };
+    };
+
+    const fakeModel = { ready: true, modelUrl: 'fake' };
+    await detectLogos(['frame-x'], { infer, model: fakeModel });
+
+    expect(calls).toHaveLength(4);
+    expect(calls[0]).toEqual({
+      frame: 'frame-x',
+      corner: 'TL',
+      ratio: 0.15,
+      model: fakeModel
+    });
+  });
+
+  it('accepts binary buffers as frames without throwing', async () => {
+    const buf = new Uint8Array([1, 2, 3]);
+    const detections = await detectLogos([buf]);
+    expect(detections).toHaveLength(4);
+    expect(detections[0].class).toBe('clean');
+  });
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -85,6 +85,12 @@ AI_GENERATED_THRESHOLD_MEDIUM = "0.6" # Human review
 # Called from the pipeline before Hive — valid_ai_signed short-circuits Hive, valid_proofmode downgrades AI-QUARANTINE to REVIEW
 INQUISITOR_BASE_URL = "https://inquisitor.divine.video"
 
+# Visible-watermark detector (corner logo classifier for consumer AI generators:
+# Meta sparkle, Sora, Veo, Runway, Kling, Pika, Luma). Points at an ONNX model
+# served over HTTPS; loaded lazily in the Worker via onnxruntime-web. Empty
+# string = detector disabled (stub inference path returns clean).
+LOGO_DETECTOR_MODEL_URL = ""
+
 # Relay Polling Configuration
 RELAY_POLLING_ENABLED = "true"                    # Enable/disable relay polling
 RELAY_POLLING_RELAY_URL = "wss://relay.divine.video"  # Relay to poll for new video events


### PR DESCRIPTION
## Summary
- Adds `detectLogos(frames)` which crops four 15% corners per frame (TL/TR/BL/BR) and runs a per-crop classifier for Meta sparkle, Sora, Veo, Runway, Kling, Pika, Luma, + `clean`/`other_logo`.
- Adds `aggregateLogoDetections(detections)` — majority vote per `(corner, class)` at confidence ≥ 0.7, triggers at ≥ 50% frames. One-off false positives are discarded.
- Model inference is stubbed behind `loadModel()` / `runInference()` so the ONNX model (via `onnxruntime-web`) can swap in once trained. `LOGO_DETECTOR_MODEL_URL` wired in `wrangler.toml`.
- Documents the class→generator mapping in `CONTENT_MODERATION.md` and notes that `meta_sparkle` is our primary Meta-AI signal only until Meta's Video Seal invisible watermark is decodable.

## Design notes
- `runInference()` currently returns `{class: 'clean', confidence: 1.0}` so the pipeline runs deterministically in dev and tests until the ONNX file ships.
- `detectLogos(frames, { infer, model })` accepts an injected `infer` for tests and for the future ONNX swap; no behavioural seam change needed when the real model lands.
- Aggregator tie-break: first by frame count, then by average confidence within tied classes, so a stronger but smaller-corner vote can't displace a broader one.

## Test plan
- [x] `npx vitest run src/moderation/logo_detector.test.mjs src/moderation/logo_aggregator.test.mjs` — **27/27 passing**
- [x] TDD: tests written and verified failing before either module existed.
- [x] Full suite: no new regressions (4 pre-existing failures on `main` are unrelated transcript + original-vine tests).
- [ ] Follow-up PR will wire `detectLogos` into `src/moderation/pipeline.mjs` once the ONNX model is trained and hosted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)