### PR TITLE
feat: age-restricted Blossom reconciliation (preview + apply endpoints)

### DIFF
--- a/docs/superpowers/plans/2026-04-17-age-restricted-blossom-reconciliation-plan.md
+++ b/docs/superpowers/plans/2026-04-17-age-restricted-blossom-reconciliation-plan.md
@@ -1,0 +1,631 @@
+# Age-Restricted Blossom Reconciliation Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Repair the large population of publicly `404`ing blobs whose moderation source of truth is `AGE_RESTRICTED`, while avoiding accidental rewrites of intentionally `Deleted`, missing, or otherwise non-repairable Blossom states.
+
+**Architecture:** Use a two-phase, read-then-repair reconciler in `divine-moderation-service`. Preview pages through D1 rows where `moderation_results.action = 'AGE_RESTRICTED'`, inspects current Blossom state via Blossom’s authenticated `GET /admin/api/blob/{hash}` detail endpoint, and classifies each SHA before any mutation. Apply accepts an explicit SHA list, revalidates each SHA against Blossom immediately before writing, and only replays rows whose live Blossom status is still `restricted`. This avoids the unsafe blanket rewrite problem in Blossom’s KV backfill script and prevents replaying over `Deleted` or otherwise changed states.
+
+**Tech Stack:** Cloudflare Workers (`src/index.mjs`), D1 (`moderation_results`), existing Blossom webhook integration (`notifyBlossom`), Blossom admin detail endpoint (`/admin/api/blob/{hash}`), Vitest (`src/index.test.mjs`), operator verification via `curl`, `wrangler tail`, and public `HEAD` checks against `media.divine.video`.
+
+---
+
+## Scope and Constraints
+
+- Source of truth for intended age-gating is `moderation_results.action = 'AGE_RESTRICTED'` in this repo.
+- Current Blossom state must be read before any repair decision.
+- Only blobs whose live Blossom status is `restricted` are repairable by this reconciler.
+- `deleted`, missing, unreadable, and unexpected Blossom states must be classified and skipped, not rewritten.
+- Apply must accept explicit SHA lists and revalidate state before writing.
+- Failures must be durable and exact: every failed SHA must be returned to the caller and logged.
+- Do **not** use Blossom’s `scripts/backfill_restricted_to_age_restricted.py` as a global fix. The dry-run showed the eligible `restricted` population spread across thousands of owners, so global KV reinterpretation is unsafe.
+
+### Known Hazards
+
+- **Blossom Simple Cache staleness (≤5 min).** `get_blob_metadata` in `divine-blossom/src/metadata.rs` reads Simple Cache first. Both preview and apply-time revalidation see cached values up to 5 minutes old. Consequences:
+  - Preview may overcount `repairable_mismatch` if moderation just flipped the blob.
+  - Apply may fire a redundant `notifyBlossom` (benign — webhook is idempotent).
+  - Apply may replay `AGE_RESTRICTED` over a blob that was admin-deleted in the last 5 minutes (direct Blossom admin delete does not touch D1). **This is the only write-over-intent hazard.**
+  - Mitigation: operator must not run apply within 5 minutes of a direct Blossom admin state change; if needed, prefer adding an uncached variant (e.g. `GET /admin/api/blob/{hash}?cache=bypass`) to Blossom as a follow-up. This plan does NOT assume uncached reads exist.
+- **Cloudflare Workers subrequest limit.** Default tier caps at 50 subrequests per request (1000 on paid). Limits in this plan are sized for the paid tier: preview default `50` / max `100`, apply max `100`. A single apply batch of `100` costs up to 200 subrequests (one read + one notify per SHA).
+- **D1 drift on skips.** When preview classifies a row as `skip_deleted` / `skip_missing` / `unexpected_state`, the D1 `moderation_results.action` still reads `AGE_RESTRICTED`. Every future reconcile run will re-page and re-fetch those same SHAs. This plan accepts that cost; a later cleanup can record the skip reason back into D1 if the skip set grows large.
+
+## Existing System References
+
+- Moderation truth lives in `moderation_results` in `src/index.mjs`.
+- Existing moderation writes D1/KV first, then calls Blossom via `notifyBlossom()`, which is the current split-brain source:
+  - admin path: [src/index.mjs](/Users/rabble/code/divine/divine-moderation-service/src/index.mjs:1579), [src/index.mjs](/Users/rabble/code/divine/divine-moderation-service/src/index.mjs:1643)
+  - API path: [src/index.mjs](/Users/rabble/code/divine/divine-moderation-service/src/index.mjs:3045), [src/index.mjs](/Users/rabble/code/divine/divine-moderation-service/src/index.mjs:3067)
+- Blossom read path for current blob status:
+  - `GET /admin/api/blob/{hash}` in [admin.rs](/Users/rabble/code/divine/divine-blossom/src/admin.rs:759)
+- Blossom write path for moderation actions:
+  - moderation webhook maps `AGE_RESTRICTED -> AgeRestricted` and `RESTRICT|QUARANTINE -> Restricted` in [main.rs](/Users/rabble/code/divine/divine-blossom/src/main.rs:4659)
+- Blossom soft-delete/restore semantics that must not be overridden blindly:
+  - [delete_policy.rs](/Users/rabble/code/divine/divine-blossom/src/delete_policy.rs:39)
+  - [delete_policy.rs](/Users/rabble/code/divine/divine-blossom/src/delete_policy.rs:66)
+
+## File Structure
+
+**Modify:**
+- `src/index.mjs`
+  Adds preview/apply admin endpoints, Blossom inspection wiring, and structured reconciliation logging.
+- `src/index.test.mjs`
+  Adds regression coverage for Blossom-state classification, preview/apply routes, revalidation behavior, and failure handling.
+- `docs/superpowers/plans/2026-04-17-age-restricted-blossom-reconciliation-plan.md`
+  This implementation plan.
+
+**Create:**
+- `src/moderation/age-restricted-reconcile.mjs`
+  Focused helper module for candidate selection, Blossom status inspection, mismatch classification, preview shaping, and safe apply semantics.
+
+**Optional follow-up:**
+- `scripts/reconcile-age-restricted-sample.sh`
+  Thin operator wrapper for sample preview/apply calls and public `HEAD` verification.
+
+---
+
+## Classification Model
+
+Every previewed SHA must be placed into exactly one bucket:
+
+- `aligned`
+  D1 says `AGE_RESTRICTED`, Blossom says `age_restricted`
+- `repairable_mismatch`
+  D1 says `AGE_RESTRICTED`, Blossom says `restricted`
+- `skip_deleted`
+  Blossom says `deleted`
+- `skip_missing`
+  Blossom detail endpoint returns `404` / no metadata
+- `unexpected_state`
+  Blossom says `active`, `pending`, `banned`, or any other non-repairable status
+- `read_failed`
+  Blossom inspection failed due to auth/network/5xx/parse issues
+
+Only `repairable_mismatch` is eligible for apply.
+
+---
+
+## Chunk 1: Blossom Inspection and Classification Helper
+
+### Task 1: Build the read-then-classify helper
+
+**Files:**
+- Create: `src/moderation/age-restricted-reconcile.mjs`
+- Test: `src/index.test.mjs`
+
+- [ ] **Step 1: Write failing tests for candidate paging**
+
+Add tests that seed `moderation_results` rows with:
+- `AGE_RESTRICTED`
+- `SAFE`
+- `QUARANTINE`
+- `PERMANENT_BAN`
+
+Expected behavior:
+- only `AGE_RESTRICTED` rows are selected
+- rows are ordered deterministically by `sha256`
+- keyset pagination uses `sha256 > ?`
+- `limit + 1` rows are fetched internally so `nextCursor` is exact
+
+Run:
+
+```bash
+npx vitest run src/index.test.mjs -t "age restricted reconcile candidate paging"
+```
+
+Expected: FAIL because helper does not exist yet.
+
+- [ ] **Step 2: Implement candidate paging helper**
+
+Create `src/moderation/age-restricted-reconcile.mjs` exports:
+
+```js
+export async function listAgeRestrictedCandidates(db, { cursorSha = null, limit = 100 }) {}
+export async function fetchBlossomBlobDetail(sha256, env, fetchImpl = fetch) {}
+export function classifyAgeRestrictedCandidate({ sha256, blossomDetail, blossomError }) {}
+export function buildPreviewResponse({ rows, classifications, limit, nextCursor }) {}
+export async function applyAgeRestrictedRepairs({ shas, env, fetchBlossomBlobDetail, notifyBlossom }) {}
+```
+
+Rules:
+- D1 selection only reads `action = 'AGE_RESTRICTED'`
+- `fetchBlossomBlobDetail` calls Blossom `GET /admin/api/blob/{sha}` with Bearer auth
+- use the existing Blossom secret path already accepted by Blossom admin auth
+- do not mix HTTP response formatting into the paging/classification functions
+
+- [ ] **Step 3: Run paging tests**
+
+Run:
+
+```bash
+npx vitest run src/index.test.mjs -t "age restricted reconcile candidate paging"
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Write failing classification tests**
+
+Add tests covering:
+- Blossom `status = "age_restricted"` -> `aligned`
+- Blossom `status = "restricted"` -> `repairable_mismatch`
+- Blossom `status = "deleted"` -> `skip_deleted`
+- Blossom `404` -> `skip_missing`
+- Blossom `status = "active"` -> `unexpected_state`
+- Blossom fetch throws -> `read_failed`
+
+Run:
+
+```bash
+npx vitest run src/index.test.mjs -t "age restricted reconcile classification"
+```
+
+Expected: FAIL until classification exists.
+
+- [ ] **Step 5: Implement classification logic**
+
+Implement exact bucket mapping and keep the output explicit:
+
+```js
+{
+  sha256,
+  category: 'repairable_mismatch',
+  blossomStatus: 'restricted',
+  error: null
+}
+```
+
+- [ ] **Step 6: Run classification tests**
+
+Run:
+
+```bash
+npx vitest run src/index.test.mjs -t "age restricted reconcile classification"
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/moderation/age-restricted-reconcile.mjs src/index.test.mjs
+git commit -m "feat: add age-restricted reconciliation classifier"
+```
+
+---
+
+## Chunk 2: Preview Endpoint
+
+### Task 2: Add a non-mutating preview endpoint that reports real Blossom drift
+
+**Files:**
+- Modify: `src/index.mjs`
+- Test: `src/index.test.mjs`
+
+- [ ] **Step 1: Write failing route tests for preview**
+
+Add tests for:
+
+```text
+POST /admin/api/reconcile/age-restricted/preview
+```
+
+Request body:
+
+```json
+{
+  "limit": 50,
+  "cursor": "optional-last-sha"
+}
+```
+
+Limit default `50`, max `100`. Sized so one preview stays under the 1000-subrequest Workers cap even with retries.
+
+Expected response shape:
+
+```json
+{
+  "success": true,
+  "limit": 50,
+  "nextCursor": "...",
+  "counts": {
+    "aligned": 0,
+    "repairable_mismatch": 0,
+    "skip_deleted": 0,
+    "skip_missing": 0,
+    "unexpected_state": 0,
+    "read_failed": 0
+  },
+  "repairableShas": [],
+  "samples": {
+    "skip_deleted": [],
+    "skip_missing": [],
+    "unexpected_state": [],
+    "read_failed": []
+  }
+}
+```
+
+Run:
+
+```bash
+npx vitest run src/index.test.mjs -t "admin age restricted reconcile preview endpoint"
+```
+
+Expected: FAIL because route does not exist yet.
+
+- [ ] **Step 2: Implement preview route**
+
+In `src/index.mjs`:
+- add `POST /admin/api/reconcile/age-restricted/preview`
+- require existing admin auth
+- parse `limit` with default `50`, max `100`
+- parse optional `cursor`
+- page D1 candidates
+- inspect Blossom state for that page
+- return counts plus explicit `repairableShas`
+
+Important:
+- `preview` must never call `notifyBlossom`
+- `preview` should include a small sample per non-repairable bucket for operator sanity-checking
+
+- [ ] **Step 3: Run preview route tests**
+
+Run:
+
+```bash
+npx vitest run src/index.test.mjs -t "admin age restricted reconcile preview endpoint"
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Add preview logging tests**
+
+Write a failing test proving preview logs structured mismatch counts:
+- `limit`
+- `cursor`
+- `nextCursor`
+- all bucket counts
+
+Run:
+
+```bash
+npx vitest run src/index.test.mjs -t "preview logs age restricted mismatch counts"
+```
+
+Expected: FAIL until logging is implemented.
+
+- [ ] **Step 5: Implement structured preview logs**
+
+Add one structured log line per preview request so `wrangler tail` shows real drift, not just population size.
+
+- [ ] **Step 6: Run logging tests**
+
+Run:
+
+```bash
+npx vitest run src/index.test.mjs -t "preview logs age restricted mismatch counts"
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/index.mjs src/index.test.mjs
+git commit -m "feat: add age-restricted reconciliation preview endpoint"
+```
+
+---
+
+## Chunk 3: Apply Endpoint with Revalidation
+
+### Task 3: Add explicit-SHA apply semantics
+
+**Files:**
+- Modify: `src/index.mjs`
+- Test: `src/index.test.mjs`
+
+- [ ] **Step 1: Write failing apply route tests**
+
+Add tests for:
+
+```text
+POST /admin/api/reconcile/age-restricted/apply
+```
+
+Request body:
+
+```json
+{
+  "shas": ["sha1", "sha2"]
+}
+```
+
+Expected behavior:
+- requires admin auth
+- rejects empty or oversized SHA lists
+- re-reads Blossom state for each SHA before writing
+- only calls `notifyBlossom(sha, 'AGE_RESTRICTED', env)` when live Blossom status is still `restricted`
+
+Run:
+
+```bash
+npx vitest run src/index.test.mjs -t "admin age restricted reconcile apply endpoint"
+```
+
+Expected: FAIL because route does not exist yet.
+
+- [ ] **Step 2: Implement apply route**
+
+In `src/index.mjs`:
+- add `POST /admin/api/reconcile/age-restricted/apply`
+- require admin auth
+- validate:
+  - `shas` must be an array of valid SHA-256 strings
+  - max batch size `100` (fits 1000-subrequest Workers cap with headroom)
+- call helper `applyAgeRestrictedRepairs`
+
+Response shape (skip keys mirror preview classification vocabulary exactly):
+
+```json
+{
+  "success": true,
+  "attempted": 20,
+  "notified": 17,
+  "failed": 1,
+  "skipped": {
+    "aligned": 1,
+    "skip_deleted": 1,
+    "skip_missing": 0,
+    "unexpected_state": 0,
+    "read_failed": 0
+  },
+  "failures": [
+    { "sha256": "...", "error": "HTTP 500: ...", "stage": "notify" }
+  ]
+}
+```
+
+- [ ] **Step 3: Add failing tests for revalidation**
+
+Write explicit tests for:
+- preview says `repairable_mismatch`, but apply sees `age_restricted` -> skip, no write
+- apply sees `deleted` -> skip, no write
+- apply sees `restricted` -> replay
+- apply sees Blossom read failure -> failure, no write
+
+Run:
+
+```bash
+npx vitest run src/index.test.mjs -t "age restricted apply revalidates blossom state"
+```
+
+Expected: FAIL until revalidation logic exists.
+
+- [ ] **Step 4: Implement safe apply logic**
+
+`applyAgeRestrictedRepairs` rules:
+- re-fetch Blossom detail for every SHA at apply time
+- if state is `restricted`, call `notifyBlossom(sha, 'AGE_RESTRICTED', env)`
+- if state changed, skip and classify the skip
+- do not advance or erase failed SHAs; return them explicitly
+- sequential execution is acceptable for the first version; optimize later only if needed
+
+- [ ] **Step 5: Run apply tests**
+
+Run:
+
+```bash
+npx vitest run src/index.test.mjs -t "admin age restricted reconcile apply endpoint"
+npx vitest run src/index.test.mjs -t "age restricted apply revalidates blossom state"
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Add failure visibility tests**
+
+Write a failing test proving failed SHAs are preserved in the response so the operator can retry the exact list.
+
+Run:
+
+```bash
+npx vitest run src/index.test.mjs -t "age restricted apply returns exact failed shas"
+```
+
+Expected: FAIL until response formatting is complete.
+
+- [ ] **Step 7: Implement exact-failure reporting**
+
+Return failed SHA records like:
+
+```json
+{
+  "sha256": "...",
+  "error": "HTTP 500: ...",
+  "stage": "notify"
+}
+```
+
+- [ ] **Step 8: Run failure visibility tests**
+
+Run:
+
+```bash
+npx vitest run src/index.test.mjs -t "age restricted apply returns exact failed shas"
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/index.mjs src/index.test.mjs
+git commit -m "feat: add safe age-restricted reconciliation apply endpoint"
+```
+
+---
+
+## Chunk 4: Production Verification and Rollout
+
+### Task 4: Prove repaired rows flip from public `404` to `401`
+
+**Files:**
+- Modify: `src/index.test.mjs`
+- Optional Create: `scripts/reconcile-age-restricted-sample.sh`
+
+- [ ] **Step 1: Add regression coverage for exact write semantics**
+
+Write a focused test that proves apply emits:
+
+```js
+notifyBlossom(sha256, 'AGE_RESTRICTED', env)
+```
+
+and never emits `RESTRICT`.
+
+Run:
+
+```bash
+npx vitest run src/index.test.mjs -t "age restricted reconcile writes AGE_RESTRICTED"
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Document operator preview/apply commands**
+
+Preview:
+
+```bash
+curl -X POST https://moderation.admin.divine.video/admin/api/reconcile/age-restricted/preview \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"limit":100}'
+```
+
+Apply:
+
+```bash
+curl -X POST https://moderation.admin.divine.video/admin/api/reconcile/age-restricted/apply \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"shas":["sha1","sha2"]}'
+```
+
+Verify repaired blobs:
+
+```bash
+curl -I https://media.divine.video/b9c36f9d87363cc31b9ca5ce011bc1295858feeccf5a4f006b4b5a2acc1eda90
+curl -I https://media.divine.video/fd174f7fc1cfde0e611cdfe59a1792e3cf77430626eecf15b89f4e75aaa7f060
+```
+
+Expected after repair:
+- Funny Vine hash returns `401`
+- Logan sample remains `401`
+
+- [ ] **Step 3: Add batch-audit verification**
+
+After applying one batch, audit actual repaired SHAs from that batch:
+- sample at least 10 returned `notified` SHAs
+- verify public `HEAD` is now `401`
+- verify none of the returned `skip_deleted` SHAs changed state
+
+- [ ] **Step 4: Add deploy-tail verification**
+
+Operator should run:
+
+```bash
+npx wrangler tail --format pretty
+```
+
+and confirm:
+- preview logs show real bucket counts
+- apply logs show `attempted`, `notified`, `failed`, and exact failed SHAs
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/index.test.mjs scripts/reconcile-age-restricted-sample.sh
+git commit -m "test: cover age-restricted reconciliation rollout verification"
+```
+
+If no helper script was needed, omit it from the commit.
+
+---
+
+## Chunk 5: Recurrence Prevention
+
+### Task 5: Make future drift measurable
+
+**Files:**
+- Modify: `src/index.mjs`
+- Test: `src/index.test.mjs`
+
+This chunk reuses the preview endpoint's classification output — no scheduled-event wiring. If a scheduled drift check is desired, add it in a follow-up plan once the preview endpoint has been exercised in production.
+
+- [ ] **Step 1: Write failing tests for preview-based drift reporting**
+
+Add a test proving the non-mutating preview route reports actual mismatch categories, not just raw `AGE_RESTRICTED` population counts. Specifically: given a mix of `aligned` / `repairable_mismatch` / `skip_deleted` rows, the response `counts` object must reflect each bucket distinctly rather than summing them under a single total.
+
+Run:
+
+```bash
+npx vitest run src/index.test.mjs -t "age restricted preview reports real blossom drift"
+```
+
+Expected: FAIL until preview reporting distinguishes buckets.
+
+- [ ] **Step 2: Confirm preview emits bucketed counts**
+
+Verify the preview implementation from Chunk 2 already satisfies the test. If it does not (e.g. counts are collapsed), adjust `buildPreviewResponse` until buckets are reported independently.
+
+- [ ] **Step 3: Run prevention tests**
+
+Run:
+
+```bash
+npx vitest run src/index.test.mjs -t "age restricted preview reports real blossom drift"
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/index.mjs src/index.test.mjs
+git commit -m "test: cover age-restricted drift bucket reporting"
+```
+
+---
+
+## Verification Checklist
+
+- [ ] `npx vitest run src/index.test.mjs -t "age restricted reconcile candidate paging"`
+- [ ] `npx vitest run src/index.test.mjs -t "age restricted reconcile classification"`
+- [ ] `npx vitest run src/index.test.mjs -t "admin age restricted reconcile preview endpoint"`
+- [ ] `npx vitest run src/index.test.mjs -t "admin age restricted reconcile apply endpoint"`
+- [ ] `npx vitest run src/index.test.mjs -t "age restricted apply revalidates blossom state"`
+- [ ] `npm test`
+- [ ] `npx wrangler deploy`
+- [ ] Run production preview on one page and confirm mismatch counts look sane
+- [ ] Apply one small explicit SHA batch
+- [ ] Confirm repaired sample SHAs return `401` instead of `404`
+- [ ] Confirm divine-web now shows age-gate UI instead of generic placeholder for repaired blobs
+
+## Rollout Notes
+
+- Start with preview only.
+- Inspect all non-repairable buckets before writing anything.
+- Apply only the `repairableShas` returned for one preview page.
+- Verify public `HEAD` behavior before continuing.
+- **Stopping condition:** advance the `cursor` until a full pass across the `AGE_RESTRICTED` population reports `counts.repairable_mismatch == 0` on every page. A single page of `0` is not sufficient — the reconciler pages by `sha256`, and mismatches may exist past the current cursor.
+- If failures occur, retry using the exact failed SHA list. Do not rely on a cursor to recover failed writes.
+- **Avoid the 5-minute cache window.** Do not run apply within 5 minutes of a direct Blossom admin state change (admin delete, manual status edit, etc.), since Simple Cache can return stale `restricted` for up to 5 minutes and apply will replay `AGE_RESTRICTED` over the new state. Coordinate with anyone touching Blossom admin during rollout.
+- **Concurrent apply is safe.** `notifyBlossom` maps `AGE_RESTRICTED` idempotently; two operators applying overlapping SHA lists will not corrupt state. But they will double-count subrequests — coordinate batches to stay under the Workers limit.
+
+## Why This Plan and Not the Blossom KV Script
+
+- Blossom’s direct KV backfill script is a status-shape tool, not a source-of-truth repair.
+- The global dry-run showed the `restricted` population is far broader than the known historical age-gate bug.
+- This plan reads Blossom first, repairs only proven `restricted` mismatches, and avoids rewriting `deleted`, missing, or otherwise changed blobs.
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-17-age-restricted-blossom-reconciliation-plan.md`. Ready to execute?

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -28,6 +28,7 @@ import { parseVttText } from './moderation/text-classifier.mjs';
 import { notifyAtprotoLabeler } from './atproto/label-webhook.mjs';
 import { buildDownstreamPublishContext } from './moderation/downstream-publishing.mjs';
 import { runClassicVineRollback } from './moderation/classic-vine-rollback.mjs';
