### PR TITLE
feat: interpret and persist Video Seal signals

### DIFF
--- a/CONTENT_MODERATION.md
+++ b/CONTENT_MODERATION.md
@@ -28,6 +28,14 @@ graph TD
 2. **Multi-stage**: Quick checks first, expensive analysis later
 3. **Fail-safe**: Content remains accessible unless definitively harmful
 
+## Video Seal
+
+Video Seal is a neural watermark embedded in video pixels. Extraction happens upstream in the ingest pipeline because Meta's reference extractor is PyTorch-only; this worker only interprets the extracted queue fields `videoSealPayload` and `videoSealBitAccuracy`.
+
+The moderation pipeline treats Video Seal as an auxiliary provenance signal, not a short-circuit. If the payload is missing or the upstream bit accuracy is below `0.85`, the signal is recorded as not detected. Known prefixes are mapped in [`src/moderation/videoseal.mjs`](./src/moderation/videoseal.mjs); today `0x01` is reserved for Divine attestations (`source: divine`, `isAI: false`, trusted).
+
+Meta prefixes for Facebook and Instagram are intentionally left empty for now. We do not yet have a verified production payload registry from Meta, so adding guessed prefixes would create false confidence. Once a Meta prefix is confirmed empirically, add it to `KNOWN_PAYLOAD_PREFIXES` in `src/moderation/videoseal.mjs`, include its `source`, `isAI`, and `verified` metadata, and extend `src/moderation/videoseal.test.mjs` with a fixture that proves the new mapping.
+
 ## Hook System Design
 
 ### 1. Upload Hook Integration

--- a/migrations/007-videoseal.sql
+++ b/migrations/007-videoseal.sql
@@ -1,0 +1,5 @@
+-- Persist interpreted Video Seal metadata alongside the durable moderation record.
+-- The value is stored as JSON text so the signal shape can evolve without
+-- requiring a migration for each additional field.
+
+ALTER TABLE moderation_results ADD COLUMN videoseal TEXT;

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -651,7 +651,7 @@ async function getAdminLookupVideo(identifier, env, options = {}) {
   const cdnUrl = `https://${env.CDN_DOMAIN || 'media.divine.video'}/${hash}`;
   if (hash) {
     const moderatedRow = await env.BLOSSOM_DB.prepare(`
-      SELECT sha256, action, provider, scores, categories, moderated_at, reviewed_by, reviewed_at, review_notes, uploaded_by, raw_response
+      SELECT sha256, action, provider, scores, categories, moderated_at, reviewed_by, reviewed_at, review_notes, uploaded_by, raw_response, videoseal
       FROM moderation_results
       WHERE sha256 = ?
     `).bind(hash).first();
@@ -684,7 +684,8 @@ async function getAdminLookupVideo(identifier, env, options = {}) {
         detailedCategories: parseMaybeJson(kvModeration?.detailedCategories, null),
         categoryVerifications: parseMaybeJson(kvModeration?.categoryVerifications, {}) || {},
         cdnUrl: kvModeration?.cdnUrl || cdnUrl,
-        c2pa: (storedRaw && typeof storedRaw === 'object' && storedRaw.c2pa) || null
+        c2pa: (storedRaw && typeof storedRaw === 'object' && storedRaw.c2pa) || null,
+        videoseal: parseMaybeJson(kvModeration?.videoseal, null) || parseMaybeJson(moderatedRow?.videoseal, null)
       }, env);
     }
 
