### PR TITLE
fix(nip98): normalize URLs before comparing u tag to expected URL

### DIFF
--- a/src/creator-delete/nip98.mjs
+++ b/src/creator-delete/nip98.mjs
@@ -9,6 +9,44 @@ import { verifyEvent } from 'nostr-tools/pure';
 const CLOCK_DRIFT_SECONDS = 60;
 const EXPECTED_KIND = 27235;
 
+/**
+ * Canonicalize a URL for NIP-98 `u` tag comparison. Normalizes forms that are
+ * semantically equivalent but textually distinct so that a signed `u` tag from
+ * a well-behaved client matches the request URL we build server-side.
+ *
+ * What normalizes:
+ * - Scheme and host case (`HTTPS://Example.COM` → `https://example.com`).
+ * - Explicit default ports (`https://x:443/path` → `https://x/path`,
+ *   `http://x:80/path` → `http://x/path`).
+ * - Root path (`https://x` → `https://x/`).
+ * - Fragment stripped (fragments never reach the server).
+ * - Userinfo stripped (not expected on API auth URLs; normalized away so a
+ *   stray `user@host` form doesn't mismatch).
+ *
+ * What does NOT normalize (documented behavior — signer and verifier must agree):
+ * - Non-root trailing slash (`/path` vs `/path/` are distinct resources).
+ * - Query parameter ordering.
+ * - Percent-encoding of reserved or unreserved characters (the URL constructor
+ *   preserves the encoding as-received). If a signer produces `%7E` and the
+ *   request URL has `~`, they will not match. Clients should build both sides
+ *   with the same serialization; the typical path is `new URL(x).toString()`.
+ *
+ * Returns `null` if the input cannot be parsed as a URL. Callers must treat
+ * `null === null` as a mismatch, not a match.
+ */
+function normalizeUrl(url) {
+  if (typeof url !== 'string' || url.length === 0) return null;
+  try {
+    const u = new URL(url);
+    u.hash = '';
+    u.username = '';
+    u.password = '';
+    return u.toString();
+  } catch (e) {
+    return null;
+  }
+}
+
 export async function validateNip98Header(authorizationHeader, expectedUrl, expectedMethod) {
   if (!authorizationHeader || !authorizationHeader.startsWith('Nostr ')) {
     return { valid: false, error: 'Missing or malformed Authorization header (expected "Nostr <base64>")' };
@@ -40,8 +78,17 @@ export async function validateNip98Header(authorizationHeader, expectedUrl, expe
   const uTag = event.tags.find(t => t[0] === 'u')?.[1];
   const methodTag = event.tags.find(t => t[0] === 'method')?.[1];
 
-  if (uTag !== expectedUrl) {
-    return { valid: false, error: `u tag '${uTag}' does not match expected URL '${expectedUrl}'` };
+  const normalizedUTag = normalizeUrl(uTag);
+  const normalizedExpectedUrl = normalizeUrl(expectedUrl);
+  if (
+    normalizedUTag === null ||
+    normalizedExpectedUrl === null ||
+    normalizedUTag !== normalizedExpectedUrl
+  ) {
+    return {
+      valid: false,
+      error: `u tag '${uTag}' does not match expected URL '${expectedUrl}' after canonicalization`,
+    };
   }
 
   if ((methodTag || '').toUpperCase() !== expectedMethod.toUpperCase()) {
@@ -54,3 +101,7 @@ export async function validateNip98Header(authorizationHeader, expectedUrl, expe
 
   return { valid: true, pubkey: event.pubkey };
 }
+
+// Exported for tests so callers can pin behavior without invoking the full
+// validator.
+export { normalizeUrl };

--- a/src/creator-delete/nip98.mjs
+++ b/src/creator-delete/nip98.mjs
@@ -14,14 +14,15 @@ const EXPECTED_KIND = 27235;
  * semantically equivalent but textually distinct so that a signed `u` tag from
  * a well-behaved client matches the request URL we build server-side.
  *
- * What normalizes:
- * - Scheme and host case (`HTTPS://Example.COM` → `https://example.com`).
- * - Explicit default ports (`https://x:443/path` → `https://x/path`,
- *   `http://x:80/path` → `http://x/path`).
- * - Root path (`https://x` → `https://x/`).
- * - Fragment stripped (fragments never reach the server).
- * - Userinfo stripped (not expected on API auth URLs; normalized away so a
- *   stray `user@host` form doesn't mismatch).
+ * Explicit behaviors this helper performs:
+ * - Strip fragment (never reaches the server).
+ * - Strip userinfo (see comment at the assignment below).
+ *
+ * Behaviors the WHATWG URL constructor performs for us (stable across every
+ * JS runtime that hosts CF Workers):
+ * - Lowercase scheme and host.
+ * - Strip explicit default ports (`:443` on https, `:80` on http).
+ * - Normalize a bare root (`https://x`) to `https://x/`.
  *
  * What does NOT normalize (documented behavior — signer and verifier must agree):
  * - Non-root trailing slash (`/path` vs `/path/` are distinct resources).
@@ -39,6 +40,13 @@ function normalizeUrl(url) {
   try {
     const u = new URL(url);
     u.hash = '';
+    // Strip userinfo. API auth URLs never carry credentials, so a signed
+    // `https://user@host/path` is treated as equivalent to `https://host/path`.
+    // Intentional: clients that accidentally include userinfo in their signed
+    // `u` tag should still match the server's clean expected URL. A malicious
+    // signer cannot exploit this to forge auth because the signature is bound
+    // to the original event (including the original u tag), not to the
+    // normalized form used only for comparison.
     u.username = '';
     u.password = '';
     return u.toString();

--- a/src/creator-delete/nip98.test.mjs
+++ b/src/creator-delete/nip98.test.mjs
@@ -6,7 +6,7 @@
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import { generateSecretKey, getPublicKey, finalizeEvent } from 'nostr-tools/pure';
-import { validateNip98Header } from './nip98.mjs';
+import { validateNip98Header, normalizeUrl } from './nip98.mjs';
 
 describe('validateNip98Header', () => {
   let sk, pk;
@@ -111,5 +111,157 @@ describe('validateNip98Header', () => {
     const result = await validateNip98Header(header, 'https://x/y', 'POST');
     expect(result.valid).toBe(false);
     expect(result.error).toMatch(/Signature/);
+  });
+
+  describe('URL canonicalization', () => {
+    it('accepts signed https://host:443/ when request is https://host/', async () => {
+      const header = signNip98('https://moderation-api.divine.video:443/api/delete/abc123', 'POST');
+      const result = await validateNip98Header(
+        header,
+        'https://moderation-api.divine.video/api/delete/abc123',
+        'POST'
+      );
+      expect(result.valid).toBe(true);
+    });
+
+    it('accepts signed http://host:80/ when request is http://host/', async () => {
+      const header = signNip98('http://moderation-api.divine.video:80/api/delete/abc123', 'POST');
+      const result = await validateNip98Header(
+        header,
+        'http://moderation-api.divine.video/api/delete/abc123',
+        'POST'
+      );
+      expect(result.valid).toBe(true);
+    });
+
+    it('accepts uppercase scheme and host', async () => {
+      const header = signNip98('HTTPS://Moderation-API.Divine.Video/api/delete/abc123', 'POST');
+      const result = await validateNip98Header(
+        header,
+        'https://moderation-api.divine.video/api/delete/abc123',
+        'POST'
+      );
+      expect(result.valid).toBe(true);
+    });
+
+    it('accepts root URL with and without trailing slash', async () => {
+      const header = signNip98('https://moderation-api.divine.video', 'POST');
+      const result = await validateNip98Header(
+        header,
+        'https://moderation-api.divine.video/',
+        'POST'
+      );
+      expect(result.valid).toBe(true);
+    });
+
+    it('strips fragment when comparing', async () => {
+      const header = signNip98('https://moderation-api.divine.video/api/delete/abc123#frag', 'POST');
+      const result = await validateNip98Header(
+        header,
+        'https://moderation-api.divine.video/api/delete/abc123',
+        'POST'
+      );
+      expect(result.valid).toBe(true);
+    });
+
+    it('keeps non-root trailing slash distinct (not equivalent resources)', async () => {
+      const header = signNip98('https://moderation-api.divine.video/api/delete/abc123/', 'POST');
+      const result = await validateNip98Header(
+        header,
+        'https://moderation-api.divine.video/api/delete/abc123',
+        'POST'
+      );
+      expect(result.valid).toBe(false);
+      expect(result.error).toMatch(/does not match/);
+    });
+
+    it('keeps different paths distinct', async () => {
+      const header = signNip98('https://moderation-api.divine.video/api/delete/abc123', 'POST');
+      const result = await validateNip98Header(
+        header,
+        'https://moderation-api.divine.video/api/delete/xyz789',
+        'POST'
+      );
+      expect(result.valid).toBe(false);
+    });
+
+    it('rejects mismatched host even after canonicalization', async () => {
+      const header = signNip98('https://evil.example.com/api/delete/abc123', 'POST');
+      const result = await validateNip98Header(
+        header,
+        'https://moderation-api.divine.video/api/delete/abc123',
+        'POST'
+      );
+      expect(result.valid).toBe(false);
+    });
+
+    it('rejects an unparseable u tag as a URL', async () => {
+      const header = signNip98('not a url', 'POST');
+      const result = await validateNip98Header(header, 'https://x/y', 'POST');
+      expect(result.valid).toBe(false);
+      expect(result.error).toMatch(/canonicalization/);
+    });
+
+    it('leaves the existing replay-window check unchanged (expired event still rejected)', async () => {
+      const event = finalizeEvent({
+        kind: 27235,
+        created_at: Math.floor(Date.now() / 1000) - 120,
+        tags: [['u', 'https://x/y'], ['method', 'POST']],
+        content: ''
+      }, sk);
+      const header = `Nostr ${btoa(JSON.stringify(event))}`;
+      const result = await validateNip98Header(header, 'https://x/y', 'POST');
+      expect(result.valid).toBe(false);
+      expect(result.error).toMatch(/outside.*window/);
+    });
+
+    it('leaves the existing method check unchanged (method mismatch rejected)', async () => {
+      const header = signNip98('https://x/y', 'GET');
+      const result = await validateNip98Header(header, 'https://x/y', 'POST');
+      expect(result.valid).toBe(false);
+      expect(result.error).toMatch(/method/);
+    });
+  });
+
+  describe('normalizeUrl helper', () => {
+    it('normalizes explicit https default port', () => {
+      expect(normalizeUrl('https://x:443/path')).toBe('https://x/path');
+    });
+
+    it('normalizes explicit http default port', () => {
+      expect(normalizeUrl('http://x:80/path')).toBe('http://x/path');
+    });
+
+    it('preserves non-default port', () => {
+      expect(normalizeUrl('https://x:8443/path')).toBe('https://x:8443/path');
+    });
+
+    it('lowercases scheme and host', () => {
+      expect(normalizeUrl('HTTPS://X.Example.COM/path')).toBe('https://x.example.com/path');
+    });
+
+    it('adds root trailing slash', () => {
+      expect(normalizeUrl('https://x')).toBe('https://x/');
+    });
+
+    it('preserves non-root path as-is', () => {
+      expect(normalizeUrl('https://x/foo')).toBe('https://x/foo');
+      expect(normalizeUrl('https://x/foo/')).toBe('https://x/foo/');
+    });
+
+    it('strips fragment', () => {
+      expect(normalizeUrl('https://x/path#frag')).toBe('https://x/path');
+    });
+
+    it('strips userinfo', () => {
+      expect(normalizeUrl('https://user:pass@x/path')).toBe('https://x/path');
+    });
+
+    it('returns null for unparseable input', () => {
+      expect(normalizeUrl('not a url')).toBeNull();
+      expect(normalizeUrl('')).toBeNull();
+      expect(normalizeUrl(null)).toBeNull();
+      expect(normalizeUrl(undefined)).toBeNull();
+    });
   });
 });


### PR DESCRIPTION
Closes #100.

Stacked on #92 (`spec/per-video-delete-enforcement`) because `nip98.mjs` lives there. Do not merge until #92 lands.

## Problem

The existing NIP-98 validator compared the signed `u` tag against the server-computed expected URL with raw string equality. Semantically equivalent forms produced false negatives:

- `https://host:443/path` vs `https://host/path`
- `HTTPS://Host/path` vs `https://host/path`
- `https://host` vs `https://host/`
- `https://host/path#frag` vs `https://host/path`

Any well-behaved client that emitted one form while the server computed the other would fail auth.

## Fix

Added `normalizeUrl` helper that runs both sides through `new URL(...).toString()` and explicitly strips fragment and userinfo. Comparison runs on the normalized forms.

### What normalizes
- **Via the WHATWG URL constructor** (stable across all JS runtimes that host CF Workers): lowercase scheme and host; strip default ports (`:443` on https, `:80` on http); normalize bare root (`https://x`) to `https://x/`.
- **Explicit in the helper**: strip fragment (never reaches server); strip userinfo (API auth URLs never carry credentials; see inline comment for the security rationale).

### What deliberately does NOT normalize (documented in the helper comment)
- Non-root trailing slash (`/foo` vs `/foo/` are distinct resources by HTTP convention).
- Query parameter ordering.
- Percent-encoding of reserved/unreserved characters.

Signer and verifier must agree on these dimensions. The URL constructor is the natural tool on both sides.

## Unchanged

Replay-window (`±60s` clock drift) and method comparison run exactly as before. Signature verification still runs on the original event — canonicalization only affects the equality check, not the cryptographic verification.

## Tests

19 new test cases across two describe blocks:

- `URL canonicalization` (10 tests) exercises the full validator: default ports, uppercase scheme/host, root slash, fragment, non-root trailing slash staying distinct, different paths, different hosts, unparseable u tag. Includes explicit guards that replay-window and method-mismatch rejections still fire unchanged.
- `normalizeUrl helper` (9 tests) unit-tests the helper directly across the canonicalization rules and the null-on-unparseable contract.

All 70 tests in the creator-delete module pass locally (`npx vitest run src/creator-delete/`).

## Review pass

Ran a code-review pass on the diff before opening. Key findings addressed in a follow-up commit:
- Docstring attribution corrected: the URL constructor (not the helper) does default-port stripping, scheme/host lowercasing, and bare-root-slash normalization.
- Added inline comment at the userinfo-stripping lines noting the security tradeoff — signer is bound to the original event, not the normalized form used only for equality.

## Verification

Every claim was cross-checked against `spec/per-video-delete-enforcement` at `bcf2a1f`.