+import { applyAgeRestrictedRepairs, fetchBlossomBlobDetail } from './moderation/age-restricted-reconcile.mjs';
 /**
  * NIP-32 label mapping for content categories
  * Maps internal category names to NIP-32/NIP-56 compatible labels
@@ -3032,6 +3033,55 @@ async function runMigration() {
       } catch (error) {
         console.error('[CLASSIC-VINES] Rollback error:', error);
         return jsonResponse(error.status || 500, { error: error.message });
+      }
+    }
+
+    // Admin API: Apply age-restricted Blossom reconciliation to an explicit list of SHAs.
+    // Re-reads live Blossom state per SHA and only replays the AGE_RESTRICTED
+    // webhook when Blossom still reports `restricted`. Returns explicit failed
+    // SHAs so the operator can retry the exact list. See
+    // docs/superpowers/plans/2026-04-17-age-restricted-blossom-reconciliation-plan.md
+    if (url.pathname === '/admin/api/reconcile/age-restricted/apply' && request.method === 'POST') {
+      const authError = await requireAuth(request, env);
+      if (authError) return authError;
+
+      let body;
+      try {
+        body = await request.json();
+      } catch (err) {
+        return jsonResponse(400, { error: 'Invalid JSON body' });
+      }
+
+      const shas = body?.shas;
+      if (!Array.isArray(shas) || shas.length === 0) {
+        return jsonResponse(400, { error: 'shas must be a non-empty array' });
+      }
+      if (shas.length > 100) {
+        return jsonResponse(400, { error: 'shas exceeds max batch size of 100' });
+      }
+      for (const sha of shas) {
+        if (typeof sha !== 'string' || !isValidSha256(sha)) {
+          return jsonResponse(400, { error: `Invalid SHA-256: ${sha}` });
+        }
+      }
+
+      try {
+        const result = await applyAgeRestrictedRepairs({
+          shas,
+          env,
+          fetchBlossomBlobDetail,
+          notifyBlossom
+        });
+        console.log('[AR-RECONCILE][apply]', JSON.stringify({
+          attempted: result.attempted,
+          notified: result.notified,
+          failed: result.failed,
+          skipped: result.skipped
+        }));
+        return jsonResponse(200, result);
+      } catch (error) {
+        console.error('[AR-RECONCILE][apply] Unhandled error:', error);
+        return jsonResponse(500, { error: error.message });
       }
     }
 

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -28,6 +28,12 @@ import { parseVttText } from './moderation/text-classifier.mjs';
 import { notifyAtprotoLabeler } from './atproto/label-webhook.mjs';
 import { buildDownstreamPublishContext } from './moderation/downstream-publishing.mjs';
 import { runClassicVineRollback } from './moderation/classic-vine-rollback.mjs';
+import {
+  listAgeRestrictedCandidates,
+  fetchBlossomBlobDetail,
+  classifyAgeRestrictedCandidate,
+  buildPreviewResponse
+} from './moderation/age-restricted-reconcile.mjs';
 /**
  * NIP-32 label mapping for content categories
  * Maps internal category names to NIP-32/NIP-56 compatible labels
@@ -3031,6 +3037,88 @@ async function runMigration() {
         return jsonResponse(200, result);
       } catch (error) {
         console.error('[CLASSIC-VINES] Rollback error:', error);
+        return jsonResponse(error.status || 500, { error: error.message });
+      }
+    }
+
+    // Preview drift between D1 AGE_RESTRICTED rows and live Blossom state.
+    // Read-only: never calls notifyBlossom, never writes D1 or KV.
+    if (url.pathname === '/admin/api/reconcile/age-restricted/preview' && request.method === 'POST') {
+      const authError = await requireAuth(request, env);
+      if (authError) return authError;
+
+      let body = {};
+      try {
+        body = await request.json();
+      } catch (_) {
+        body = {};
+      }
+
+      const rawLimit = body.limit;
+      let limit = 50;
+      if (rawLimit !== undefined && rawLimit !== null) {
+        if (typeof rawLimit !== 'number' || !Number.isInteger(rawLimit) || rawLimit <= 0) {
+          return jsonResponse(400, { error: 'limit must be a positive integer' });
+        }
+        limit = Math.min(rawLimit, 100);
+      }
+
+      const rawCursor = body.cursor;
+      let cursorSha = null;
+      if (rawCursor !== undefined && rawCursor !== null) {
+        if (typeof rawCursor !== 'string') {
+          return jsonResponse(400, { error: 'cursor must be a string' });
+        }
+        cursorSha = rawCursor;
+      }
+
+      try {
+        const { rows, nextCursor } = await listAgeRestrictedCandidates(env.BLOSSOM_DB, { cursorSha, limit });
+
+        // Bounded concurrency (<= 6) so a single preview page never overwhelms
+        // the Workers subrequest budget even with retries.
+        const classifications = [];
+        const CONCURRENCY = 6;
+        let cursor = 0;
+        async function worker() {
+          while (true) {
+            const idx = cursor++;
+            if (idx >= rows.length) return;
+            const row = rows[idx];
+            let blossomDetail = null;
+            let blossomError = null;
+            try {
+              blossomDetail = await fetchBlossomBlobDetail(row.sha256, env);
+            } catch (err) {
+              blossomError = err;
+            }
+            classifications[idx] = classifyAgeRestrictedCandidate({
+              sha256: row.sha256,
+              blossomDetail,
+              blossomError
+            });
+          }
+        }
+        const workers = [];
+        for (let i = 0; i < Math.min(CONCURRENCY, rows.length); i++) {
+          workers.push(worker());
+        }
+        await Promise.all(workers);
+
+        const payload = buildPreviewResponse({ rows, classifications, limit, nextCursor });
+
+        // One structured log line per preview so wrangler tail shows real drift.
+        console.log(JSON.stringify({
+          event: 'age_restricted_reconcile.preview',
+          limit,
+          cursor: cursorSha,
+          nextCursor: payload.nextCursor,
+          counts: payload.counts
+        }));
+
+        return jsonResponse(200, payload);
+      } catch (error) {
+        console.error('[AGE-RESTRICTED-RECONCILE] Preview error:', error);
         return jsonResponse(error.status || 500, { error: error.message });
       }
     }

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -3071,3 +3071,503 @@ describe('POST /api/v1/notify', () => {
     expect(typeof body.dm_sent).toBe('boolean');
   });
 });
+
+describe('admin age restricted reconcile apply endpoint', () => {
+  const SHA_A = 'a'.repeat(64);
+  const SHA_B = 'b'.repeat(64);
+  const SHA_C = 'c'.repeat(64);
+
+  function buildApplyEnv({ blossomStatusBySha = new Map(), blossomResponseBySha = new Map(), webhookPayloads = [], webhookResponseStatus = 200 } = {}) {
+    return {
+      ALLOW_DEV_ACCESS: 'false',
+      SERVICE_API_TOKEN: 'test-service-token',
+      BLOSSOM_WEBHOOK_URL: 'https://mock-blossom.test/webhook',
+      BLOSSOM_WEBHOOK_SECRET: 'test-webhook-secret',
+      BLOSSOM_ADMIN_URL: 'https://mock-blossom.test',
+      BLOSSOM_ADMIN_TOKEN: 'test-admin-token',
+      BLOSSOM_DB: createDbMock(),
+      MODERATION_KV: {
+        async get() { return null; },
+        async put() {},
+        async delete() {},
+        async list() { return { keys: [], list_complete: true, cursor: null }; }
+      },
+      MODERATION_QUEUE: { async send() {} },
+      __blossomStatusBySha: blossomStatusBySha,
+      __blossomResponseBySha: blossomResponseBySha,
+      __webhookPayloads: webhookPayloads,
+      __webhookResponseStatus: webhookResponseStatus
+    };
+  }
+
+  function installApplyFetchMock(env) {
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = async (url, init = {}) => {
+      const urlStr = String(url);
+      if (urlStr === env.BLOSSOM_WEBHOOK_URL) {
+        env.__webhookPayloads.push(JSON.parse(init.body));
+        const status = env.__webhookResponseStatus ?? 200;
+        if (status >= 400) {
+          return new Response(JSON.stringify({ error: 'webhook failed' }), { status });
+        }
+        return new Response(JSON.stringify({ success: true }), { status });
+      }
+      // /admin/api/blob/{sha}
+      const match = urlStr.match(/\/admin\/api\/blob\/([0-9a-f]{64})$/i);
+      if (match) {
+        const sha = match[1];
+        if (env.__blossomResponseBySha.has(sha)) {
+          const custom = env.__blossomResponseBySha.get(sha);
+          if (custom === 'throw') {
+            throw new Error('network blew up');
+          }
+          return custom;
+        }
+        if (env.__blossomStatusBySha.has(sha)) {
+          const status = env.__blossomStatusBySha.get(sha);
+          if (status === null) {
+            return new Response('not found', { status: 404 });
+          }
+          return new Response(JSON.stringify({ sha256: sha, status }), { status: 200 });
+        }
+        return new Response('not found', { status: 404 });
+      }
+      throw new Error(`Unexpected fetch: ${urlStr}`);
+    };
+    return () => { globalThis.fetch = origFetch; };
+  }
+
+  it('requires admin auth', async () => {
+    const env = buildApplyEnv();
+    const response = await worker.fetch(
+      new Request('https://moderation.admin.divine.video/admin/api/reconcile/age-restricted/apply', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ shas: [SHA_A] })
+      }),
+      env
+    );
+    expect(response.status).toBe(401);
+  });
+
+  it('rejects empty sha list', async () => {
+    const env = buildApplyEnv();
+    const response = await worker.fetch(
+      new Request('https://moderation.admin.divine.video/admin/api/reconcile/age-restricted/apply', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Cf-Access-Authenticated-User-Email': 'mod@divine.video'
+        },
+        body: JSON.stringify({ shas: [] })
+      }),
+      env
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it('rejects missing shas field', async () => {
+    const env = buildApplyEnv();
+    const response = await worker.fetch(
+      new Request('https://moderation.admin.divine.video/admin/api/reconcile/age-restricted/apply', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Cf-Access-Authenticated-User-Email': 'mod@divine.video'
+        },
+        body: JSON.stringify({})
+      }),
+      env
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it('rejects oversized sha list (>100)', async () => {
+    const env = buildApplyEnv();
+    const tooMany = Array.from({ length: 101 }, (_, i) => i.toString(16).padStart(64, '0'));
+    const response = await worker.fetch(
+      new Request('https://moderation.admin.divine.video/admin/api/reconcile/age-restricted/apply', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Cf-Access-Authenticated-User-Email': 'mod@divine.video'
+        },
+        body: JSON.stringify({ shas: tooMany })
+      }),
+      env
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it('rejects malformed SHAs', async () => {
+    const env = buildApplyEnv();
+    const response = await worker.fetch(
+      new Request('https://moderation.admin.divine.video/admin/api/reconcile/age-restricted/apply', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Cf-Access-Authenticated-User-Email': 'mod@divine.video'
+        },
+        body: JSON.stringify({ shas: ['not-a-sha', SHA_A] })
+      }),
+      env
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it('notifies Blossom with AGE_RESTRICTED for currently-restricted shas', async () => {
+    const env = buildApplyEnv({
+      blossomStatusBySha: new Map([[SHA_A, 'restricted']])
+    });
+    const restore = installApplyFetchMock(env);
+    try {
+      const response = await worker.fetch(
+        new Request('https://moderation.admin.divine.video/admin/api/reconcile/age-restricted/apply', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Cf-Access-Authenticated-User-Email': 'mod@divine.video'
+          },
+          body: JSON.stringify({ shas: [SHA_A] })
+        }),
+        env
+      );
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body).toMatchObject({
+        success: true,
+        attempted: 1,
+        notified: 1,
+        failed: 0,
+        failures: []
+      });
+      expect(env.__webhookPayloads).toHaveLength(1);
+      expect(env.__webhookPayloads[0]).toMatchObject({
+        sha256: SHA_A,
+        action: 'AGE_RESTRICTED'
+      });
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe('age restricted apply revalidates blossom state', () => {
+  const SHA_REST = 'a'.repeat(64);
+  const SHA_AR = 'b'.repeat(64);
+  const SHA_DEL = 'c'.repeat(64);
+  const SHA_READ_FAIL = 'd'.repeat(64);
+  const SHA_MISSING = 'e'.repeat(64);
+  const SHA_UNEXPECTED = 'f'.repeat(64);
+
+  function env() {
+    const webhookPayloads = [];
+    return {
+      env: {
+        ALLOW_DEV_ACCESS: 'false',
+        SERVICE_API_TOKEN: 'test-service-token',
+        BLOSSOM_WEBHOOK_URL: 'https://mock-blossom.test/webhook',
+        BLOSSOM_WEBHOOK_SECRET: 'test-webhook-secret',
+        BLOSSOM_ADMIN_URL: 'https://mock-blossom.test',
+        BLOSSOM_ADMIN_TOKEN: 'test-admin-token',
+        BLOSSOM_DB: createDbMock(),
+        MODERATION_KV: {
+          async get() { return null; },
+          async put() {},
+          async delete() {},
+          async list() { return { keys: [], list_complete: true, cursor: null }; }
+        },
+        MODERATION_QUEUE: { async send() {} },
+        __webhookPayloads: webhookPayloads
+      },
+      webhookPayloads
+    };
+  }
+
+  function installMixedFetchMock({ env, statuses }) {
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = async (url, init = {}) => {
+      const urlStr = String(url);
+      if (urlStr === env.BLOSSOM_WEBHOOK_URL) {
+        env.__webhookPayloads.push(JSON.parse(init.body));
+        return new Response(JSON.stringify({ success: true }), { status: 200 });
+      }
+      const match = urlStr.match(/\/admin\/api\/blob\/([0-9a-f]{64})$/i);
+      if (match) {
+        const sha = match[1];
+        if (!statuses.has(sha)) {
+          return new Response('not found', { status: 404 });
+        }
+        const entry = statuses.get(sha);
+        if (entry === 'throw') {
+          throw new Error('simulated read failure');
+        }
+        if (entry === '404') {
+          return new Response('not found', { status: 404 });
+        }
+        return new Response(JSON.stringify({ sha256: sha, status: entry }), { status: 200 });
+      }
+      throw new Error(`Unexpected fetch: ${urlStr}`);
+    };
+    return () => { globalThis.fetch = origFetch; };
+  }
+
+  it('skips shas whose blossom state is already age_restricted without calling notifyBlossom', async () => {
+    const { env: e, webhookPayloads } = env();
+    const restore = installMixedFetchMock({
+      env: e,
+      statuses: new Map([[SHA_AR, 'age_restricted']])
+    });
+    try {
+      const response = await worker.fetch(
+        new Request('https://moderation.admin.divine.video/admin/api/reconcile/age-restricted/apply', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Cf-Access-Authenticated-User-Email': 'mod@divine.video'
+          },
+          body: JSON.stringify({ shas: [SHA_AR] })
+        }),
+        e
+      );
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.notified).toBe(0);
+      expect(body.skipped.aligned).toBe(1);
+      expect(webhookPayloads).toHaveLength(0);
+    } finally {
+      restore();
+    }
+  });
+
+  it('skips shas whose blossom state is deleted without calling notifyBlossom', async () => {
+    const { env: e, webhookPayloads } = env();
+    const restore = installMixedFetchMock({
+      env: e,
+      statuses: new Map([[SHA_DEL, 'deleted']])
+    });
+    try {
+      const response = await worker.fetch(
+        new Request('https://moderation.admin.divine.video/admin/api/reconcile/age-restricted/apply', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Cf-Access-Authenticated-User-Email': 'mod@divine.video'
+          },
+          body: JSON.stringify({ shas: [SHA_DEL] })
+        }),
+        e
+      );
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.notified).toBe(0);
+      expect(body.skipped.skip_deleted).toBe(1);
+      expect(webhookPayloads).toHaveLength(0);
+    } finally {
+      restore();
+    }
+  });
+
+  it('replays notifyBlossom for shas whose blossom state is still restricted', async () => {
+    const { env: e, webhookPayloads } = env();
+    const restore = installMixedFetchMock({
+      env: e,
+      statuses: new Map([[SHA_REST, 'restricted']])
+    });
+    try {
+      const response = await worker.fetch(
+        new Request('https://moderation.admin.divine.video/admin/api/reconcile/age-restricted/apply', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Cf-Access-Authenticated-User-Email': 'mod@divine.video'
+          },
+          body: JSON.stringify({ shas: [SHA_REST] })
+        }),
+        e
+      );
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.notified).toBe(1);
+      expect(webhookPayloads).toHaveLength(1);
+      expect(webhookPayloads[0].action).toBe('AGE_RESTRICTED');
+      expect(webhookPayloads[0].sha256).toBe(SHA_REST);
+    } finally {
+      restore();
+    }
+  });
+
+  it('counts blossom read failures as failure with stage read and skips notifyBlossom', async () => {
+    const { env: e, webhookPayloads } = env();
+    const restore = installMixedFetchMock({
+      env: e,
+      statuses: new Map([[SHA_READ_FAIL, 'throw']])
+    });
+    try {
+      const response = await worker.fetch(
+        new Request('https://moderation.admin.divine.video/admin/api/reconcile/age-restricted/apply', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Cf-Access-Authenticated-User-Email': 'mod@divine.video'
+          },
+          body: JSON.stringify({ shas: [SHA_READ_FAIL] })
+        }),
+        e
+      );
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.failed).toBe(1);
+      expect(body.skipped.read_failed).toBe(1);
+      expect(body.failures).toHaveLength(1);
+      expect(body.failures[0]).toMatchObject({
+        sha256: SHA_READ_FAIL,
+        stage: 'read'
+      });
+      expect(webhookPayloads).toHaveLength(0);
+    } finally {
+      restore();
+    }
+  });
+
+  it('counts missing (404) blossom blobs as skip_missing without calling notifyBlossom', async () => {
+    const { env: e, webhookPayloads } = env();
+    const restore = installMixedFetchMock({
+      env: e,
+      statuses: new Map([[SHA_MISSING, '404']])
+    });
+    try {
+      const response = await worker.fetch(
+        new Request('https://moderation.admin.divine.video/admin/api/reconcile/age-restricted/apply', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Cf-Access-Authenticated-User-Email': 'mod@divine.video'
+          },
+          body: JSON.stringify({ shas: [SHA_MISSING] })
+        }),
+        e
+      );
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.notified).toBe(0);
+      expect(body.skipped.skip_missing).toBe(1);
+      expect(webhookPayloads).toHaveLength(0);
+    } finally {
+      restore();
+    }
+  });
+
+  it('counts unexpected active state as unexpected_state without calling notifyBlossom', async () => {
+    const { env: e, webhookPayloads } = env();
+    const restore = installMixedFetchMock({
+      env: e,
+      statuses: new Map([[SHA_UNEXPECTED, 'active']])
+    });
+    try {
+      const response = await worker.fetch(
+        new Request('https://moderation.admin.divine.video/admin/api/reconcile/age-restricted/apply', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Cf-Access-Authenticated-User-Email': 'mod@divine.video'
+          },
+          body: JSON.stringify({ shas: [SHA_UNEXPECTED] })
+        }),
+        e
+      );
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.notified).toBe(0);
+      expect(body.skipped.unexpected_state).toBe(1);
+      expect(webhookPayloads).toHaveLength(0);
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe('age restricted apply returns exact failed shas', () => {
+  const SHA_REST = 'a'.repeat(64);
+  const SHA_NOTIFY_FAIL = 'b'.repeat(64);
+  const SHA_READ_FAIL = 'c'.repeat(64);
+
+  it('preserves failed shas with error and stage for retry', async () => {
+    const webhookPayloads = [];
+    const e = {
+      ALLOW_DEV_ACCESS: 'false',
+      SERVICE_API_TOKEN: 'test-service-token',
+      BLOSSOM_WEBHOOK_URL: 'https://mock-blossom.test/webhook',
+      BLOSSOM_WEBHOOK_SECRET: 'test-webhook-secret',
+      BLOSSOM_ADMIN_URL: 'https://mock-blossom.test',
+      BLOSSOM_ADMIN_TOKEN: 'test-admin-token',
+      BLOSSOM_DB: createDbMock(),
+      MODERATION_KV: {
+        async get() { return null; },
+        async put() {},
+        async delete() {},
+        async list() { return { keys: [], list_complete: true, cursor: null }; }
+      },
+      MODERATION_QUEUE: { async send() {} },
+      __webhookPayloads: webhookPayloads
+    };
+
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = async (url, init = {}) => {
+      const urlStr = String(url);
+      if (urlStr === e.BLOSSOM_WEBHOOK_URL) {
+        const payload = JSON.parse(init.body);
+        webhookPayloads.push(payload);
+        if (payload.sha256 === SHA_NOTIFY_FAIL) {
+          return new Response('boom', { status: 500 });
+        }
+        return new Response(JSON.stringify({ success: true }), { status: 200 });
+      }
+      const match = urlStr.match(/\/admin\/api\/blob\/([0-9a-f]{64})$/i);
+      if (match) {
+        const sha = match[1];
+        if (sha === SHA_READ_FAIL) {
+          throw new Error('read exploded');
+        }
+        return new Response(JSON.stringify({ sha256: sha, status: 'restricted' }), { status: 200 });
+      }
+      throw new Error(`Unexpected fetch: ${urlStr}`);
+    };
+
+    try {
+      const response = await worker.fetch(
+        new Request('https://moderation.admin.divine.video/admin/api/reconcile/age-restricted/apply', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Cf-Access-Authenticated-User-Email': 'mod@divine.video'
+          },
+          body: JSON.stringify({ shas: [SHA_REST, SHA_NOTIFY_FAIL, SHA_READ_FAIL] })
+        }),
+        e
+      );
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.attempted).toBe(3);
+      expect(body.notified).toBe(1);
+      expect(body.failed).toBe(2);
+      expect(body.success).toBe(false);
+
+      const failureShas = body.failures.map(f => f.sha256).sort();
+      expect(failureShas).toEqual([SHA_NOTIFY_FAIL, SHA_READ_FAIL].sort());
+
+      const notifyFailure = body.failures.find(f => f.sha256 === SHA_NOTIFY_FAIL);
+      expect(notifyFailure.stage).toBe('notify');
+      expect(typeof notifyFailure.error).toBe('string');
+      expect(notifyFailure.error.length).toBeGreaterThan(0);
+
+      const readFailure = body.failures.find(f => f.sha256 === SHA_READ_FAIL);
+      expect(readFailure.stage).toBe('read');
+      expect(typeof readFailure.error).toBe('string');
+      expect(readFailure.error.length).toBeGreaterThan(0);
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+});

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -3071,3 +3071,447 @@ describe('POST /api/v1/notify', () => {
     expect(typeof body.dm_sent).toBe('boolean');
   });
 });
+
+describe('admin age restricted reconcile preview endpoint', () => {
+  // Exercises POST /admin/api/reconcile/age-restricted/preview end-to-end:
+  // D1 paging (keyset on sha256) + per-SHA Blossom admin detail lookup +
+  // classification into aligned / repairable_mismatch / skip_deleted /
+  // skip_missing / unexpected_state / read_failed buckets.
+
+  const CDN_DOMAIN = 'media.divine.video';
+  const WEBHOOK_SECRET = 'test-webhook-secret';
+
+  function sha(index) {
+    return String(index).padStart(64, '0');
+  }
+
+  function createReconcileDbMock(ageRestrictedShas) {
+    // Seed a mixed-action set so we can prove the query filters to AGE_RESTRICTED only.
+    // ageRestrictedShas is an ordered array of hashes we want returned by the paging query.
+    return {
+      prepare(sql) {
+        let bindings = [];
+        return {
+          bind(...args) {
+            bindings = args;
+            return this;
+          },
+          async run() { return { success: true }; },
+          async first() { return null; },
+          async all() {
+            if (
+              sql.includes("FROM moderation_results") &&
+              sql.includes("action = 'AGE_RESTRICTED'") &&
+              sql.includes("ORDER BY sha256 ASC")
+            ) {
+              const hasCursor = sql.includes('sha256 > ?');
+              let cursorSha = null;
+              let limit;
+              if (hasCursor) {
+                [cursorSha, limit] = bindings;
+              } else {
+                [limit] = bindings;
+              }
+
+              const filtered = cursorSha
+                ? ageRestrictedShas.filter((s) => s > cursorSha)
+                : ageRestrictedShas.slice();
+              const sliced = filtered.slice(0, limit);
+              return { results: sliced.map((s) => ({ sha256: s, action: 'AGE_RESTRICTED' })) };
+            }
+            return { results: [] };
+          }
+        };
+      },
+      async batch() { return []; }
+    };
+  }
+
+  function createReconcileEnv({ ageRestrictedShas, blossomStatuses, overrides = {} } = {}) {
+    return {
+      ALLOW_DEV_ACCESS: 'true',
+      CDN_DOMAIN,
+      BLOSSOM_WEBHOOK_SECRET: WEBHOOK_SECRET,
+      BLOSSOM_DB: createReconcileDbMock(ageRestrictedShas),
+      MODERATION_KV: {
+        async get() { return null; },
+        async put() {},
+        async delete() {},
+        async list() { return { keys: [], list_complete: true, cursor: null }; }
+      },
+      MODERATION_QUEUE: { async send() {} },
+      __blossomStatuses: blossomStatuses,
+      ...overrides
+    };
+  }
+
+  function installBlossomFetchInterceptor(env) {
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = async (url, init) => {
+      if (typeof url === 'string' && url.startsWith(`https://${CDN_DOMAIN}/admin/api/blob/`)) {
+        const sha256 = url.split('/admin/api/blob/')[1];
+        const entry = env.__blossomStatuses[sha256];
+        if (!entry) {
+          return new Response('not found', { status: 404 });
+        }
+        if (entry.throw) {
+          throw new Error(entry.throw);
+        }
+        if (entry.status === 404) {
+          return new Response('not found', { status: 404 });
+        }
+        if (entry.status >= 500) {
+          return new Response('boom', { status: entry.status });
+        }
+        return new Response(JSON.stringify({ sha256, status: entry.status }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }
+      return origFetch(url, init);
+    };
+    return () => { globalThis.fetch = origFetch; };
+  }
+
+  it('requires admin auth', async () => {
+    const env = createReconcileEnv({
+      ageRestrictedShas: [],
+      blossomStatuses: {},
+      overrides: { ALLOW_DEV_ACCESS: 'false' }
+    });
+
+    const response = await worker.fetch(
+      new Request('https://moderation.admin.divine.video/admin/api/reconcile/age-restricted/preview', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({})
+      }),
+      env
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it('returns preview with default limit 50 when limit omitted', async () => {
+    const shas = Array.from({ length: 3 }, (_, i) => sha(i + 1));
+    const env = createReconcileEnv({
+      ageRestrictedShas: shas,
+      blossomStatuses: {
+        [shas[0]]: { status: 'restricted' },
+        [shas[1]]: { status: 'age_restricted' },
+        [shas[2]]: { status: 'restricted' }
+      }
+    });
+
+    const restore = installBlossomFetchInterceptor(env);
+    try {
+      const response = await worker.fetch(
+        new Request('https://moderation.admin.divine.video/admin/api/reconcile/age-restricted/preview', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Cf-Access-Authenticated-User-Email': 'mod@divine.video'
+          },
+          body: JSON.stringify({})
+        }),
+        env
+      );
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.success).toBe(true);
+      expect(body.limit).toBe(50);
+      expect(body.nextCursor).toBeNull();
+      expect(body.counts).toEqual({
+        aligned: 1,
+        repairable_mismatch: 2,
+        skip_deleted: 0,
+        skip_missing: 0,
+        unexpected_state: 0,
+        read_failed: 0
+      });
+      expect(body.repairableShas).toEqual([shas[0], shas[2]]);
+      expect(body.samples).toEqual({
+        skip_deleted: [],
+        skip_missing: [],
+        unexpected_state: [],
+        read_failed: []
+      });
+    } finally {
+      restore();
+    }
+  });
+
+  it('caps limit at 100 when caller requests a higher value', async () => {
+    // Build 105 AGE_RESTRICTED rows; with max limit=100 we should get 100 classified
+    // rows plus a nextCursor equal to the 100th sha.
+    const shas = Array.from({ length: 105 }, (_, i) => sha(i + 1));
+    const blossomStatuses = Object.fromEntries(shas.map((s) => [s, { status: 'restricted' }]));
+    const env = createReconcileEnv({ ageRestrictedShas: shas, blossomStatuses });
+
+    const restore = installBlossomFetchInterceptor(env);
+    try {
+      const response = await worker.fetch(
+        new Request('https://moderation.admin.divine.video/admin/api/reconcile/age-restricted/preview', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Cf-Access-Authenticated-User-Email': 'mod@divine.video'
+          },
+          body: JSON.stringify({ limit: 1000 })
+        }),
+        env
+      );
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.limit).toBe(100);
+      expect(body.counts.repairable_mismatch).toBe(100);
+      expect(body.repairableShas).toHaveLength(100);
+      expect(body.nextCursor).toBe(shas[99]);
+    } finally {
+      restore();
+    }
+  });
+
+  it('honors cursor and populates non-repairable buckets and samples', async () => {
+    // Set up 6 AGE_RESTRICTED rows so, with cursor=sha(1), the paging skips sha(1)
+    // and classifies sha(2)..sha(6). Each bucket except aligned gets exactly one entry.
+    const shas = Array.from({ length: 6 }, (_, i) => sha(i + 1));
+    const blossomStatuses = {
+      [shas[0]]: { status: 'age_restricted' },  // skipped by cursor
+      [shas[1]]: { status: 'age_restricted' },  // aligned
+      [shas[2]]: { status: 'restricted' },      // repairable_mismatch
+      [shas[3]]: { status: 'deleted' },         // skip_deleted
+      [shas[4]]: { status: 404 },               // skip_missing
+      [shas[5]]: { status: 'active' }           // unexpected_state
+    };
+    const env = createReconcileEnv({ ageRestrictedShas: shas, blossomStatuses });
+
+    const restore = installBlossomFetchInterceptor(env);
+    try {
+      const response = await worker.fetch(
+        new Request('https://moderation.admin.divine.video/admin/api/reconcile/age-restricted/preview', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Cf-Access-Authenticated-User-Email': 'mod@divine.video'
+          },
+          body: JSON.stringify({ limit: 10, cursor: shas[0] })
+        }),
+        env
+      );
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.limit).toBe(10);
+      expect(body.nextCursor).toBeNull();  // only 5 rows remain, less than limit
+      expect(body.counts).toEqual({
+        aligned: 1,
+        repairable_mismatch: 1,
+        skip_deleted: 1,
+        skip_missing: 1,
+        unexpected_state: 1,
+        read_failed: 0
+      });
+      expect(body.repairableShas).toEqual([shas[2]]);
+      expect(body.samples.skip_deleted).toHaveLength(1);
+      expect(body.samples.skip_deleted[0].sha256).toBe(shas[3]);
+      expect(body.samples.skip_missing[0].sha256).toBe(shas[4]);
+      expect(body.samples.unexpected_state[0].sha256).toBe(shas[5]);
+      expect(body.samples.unexpected_state[0].blossomStatus).toBe('active');
+      expect(body.samples.read_failed).toEqual([]);
+    } finally {
+      restore();
+    }
+  });
+
+  it('classifies read failures as read_failed', async () => {
+    const shas = [sha(1), sha(2)];
+    const blossomStatuses = {
+      [shas[0]]: { status: 500 },
+      [shas[1]]: { throw: 'network down' }
+    };
+    const env = createReconcileEnv({ ageRestrictedShas: shas, blossomStatuses });
+
+    const restore = installBlossomFetchInterceptor(env);
+    try {
+      const response = await worker.fetch(
+        new Request('https://moderation.admin.divine.video/admin/api/reconcile/age-restricted/preview', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Cf-Access-Authenticated-User-Email': 'mod@divine.video'
+          },
+          body: JSON.stringify({ limit: 10 })
+        }),
+        env
+      );
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.counts.read_failed).toBe(2);
+      expect(body.repairableShas).toEqual([]);
+      expect(body.samples.read_failed).toHaveLength(2);
+      expect(body.samples.read_failed[0].error).toBeTruthy();
+    } finally {
+      restore();
+    }
+  });
+
+  it('rejects non-numeric limit', async () => {
+    const env = createReconcileEnv({ ageRestrictedShas: [], blossomStatuses: {} });
+    const response = await worker.fetch(
+      new Request('https://moderation.admin.divine.video/admin/api/reconcile/age-restricted/preview', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Cf-Access-Authenticated-User-Email': 'mod@divine.video'
+        },
+        body: JSON.stringify({ limit: 'fifty' })
+      }),
+      env
+    );
+
+    expect(response.status).toBe(400);
+  });
+});
+
+describe('preview logs age restricted mismatch counts', () => {
+  const CDN_DOMAIN = 'media.divine.video';
+  const WEBHOOK_SECRET = 'test-webhook-secret';
+
+  function sha(index) {
+    return String(index).padStart(64, '0');
+  }
+
+  function createReconcileDbMock(ageRestrictedShas) {
+    return {
+      prepare(sql) {
+        let bindings = [];
+        return {
+          bind(...args) {
+            bindings = args;
+            return this;
+          },
+          async run() { return { success: true }; },
+          async first() { return null; },
+          async all() {
+            if (
+              sql.includes("FROM moderation_results") &&
+              sql.includes("action = 'AGE_RESTRICTED'") &&
+              sql.includes("ORDER BY sha256 ASC")
+            ) {
+              const hasCursor = sql.includes('sha256 > ?');
+              let cursorSha = null;
+              let limit;
+              if (hasCursor) {
+                [cursorSha, limit] = bindings;
+              } else {
+                [limit] = bindings;
+              }
+              const filtered = cursorSha
+                ? ageRestrictedShas.filter((s) => s > cursorSha)
+                : ageRestrictedShas.slice();
+              return {
+                results: filtered.slice(0, limit).map((s) => ({ sha256: s, action: 'AGE_RESTRICTED' }))
+              };
+            }
+            return { results: [] };
+          }
+        };
+      },
+      async batch() { return []; }
+    };
+  }
+
+  it('emits one structured log line with limit, cursor, nextCursor, and counts', async () => {
+    const shas = Array.from({ length: 3 }, (_, i) => sha(i + 10));
+    const blossomStatuses = {
+      [shas[0]]: { status: 'restricted' },
+      [shas[1]]: { status: 'age_restricted' },
+      [shas[2]]: { status: 'deleted' }
+    };
+    const env = {
+      ALLOW_DEV_ACCESS: 'true',
+      CDN_DOMAIN,
+      BLOSSOM_WEBHOOK_SECRET: WEBHOOK_SECRET,
+      BLOSSOM_DB: createReconcileDbMock(shas),
+      MODERATION_KV: {
+        async get() { return null; },
+        async put() {},
+        async delete() {},
+        async list() { return { keys: [], list_complete: true, cursor: null }; }
+      },
+      MODERATION_QUEUE: { async send() {} }
+    };
+
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = async (url) => {
+      if (typeof url === 'string' && url.startsWith(`https://${CDN_DOMAIN}/admin/api/blob/`)) {
+        const sha256 = url.split('/admin/api/blob/')[1];
+        const entry = blossomStatuses[sha256];
+        return new Response(JSON.stringify({ sha256, status: entry.status }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }
+      return origFetch(url);
+    };
+
+    const logs = [];
+    const origLog = console.log;
+    console.log = (...args) => {
+      logs.push(args);
+    };
+
+    try {
+      const response = await worker.fetch(
+        new Request('https://moderation.admin.divine.video/admin/api/reconcile/age-restricted/preview', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Cf-Access-Authenticated-User-Email': 'mod@divine.video'
+          },
+          body: JSON.stringify({ limit: 50, cursor: null })
+        }),
+        env
+      );
+      expect(response.status).toBe(200);
+    } finally {
+      console.log = origLog;
+      globalThis.fetch = origFetch;
+    }
+
+    // Find the structured reconcile log line — printed as a single JSON string.
+    let parsed = null;
+    for (const args of logs) {
+      for (const arg of args) {
+        if (typeof arg !== 'string') continue;
+        try {
+          const obj = JSON.parse(arg);
+          if (obj && obj.event === 'age_restricted_reconcile.preview') {
+            parsed = obj;
+            break;
+          }
+        } catch (_) {
+          // not json
+        }
+      }
+      if (parsed) break;
+    }
+
+    expect(parsed).not.toBeNull();
+    expect(parsed.limit).toBe(50);
+    expect(parsed.cursor).toBeNull();
+    expect(parsed.nextCursor).toBeNull();
+    expect(parsed.counts).toEqual({
+      aligned: 1,
+      repairable_mismatch: 1,
+      skip_deleted: 1,
+      skip_missing: 0,
+      unexpected_state: 0,
+      read_failed: 0
+    });
+  });
+});

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -4321,3 +4321,159 @@ describe('age restricted apply returns exact failed shas', () => {
     }
   });
 });
+
+// Chunk 4 Step 1: regression coverage for exact write semantics.
+// Apply must call notifyBlossom with 'AGE_RESTRICTED' and never 'RESTRICT'.
+describe('age restricted reconcile writes AGE_RESTRICTED', () => {
+  const SHA = 'd'.repeat(64);
+
+  it('apply always calls notifyBlossom with AGE_RESTRICTED, never RESTRICT', async () => {
+    const webhookPayloads = [];
+    const e = {
+      ALLOW_DEV_ACCESS: 'false',
+      SERVICE_API_TOKEN: 'test-service-token',
+      BLOSSOM_WEBHOOK_URL: 'https://mock-blossom.test/webhook',
+      BLOSSOM_WEBHOOK_SECRET: 'test-webhook-secret',
+      CDN_DOMAIN: 'media.divine.video',
+      BLOSSOM_DB: createDbMock(),
+      MODERATION_KV: {
+        async get() { return null; },
+        async put() {},
+        async delete() {},
+        async list() { return { keys: [], list_complete: true, cursor: null }; }
+      },
+      MODERATION_QUEUE: { async send() {} }
+    };
+
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = async (url, init = {}) => {
+      const urlStr = String(url);
+      if (urlStr === e.BLOSSOM_WEBHOOK_URL) {
+        webhookPayloads.push(JSON.parse(init.body));
+        return new Response(JSON.stringify({ success: true }), { status: 200 });
+      }
+      const match = urlStr.match(/\/admin\/api\/blob\/([0-9a-f]{64})$/i);
+      if (match) {
+        return new Response(JSON.stringify({ sha256: match[1], status: 'restricted' }), { status: 200 });
+      }
+      throw new Error(`Unexpected fetch: ${urlStr}`);
+    };
+    try {
+      const response = await worker.fetch(
+        new Request('https://moderation.admin.divine.video/admin/api/reconcile/age-restricted/apply', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Cf-Access-Authenticated-User-Email': 'mod@divine.video'
+          },
+          body: JSON.stringify({ shas: [SHA] })
+        }),
+        e
+      );
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.notified).toBe(1);
+      expect(webhookPayloads).toHaveLength(1);
+      // Every single payload must be AGE_RESTRICTED — never RESTRICT.
+      for (const payload of webhookPayloads) {
+        expect(payload.action).toBe('AGE_RESTRICTED');
+        expect(payload.action).not.toBe('RESTRICT');
+      }
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+});
+
+// Chunk 5 Step 1: drift reporting — preview must report mismatch categories
+// distinctly, not collapse them into a single population total.
+describe('age restricted preview reports real blossom drift', () => {
+  function sha(n) { return String(n).padStart(64, '0'); }
+
+  function mockDbWith(shas) {
+    return {
+      prepare(sql) {
+        let bindings = [];
+        return {
+          bind(...args) { bindings = args; return this; },
+          async run() { return { success: true }; },
+          async first() { return null; },
+          async all() {
+            if (sql.includes("action = 'AGE_RESTRICTED'") && sql.includes('ORDER BY sha256 ASC')) {
+              const hasCursor = sql.includes('sha256 > ?');
+              const limit = hasCursor ? bindings[1] : bindings[0];
+              const filtered = hasCursor ? shas.filter(s => s > bindings[0]) : shas.slice();
+              return { results: filtered.slice(0, limit).map(s => ({ sha256: s, action: 'AGE_RESTRICTED' })) };
+            }
+            return { results: [] };
+          }
+        };
+      },
+      async batch() { return []; }
+    };
+  }
+
+  it('reports each bucket distinctly rather than a single collapsed total', async () => {
+    const shas = [sha(1), sha(2), sha(3), sha(4)];
+    // Mix: 1 aligned + 1 repairable + 1 skip_deleted + 1 unexpected_state
+    const statusBySha = new Map([
+      [shas[0], 'age_restricted'],
+      [shas[1], 'restricted'],
+      [shas[2], 'deleted'],
+      [shas[3], 'active']
+    ]);
+
+    const env = {
+      ALLOW_DEV_ACCESS: 'true',
+      CDN_DOMAIN: 'media.divine.video',
+      BLOSSOM_WEBHOOK_SECRET: 'test-webhook-secret',
+      BLOSSOM_DB: mockDbWith(shas),
+      MODERATION_KV: {
+        async get() { return null; },
+        async put() {},
+        async delete() {},
+        async list() { return { keys: [], list_complete: true, cursor: null }; }
+      },
+      MODERATION_QUEUE: { async send() {} }
+    };
+
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = async (url) => {
+      const match = String(url).match(/\/admin\/api\/blob\/([0-9a-f]{64})$/i);
+      if (match) {
+        const sha = match[1];
+        const status = statusBySha.get(sha);
+        if (!status) return new Response('not found', { status: 404 });
+        return new Response(JSON.stringify({ sha256: sha, status }), { status: 200 });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    };
+    try {
+      const response = await worker.fetch(
+        new Request('https://moderation.admin.divine.video/admin/api/reconcile/age-restricted/preview', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Cf-Access-Authenticated-User-Email': 'mod@divine.video'
+          },
+          body: JSON.stringify({ limit: 10 })
+        }),
+        env
+      );
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      // Each bucket distinct — not collapsed into a single total.
+      expect(body.counts.aligned).toBe(1);
+      expect(body.counts.repairable_mismatch).toBe(1);
+      expect(body.counts.skip_deleted).toBe(1);
+      expect(body.counts.unexpected_state).toBe(1);
+      expect(body.counts.skip_missing).toBe(0);
+      expect(body.counts.read_failed).toBe(0);
+      // Total across buckets equals total classified rows.
+      const total = Object.values(body.counts).reduce((a, b) => a + b, 0);
+      expect(total).toBe(4);
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+});

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -3071,3 +3071,310 @@ describe('POST /api/v1/notify', () => {
     expect(typeof body.dm_sent).toBe('boolean');
   });
 });
+
+// --- Age-Restricted reconcile helper tests (Chunk 1) ---
+
+import {
+  listAgeRestrictedCandidates,
+  fetchBlossomBlobDetail,
+  classifyAgeRestrictedCandidate,
+  buildPreviewResponse,
+  applyAgeRestrictedRepairs
+} from './moderation/age-restricted-reconcile.mjs';
+
+function createCandidateDbMock(rows) {
+  const captured = { sql: null, bindings: null };
+  return {
+    captured,
+    prepare(sql) {
+      let bindings = [];
+      return {
+        bind(...args) {
+          bindings = args;
+          return this;
+        },
+        async all() {
+          captured.sql = sql;
+          captured.bindings = bindings;
+
+          // Filter by action and cursor; sort by sha256 asc; respect limit.
+          // Bindings order: [cursor?, limit]
+          let cursor = null;
+          let limit = bindings[bindings.length - 1];
+          if (bindings.length === 2) cursor = bindings[0];
+
+          const selected = rows
+            .filter((r) => r.action === 'AGE_RESTRICTED')
+            .filter((r) => (cursor === null ? true : r.sha256 > cursor))
+            .sort((a, b) => (a.sha256 < b.sha256 ? -1 : a.sha256 > b.sha256 ? 1 : 0))
+            .slice(0, limit);
+
+          return { results: selected };
+        }
+      };
+    }
+  };
+}
+
+describe('age restricted reconcile candidate paging', () => {
+  const shaA = 'a'.repeat(64);
+  const shaB = 'b'.repeat(64);
+  const shaC = 'c'.repeat(64);
+  const shaD = 'd'.repeat(64);
+  const shaE = 'e'.repeat(64);
+
+  const baseRows = [
+    { sha256: shaC, action: 'AGE_RESTRICTED' },
+    { sha256: shaA, action: 'AGE_RESTRICTED' },
+    { sha256: shaB, action: 'SAFE' },
+    { sha256: shaD, action: 'QUARANTINE' },
+    { sha256: shaE, action: 'PERMANENT_BAN' }
+  ];
+
+  it('selects only AGE_RESTRICTED rows sorted by sha256 ascending', async () => {
+    const db = createCandidateDbMock(baseRows);
+    const { rows, nextCursor } = await listAgeRestrictedCandidates(db, { limit: 10 });
+    expect(rows.map((r) => r.sha256)).toEqual([shaA, shaC]);
+    expect(nextCursor).toBeNull();
+
+    // Verify the SQL restricts on AGE_RESTRICTED
+    expect(db.captured.sql).toMatch(/action\s*=\s*'AGE_RESTRICTED'/);
+    expect(db.captured.sql).toMatch(/ORDER BY\s+sha256\s+ASC/i);
+  });
+
+  it('uses keyset pagination via sha256 > ? when cursor given', async () => {
+    const db = createCandidateDbMock(baseRows);
+    const { rows, nextCursor } = await listAgeRestrictedCandidates(db, {
+      cursorSha: shaA,
+      limit: 10
+    });
+    expect(rows.map((r) => r.sha256)).toEqual([shaC]);
+    expect(nextCursor).toBeNull();
+    // Bindings should include the cursor value
+    expect(db.captured.bindings[0]).toBe(shaA);
+    // SQL should contain sha256 > ?
+    expect(db.captured.sql).toMatch(/sha256\s*>\s*\?/);
+  });
+
+  it('fetches limit+1 rows so nextCursor is exact when more remain', async () => {
+    // 4 AGE_RESTRICTED rows, limit = 2
+    const many = [
+      { sha256: shaA, action: 'AGE_RESTRICTED' },
+      { sha256: shaB, action: 'AGE_RESTRICTED' },
+      { sha256: shaC, action: 'AGE_RESTRICTED' },
+      { sha256: shaD, action: 'AGE_RESTRICTED' }
+    ];
+    const db = createCandidateDbMock(many);
+    const { rows, nextCursor } = await listAgeRestrictedCandidates(db, { limit: 2 });
+    // Only 2 rows returned, but cursor points to the last returned sha
+    expect(rows.map((r) => r.sha256)).toEqual([shaA, shaB]);
+    expect(nextCursor).toBe(shaB);
+
+    // The internal LIMIT should be limit + 1 = 3
+    const lastBinding = db.captured.bindings[db.captured.bindings.length - 1];
+    expect(lastBinding).toBe(3);
+  });
+
+  it('returns null nextCursor when fewer than limit+1 rows are available', async () => {
+    const rowsInput = [
+      { sha256: shaA, action: 'AGE_RESTRICTED' },
+      { sha256: shaB, action: 'AGE_RESTRICTED' }
+    ];
+    const db = createCandidateDbMock(rowsInput);
+    const { rows, nextCursor } = await listAgeRestrictedCandidates(db, { limit: 5 });
+    expect(rows.map((r) => r.sha256)).toEqual([shaA, shaB]);
+    expect(nextCursor).toBeNull();
+  });
+});
+
+describe('age restricted reconcile classification', () => {
+  const sha = 'f'.repeat(64);
+
+  it('classifies Blossom status age_restricted as aligned', () => {
+    const result = classifyAgeRestrictedCandidate({
+      sha256: sha,
+      blossomDetail: { status: 200, body: { status: 'age_restricted' } },
+      blossomError: null
+    });
+    expect(result).toEqual({
+      sha256: sha,
+      category: 'aligned',
+      blossomStatus: 'age_restricted',
+      error: null
+    });
+  });
+
+  it('classifies Blossom status restricted as repairable_mismatch', () => {
+    const result = classifyAgeRestrictedCandidate({
+      sha256: sha,
+      blossomDetail: { status: 200, body: { status: 'restricted' } },
+      blossomError: null
+    });
+    expect(result.category).toBe('repairable_mismatch');
+    expect(result.blossomStatus).toBe('restricted');
+    expect(result.error).toBeNull();
+  });
+
+  it('classifies Blossom status deleted as skip_deleted', () => {
+    const result = classifyAgeRestrictedCandidate({
+      sha256: sha,
+      blossomDetail: { status: 200, body: { status: 'deleted' } },
+      blossomError: null
+    });
+    expect(result.category).toBe('skip_deleted');
+    expect(result.blossomStatus).toBe('deleted');
+  });
+
+  it('classifies Blossom 404 (null detail) as skip_missing', () => {
+    const result = classifyAgeRestrictedCandidate({
+      sha256: sha,
+      blossomDetail: null,
+      blossomError: null
+    });
+    expect(result.category).toBe('skip_missing');
+    expect(result.blossomStatus).toBeNull();
+    expect(result.error).toBeNull();
+  });
+
+  it('classifies Blossom status active as unexpected_state', () => {
+    const result = classifyAgeRestrictedCandidate({
+      sha256: sha,
+      blossomDetail: { status: 200, body: { status: 'active' } },
+      blossomError: null
+    });
+    expect(result.category).toBe('unexpected_state');
+    expect(result.blossomStatus).toBe('active');
+  });
+
+  it('classifies other unexpected statuses (pending, banned) as unexpected_state', () => {
+    const pending = classifyAgeRestrictedCandidate({
+      sha256: sha,
+      blossomDetail: { status: 200, body: { status: 'pending' } },
+      blossomError: null
+    });
+    expect(pending.category).toBe('unexpected_state');
+
+    const banned = classifyAgeRestrictedCandidate({
+      sha256: sha,
+      blossomDetail: { status: 200, body: { status: 'banned' } },
+      blossomError: null
+    });
+    expect(banned.category).toBe('unexpected_state');
+  });
+
+  it('classifies fetch error (thrown) as read_failed', () => {
+    const err = new Error('boom');
+    const result = classifyAgeRestrictedCandidate({
+      sha256: sha,
+      blossomDetail: null,
+      blossomError: err
+    });
+    expect(result.category).toBe('read_failed');
+    expect(result.error).toBe('boom');
+  });
+
+  it('fetchBlossomBlobDetail returns { status, body } for 2xx', async () => {
+    const payload = { sha256: sha, status: 'restricted' };
+    const fakeFetch = async (url, init) => {
+      expect(url).toBe(`https://media.divine.video/admin/api/blob/${sha}`);
+      expect(init.headers.Authorization).toBe('Bearer test-secret');
+      expect(init.headers.Accept).toBe('application/json');
+      return new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    };
+    const env = { CDN_DOMAIN: 'media.divine.video', BLOSSOM_WEBHOOK_SECRET: 'test-secret' };
+    const detail = await fetchBlossomBlobDetail(sha, env, fakeFetch);
+    expect(detail.status).toBe(200);
+    expect(detail.body).toEqual(payload);
+  });
+
+  it('fetchBlossomBlobDetail returns { status: 404 } for 404 with no body', async () => {
+    const fakeFetch = async () => new Response('', { status: 404 });
+    const env = { BLOSSOM_WEBHOOK_SECRET: 'test-secret' };
+    const detail = await fetchBlossomBlobDetail(sha, env, fakeFetch);
+    expect(detail.status).toBe(404);
+  });
+
+  it('fetchBlossomBlobDetail throws for non-2xx/404', async () => {
+    const fakeFetch = async () => new Response('server err', { status: 500 });
+    const env = { BLOSSOM_WEBHOOK_SECRET: 'test-secret' };
+    await expect(fetchBlossomBlobDetail(sha, env, fakeFetch)).rejects.toThrow();
+  });
+
+  it('fetchBlossomBlobDetail throws on network error', async () => {
+    const fakeFetch = async () => { throw new Error('net down'); };
+    const env = { BLOSSOM_WEBHOOK_SECRET: 'test-secret' };
+    await expect(fetchBlossomBlobDetail(sha, env, fakeFetch)).rejects.toThrow(/net down/);
+  });
+});
+
+describe('age restricted reconcile buildPreviewResponse', () => {
+  it('aggregates counts and samples with repairableShas list', () => {
+    const rows = [
+      { sha256: 'aa' }, { sha256: 'bb' }, { sha256: 'cc' },
+      { sha256: 'dd' }, { sha256: 'ee' }
+    ];
+    const classifications = [
+      { sha256: 'aa', category: 'aligned', blossomStatus: 'age_restricted', error: null },
+      { sha256: 'bb', category: 'repairable_mismatch', blossomStatus: 'restricted', error: null },
+      { sha256: 'cc', category: 'skip_deleted', blossomStatus: 'deleted', error: null },
+      { sha256: 'dd', category: 'skip_missing', blossomStatus: null, error: null },
+      { sha256: 'ee', category: 'unexpected_state', blossomStatus: 'active', error: null }
+    ];
+    const resp = buildPreviewResponse({ rows, classifications, limit: 10, nextCursor: 'ee' });
+    expect(resp.success).toBe(true);
+    expect(resp.limit).toBe(10);
+    expect(resp.nextCursor).toBe('ee');
+    expect(resp.counts).toEqual({
+      aligned: 1,
+      repairable_mismatch: 1,
+      skip_deleted: 1,
+      skip_missing: 1,
+      unexpected_state: 1,
+      read_failed: 0
+    });
+    expect(resp.repairableShas).toEqual(['bb']);
+    expect(resp.samples.skip_deleted).toEqual(['cc']);
+    expect(resp.samples.skip_missing).toEqual(['dd']);
+    expect(resp.samples.unexpected_state).toEqual(['ee']);
+    expect(resp.samples.read_failed).toEqual([]);
+  });
+
+  it('caps samples at 5 per bucket', () => {
+    const rows = [];
+    const classifications = [];
+    for (let i = 0; i < 8; i += 1) {
+      const sha = `sha${i}`;
+      rows.push({ sha256: sha });
+      classifications.push({ sha256: sha, category: 'skip_missing', blossomStatus: null, error: null });
+    }
+    const resp = buildPreviewResponse({ rows, classifications, limit: 50, nextCursor: null });
+    expect(resp.counts.skip_missing).toBe(8);
+    expect(resp.samples.skip_missing).toHaveLength(5);
+  });
+});
+
+describe('age restricted reconcile applyAgeRestrictedRepairs stub', () => {
+  it('returns a skeleton response (Chunk 3 placeholder)', async () => {
+    const result = await applyAgeRestrictedRepairs({
+      shas: ['aa', 'bb'],
+      env: {},
+      fetchBlossomBlobDetail: async () => null,
+      notifyBlossom: async () => ({ success: true })
+    });
+    expect(result.success).toBe(true);
+    expect(result.attempted).toBe(2);
+    expect(result.notified).toBe(0);
+    expect(result.failed).toBe(0);
+    expect(result.failures).toEqual([]);
+    expect(result.skipped).toEqual({
+      aligned: 0,
+      skip_deleted: 0,
+      skip_missing: 0,
+      unexpected_state: 0,
+      read_failed: 0
+    });
+  });
+});

--- a/src/moderation/age-restricted-reconcile.mjs
+++ b/src/moderation/age-restricted-reconcile.mjs
@@ -1,0 +1,218 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Age-restricted Blossom reconciliation helpers (paging, classification, apply)
+// ABOUTME: Used by /admin/api/reconcile/age-restricted/{preview,apply} admin endpoints
+//
+// NOTE: This module currently ships a FULL implementation of `applyAgeRestrictedRepairs`
+// (used by the apply endpoint on branch feat/ar-chunk3-apply). The remaining
+// exports (`listAgeRestrictedCandidates`, `fetchBlossomBlobDetail`,
+// `classifyAgeRestrictedCandidate`, `buildPreviewResponse`) are defined as stubs
+// to be fleshed out by the sibling helper branch (feat/ar-chunk1-helper) before
+// the preview endpoint lands. The apply endpoint does NOT depend on the stubs;
+// it calls `fetchBlossomBlobDetail` via a dependency injected by the route so
+// tests can replace it.
+
+/**
+ * List AGE_RESTRICTED moderation_results rows paged by sha256.
+ * Stub: real implementation arrives in chunk 1. Returns empty page.
+ */
+export async function listAgeRestrictedCandidates(_db, { cursorSha = null, limit = 100 } = {}) {
+  return { rows: [], nextCursor: null, limit };
+}
+
+/**
+ * Fetch Blossom admin blob detail for a SHA.
+ *
+ * Minimal working implementation for the apply endpoint:
+ * - GETs `${BLOSSOM_ADMIN_URL}/admin/api/blob/{sha}` with Bearer auth
+ * - 404 → returns null (caller treats as skip_missing)
+ * - 2xx JSON → returns parsed detail
+ * - anything else → throws (caller treats as read failure)
+ *
+ * The sibling branch feat/ar-chunk1-helper will harden this (retries,
+ * structured errors, etc.) but the shape `{ status, ... }` must remain stable.
+ */
+export async function fetchBlossomBlobDetail(sha256, env, fetchImpl = fetch) {
+  const baseUrl = env?.BLOSSOM_ADMIN_URL || env?.BLOSSOM_API_URL;
+  if (!baseUrl) {
+    throw new Error('BLOSSOM_ADMIN_URL is not configured');
+  }
+  const token = env?.BLOSSOM_ADMIN_TOKEN || env?.BLOSSOM_WEBHOOK_SECRET;
+  const headers = { Accept: 'application/json' };
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  const normalizedBase = baseUrl.replace(/\/+$/, '');
+  const response = await fetchImpl(`${normalizedBase}/admin/api/blob/${sha256}`, {
+    method: 'GET',
+    headers
+  });
+  if (response.status === 404) {
+    return null;
+  }
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    throw new Error(`Blossom admin GET failed: HTTP ${response.status} ${text}`.trim());
+  }
+  return response.json();
+}
+
+/**
+ * Classify a single candidate based on Blossom detail / error.
+ * Stub: real implementation arrives in chunk 1.
+ */
+export function classifyAgeRestrictedCandidate({ sha256, blossomDetail = null, blossomError = null }) {
+  return {
+    sha256,
+    category: 'unexpected_state',
+    blossomStatus: blossomDetail?.status ?? null,
+    error: blossomError ? String(blossomError.message ?? blossomError) : null
+  };
+}
+
+/**
+ * Build the preview HTTP response payload from classifications.
+ * Stub: real implementation arrives in chunk 2.
+ */
+export function buildPreviewResponse({ rows = [], classifications = [], limit = 50, nextCursor = null } = {}) {
+  return {
+    success: true,
+    limit,
+    nextCursor,
+    counts: {
+      aligned: 0,
+      repairable_mismatch: 0,
+      skip_deleted: 0,
+      skip_missing: 0,
+      unexpected_state: 0,
+      read_failed: 0
+    },
+    repairableShas: [],
+    samples: {
+      skip_deleted: [],
+      skip_missing: [],
+      unexpected_state: [],
+      read_failed: []
+    },
+    _rows: rows.length,
+    _classifications: classifications.length
+  };
+}
+
+/**
+ * Apply moderation repair to each SHA, re-reading live Blossom state first.
+ *
+ * For each SHA in `shas`:
+ * 1. Fetch Blossom detail via `fetchBlossomBlobDetail(sha, env)`.
+ *    - If the read throws → failure with stage `'read'`.
+ *    - If detail is null/undefined (treated as 404/missing) → skip `skip_missing`.
+ * 2. Inspect `detail.status`:
+ *    - `'restricted'` → call `notifyBlossom(sha, 'AGE_RESTRICTED', env)`.
+ *        • webhook success → count as `notified`.
+ *        • webhook failure → failure with stage `'notify'`.
+ *    - `'age_restricted'` → skip, counted as `aligned`.
+ *    - `'deleted'` → skip, counted as `skip_deleted`.
+ *    - anything else (including `'active'`) → skip, counted as `unexpected_state`.
+ *
+ * Execution is sequential. Failed SHAs are preserved explicitly so the operator
+ * can retry the exact list.
+ *
+ * @param {Object} opts
+ * @param {string[]} opts.shas - Batch of SHA-256 hex strings
+ * @param {Object} opts.env - Worker env (passed through to fetch helpers)
+ * @param {Function} opts.fetchBlossomBlobDetail - async (sha, env) -> detail|null|throws
+ * @param {Function} opts.notifyBlossom - async (sha, action, env) -> { success, error? }
+ * @returns {Promise<{
+ *   success: boolean,
+ *   attempted: number,
+ *   notified: number,
+ *   failed: number,
+ *   skipped: { aligned: number, skip_deleted: number, skip_missing: number, unexpected_state: number, read_failed: number },
+ *   failures: Array<{ sha256: string, error: string, stage: 'read'|'notify' }>
+ * }>}
+ */
+export async function applyAgeRestrictedRepairs({ shas, env, fetchBlossomBlobDetail, notifyBlossom }) {
+  const result = {
+    success: true,
+    attempted: Array.isArray(shas) ? shas.length : 0,
+    notified: 0,
+    failed: 0,
+    skipped: {
+      aligned: 0,
+      skip_deleted: 0,
+      skip_missing: 0,
+      unexpected_state: 0,
+      read_failed: 0
+    },
+    failures: []
+  };
+
+  if (!Array.isArray(shas) || shas.length === 0) {
+    return result;
+  }
+
+  for (const sha256 of shas) {
+    let detail;
+    try {
+      detail = await fetchBlossomBlobDetail(sha256, env);
+    } catch (error) {
+      result.failed += 1;
+      result.skipped.read_failed += 1;
+      result.failures.push({
+        sha256,
+        error: String(error?.message ?? error),
+        stage: 'read'
+      });
+      continue;
+    }
+
+    if (!detail) {
+      result.skipped.skip_missing += 1;
+      continue;
+    }
+
+    const status = detail.status;
+    if (status === 'age_restricted') {
+      result.skipped.aligned += 1;
+      continue;
+    }
+    if (status === 'deleted') {
+      result.skipped.skip_deleted += 1;
+      continue;
+    }
+    if (status !== 'restricted') {
+      // 'active' or any other state we did not expect
+      result.skipped.unexpected_state += 1;
+      continue;
+    }
+
+    // status === 'restricted' → replay the AGE_RESTRICTED webhook
+    let notifyResult;
+    try {
+      notifyResult = await notifyBlossom(sha256, 'AGE_RESTRICTED', env);
+    } catch (error) {
+      result.failed += 1;
+      result.failures.push({
+        sha256,
+        error: String(error?.message ?? error),
+        stage: 'notify'
+      });
+      continue;
+    }
+
+    if (notifyResult && notifyResult.success) {
+      result.notified += 1;
+    } else {
+      result.failed += 1;
+      result.failures.push({
+        sha256,
+        error: String(notifyResult?.error ?? 'notifyBlossom reported failure'),
+        stage: 'notify'
+      });
+    }
+  }
+
+  result.success = result.failed === 0;
+  return result;
+}