@@ -3457,7 +3458,7 @@ async function runMigration() {
 
       // Query D1 for moderation result
       const d1Result = await env.BLOSSOM_DB.prepare(`
-        SELECT sha256, action, provider, scores, categories, moderated_at, reviewed_by, reviewed_at
+        SELECT sha256, action, provider, scores, categories, moderated_at, reviewed_by, reviewed_at, videoseal
         FROM moderation_results
         WHERE sha256 = ?
       `).bind(sha256).first();
@@ -3488,6 +3489,7 @@ async function runMigration() {
         provider: d1Result.provider,
         scores: d1Result.scores ? JSON.parse(d1Result.scores) : null,
         categories: d1Result.categories ? JSON.parse(d1Result.categories) : null,
+        videoseal: parseMaybeJson(d1Result.videoseal, null),
         moderated_at: d1Result.moderated_at,
         reviewed_by: d1Result.reviewed_by,
         reviewed_at: d1Result.reviewed_at
@@ -3928,7 +3930,14 @@ async function runMigration() {
           continue;
         }
 
-        const { sha256, uploadedBy, uploadedAt, metadata } = validation.data;
+        const {
+          sha256,
+          uploadedBy,
+          uploadedAt,
+          metadata,
+          videoSealPayload,
+          videoSealBitAccuracy
+        } = validation.data;
         console.log(`[MODERATION] Step 2: Message validated for ${sha256}`);
 
         // Check if already moderated (duplicate prevention) - use D1
@@ -3952,7 +3961,9 @@ async function runMigration() {
           sha256,
           uploadedBy,
           uploadedAt,
-          metadata
+          metadata,
+          videoSealPayload,
+          videoSealBitAccuracy
         }, env);
 
         if (result.uploadedBy) {
@@ -3980,8 +3991,8 @@ async function runMigration() {
         await env.BLOSSOM_DB.prepare(`
           INSERT OR REPLACE INTO moderation_results
           (sha256, action, provider, scores, categories, raw_response, moderated_at, uploaded_by,
-           title, author, event_id, content_url, published_at)
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+           title, author, event_id, content_url, published_at, videoseal)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         `).bind(
           sha256,
           result.action,
@@ -3995,7 +4006,8 @@ async function runMigration() {
           result.nostrContext?.author || null,
           result.nostrEventId || null,
           result.nostrContext?.url || result.cdnUrl || null,
-          result.nostrContext?.publishedAt || null
+          result.nostrContext?.publishedAt || null,
+          JSON.stringify(result.videoseal || null)
         ).run();
         console.log(`[MODERATION] Step 7: D1 write successful`);
 
@@ -4421,4 +4433,3 @@ function blossomFailureResponse(sha256, action, blossomError) {
     headers: { 'Content-Type': 'application/json' }
   });
 }
-

--- a/src/index.queue.test.mjs
+++ b/src/index.queue.test.mjs
@@ -1,0 +1,169 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Queue consumer regression tests for moderation worker
+// ABOUTME: Verifies validated queue fields are forwarded into the moderation pipeline
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const moderateVideoMock = vi.fn();
+
+function createDbMock({ writes = [] } = {}) {
+  return {
+    prepare(sql) {
+      let bindings = [];
+
+      return {
+        bind(...args) {
+          bindings = args;
+          return this;
+        },
+        async first() {
+          return null;
+        },
+        async run() {
+          writes.push({ sql, bindings });
+          return { success: true, bindings };
+        }
+      };
+    },
+    async batch() {
+      return [];
+    }
+  };
+}
+
+function createEnv(overrides = {}) {
+  return {
+    BLOSSOM_DB: createDbMock(),
+    MODERATION_KV: {
+      async get() { return null; },
+      async put() {},
+      async delete() {},
+      async list() { return { keys: [], list_complete: true, cursor: null }; }
+    },
+    CDN_DOMAIN: 'media.divine.video',
+    ...overrides
+  };
+}
+
+describe('queue consumer', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    moderateVideoMock.mockReset();
+    moderateVideoMock.mockResolvedValue({
+      sha256: 'a'.repeat(64),
+      action: 'SAFE',
+      severity: 'low',
+      scores: { nudity: 0, violence: 0, ai_generated: 0 },
+      categories: [],
+      provider: 'mock-provider',
+      rawClassifierData: null,
+      sceneClassification: null,
+      topicProfile: null,
+      cdnUrl: `https://media.divine.video/${'a'.repeat(64)}`,
+      uploadedBy: null,
+      nostrContext: null
+    });
+  });
+
+  it('forwards Video Seal fields from the queue message into moderateVideo', async () => {
+    vi.doMock('./moderation/pipeline.mjs', async (importOriginal) => {
+      const actual = await importOriginal();
+      return {
+        ...actual,
+        moderateVideo: moderateVideoMock
+      };
+    });
+
+    const { default: worker } = await import('./index.mjs');
+
+    const ack = vi.fn();
+    const retry = vi.fn();
+    const payload = `01${'b'.repeat(62)}`;
+
+    await worker.queue({
+      messages: [{
+        body: {
+          sha256: 'a'.repeat(64),
+          uploadedAt: Date.now(),
+          metadata: { source: 'blossom' },
+          videoSealPayload: payload,
+          videoSealBitAccuracy: 0.93
+        },
+        attempts: 0,
+        ack,
+        retry
+      }]
+    }, createEnv());
+
+    expect(moderateVideoMock).toHaveBeenCalledTimes(1);
+    expect(moderateVideoMock).toHaveBeenCalledWith(expect.objectContaining({
+      videoSealPayload: payload,
+      videoSealBitAccuracy: 0.93
+    }), expect.any(Object));
+    expect(ack).toHaveBeenCalledTimes(1);
+    expect(retry).not.toHaveBeenCalled();
+  });
+
+  it('persists the interpreted Video Seal signal in D1', async () => {
+    const writes = [];
+    const videoseal = {
+      signal: 'videoseal',
+      detected: true,
+      source: 'divine',
+      isAI: false,
+      payload: `01${'d'.repeat(62)}`,
+      confidence: 0.93
+    };
+
+    moderateVideoMock.mockResolvedValue({
+      sha256: 'a'.repeat(64),
+      action: 'SAFE',
+      severity: 'low',
+      scores: { nudity: 0, violence: 0, ai_generated: 0 },
+      categories: [],
+      provider: 'mock-provider',
+      rawClassifierData: null,
+      sceneClassification: null,
+      topicProfile: null,
+      cdnUrl: `https://media.divine.video/${'a'.repeat(64)}`,
+      uploadedBy: null,
+      nostrContext: null,
+      videoseal
+    });
+
+    vi.doMock('./moderation/pipeline.mjs', async (importOriginal) => {
+      const actual = await importOriginal();
+      return {
+        ...actual,
+        moderateVideo: moderateVideoMock
+      };
+    });
+
+    const { default: worker } = await import('./index.mjs');
+
+    await worker.queue({
+      messages: [{
+        body: {
+          sha256: 'a'.repeat(64),
+          uploadedAt: Date.now(),
+          metadata: { source: 'blossom' },
+          videoSealPayload: videoseal.payload,
+          videoSealBitAccuracy: 0.93
+        },
+        attempts: 0,
+        ack: vi.fn(),
+        retry: vi.fn()
+      }]
+    }, createEnv({
+      BLOSSOM_DB: createDbMock({ writes })
+    }));
+
+    const moderationWrite = writes.find(({ sql }) => sql.includes('INSERT OR REPLACE INTO moderation_results'));
+
+    expect(moderationWrite).toBeDefined();
+    expect(moderationWrite.sql).toContain('videoseal');
+    expect(moderationWrite.bindings).toContain(JSON.stringify(videoseal));
+  });
+});

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -372,6 +372,48 @@ describe('Admin video lookup', () => {
     }
   });
 