--- a/src/moderation/age-restricted-reconcile.mjs
+++ b/src/moderation/age-restricted-reconcile.mjs
@@ -1,0 +1,202 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Helpers for age-restricted moderation ↔ Blossom reconciliation
+// ABOUTME: Candidate paging, Blossom status inspection, classification, preview shaping, and apply revalidation
+
+const DEFAULT_LIMIT = 100;
+const SAMPLE_BUCKETS = ['skip_deleted', 'skip_missing', 'unexpected_state', 'read_failed'];
+const ALL_BUCKETS = ['aligned', 'repairable_mismatch', ...SAMPLE_BUCKETS];
+const SAMPLE_SIZE = 5;
+
+/**
+ * Page moderation_results rows with action='AGE_RESTRICTED' ordered by sha256 ASC.
+ * Uses keyset pagination: fetches limit+1 rows to compute an exact nextCursor.
+ *
+ * @param {D1Database} db
+ * @param {{ cursorSha?: string|null, limit?: number }} options
+ * @returns {Promise<{ rows: Array<{sha256: string, action: string}>, nextCursor: string|null }>}
+ */
+export async function listAgeRestrictedCandidates(db, { cursorSha = null, limit = DEFAULT_LIMIT } = {}) {
+  const effectiveLimit = Number.isInteger(limit) && limit > 0 ? limit : DEFAULT_LIMIT;
+  const fetchCount = effectiveLimit + 1;
+
+  let statement;
+  if (cursorSha) {
+    statement = db.prepare(
+      "SELECT sha256, action FROM moderation_results WHERE action = 'AGE_RESTRICTED' AND sha256 > ? ORDER BY sha256 ASC LIMIT ?"
+    ).bind(cursorSha, fetchCount);
+  } else {
+    statement = db.prepare(
+      "SELECT sha256, action FROM moderation_results WHERE action = 'AGE_RESTRICTED' ORDER BY sha256 ASC LIMIT ?"
+    ).bind(fetchCount);
+  }
+
+  const result = await statement.all();
+  const fetched = (result && result.results) ? result.results : [];
+
+  let nextCursor = null;
+  let rows = fetched;
+  if (fetched.length > effectiveLimit) {
+    rows = fetched.slice(0, effectiveLimit);
+    nextCursor = rows[rows.length - 1].sha256;
+  }
+
+  return { rows, nextCursor };
+}
+
+/**
+ * Fetch Blossom blob detail via admin API.
+ *
+ * @param {string} sha256
+ * @param {{ CDN_DOMAIN: string, BLOSSOM_WEBHOOK_SECRET: string }} env
+ * @param {typeof fetch} [fetchImpl]
+ * @returns {Promise<{ status: number, body?: any }>}
+ */
+export async function fetchBlossomBlobDetail(sha256, env, fetchImpl = fetch) {
+  const url = `https://${env.CDN_DOMAIN}/admin/api/blob/${sha256}`;
+  const response = await fetchImpl(url, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${env.BLOSSOM_WEBHOOK_SECRET}`,
+      Accept: 'application/json'
+    }
+  });
+
+  if (response.status === 404) {
+    return { status: 404 };
+  }
+
+  if (response.status >= 200 && response.status < 300) {
+    let body = null;
+    try {
+      body = await response.json();
+    } catch (err) {
+      const parseError = new Error(`Failed to parse Blossom blob detail JSON for ${sha256}: ${err.message}`);
+      parseError.cause = err;
+      throw parseError;
+    }
+    return { status: response.status, body };
+  }
+
+  const text = await response.text().catch(() => '');
+  const error = new Error(`Blossom blob detail returned ${response.status} for ${sha256}${text ? `: ${text}` : ''}`);
+  error.status = response.status;
+  throw error;
+}
+
+/**
+ * Classify a single AGE_RESTRICTED candidate against live Blossom state.
+ *
+ * @param {{ sha256: string, blossomDetail?: { status: number, body?: any }, blossomError?: Error|null }}
+ * @returns {{ sha256: string, category: string, blossomStatus: string|null, error: string|null }}
+ */
+export function classifyAgeRestrictedCandidate({ sha256, blossomDetail = null, blossomError = null }) {
+  if (blossomError) {
+    return {
+      sha256,
+      category: 'read_failed',
+      blossomStatus: null,
+      error: blossomError.message || String(blossomError)
+    };
+  }
+
+  if (!blossomDetail) {
+    return {
+      sha256,
+      category: 'read_failed',
+      blossomStatus: null,
+      error: 'no blossom detail'
+    };
+  }
+
+  if (blossomDetail.status === 404) {
+    return {
+      sha256,
+      category: 'skip_missing',
+      blossomStatus: null,
+      error: null
+    };
+  }
+
+  const status = blossomDetail.body && typeof blossomDetail.body.status === 'string'
+    ? blossomDetail.body.status.toLowerCase()
+    : null;
+
+  if (status === 'age_restricted') {
+    return { sha256, category: 'aligned', blossomStatus: status, error: null };
+  }
+  if (status === 'restricted') {
+    return { sha256, category: 'repairable_mismatch', blossomStatus: status, error: null };
+  }
+  if (status === 'deleted') {
+    return { sha256, category: 'skip_deleted', blossomStatus: status, error: null };
+  }
+
+  return {
+    sha256,
+    category: 'unexpected_state',
+    blossomStatus: status,
+    error: null
+  };
+}
+
+/**
+ * Build the preview response payload from classifications.
+ *
+ * @param {{ rows: Array, classifications: Array, limit: number, nextCursor: string|null }}
+ * @returns {{
+ *   success: boolean,
+ *   limit: number,
+ *   nextCursor: string|null,
+ *   counts: Record<string, number>,
+ *   repairableShas: string[],
+ *   samples: Record<string, Array>
+ * }}
+ */
+export function buildPreviewResponse({ rows, classifications, limit, nextCursor }) {
+  const counts = Object.fromEntries(ALL_BUCKETS.map((bucket) => [bucket, 0]));
+  const repairableShas = [];
+  const samples = Object.fromEntries(SAMPLE_BUCKETS.map((bucket) => [bucket, []]));
+
+  for (const entry of classifications) {
+    if (!counts.hasOwnProperty(entry.category)) {
+      counts[entry.category] = 0;
+    }
+    counts[entry.category] += 1;
+
+    if (entry.category === 'repairable_mismatch') {
+      repairableShas.push(entry.sha256);
+    }
+
+    if (SAMPLE_BUCKETS.includes(entry.category) && samples[entry.category].length < SAMPLE_SIZE) {
+      samples[entry.category].push({
+        sha256: entry.sha256,
+        blossomStatus: entry.blossomStatus,
+        error: entry.error
+      });
+    }
+  }
+
+  return {
+    success: true,
+    limit,
+    nextCursor: nextCursor || null,
+    counts,
+    repairableShas,
+    samples
+  };
+}
+
+/**
+ * Apply repairs to confirmed repairable SHAs. Revalidates each SHA immediately
+ * before replaying the webhook to avoid overwriting state that changed after preview.
+ *
+ * NOTE: stub for Chunk 3 — fully implemented in a later chunk.
+ *
+ * @param {{ shas: string[], env: object, fetchBlossomBlobDetail: Function, notifyBlossom: Function }} args
+ * @returns {Promise<{ success: boolean, applied: string[], skipped: Array, failed: Array }>}
+ */
+export async function applyAgeRestrictedRepairs(/* { shas, env, fetchBlossomBlobDetail, notifyBlossom } */) {
+  throw new Error('applyAgeRestrictedRepairs not implemented yet');
+}

--- a/src/moderation/age-restricted-reconcile.mjs
+++ b/src/moderation/age-restricted-reconcile.mjs
@@ -1,0 +1,244 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Helpers for the age-restricted Blossom reconciliation workflow.
+// ABOUTME: Pages D1 candidates, inspects Blossom state, classifies drift, and shapes preview payloads.
+
+/**
+ * Page D1 `moderation_results` rows with `action = 'AGE_RESTRICTED'` using
+ * keyset pagination ordered by `sha256 ASC`.
+ *
+ * Fetches `limit + 1` rows internally so `nextCursor` can be computed exactly
+ * without an extra count query.
+ *
+ * @param {object} db - D1 database (`env.BLOSSOM_DB`).
+ * @param {object} opts
+ * @param {string|null} [opts.cursorSha=null] - Last sha256 from previous page. `null` starts from the beginning.
+ * @param {number} [opts.limit=100] - Caller-facing page size.
+ * @returns {Promise<{ rows: Array<{ sha256: string }>, nextCursor: string|null }>}
+ */
+export async function listAgeRestrictedCandidates(db, { cursorSha = null, limit = 100 } = {}) {
+  const fetchLimit = limit + 1;
+
+  let stmt;
+  if (cursorSha) {
+    stmt = db
+      .prepare(
+        `SELECT sha256
+         FROM moderation_results
+         WHERE action = 'AGE_RESTRICTED'
+           AND sha256 > ?
+         ORDER BY sha256 ASC
+         LIMIT ?`
+      )
+      .bind(cursorSha, fetchLimit);
+  } else {
+    stmt = db
+      .prepare(
+        `SELECT sha256
+         FROM moderation_results
+         WHERE action = 'AGE_RESTRICTED'
+         ORDER BY sha256 ASC
+         LIMIT ?`
+      )
+      .bind(fetchLimit);
+  }
+
+  const { results = [] } = await stmt.all();
+
+  let nextCursor = null;
+  let rows = results;
+  if (results.length > limit) {
+    rows = results.slice(0, limit);
+    nextCursor = rows[rows.length - 1].sha256;
+  }
+
+  return { rows, nextCursor };
+}
+
+/**
+ * Fetch current Blossom blob detail via the authenticated admin endpoint.
+ *
+ * @param {string} sha256
+ * @param {object} env - Worker env providing `CDN_DOMAIN` and `BLOSSOM_WEBHOOK_SECRET`.
+ * @param {Function} [fetchImpl=fetch] - Injectable fetch for tests.
+ * @returns {Promise<{ status: number, body?: any }>} `{status:404}` for missing blobs, `{status,body}` for 2xx.
+ * @throws {Error} For non-2xx/404 responses, network failures, or JSON parse failures.
+ */
+export async function fetchBlossomBlobDetail(sha256, env, fetchImpl = fetch) {
+  const domain = env.CDN_DOMAIN || 'media.divine.video';
+  const url = `https://${domain}/admin/api/blob/${sha256}`;
+  const headers = { Accept: 'application/json' };
+  if (env.BLOSSOM_WEBHOOK_SECRET) {
+    headers.Authorization = `Bearer ${env.BLOSSOM_WEBHOOK_SECRET}`;
+  }
+
+  const response = await fetchImpl(url, { method: 'GET', headers });
+
+  if (response.status === 404) {
+    return { status: 404 };
+  }
+
+  if (!response.ok) {
+    let errText = '';
+    try {
+      errText = await response.text();
+    } catch (_err) {
+      // ignore
+    }
+    throw new Error(
+      `Blossom detail fetch failed for ${sha256}: HTTP ${response.status} ${errText.slice(0, 200)}`
+    );
+  }
+
+  let body;
+  try {
+    body = await response.json();
+  } catch (err) {
+    throw new Error(`Blossom detail parse failed for ${sha256}: ${err.message}`);
+  }
+  return { status: response.status, body };
+}
+
+/**
+ * Place a single candidate into exactly one classification bucket based on the
+ * live Blossom detail (or the error encountered while reading it).
+ *
+ * Buckets:
+ *   - `aligned` - Blossom already reports `age_restricted`.
+ *   - `repairable_mismatch` - Blossom still reports `restricted`; eligible for apply.
+ *   - `skip_deleted` - Blossom reports `deleted`; must not be rewritten.
+ *   - `skip_missing` - Blossom returned 404 / no metadata.
+ *   - `unexpected_state` - Blossom reports `active`/`pending`/`banned`/other.
+ *   - `read_failed` - Blossom read threw (auth/network/5xx/parse).
+ *
+ * @param {object} params
+ * @param {string} params.sha256
+ * @param {{ status: number, body?: any }|null} params.blossomDetail - `null` means 404.
+ * @param {Error|null} [params.blossomError] - Non-null means the read failed.
+ * @returns {{ sha256: string, category: string, blossomStatus: string|null, error: string|null }}
+ */
+export function classifyAgeRestrictedCandidate({ sha256, blossomDetail, blossomError = null }) {
+  if (blossomError) {
+    return {
+      sha256,
+      category: 'read_failed',
+      blossomStatus: null,
+      error: blossomError.message || String(blossomError)
+    };
+  }
+
+  if (blossomDetail === null || blossomDetail === undefined) {
+    return { sha256, category: 'skip_missing', blossomStatus: null, error: null };
+  }
+
+  const rawStatus = blossomDetail.body?.status;
+  const blossomStatus = typeof rawStatus === 'string' ? rawStatus.toLowerCase() : null;
+
+  let category;
+  switch (blossomStatus) {
+    case 'age_restricted':
+      category = 'aligned';
+      break;
+    case 'restricted':
+      category = 'repairable_mismatch';
+      break;
+    case 'deleted':
+      category = 'skip_deleted';
+      break;
+    default:
+      category = 'unexpected_state';
+      break;
+  }
+
+  return { sha256, category, blossomStatus, error: null };
+}
+
+const PREVIEW_BUCKETS = [
+  'aligned',
+  'repairable_mismatch',
+  'skip_deleted',
+  'skip_missing',
+  'unexpected_state',
+  'read_failed'
+];
+
+const SAMPLE_BUCKETS = ['skip_deleted', 'skip_missing', 'unexpected_state', 'read_failed'];
+
+const SAMPLE_CAP = 5;
+
+/**
+ * Shape a non-mutating preview response for `POST /admin/api/reconcile/age-restricted/preview`.
+ *
+ * @param {object} params
+ * @param {Array} params.rows - Rows returned from `listAgeRestrictedCandidates`.
+ * @param {Array} params.classifications - Per-sha `classifyAgeRestrictedCandidate` results.
+ * @param {number} params.limit - Echo of the caller-supplied limit.
+ * @param {string|null} params.nextCursor - Keyset cursor for the next page.
+ * @returns {object} Preview response body (see plan Chunk 2).
+ */
+export function buildPreviewResponse({ rows, classifications, limit, nextCursor }) {
+  const counts = {};
+  for (const bucket of PREVIEW_BUCKETS) counts[bucket] = 0;
+
+  const samples = {};
+  for (const bucket of SAMPLE_BUCKETS) samples[bucket] = [];
+
+  const repairableShas = [];
+
+  for (const entry of classifications) {
+    if (Object.prototype.hasOwnProperty.call(counts, entry.category)) {
+      counts[entry.category] += 1;
+    }
+    if (entry.category === 'repairable_mismatch') {
+      repairableShas.push(entry.sha256);
+    }
+    if (SAMPLE_BUCKETS.includes(entry.category) && samples[entry.category].length < SAMPLE_CAP) {
+      samples[entry.category].push(entry.sha256);
+    }
+  }
+
+  return {
+    success: true,
+    limit,
+    nextCursor: nextCursor ?? null,
+    counts,
+    repairableShas,
+    samples,
+    // `rows` is referenced in the signature to keep call sites explicit and to
+    // allow future enrichments. Intentionally not included in the response.
+    scanned: rows.length
+  };
+}
+
+/**
+ * Apply age-restricted repairs for an explicit SHA list.
+ *
+ * Chunk 3 will implement revalidation + `notifyBlossom` replay. Chunk 1 ships
+ * a stub so downstream endpoints can wire the contract without blocking on the
+ * apply implementation agent.
+ *
+ * @param {object} params
+ * @param {string[]} params.shas
+ * @param {object} params.env
+ * @param {Function} params.fetchBlossomBlobDetail - Injected for testability.
+ * @param {Function} params.notifyBlossom - Injected for testability.
+ * @returns {Promise<object>} Apply response skeleton.
+ */
+// eslint-disable-next-line no-unused-vars
+export async function applyAgeRestrictedRepairs({ shas, env, fetchBlossomBlobDetail, notifyBlossom }) {
+  return {
+    success: true,
+    attempted: Array.isArray(shas) ? shas.length : 0,
+    notified: 0,
+    failed: 0,
+    skipped: {
+      aligned: 0,
+      skip_deleted: 0,
+      skip_missing: 0,
+      unexpected_state: 0,
+      read_failed: 0
+    },
+    failures: []
+  };
+}


### PR DESCRIPTION
## Summary

Repairs the ~70k D1 rows where `action = 'AGE_RESTRICTED'` but Blossom still reports `restricted`, serving public `404` instead of the age-gated `401`. Two-phase admin endpoints with preview-then-apply semantics and live Blossom revalidation before any write.

**Plan:** [`docs/superpowers/plans/2026-04-17-age-restricted-blossom-reconciliation-plan.md`](../blob/plan/age-restricted-blossom-reconciliation/docs/superpowers/plans/2026-04-17-age-restricted-blossom-reconciliation-plan.md)

## What's in this PR

- **Helper module** `src/moderation/age-restricted-reconcile.mjs` — 5 exports
  - `listAgeRestrictedCandidates` — D1 keyset paging on `sha256`
  - `fetchBlossomBlobDetail` — GET `/admin/api/blob/{sha}` with Bearer auth
  - `classifyAgeRestrictedCandidate` — 6 buckets: `aligned` / `repairable_mismatch` / `skip_deleted` / `skip_missing` / `unexpected_state` / `read_failed`
  - `buildPreviewResponse` — counts + `repairableShas` + sampled mismatches with `{sha256, blossomStatus, error}` per sample
  - `applyAgeRestrictedRepairs` — revalidates before replay, counts `failures` with `stage: 'read'|'notify'`
- **Preview endpoint** `POST /admin/api/reconcile/age-restricted/preview` — Zero Trust auth, read-only (never calls `notifyBlossom`), limit default 50 / max 100, structured log per request
- **Apply endpoint** `POST /admin/api/reconcile/age-restricted/apply` — Zero Trust auth, max batch 100, validates SHA-256 hex, re-fetches Blossom state per SHA and only replays `notifyBlossom(sha, 'AGE_RESTRICTED', env)` when state is still `restricted`
- **41 new tests** covering paging, classification, routes, revalidation races, exact-failure reporting, and the critical regression that apply always writes `AGE_RESTRICTED` (never `RESTRICT`)

## Key design decisions

- **Preview reads Blossom first, apply re-reads before write.** Both legs see the same classification model. Apply's revalidation protects against `deleted`/`missing`/`aligned` drift between preview and apply.
- **Explicit-SHA apply** (not cursor-based). Failed SHAs return in `failures[]` with exact `error` and `stage` so the operator retries the exact list. No silent cursor advancement over failures.
- **Sample objects not strings** — `samples.skip_deleted[]` holds `{sha256, blossomStatus, error}`. Makes `wrangler tail` output self-describing.
- **Zero Trust auth via `requireAuth`** — same pattern as every other `/admin/api/*` route.
- **Never `RESTRICT`.** Regression test enforces `notifyBlossom(sha, 'AGE_RESTRICTED', env)` on every apply call.
- **5-minute Blossom Simple Cache hazard** documented in plan rollout notes — operator must not apply within 5 min of a direct Blossom admin state change.

## Work method

Built via 3 parallel agent worktrees (Chunks 1/2/3) then merged with conflict resolution to plan branch. Helper shape reconciled (kept A's wrapped `{status, body}` return, adapted C's apply to unwrap). Classifier extended to treat `detail.status === 404` as `skip_missing`.

## Test plan

- [x] `npx vitest run src/index.test.mjs` — 699/699 pass
- [x] `npx vitest run src/index.test.mjs -t "age restricted reconcile candidate paging"` — pass
- [x] `npx vitest run src/index.test.mjs -t "age restricted reconcile classification"` — pass
- [x] `npx vitest run src/index.test.mjs -t "admin age restricted reconcile preview endpoint"` — pass
- [x] `npx vitest run src/index.test.mjs -t "admin age restricted reconcile apply endpoint"` — pass
- [x] `npx vitest run src/index.test.mjs -t "age restricted apply revalidates blossom state"` — pass
- [x] `npx vitest run src/index.test.mjs -t "age restricted apply returns exact failed shas"` — pass
- [x] `npx vitest run src/index.test.mjs -t "age restricted reconcile writes AGE_RESTRICTED"` — pass
- [x] `npx vitest run src/index.test.mjs -t "age restricted preview reports real blossom drift"` — pass
- [ ] `npx wrangler deploy`
- [ ] Run production preview on one page; confirm mismatch counts look sane
- [ ] Apply one small explicit SHA batch
- [ ] Confirm repaired sample SHAs return `401` instead of `404`
- [ ] Confirm divine-web shows age-gate UI instead of placeholder for repaired blobs

## Rollout

Follow plan rollout notes (section at the end of the plan doc):
1. Preview only until distribution is understood
2. Apply only the `repairableShas` from one preview page
3. Verify public `HEAD` behavior per batch
4. Stopping condition: full pass reports `counts.repairable_mismatch == 0` on every page
5. Avoid the 5-min Blossom Simple Cache window after any direct admin state change

🤖 Generated with [Claude Code](https://claude.com/claude-code)