+  it('returns persisted videoseal metadata from D1', async () => {
+    const videoseal = {
+      signal: 'videoseal',
+      detected: true,
+      source: 'divine',
+      isAI: false,
+      payload: `01${'e'.repeat(62)}`,
+      confidence: 0.9
+    };
+
+    const env = createEnv({
+      BLOSSOM_DB: createDbMock({
+        moderationResults: new Map([[SHA256, {
+          sha256: SHA256,
+          action: 'SAFE',
+          provider: 'hiveai',
+          scores: JSON.stringify({ nudity: 0.01 }),
+          categories: JSON.stringify(['safe']),
+          moderated_at: '2026-03-07T00:00:00.000Z',
+          reviewed_by: null,
+          reviewed_at: null,
+          videoseal: JSON.stringify(videoseal)
+        }]])
+      })
+    });
+
+    const response = await worker.fetch(
+      new Request(`https://moderation.admin.divine.video/admin/api/video/${SHA256}`, {
+        headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
+      }),
+      env
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      video: {
+        sha256: SHA256,
+        videoseal
+      }
+    });
+  });
+
   it('uses FunnelCake REST instead of WebSocket when moderated metadata is missing', async () => {
     const originalFetch = globalThis.fetch;
     const originalWebSocket = globalThis.WebSocket;

--- a/src/moderation/pipeline-classification.test.mjs
+++ b/src/moderation/pipeline-classification.test.mjs
@@ -264,6 +264,34 @@ how to learn the basics so you can understand this concept`;
     });
   });
 
+  describe('videoseal field', () => {
+    it('should attach the interpreted Video Seal signal without changing moderation flow', async () => {
+      const payload = `01${'c'.repeat(62)}`;
+      const mockFetch = buildMockFetch({ vttStatus: 404 });
+
+      const result = await moderateVideo(
+        {
+          sha256,
+          uploadedAt: Date.now(),
+          videoSealPayload: payload,
+          videoSealBitAccuracy: 0.9
+        },
+        baseEnv,
+        mockFetch
+      );
+
+      expect(result.action).toBe('SAFE');
+      expect(result.videoseal).toEqual({
+        signal: 'videoseal',
+        detected: true,
+        source: 'divine',
+        isAI: false,
+        payload,
+        confidence: 0.9
+      });
+    });
+  });
+
   describe('parallel execution', () => {
     it('should run both moderation and classification, returning all results', async () => {
       const vttText = `WEBVTT

--- a/src/moderation/pipeline.mjs
+++ b/src/moderation/pipeline.mjs
@@ -7,6 +7,7 @@
 import { moderateWithFallback } from './providers/index.mjs';
 import { classifyModerationResult, getKVThresholds, kvThresholdsToEnv } from './classifier.mjs';
 import { classifyText, parseVttText } from './text-classifier.mjs';
+import { interpretVideoSealPayload } from './videoseal.mjs';
 import { fetchNostrEventBySha256, parseVideoEventMetadata, isOriginalVine, hasStrongOriginalVineEvidence } from '../nostr/relay-client.mjs';
 import { classifyVideo } from '../classification/pipeline.mjs';
 import { extractTopics } from '../classification/topic-extractor.mjs';
@@ -43,7 +44,7 @@ async function getCachedC2paOrVerify({ sha256, videoUrl, env, fetchFn }) {
   return result;
 }
 
-function buildSignedAiShortCircuitResult({ sha256, uploadedBy, uploadedAt, metadata, videoUrl, nostrContext, nostrEventId, c2pa }) {
+function buildSignedAiShortCircuitResult({ sha256, uploadedBy, uploadedAt, metadata, videoUrl, nostrContext, nostrEventId, c2pa, videoseal }) {
   const claimGenerator = c2pa.claimGenerator || 'unknown';
   const reason = `c2pa-ai-signed:${claimGenerator} — quarantined pending moderator review`;
   return {
@@ -84,6 +85,7 @@ function buildSignedAiShortCircuitResult({ sha256, uploadedBy, uploadedAt, metad
     sceneClassification: null,
     topicProfile: null,
     c2pa,
+    videoseal,
   };
 }
 
@@ -306,7 +308,14 @@ export async function classifyVideoOnly(sha256, env, options = {}) {
  * @returns {Promise<Object>} Complete moderation result with classification
  */
 export async function moderateVideo(videoData, env, fetchFn = fetch) {
-  const { sha256, uploadedBy, uploadedAt, metadata } = videoData;
+  const {
+    sha256,
+    uploadedBy,
+    uploadedAt,
+    metadata,
+    videoSealPayload = null,
+    videoSealBitAccuracy = null
+  } = videoData;
 
   // Validate configuration
   if (!env.CDN_DOMAIN) {
@@ -361,12 +370,13 @@ export async function moderateVideo(videoData, env, fetchFn = fetch) {
   // Step 2.5: Call divine-inquisitor first so valid_ai_signed content can short-circuit Hive
   const c2pa = await getCachedC2paOrVerify({ sha256, videoUrl, env, fetchFn });
   console.log(`[MODERATION] ${sha256} - C2PA state: ${c2pa.state}${c2pa.claimGenerator ? ` (claim=${c2pa.claimGenerator})` : ''}`);
+  const videoseal = interpretVideoSealPayload(videoSealPayload, videoSealBitAccuracy);
 
   if (c2pa.state === 'valid_ai_signed') {
     console.log(`[MODERATION] ${sha256} - signed-AI short-circuit, skipping Hive and Reality Defender`);
     return buildSignedAiShortCircuitResult({
       sha256, uploadedBy, uploadedAt, metadata,
-      videoUrl, nostrContext, nostrEventId, c2pa,
+      videoUrl, nostrContext, nostrEventId, c2pa, videoseal,
     });
   }
 
@@ -592,5 +602,9 @@ export async function moderateVideo(videoData, env, fetchFn = fetch) {
     // valid_ai_signed is handled earlier via short-circuit; valid_proofmode may have
     // downgraded the action above.
     c2pa,
+
+    // Interpreted upstream Video Seal watermark payload
+    // Always present so downstream consumers can rely on a stable signal shape
+    videoseal
   };
 }

--- a/src/moderation/videoseal.mjs
+++ b/src/moderation/videoseal.mjs
@@ -1,0 +1,64 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Interprets upstream Video Seal watermark payloads into moderation signals
+// ABOUTME: Maps known payload prefixes to trusted provenance metadata and flags unknown prefixes for research
+
+const SIGNAL = 'videoseal';
+const MINIMUM_BIT_ACCURACY = 0.85;
+
+const KNOWN_PAYLOAD_PREFIXES = {
+  0x01: {
+    source: 'divine',
+    isAI: false,
+    verified: true
+  },
+  // TODO: Populate Meta prefix entries once Facebook/Instagram production payload
+  // schemas are validated empirically from real extracted payloads.
+};
+
+function buildUndetectedSignal() {
+  return {
+    signal: SIGNAL,
+    detected: false,
+    confidence: 0
+  };
+}
+
+export function interpretVideoSealPayload(payload, bitAccuracy) {
+  if (
+    typeof payload !== 'string'
+    || payload.length === 0
+    || typeof bitAccuracy !== 'number'
+    || !Number.isFinite(bitAccuracy)
+    || bitAccuracy < MINIMUM_BIT_ACCURACY
+  ) {
+    return buildUndetectedSignal();
+  }
+
+  const prefix = Number.parseInt(payload.slice(0, 2), 16);
+  const knownPrefix = KNOWN_PAYLOAD_PREFIXES[prefix];
+
+  if (!knownPrefix) {
+    // Unknown prefixes are research signals only; downweight until calibrated
+    // against production payloads from a known extractor/model pair.
+    return {
+      signal: SIGNAL,
+      detected: true,
+      source: 'unknown',
+      isAI: null,
+      action: 'flag_for_research',
+      payload,
+      confidence: bitAccuracy * 0.5
+    };
+  }
+
+  return {
+    signal: SIGNAL,
+    detected: true,
+    source: knownPrefix.source,
+    isAI: knownPrefix.isAI,
+    payload,
+    confidence: bitAccuracy * (knownPrefix.verified ? 1 : 0.5)
+  };
+}

--- a/src/moderation/videoseal.test.mjs
+++ b/src/moderation/videoseal.test.mjs
@@ -1,0 +1,64 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Tests for Video Seal watermark payload interpretation
+// ABOUTME: Verifies prefix decoding, confidence thresholds, and unknown payload handling
+
+import { describe, it, expect } from 'vitest';
+import { interpretVideoSealPayload } from './videoseal.mjs';
+
+describe('interpretVideoSealPayload', () => {
+  const divinePayload = `01${'a'.repeat(62)}`;
+
+  it('returns not detected when payload is null', () => {
+    expect(interpretVideoSealPayload(null, 1)).toEqual({
+      signal: 'videoseal',
+      detected: false,
+      confidence: 0
+    });
+  });
+
+  it('returns not detected when bit accuracy is below threshold', () => {
+    expect(interpretVideoSealPayload(divinePayload, 0.8499)).toEqual({
+      signal: 'videoseal',
+      detected: false,
+      confidence: 0
+    });
+  });
+
+  it('interprets the known divine prefix', () => {
+    expect(interpretVideoSealPayload(divinePayload, 0.9)).toEqual({
+      signal: 'videoseal',
+      detected: true,
+      source: 'divine',
+      isAI: false,
+      payload: divinePayload,
+      confidence: 0.9
+    });
+  });
+
+  it('flags unknown prefixes for research', () => {
+    const payload = `ff${'b'.repeat(62)}`;
+
+    expect(interpretVideoSealPayload(payload, 0.91)).toMatchObject({
+      signal: 'videoseal',
+      detected: true,
+      source: 'unknown',
+      isAI: null,
+      action: 'flag_for_research',
+      payload
+    });
+  });
+
+  it('treats 0.85 and 1.0 as valid bit accuracy boundaries', () => {
+    expect(interpretVideoSealPayload(divinePayload, 0.85)).toMatchObject({
+      detected: true,
+      confidence: 0.85
+    });
+
+    expect(interpretVideoSealPayload(divinePayload, 1)).toMatchObject({
+      detected: true,
+      confidence: 1
+    });
+  });
+});

--- a/src/schemas/queue-message.mjs
+++ b/src/schemas/queue-message.mjs
@@ -14,6 +14,8 @@
  * @property {number} [metadata.fileSize] - File size in bytes
  * @property {string} [metadata.contentType] - MIME type
  * @property {number} [metadata.duration] - Duration in seconds
+ * @property {string | null} [videoSealPayload] - Upstream Video Seal payload as 64 hex chars
+ * @property {number | null} [videoSealBitAccuracy] - Upstream Video Seal bit accuracy from 0 to 1
  */
 
 const HEX_64_REGEX = /^[0-9a-f]{64}$/i;
@@ -49,6 +51,29 @@ export function validateQueueMessage(message) {
   // Validate uploadedAt
   if (!message.uploadedAt || typeof message.uploadedAt !== 'number') {
     return { valid: false, error: 'uploadedAt is required and must be a number' };
+  }
+
+  if (message.videoSealPayload !== undefined) {
+    if (message.videoSealPayload !== null && typeof message.videoSealPayload !== 'string') {
+      return { valid: false, error: 'videoSealPayload must be null or a string' };
+    }
+    if (typeof message.videoSealPayload === 'string' && !HEX_64_REGEX.test(message.videoSealPayload)) {
+      return { valid: false, error: 'videoSealPayload must be null or 64 hexadecimal characters' };
+    }
+  }
+
+  if (message.videoSealBitAccuracy !== undefined) {
+    if (message.videoSealBitAccuracy !== null && typeof message.videoSealBitAccuracy !== 'number') {
+      return { valid: false, error: 'videoSealBitAccuracy must be null or a number' };
+    }
+    if (
+      typeof message.videoSealBitAccuracy === 'number'
+      && (!Number.isFinite(message.videoSealBitAccuracy)
+        || message.videoSealBitAccuracy < 0
+        || message.videoSealBitAccuracy > 1)
+    ) {
+      return { valid: false, error: 'videoSealBitAccuracy must be null or a number between 0 and 1' };
+    }
   }
 
   // Metadata is optional, no validation needed

--- a/src/schemas/queue-message.test.mjs
+++ b/src/schemas/queue-message.test.mjs
@@ -5,7 +5,7 @@
 // ABOUTME: Ensures messages from main service have correct structure
 
 import { describe, it, expect } from 'vitest';
-import { validateQueueMessage, QueueMessageSchema } from './queue-message.mjs';
+import { validateQueueMessage } from './queue-message.mjs';
 
 describe('QueueMessage Schema', () => {
   it('should validate a complete queue message', () => {
@@ -79,5 +79,49 @@ describe('QueueMessage Schema', () => {
 
     const result = validateQueueMessage(message);
     expect(result.valid).toBe(true);
+  });
+
+  it('should allow optional Video Seal fields when null or valid', () => {
+    const message = {
+      sha256: 'a'.repeat(64),
+      uploadedAt: Date.now(),
+      videoSealPayload: `01${'b'.repeat(62)}`,
+      videoSealBitAccuracy: 0.92
+    };
+
+    const result = validateQueueMessage(message);
+    expect(result.valid).toBe(true);
+    expect(result.data).toEqual(message);
+
+    const nullResult = validateQueueMessage({
+      sha256: 'c'.repeat(64),
+      uploadedAt: Date.now(),
+      videoSealPayload: null,
+      videoSealBitAccuracy: null
+    });
+
+    expect(nullResult.valid).toBe(true);
+  });
+
+  it('should reject invalid Video Seal payload values', () => {
+    const result = validateQueueMessage({
+      sha256: 'a'.repeat(64),
+      uploadedAt: Date.now(),
+      videoSealPayload: 'not-hex'
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('videoSealPayload');
+  });
+
+  it('should reject invalid Video Seal bit accuracy values', () => {
+    const result = validateQueueMessage({
+      sha256: 'a'.repeat(64),
+      uploadedAt: Date.now(),
+      videoSealBitAccuracy: 1.2
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('videoSealBitAccuracy');
   });
 });


### PR DESCRIPTION
## Summary
- accept upstream Video Seal queue fields and interpret payloads in the moderation pipeline
- persist the interpreted `videoseal` signal in D1 and expose it from admin/public moderation lookups
- add schema validation, tests, docs, and the D1 migration for the new signal

## Test Plan
- [x] npm test
- [x] npx wrangler d1 execute blossom-webhook-events --remote --command "PRAGMA table_info(moderation_results);"
