### PR TITLE
feat: route watermark_visible through divine-ai-detector

### DIFF
--- a/src/moderation/ai-detector-circuit-breaker.mjs
+++ b/src/moderation/ai-detector-circuit-breaker.mjs
@@ -1,0 +1,118 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: In-memory circuit breaker for the divine-ai-detector HTTP client
+// ABOUTME: CLOSED -> OPEN on N consecutive failures; HALF_OPEN after cooldown; one probe at a time
+//
+// Design note: breaker state is intentionally per-isolate / in-memory. Cloudflare
+// Workers recreate isolates on cold start and on deploy, which is a reasonable
+// reset point for a fast-fail breaker whose only job is to shed load while the
+// upstream is visibly unhealthy. Persisting state to KV or a Durable Object
+// would add its own failure modes and latency; we want the breaker to be a
+// *relief valve*, not another cross-service hop. If one isolate's breaker is
+// open while another's is closed, the open one stops calling until its own
+// samples recover — which is the correct behavior for per-isolate back-pressure.
+
+export const STATE_CLOSED = 'closed';
+export const STATE_OPEN = 'open';
+export const STATE_HALF_OPEN = 'half_open';
+
+/**
+ * Creates a circuit breaker.
+ *
+ * States:
+ *   CLOSED     — normal operation; track consecutive failures.
+ *   OPEN       — fail fast; reject all calls until cooldown elapses.
+ *   HALF_OPEN  — allow exactly one probe through. While that probe is in
+ *                flight, further calls are rejected (no thundering herd).
+ *                Success closes, failure re-opens with a fresh cooldown.
+ *
+ * @param {Object} [opts]
+ * @param {number} [opts.failureThreshold=5]  consecutive failures that trip OPEN
+ * @param {number} [opts.cooldownMs=10000]    ms to stay OPEN before HALF_OPEN
+ * @param {() => number} [opts.now]           injectable clock for tests
+ * @param {(msg: string, ctx: Object) => void} [opts.log]
+ */
+export function createCircuitBreaker({
+  failureThreshold = 5,
+  cooldownMs = 10_000,
+  now = () => Date.now(),
+  log = () => {}
+} = {}) {
+  let state = STATE_CLOSED;
+  let consecutiveFailures = 0;
+  let openedAt = 0;        // ms timestamp of most recent OPEN transition
+  let probeInFlight = false;
+
+  function transition(next, ctx = {}) {
+    if (state === next) return;
+    state = next;
+    if (next === STATE_OPEN) {
+      log('ai-detector.circuit.open', { consecutive_failures: consecutiveFailures, ...ctx });
+    } else if (next === STATE_HALF_OPEN) {
+      log('ai-detector.circuit.half_open', { consecutive_failures: consecutiveFailures, ...ctx });
+    } else if (next === STATE_CLOSED) {
+      log('ai-detector.circuit.close', ctx);
+    }
+  }
+
+  function shouldAllow() {
+    if (state === STATE_CLOSED) {
+      return STATE_CLOSED;
+    }
+
+    if (state === STATE_OPEN) {
+      const elapsed = now() - openedAt;
+      if (elapsed < cooldownMs) {
+        return null; // still cooling down
+      }
+      // Cooldown elapsed — move to HALF_OPEN and let THIS caller be the probe.
+      transition(STATE_HALF_OPEN);
+      probeInFlight = true;
+      return STATE_HALF_OPEN;
+    }
+
+    // HALF_OPEN: only one probe allowed at a time.
+    if (state === STATE_HALF_OPEN) {
+      if (probeInFlight) {
+        return null;
+      }
+      probeInFlight = true;
+      return STATE_HALF_OPEN;
+    }
+
+    return null;
+  }
+
+  function recordSuccess() {
+    consecutiveFailures = 0;
+    probeInFlight = false;
+    if (state !== STATE_CLOSED) {
+      transition(STATE_CLOSED);
+    }
+  }
+
+  function recordFailure() {
+    probeInFlight = false;
+    if (state === STATE_HALF_OPEN) {
+      // Probe failed: slam back OPEN with a fresh cooldown.
+      openedAt = now();
+      transition(STATE_OPEN, { from: 'half_open' });
+      return;
+    }
+    consecutiveFailures += 1;
+    if (state === STATE_CLOSED && consecutiveFailures >= failureThreshold) {
+      openedAt = now();
+      transition(STATE_OPEN);
+    }
+  }
+
+  return {
+    shouldAllow,
+    recordSuccess,
+    recordFailure,
+    // Inspectors (useful for tests and for surfacing state in responses).
+    getState: () => state,
+    getConsecutiveFailures: () => consecutiveFailures
+  };
+}

--- a/src/moderation/ai-detector-client.mjs
+++ b/src/moderation/ai-detector-client.mjs
@@ -135,7 +135,12 @@ export async function detectSignals(req, env, opts = {}) {
   const respSignals = (payload && payload.signals) || {};
   for (const sig of signals) {
     const env_ = respSignals[sig];
-    if (env_ && typeof env_ === 'object' && typeof env_.state === 'string') {
+    if (
+      env_ &&
+      typeof env_ === 'object' &&
+      typeof env_.state === 'string' &&
+      SIGNAL_STATES.includes(env_.state)
+    ) {
       merged[sig] = env_;
     } else {
       merged[sig] = { state: 'skipped', model: null };

--- a/src/moderation/ai-detector-client.mjs
+++ b/src/moderation/ai-detector-client.mjs
@@ -1,0 +1,151 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Thin HTTP client for divine-ai-detector's POST /detect endpoint
+// ABOUTME: Returns per-signal envelopes; fetch failures become error envelopes
+
+// Per the design doc (2026-04-17-divine-ai-detector-design.md §API), the
+// service returns one envelope per requested signal:
+//
+//   {
+//     sha256, checked_at, duration_ms,
+//     signals: {
+//       watermark_visible: {
+//         state: detected | absent | error | skipped,
+//         class?: string,
+//         confidence?: number,
+//         frames_flagged?: number,
+//         total_frames?: number,
+//         model?: string,
+//         error?: string
+//       }
+//     }
+//   }
+//
+// On transport errors (timeout, non-2xx, malformed JSON) we synthesize an
+// `error` envelope for every requested signal so callers have a uniform
+// branch point and can fall through to vendor (Hive / Reality Defender).
+
+export const DEFAULT_TIMEOUT_MS = 5000;
+
+// Per spec §"Non-negotiable contracts": state ∈ {detected, absent, error, skipped}.
+export const SIGNAL_STATES = Object.freeze(['detected', 'absent', 'error', 'skipped']);
+
+export function resolveBaseUrl(env) {
+  if (!env) return null;
+  if (env.AI_DETECTOR_BASE_URL) return env.AI_DETECTOR_BASE_URL;
+  // Deprecated: LOGO_DETECTOR_MODEL_URL used to point at the ONNX model
+  // directly. It is not the same shape as the new service base URL, but we
+  // tolerate it during cutover so that deployed configs don't break if a
+  // wrangler secret hasn't been rotated yet.
+  if (env.LOGO_DETECTOR_MODEL_URL) return env.LOGO_DETECTOR_MODEL_URL;
+  return null;
+}
+
+function errorEnvelope(signal, message) {
+  return {
+    state: 'error',
+    error: message,
+    model: null
+  };
+}
+
+function errorResponse(signals, message) {
+  const out = {};
+  for (const sig of signals) out[sig] = errorEnvelope(sig, message);
+  return {
+    sha256: null,
+    checked_at: new Date().toISOString(),
+    duration_ms: 0,
+    signals: out,
+    transport_error: message
+  };
+}
+
+/**
+ * Calls divine-ai-detector's POST /detect.
+ *
+ * @param {Object} req
+ * @param {string} req.url          - media URL the service should fetch
+ * @param {string} [req.mime_type]  - declared mime type of the media
+ * @param {string} [req.sha256]     - sha256 cache key
+ * @param {string[]} [req.signals]  - which signals to run; defaults to ['watermark_visible']
+ * @param {Object} env              - Worker env bindings (must carry AI_DETECTOR_BASE_URL)
+ * @param {Object} [opts]
+ * @param {number} [opts.timeoutMs] - fetch timeout, default DEFAULT_TIMEOUT_MS
+ * @param {typeof fetch} [opts.fetchImpl] - override for tests
+ * @returns {Promise<{sha256: string|null, checked_at: string, duration_ms: number, signals: Record<string,Object>, transport_error?: string}>}
+ */
+export async function detectSignals(req, env, opts = {}) {
+  const signals = (req && req.signals && req.signals.length > 0)
+    ? req.signals
+    : ['watermark_visible'];
+
+  const baseUrl = resolveBaseUrl(env);
+  if (!baseUrl) {
+    return errorResponse(signals, 'AI_DETECTOR_BASE_URL not configured');
+  }
+
+  const fetchImpl = opts.fetchImpl || globalThis.fetch;
+  const timeoutMs = Number.isFinite(opts.timeoutMs) ? opts.timeoutMs : DEFAULT_TIMEOUT_MS;
+
+  const endpoint = baseUrl.replace(/\/+$/, '') + '/detect';
+  const body = {
+    url: req.url,
+    mime_type: req.mime_type,
+    sha256: req.sha256,
+    signals
+  };
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  let res;
+  try {
+    res = await fetchImpl(endpoint, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+      signal: controller.signal
+    });
+  } catch (err) {
+    clearTimeout(timer);
+    const message = err && err.name === 'AbortError'
+      ? `timeout after ${timeoutMs}ms`
+      : (err && err.message ? err.message : 'fetch failed');
+    return errorResponse(signals, message);
+  }
+  clearTimeout(timer);
+
+  if (!res || !res.ok) {
+    const status = res ? res.status : 0;
+    return errorResponse(signals, `HTTP ${status}`);
+  }
+
+  let payload;
+  try {
+    payload = await res.json();
+  } catch (err) {
+    return errorResponse(signals, `invalid JSON: ${err && err.message ? err.message : 'parse error'}`);
+  }
+
+  // Defensive: ensure every requested signal has an envelope even if the
+  // service omits one (treat "missing" as skipped so callers can branch).
+  const merged = {};
+  const respSignals = (payload && payload.signals) || {};
+  for (const sig of signals) {
+    const env_ = respSignals[sig];
+    if (env_ && typeof env_ === 'object' && typeof env_.state === 'string') {
+      merged[sig] = env_;
+    } else {
+      merged[sig] = { state: 'skipped', model: null };
+    }
+  }
+
+  return {
+    sha256: payload && payload.sha256 ? payload.sha256 : (req.sha256 || null),
+    checked_at: payload && payload.checked_at ? payload.checked_at : new Date().toISOString(),
+    duration_ms: payload && Number.isFinite(payload.duration_ms) ? payload.duration_ms : 0,
+    signals: merged
+  };
+}

--- a/src/moderation/ai-detector-client.mjs
+++ b/src/moderation/ai-detector-client.mjs
@@ -2,7 +2,7 @@
 // If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // ABOUTME: Thin HTTP client for divine-ai-detector's POST /detect endpoint
-// ABOUTME: Returns per-signal envelopes; fetch failures become error envelopes
+// ABOUTME: Bounded retry + 429 Retry-After + circuit breaker. Failures become error envelopes.
 
 // Per the design doc (2026-04-17-divine-ai-detector-design.md §API), the
 // service returns one envelope per requested signal:
@@ -25,11 +25,34 @@
 // On transport errors (timeout, non-2xx, malformed JSON) we synthesize an
 // `error` envelope for every requested signal so callers have a uniform
 // branch point and can fall through to vendor (Hive / Reality Defender).
+//
+// Resilience contract:
+//   - Bounded retry on transient errors (network / timeout / 5xx / 429),
+//     capped at 2 retries (3 attempts total) and a shared wall-clock budget.
+//   - HTTP 429 honors Retry-After (delta-seconds or HTTP-date).
+//   - A per-isolate circuit breaker sheds load after repeated failures.
+//   - `circuit_state` ∈ {closed, half_open, open} is always present on the
+//     response so callers / shadow mode can observe breaker state.
+
+import {
+  createCircuitBreaker,
+  STATE_CLOSED,
+  STATE_OPEN,
+  STATE_HALF_OPEN
+} from './ai-detector-circuit-breaker.mjs';
 
 export const DEFAULT_TIMEOUT_MS = 5000;
+export const DEFAULT_RETRY_BACKOFF_MS = Object.freeze([100, 300]);
+// If the remaining wall-clock budget is below this, don't bother starting
+// another attempt — we'd spend more time on the backoff than on the request.
+const MIN_ATTEMPT_BUDGET_MS = 50;
 
 // Per spec §"Non-negotiable contracts": state ∈ {detected, absent, error, skipped}.
 export const SIGNAL_STATES = Object.freeze(['detected', 'absent', 'error', 'skipped']);
+
+// Singleton: one breaker per isolate. Tests can inject their own via
+// `opts.circuitBreaker` to avoid cross-test contamination.
+const defaultCircuitBreaker = createCircuitBreaker();
 
 export function resolveBaseUrl(env) {
   if (!env) return null;
@@ -42,7 +65,7 @@ export function resolveBaseUrl(env) {
   return null;
 }
 
-function errorEnvelope(signal, message) {
+function errorEnvelope(_signal, message) {
   return {
     state: 'error',
     error: message,
@@ -50,7 +73,7 @@ function errorEnvelope(signal, message) {
   };
 }
 
-function errorResponse(signals, message) {
+function errorResponse(signals, message, circuitState) {
   const out = {};
   for (const sig of signals) out[sig] = errorEnvelope(sig, message);
   return {
@@ -58,8 +81,56 @@ function errorResponse(signals, message) {
     checked_at: new Date().toISOString(),
     duration_ms: 0,
     signals: out,
-    transport_error: message
+    transport_error: message,
+    circuit_state: circuitState
   };
+}
+
+/**
+ * Parse a Retry-After header into a delay in milliseconds.
+ * Accepts delta-seconds (e.g. "3") or HTTP-date (e.g. "Wed, 21 Oct 2015 07:28:00 GMT").
+ * Returns null if the value is missing or unparseable.
+ */
+export function parseRetryAfter(value, nowMs = Date.now()) {
+  if (value === undefined || value === null) return null;
+  const raw = String(value).trim();
+  if (raw === '') return null;
+
+  // delta-seconds (RFC 7231 §7.1.3): a non-negative integer.
+  if (/^\d+$/.test(raw)) {
+    const seconds = Number(raw);
+    if (!Number.isFinite(seconds) || seconds < 0) return null;
+    return seconds * 1000;
+  }
+
+  // HTTP-date: parse with Date, then compute delta from now.
+  const parsed = Date.parse(raw);
+  if (!Number.isFinite(parsed)) return null;
+  const delta = parsed - nowMs;
+  return delta > 0 ? delta : 0;
+}
+
+/**
+ * Sleep that honors an AbortSignal so a mid-backoff abort unblocks us.
+ * Not aborted if signal is undefined.
+ */
+function sleep(ms, signal) {
+  if (ms <= 0) return Promise.resolve();
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    if (signal) {
+      const onAbort = () => {
+        clearTimeout(timer);
+        resolve();
+      };
+      if (signal.aborted) {
+        clearTimeout(timer);
+        resolve();
+      } else {
+        signal.addEventListener('abort', onAbort, { once: true });
+      }
+    }
+  });
 }
 
 /**
@@ -72,9 +143,13 @@ function errorResponse(signals, message) {
  * @param {string[]} [req.signals]  - which signals to run; defaults to ['watermark_visible']
  * @param {Object} env              - Worker env bindings (must carry AI_DETECTOR_BASE_URL)
  * @param {Object} [opts]
- * @param {number} [opts.timeoutMs] - fetch timeout, default DEFAULT_TIMEOUT_MS
- * @param {typeof fetch} [opts.fetchImpl] - override for tests
- * @returns {Promise<{sha256: string|null, checked_at: string, duration_ms: number, signals: Record<string,Object>, transport_error?: string}>}
+ * @param {number} [opts.timeoutMs]               - total wall-clock budget, default DEFAULT_TIMEOUT_MS
+ * @param {number[]} [opts.retryBackoffMs]        - backoff schedule, default [100, 300]
+ * @param {typeof fetch} [opts.fetchImpl]         - override for tests
+ * @param {Object} [opts.circuitBreaker]          - breaker instance; defaults to module singleton
+ * @param {() => number} [opts.now]               - injectable clock
+ * @param {(msg: string, ctx: Object) => void} [opts.log]
+ * @returns {Promise<{sha256: string|null, checked_at: string, duration_ms: number, signals: Record<string,Object>, transport_error?: string, circuit_state: string}>}
  */
 export async function detectSignals(req, env, opts = {}) {
   const signals = (req && req.signals && req.signals.length > 0)
@@ -82,12 +157,26 @@ export async function detectSignals(req, env, opts = {}) {
     : ['watermark_visible'];
 
   const baseUrl = resolveBaseUrl(env);
+  const breaker = opts.circuitBreaker || defaultCircuitBreaker;
+  const now = typeof opts.now === 'function' ? opts.now : () => Date.now();
+
   if (!baseUrl) {
-    return errorResponse(signals, 'AI_DETECTOR_BASE_URL not configured');
+    // No breaker interaction when misconfigured — config errors are not
+    // upstream failures; we shouldn't trip the breaker on them.
+    return errorResponse(signals, 'AI_DETECTOR_BASE_URL not configured', breaker.getState());
+  }
+
+  const admittedState = breaker.shouldAllow();
+  if (admittedState === null) {
+    return errorResponse(signals, 'circuit_open', STATE_OPEN);
   }
 
   const fetchImpl = opts.fetchImpl || globalThis.fetch;
   const timeoutMs = Number.isFinite(opts.timeoutMs) ? opts.timeoutMs : DEFAULT_TIMEOUT_MS;
+  const backoffSchedule = Array.isArray(opts.retryBackoffMs) && opts.retryBackoffMs.length > 0
+    ? opts.retryBackoffMs
+    : DEFAULT_RETRY_BACKOFF_MS;
+  const maxAttempts = backoffSchedule.length + 1; // e.g. [100,300] => 3 attempts
 
   const endpoint = baseUrl.replace(/\/+$/, '') + '/detect';
   const body = {
@@ -96,61 +185,153 @@ export async function detectSignals(req, env, opts = {}) {
     sha256: req.sha256,
     signals
   };
+  const serializedBody = JSON.stringify(body);
 
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  const started = now();
+  const deadline = started + timeoutMs;
 
-  let res;
-  try {
-    res = await fetchImpl(endpoint, {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify(body),
-      signal: controller.signal
-    });
-  } catch (err) {
-    clearTimeout(timer);
-    const message = err && err.name === 'AbortError'
-      ? `timeout after ${timeoutMs}ms`
-      : (err && err.message ? err.message : 'fetch failed');
-    return errorResponse(signals, message);
-  }
-  clearTimeout(timer);
+  let lastError = null;
+  let attempt = 0;
 
-  if (!res || !res.ok) {
-    const status = res ? res.status : 0;
-    return errorResponse(signals, `HTTP ${status}`);
-  }
-
-  let payload;
-  try {
-    payload = await res.json();
-  } catch (err) {
-    return errorResponse(signals, `invalid JSON: ${err && err.message ? err.message : 'parse error'}`);
-  }
-
-  // Defensive: ensure every requested signal has an envelope even if the
-  // service omits one (treat "missing" as skipped so callers can branch).
-  const merged = {};
-  const respSignals = (payload && payload.signals) || {};
-  for (const sig of signals) {
-    const env_ = respSignals[sig];
-    if (
-      env_ &&
-      typeof env_ === 'object' &&
-      typeof env_.state === 'string' &&
-      SIGNAL_STATES.includes(env_.state)
-    ) {
-      merged[sig] = env_;
-    } else {
-      merged[sig] = { state: 'skipped', model: null };
+  while (attempt < maxAttempts) {
+    attempt += 1;
+    const remaining = deadline - now();
+    // Only skip the attempt if budget is gone AND we've already tried once.
+    // The first attempt always runs (with whatever budget we have) so that a
+    // pathologically small timeoutMs still surfaces a real timeout error
+    // instead of being short-circuited.
+    if (remaining < MIN_ATTEMPT_BUDGET_MS && attempt > 1) {
+      lastError = lastError || `timeout after ${timeoutMs}ms`;
+      break;
     }
+
+    const attemptBudget = Math.max(remaining, 1);
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), attemptBudget);
+
+    let res;
+    let networkErr = null;
+    try {
+      res = await fetchImpl(endpoint, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: serializedBody,
+        signal: controller.signal
+      });
+    } catch (err) {
+      networkErr = err;
+    } finally {
+      clearTimeout(timer);
+    }
+
+    if (networkErr) {
+      const isAbort = networkErr && networkErr.name === 'AbortError';
+      // If the abort fired because the overall budget is gone, treat as timeout.
+      if (isAbort && (deadline - now()) < MIN_ATTEMPT_BUDGET_MS) {
+        lastError = `timeout after ${timeoutMs}ms`;
+        break;
+      }
+      lastError = isAbort
+        ? `timeout after ${timeoutMs}ms`
+        : (networkErr && networkErr.message ? networkErr.message : 'fetch failed');
+      // Network errors / timeouts are retryable — fall through to backoff.
+      if (attempt >= maxAttempts) break;
+      const backoff = backoffSchedule[attempt - 1];
+      if ((deadline - now()) < backoff + MIN_ATTEMPT_BUDGET_MS) break;
+      await sleep(backoff);
+      continue;
+    }
+
+    // At this point we have a Response.
+    const status = res ? res.status : 0;
+
+    if (res && res.ok) {
+      let payload;
+      try {
+        payload = await res.json();
+      } catch (err) {
+        // Malformed JSON is a contract bug, not a transient error — don't retry.
+        breaker.recordFailure();
+        return errorResponse(
+          signals,
+          `invalid JSON: ${err && err.message ? err.message : 'parse error'}`,
+          breaker.getState()
+        );
+      }
+
+      // Defensive: ensure every requested signal has an envelope even if the
+      // service omits one (treat "missing" as skipped so callers can branch).
+      // Unknown states (outside SIGNAL_STATES) are also treated as skipped.
+      const merged = {};
+      const respSignals = (payload && payload.signals) || {};
+      for (const sig of signals) {
+        const env_ = respSignals[sig];
+        if (
+          env_ &&
+          typeof env_ === 'object' &&
+          typeof env_.state === 'string' &&
+          SIGNAL_STATES.includes(env_.state)
+        ) {
+          merged[sig] = env_;
+        } else {
+          merged[sig] = { state: 'skipped', model: null };
+        }
+      }
+
+      breaker.recordSuccess();
+      return {
+        sha256: payload && payload.sha256 ? payload.sha256 : (req.sha256 || null),
+        checked_at: payload && payload.checked_at ? payload.checked_at : new Date().toISOString(),
+        duration_ms: payload && Number.isFinite(payload.duration_ms) ? payload.duration_ms : 0,
+        signals: merged,
+        circuit_state: breaker.getState()
+      };
+    }
+
+    // Non-2xx. Decide whether to retry.
+    lastError = `HTTP ${status}`;
+
+    const retryable5xx = status >= 500 && status < 600;
+    const is429 = status === 429;
+
+    if (!retryable5xx && !is429) {
+      // 4xx other than 429 — caller body / contract problem. Don't retry.
+      breaker.recordFailure();
+      return errorResponse(signals, `HTTP ${status}`, breaker.getState());
+    }
+
+    if (attempt >= maxAttempts) break;
+
+    // Compute wait time before the next attempt.
+    let waitMs = backoffSchedule[attempt - 1];
+
+    if (is429 && res && res.headers) {
+      const retryAfterRaw = typeof res.headers.get === 'function'
+        ? res.headers.get('retry-after') || res.headers.get('Retry-After')
+        : (res.headers['retry-after'] || res.headers['Retry-After']);
+      const parsed = parseRetryAfter(retryAfterRaw, now());
+      if (parsed !== null) {
+        const budget = deadline - now();
+        if (parsed > budget) {
+          // Retry-After exceeds remaining budget — give up immediately.
+          breaker.recordFailure();
+          return errorResponse(signals, '429 Retry-After exceeds budget', breaker.getState());
+        }
+        waitMs = parsed;
+      }
+    }
+
+    if ((deadline - now()) < waitMs + MIN_ATTEMPT_BUDGET_MS) break;
+    await sleep(waitMs);
   }
 
-  return {
-    sha256: payload && payload.sha256 ? payload.sha256 : (req.sha256 || null),
-    checked_at: payload && payload.checked_at ? payload.checked_at : new Date().toISOString(),
-    duration_ms: payload && Number.isFinite(payload.duration_ms) ? payload.duration_ms : 0,
-    signals: merged
-  };
+  breaker.recordFailure();
+  return errorResponse(signals, lastError || 'fetch failed', breaker.getState());
 }
+
+// Exposed for tests that want to reach into the module singleton.
+export function _getDefaultCircuitBreaker() {
+  return defaultCircuitBreaker;
+}
+
+export { STATE_CLOSED, STATE_OPEN, STATE_HALF_OPEN };

--- a/src/moderation/ai-detector-client.test.mjs
+++ b/src/moderation/ai-detector-client.test.mjs
@@ -1,0 +1,219 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Tests for the divine-ai-detector HTTP client
+// ABOUTME: Covers happy path, non-2xx, transport failure, timeout, env resolution
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  detectSignals,
+  resolveBaseUrl,
+  SIGNAL_STATES,
+  DEFAULT_TIMEOUT_MS
+} from './ai-detector-client.mjs';
+
+function mockFetch(response, { delayMs = 0, throwError = null } = {}) {
+  return vi.fn(async (_url, _init) => {
+    if (throwError) {
+      if (_init && _init.signal) {
+        // Respect aborts so timeout tests can pass.
+        if (_init.signal.aborted) {
+          const err = new Error('aborted');
+          err.name = 'AbortError';
+          throw err;
+        }
+      }
+      throw throwError;
+    }
+    if (delayMs > 0) {
+      await new Promise((resolve, reject) => {
+        const timer = setTimeout(resolve, delayMs);
+        if (_init && _init.signal) {
+          _init.signal.addEventListener('abort', () => {
+            clearTimeout(timer);
+            const err = new Error('aborted');
+            err.name = 'AbortError';
+            reject(err);
+          });
+        }
+      });
+    }
+    return response;
+  });
+}
+
+function jsonResponse(body, { status = 200 } = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body
+  };
+}
+
+describe('ai-detector-client - SIGNAL_STATES', () => {
+  it('exposes the four spec-defined states', () => {
+    expect(SIGNAL_STATES).toEqual(['detected', 'absent', 'error', 'skipped']);
+  });
+});
+
+describe('ai-detector-client - resolveBaseUrl', () => {
+  it('prefers AI_DETECTOR_BASE_URL', () => {
+    expect(resolveBaseUrl({
+      AI_DETECTOR_BASE_URL: 'https://ai-detector.staging.divine.video',
+      LOGO_DETECTOR_MODEL_URL: 'https://old.example/model.onnx'
+    })).toBe('https://ai-detector.staging.divine.video');
+  });
+
+  it('falls back to LOGO_DETECTOR_MODEL_URL during cutover', () => {
+    expect(resolveBaseUrl({
+      LOGO_DETECTOR_MODEL_URL: 'https://old.example/model.onnx'
+    })).toBe('https://old.example/model.onnx');
+  });
+
+  it('returns null when env is null', () => {
+    expect(resolveBaseUrl(null)).toBeNull();
+  });
+
+  it('returns null when neither var is set', () => {
+    expect(resolveBaseUrl({})).toBeNull();
+  });
+});
+
+describe('ai-detector-client - detectSignals happy path', () => {
+  it('returns the parsed envelope when the service responds 200', async () => {
+    const body = {
+      sha256: 'abc123',
+      checked_at: '2026-04-17T12:00:00Z',
+      duration_ms: 430,
+      signals: {
+        watermark_visible: {
+          state: 'detected',
+          class: 'meta_sparkle',
+          confidence: 0.92,
+          frames_flagged: 3,
+          total_frames: 4,
+          model: 'logo-v1.2.0'
+        }
+      }
+    };
+    const fetchImpl = mockFetch(jsonResponse(body));
+    const env = { AI_DETECTOR_BASE_URL: 'https://ai-detector.divine.video' };
+
+    const result = await detectSignals(
+      { url: 'https://media.divine.video/abc123.mp4', mime_type: 'video/mp4', sha256: 'abc123' },
+      env,
+      { fetchImpl }
+    );
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [calledUrl, init] = fetchImpl.mock.calls[0];
+    expect(calledUrl).toBe('https://ai-detector.divine.video/detect');
+    expect(init.method).toBe('POST');
+    expect(init.headers['content-type']).toBe('application/json');
+    expect(JSON.parse(init.body)).toEqual({
+      url: 'https://media.divine.video/abc123.mp4',
+      mime_type: 'video/mp4',
+      sha256: 'abc123',
+      signals: ['watermark_visible']
+    });
+
+    expect(result.sha256).toBe('abc123');
+    expect(result.duration_ms).toBe(430);
+    expect(result.signals.watermark_visible).toEqual(body.signals.watermark_visible);
+  });
+
+  it('defaults to requesting the watermark_visible signal', async () => {
+    const fetchImpl = mockFetch(jsonResponse({
+      sha256: 'x',
+      checked_at: 'now',
+      duration_ms: 1,
+      signals: { watermark_visible: { state: 'absent', model: 'v1' } }
+    }));
+    await detectSignals({ url: 'u' }, { AI_DETECTOR_BASE_URL: 'https://svc' }, { fetchImpl });
+    const body = JSON.parse(fetchImpl.mock.calls[0][1].body);
+    expect(body.signals).toEqual(['watermark_visible']);
+  });
+
+  it('trims trailing slashes from the base URL', async () => {
+    const fetchImpl = mockFetch(jsonResponse({
+      signals: { watermark_visible: { state: 'absent', model: 'v1' } }
+    }));
+    await detectSignals({ url: 'u' }, { AI_DETECTOR_BASE_URL: 'https://svc///' }, { fetchImpl });
+    expect(fetchImpl.mock.calls[0][0]).toBe('https://svc/detect');
+  });
+
+  it('treats a missing envelope for a requested signal as skipped', async () => {
+    const fetchImpl = mockFetch(jsonResponse({
+      sha256: 'x', checked_at: 'now', duration_ms: 1,
+      signals: {} // service returned nothing for the requested signal
+    }));
+    const result = await detectSignals(
+      { url: 'u', signals: ['watermark_visible'] },
+      { AI_DETECTOR_BASE_URL: 'https://svc' },
+      { fetchImpl }
+    );
+    expect(result.signals.watermark_visible).toEqual({ state: 'skipped', model: null });
+  });
+});
+
+describe('ai-detector-client - error paths', () => {
+  it('returns an error envelope when base URL is missing', async () => {
+    const result = await detectSignals({ url: 'u' }, {});
+    expect(result.transport_error).toMatch(/not configured/i);
+    expect(result.signals.watermark_visible.state).toBe('error');
+    expect(result.signals.watermark_visible.error).toMatch(/not configured/i);
+  });
+
+  it('returns an error envelope per requested signal on non-2xx', async () => {
+    const fetchImpl = mockFetch(jsonResponse({}, { status: 500 }));
+    const result = await detectSignals(
+      { url: 'u', signals: ['watermark_visible'] },
+      { AI_DETECTOR_BASE_URL: 'https://svc' },
+      { fetchImpl }
+    );
+    expect(result.signals.watermark_visible.state).toBe('error');
+    expect(result.signals.watermark_visible.error).toMatch(/HTTP 500/);
+  });
+
+  it('returns an error envelope on network failure', async () => {
+    const fetchImpl = mockFetch(null, { throwError: new Error('ECONNREFUSED') });
+    const result = await detectSignals(
+      { url: 'u' },
+      { AI_DETECTOR_BASE_URL: 'https://svc' },
+      { fetchImpl }
+    );
+    expect(result.signals.watermark_visible.state).toBe('error');
+    expect(result.signals.watermark_visible.error).toBe('ECONNREFUSED');
+  });
+
+  it('returns an error envelope with a timeout message when fetch exceeds timeoutMs', async () => {
+    const fetchImpl = mockFetch(jsonResponse({}), { delayMs: 200 });
+    const result = await detectSignals(
+      { url: 'u' },
+      { AI_DETECTOR_BASE_URL: 'https://svc' },
+      { fetchImpl, timeoutMs: 10 }
+    );
+    expect(result.signals.watermark_visible.state).toBe('error');
+    expect(result.signals.watermark_visible.error).toMatch(/timeout/i);
+  });
+
+  it('returns an error envelope when the response is invalid JSON', async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => { throw new Error('Unexpected token'); }
+    }));
+    const result = await detectSignals(
+      { url: 'u' },
+      { AI_DETECTOR_BASE_URL: 'https://svc' },
+      { fetchImpl }
+    );
+    expect(result.signals.watermark_visible.state).toBe('error');
+    expect(result.signals.watermark_visible.error).toMatch(/invalid JSON/i);
+  });
+
+  it('honors DEFAULT_TIMEOUT_MS as a sensible default', () => {
+    expect(DEFAULT_TIMEOUT_MS).toBeGreaterThan(0);
+    expect(DEFAULT_TIMEOUT_MS).toBeLessThanOrEqual(30000);
+  });
+});

--- a/src/moderation/ai-detector-client.test.mjs
+++ b/src/moderation/ai-detector-client.test.mjs
@@ -154,6 +154,19 @@ describe('ai-detector-client - detectSignals happy path', () => {
     );
     expect(result.signals.watermark_visible).toEqual({ state: 'skipped', model: null });
   });
+
+  it('treats an envelope with an unknown state as skipped', async () => {
+    const fetchImpl = mockFetch(jsonResponse({
+      sha256: 'x', checked_at: 'now', duration_ms: 1,
+      signals: { watermark_visible: { state: 'mystery', model: 'v1' } }
+    }));
+    const result = await detectSignals(
+      { url: 'u', signals: ['watermark_visible'] },
+      { AI_DETECTOR_BASE_URL: 'https://svc' },
+      { fetchImpl }
+    );
+    expect(result.signals.watermark_visible).toEqual({ state: 'skipped', model: null });
+  });
 });
 
 describe('ai-detector-client - error paths', () => {

--- a/src/moderation/ai-detector-mode.mjs
+++ b/src/moderation/ai-detector-mode.mjs
@@ -38,7 +38,7 @@ export function readGate(env, signal) {
   const raw = env[key];
   if (raw === undefined || raw === null || raw === '') return DEFAULT_GATE;
   const n = Number(raw);
-  return Number.isFinite(n) ? n : DEFAULT_GATE;
+  return Number.isFinite(n) && n >= 0 && n <= 1 ? n : DEFAULT_GATE;
 }
 
 /**

--- a/src/moderation/ai-detector-mode.mjs
+++ b/src/moderation/ai-detector-mode.mjs
@@ -1,0 +1,126 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Per-signal cutover mode dispatcher (shadow | gated | preferred | sole)
+// ABOUTME: Decides whether to use divine-ai-detector's verdict or fall through to vendor
+
+// Per the design doc §"Cutover strategy — four modes, per signal", each
+// signal has its own env var: AI_DETECTOR_MODE_<SIGNAL>, and each signal
+// optionally has a gate threshold env var: AI_DETECTOR_GATE_<SIGNAL>.
+//
+//   shadow     — call both, use vendor, log both + disagreement.
+//   gated      — internal when confidence >= GATE; else vendor.
+//   preferred  — internal when state != error; else vendor.
+//   sole       — internal only. Vendor not called.
+//
+// Default for every signal is 'shadow'. Flip via env, not via deploy.
+
+export const MODES = Object.freeze(['shadow', 'gated', 'preferred', 'sole']);
+export const DEFAULT_MODE = 'shadow';
+export const DEFAULT_GATE = 0.8;
+
+function upperSignal(signal) {
+  return String(signal || '').toUpperCase().replace(/[^A-Z0-9]+/g, '_');
+}
+
+export function readMode(env, signal) {
+  if (!env) return DEFAULT_MODE;
+  const key = `AI_DETECTOR_MODE_${upperSignal(signal)}`;
+  const raw = env[key];
+  if (!raw) return DEFAULT_MODE;
+  const v = String(raw).trim().toLowerCase();
+  return MODES.includes(v) ? v : DEFAULT_MODE;
+}
+
+export function readGate(env, signal) {
+  if (!env) return DEFAULT_GATE;
+  const key = `AI_DETECTOR_GATE_${upperSignal(signal)}`;
+  const raw = env[key];
+  if (raw === undefined || raw === null || raw === '') return DEFAULT_GATE;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : DEFAULT_GATE;
+}
+
+/**
+ * Given a signal's internal envelope (from divine-ai-detector), a function
+ * that produces the vendor verdict (called lazily — not invoked in 'sole'),
+ * and the mode/gate, decide which verdict to return and produce a log record
+ * capturing both sides for later calibration.
+ *
+ * The vendor shape is opaque to this dispatcher — we hand it through as-is.
+ *
+ * @param {Object} args
+ * @param {string} args.signal
+ * @param {Object} args.internal             - envelope from detectSignals()
+ * @param {() => Promise<any>} args.callVendor - lazy vendor call
+ * @param {Object} args.env
+ * @param {(msg: string, ctx: Object) => void} [args.log]
+ * @returns {Promise<{verdict: any, source: 'internal'|'vendor', mode: string, disagreement?: boolean}>}
+ */
+export async function dispatchSignal({ signal, internal, callVendor, env, log }) {
+  const mode = readMode(env, signal);
+  const gate = readGate(env, signal);
+  const logFn = typeof log === 'function' ? log : () => {};
+
+  const internalErrored = !internal || internal.state === 'error' || internal.state === 'skipped';
+  const confidence = internal && Number.isFinite(internal.confidence) ? internal.confidence : 0;
+
+  switch (mode) {
+    case 'sole': {
+      // Vendor never called. Caller must tolerate internal errors.
+      logFn('ai-detector.dispatch', { signal, mode, source: 'internal', internal });
+      return { verdict: internal, source: 'internal', mode };
+    }
+
+    case 'preferred': {
+      if (!internalErrored) {
+        logFn('ai-detector.dispatch', { signal, mode, source: 'internal', internal });
+        return { verdict: internal, source: 'internal', mode };
+      }
+      const vendor = await callVendor();
+      logFn('ai-detector.dispatch', { signal, mode, source: 'vendor', internal, vendor, reason: 'internal_error' });
+      return { verdict: vendor, source: 'vendor', mode };
+    }
+
+    case 'gated': {
+      if (!internalErrored && confidence >= gate) {
+        logFn('ai-detector.dispatch', { signal, mode, source: 'internal', internal, gate });
+        return { verdict: internal, source: 'internal', mode };
+      }
+      const vendor = await callVendor();
+      logFn('ai-detector.dispatch', {
+        signal, mode, source: 'vendor', internal, vendor, gate,
+        reason: internalErrored ? 'internal_error' : 'below_gate'
+      });
+      return { verdict: vendor, source: 'vendor', mode };
+    }
+
+    case 'shadow':
+    default: {
+      // Shadow: call both, use vendor verdict, log disagreement for calibration.
+      const vendor = await callVendor();
+      const disagreement = computeDisagreement(internal, vendor);
+      logFn('ai-detector.shadow', {
+        signal, mode: 'shadow', source: 'vendor',
+        internal, vendor, disagreement
+      });
+      return { verdict: vendor, source: 'vendor', mode: 'shadow', disagreement };
+    }
+  }
+}
+
+// Heuristic: mark disagreement when internal says detected but vendor says
+// nothing suspicious, or vice versa. Vendor shape is unknown here so we only
+// look at the fields that might be present (ai_generated score, detected
+// boolean). Caller can override by providing its own logger that re-derives
+// this from its own knowledge of the vendor payload.
+function computeDisagreement(internal, vendor) {
+  const internalDetected = internal && internal.state === 'detected';
+  const vendorDetected =
+    vendor && (
+      vendor.detected === true ||
+      (Number.isFinite(vendor.ai_generated) && vendor.ai_generated >= 0.7) ||
+      (Number.isFinite(vendor.confidence) && vendor.confidence >= 0.7 && vendor.class)
+    );
+  return internalDetected !== vendorDetected;
+}

--- a/src/moderation/ai-detector-mode.test.mjs
+++ b/src/moderation/ai-detector-mode.test.mjs
@@ -1,0 +1,268 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Tests for the per-signal cutover mode dispatcher
+// ABOUTME: Covers shadow | gated | preferred | sole plus env resolution
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  dispatchSignal,
+  readMode,
+  readGate,
+  MODES,
+  DEFAULT_MODE,
+  DEFAULT_GATE
+} from './ai-detector-mode.mjs';
+
+const INTERNAL_DETECTED = {
+  state: 'detected', class: 'meta_sparkle', confidence: 0.92,
+  frames_flagged: 3, total_frames: 4, model: 'logo-v1'
+};
+const INTERNAL_ABSENT = {
+  state: 'absent', confidence: 0.1, total_frames: 4, model: 'logo-v1'
+};
+const INTERNAL_ERROR = {
+  state: 'error', error: 'model crashed', model: 'logo-v1'
+};
+const INTERNAL_LOW_CONF = {
+  state: 'detected', class: 'meta_sparkle', confidence: 0.5,
+  frames_flagged: 2, total_frames: 4, model: 'logo-v1'
+};
+
+const VENDOR_VERDICT = { detected: true, ai_generated: 0.91, provider: 'hive' };
+
+describe('ai-detector-mode - constants', () => {
+  it('exposes the four spec-defined modes', () => {
+    expect(MODES).toEqual(['shadow', 'gated', 'preferred', 'sole']);
+  });
+
+  it('defaults mode to shadow', () => {
+    expect(DEFAULT_MODE).toBe('shadow');
+  });
+
+  it('defaults gate to 0.8 per spec (Hive-equivalent high threshold)', () => {
+    expect(DEFAULT_GATE).toBe(0.8);
+  });
+});
+
+describe('ai-detector-mode - readMode', () => {
+  it('reads AI_DETECTOR_MODE_<SIGNAL> (upper-cased)', () => {
+    expect(readMode({ AI_DETECTOR_MODE_WATERMARK_VISIBLE: 'preferred' }, 'watermark_visible'))
+      .toBe('preferred');
+  });
+
+  it('accepts mixed-case env values', () => {
+    expect(readMode({ AI_DETECTOR_MODE_WATERMARK_VISIBLE: 'Gated' }, 'watermark_visible'))
+      .toBe('gated');
+  });
+
+  it('defaults to shadow when the env var is missing', () => {
+    expect(readMode({}, 'watermark_visible')).toBe('shadow');
+  });
+
+  it('defaults to shadow for unknown mode values', () => {
+    expect(readMode({ AI_DETECTOR_MODE_WATERMARK_VISIBLE: 'yolo' }, 'watermark_visible'))
+      .toBe('shadow');
+  });
+});
+
+describe('ai-detector-mode - readGate', () => {
+  it('reads AI_DETECTOR_GATE_<SIGNAL> as a number', () => {
+    expect(readGate({ AI_DETECTOR_GATE_WATERMARK_VISIBLE: '0.9' }, 'watermark_visible'))
+      .toBe(0.9);
+  });
+
+  it('defaults to 0.8 when the env var is missing', () => {
+    expect(readGate({}, 'watermark_visible')).toBe(0.8);
+  });
+
+  it('defaults to 0.8 when the env var is not a number', () => {
+    expect(readGate({ AI_DETECTOR_GATE_WATERMARK_VISIBLE: 'nope' }, 'watermark_visible'))
+      .toBe(0.8);
+  });
+});
+
+describe('ai-detector-mode - dispatchSignal: shadow', () => {
+  it('calls vendor and returns vendor verdict but passes internal to the logger', async () => {
+    const callVendor = vi.fn(async () => VENDOR_VERDICT);
+    const log = vi.fn();
+    const result = await dispatchSignal({
+      signal: 'watermark_visible',
+      internal: INTERNAL_DETECTED,
+      callVendor,
+      env: {}, // default mode = shadow
+      log
+    });
+
+    expect(callVendor).toHaveBeenCalledTimes(1);
+    expect(result).toEqual(expect.objectContaining({
+      verdict: VENDOR_VERDICT,
+      source: 'vendor',
+      mode: 'shadow'
+    }));
+    expect(log).toHaveBeenCalledWith('ai-detector.shadow', expect.objectContaining({
+      signal: 'watermark_visible',
+      internal: INTERNAL_DETECTED,
+      vendor: VENDOR_VERDICT,
+      disagreement: expect.any(Boolean)
+    }));
+  });
+
+  it('flags disagreement when internal detects but vendor does not', async () => {
+    const callVendor = vi.fn(async () => ({ detected: false, ai_generated: 0.1 }));
+    const log = vi.fn();
+    const result = await dispatchSignal({
+      signal: 'watermark_visible',
+      internal: INTERNAL_DETECTED,
+      callVendor,
+      env: { AI_DETECTOR_MODE_WATERMARK_VISIBLE: 'shadow' },
+      log
+    });
+    expect(result.disagreement).toBe(true);
+  });
+
+  it('does not flag disagreement when both agree on detection', async () => {
+    const callVendor = vi.fn(async () => ({ detected: true, ai_generated: 0.9 }));
+    const result = await dispatchSignal({
+      signal: 'watermark_visible',
+      internal: INTERNAL_DETECTED,
+      callVendor,
+      env: {}
+    });
+    expect(result.disagreement).toBe(false);
+  });
+});
+
+describe('ai-detector-mode - dispatchSignal: gated', () => {
+  it('uses internal when confidence >= gate', async () => {
+    const callVendor = vi.fn(async () => VENDOR_VERDICT);
+    const result = await dispatchSignal({
+      signal: 'watermark_visible',
+      internal: INTERNAL_DETECTED, // confidence 0.92, gate default 0.8
+      callVendor,
+      env: { AI_DETECTOR_MODE_WATERMARK_VISIBLE: 'gated' }
+    });
+    expect(result.source).toBe('internal');
+    expect(result.verdict).toBe(INTERNAL_DETECTED);
+    expect(callVendor).not.toHaveBeenCalled();
+  });
+
+  it('falls through to vendor when confidence < gate', async () => {
+    const callVendor = vi.fn(async () => VENDOR_VERDICT);
+    const result = await dispatchSignal({
+      signal: 'watermark_visible',
+      internal: INTERNAL_LOW_CONF, // confidence 0.5
+      callVendor,
+      env: { AI_DETECTOR_MODE_WATERMARK_VISIBLE: 'gated' }
+    });
+    expect(result.source).toBe('vendor');
+    expect(callVendor).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls through to vendor when internal errored', async () => {
+    const callVendor = vi.fn(async () => VENDOR_VERDICT);
+    const result = await dispatchSignal({
+      signal: 'watermark_visible',
+      internal: INTERNAL_ERROR,
+      callVendor,
+      env: { AI_DETECTOR_MODE_WATERMARK_VISIBLE: 'gated' }
+    });
+    expect(result.source).toBe('vendor');
+  });
+
+  it('honors a custom gate from AI_DETECTOR_GATE_<SIGNAL>', async () => {
+    const callVendor = vi.fn(async () => VENDOR_VERDICT);
+    // Low-conf 0.5 passes a gate of 0.4 but not the 0.8 default.
+    const result = await dispatchSignal({
+      signal: 'watermark_visible',
+      internal: INTERNAL_LOW_CONF,
+      callVendor,
+      env: {
+        AI_DETECTOR_MODE_WATERMARK_VISIBLE: 'gated',
+        AI_DETECTOR_GATE_WATERMARK_VISIBLE: '0.4'
+      }
+    });
+    expect(result.source).toBe('internal');
+    expect(callVendor).not.toHaveBeenCalled();
+  });
+});
+
+describe('ai-detector-mode - dispatchSignal: preferred', () => {
+  it('uses internal when state != error, regardless of confidence', async () => {
+    const callVendor = vi.fn(async () => VENDOR_VERDICT);
+    const result = await dispatchSignal({
+      signal: 'watermark_visible',
+      internal: INTERNAL_LOW_CONF,
+      callVendor,
+      env: { AI_DETECTOR_MODE_WATERMARK_VISIBLE: 'preferred' }
+    });
+    expect(result.source).toBe('internal');
+    expect(callVendor).not.toHaveBeenCalled();
+  });
+
+  it('uses internal when state is absent', async () => {
+    const callVendor = vi.fn(async () => VENDOR_VERDICT);
+    const result = await dispatchSignal({
+      signal: 'watermark_visible',
+      internal: INTERNAL_ABSENT,
+      callVendor,
+      env: { AI_DETECTOR_MODE_WATERMARK_VISIBLE: 'preferred' }
+    });
+    expect(result.source).toBe('internal');
+  });
+
+  it('falls through to vendor on error state', async () => {
+    const callVendor = vi.fn(async () => VENDOR_VERDICT);
+    const result = await dispatchSignal({
+      signal: 'watermark_visible',
+      internal: INTERNAL_ERROR,
+      callVendor,
+      env: { AI_DETECTOR_MODE_WATERMARK_VISIBLE: 'preferred' }
+    });
+    expect(result.source).toBe('vendor');
+    expect(callVendor).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('ai-detector-mode - dispatchSignal: sole', () => {
+  it('never calls vendor, even on internal error', async () => {
+    const callVendor = vi.fn(async () => VENDOR_VERDICT);
+    const result = await dispatchSignal({
+      signal: 'watermark_visible',
+      internal: INTERNAL_ERROR,
+      callVendor,
+      env: { AI_DETECTOR_MODE_WATERMARK_VISIBLE: 'sole' }
+    });
+    expect(result.source).toBe('internal');
+    expect(result.verdict).toBe(INTERNAL_ERROR);
+    expect(callVendor).not.toHaveBeenCalled();
+  });
+
+  it('returns internal on detected', async () => {
+    const callVendor = vi.fn(async () => VENDOR_VERDICT);
+    const result = await dispatchSignal({
+      signal: 'watermark_visible',
+      internal: INTERNAL_DETECTED,
+      callVendor,
+      env: { AI_DETECTOR_MODE_WATERMARK_VISIBLE: 'sole' }
+    });
+    expect(result.source).toBe('internal');
+    expect(result.verdict).toBe(INTERNAL_DETECTED);
+    expect(callVendor).not.toHaveBeenCalled();
+  });
+});
+
+describe('ai-detector-mode - dispatchSignal: default mode', () => {
+  it('defaults to shadow when env is empty (no behavior change without rollout)', async () => {
+    const callVendor = vi.fn(async () => VENDOR_VERDICT);
+    const result = await dispatchSignal({
+      signal: 'watermark_visible',
+      internal: INTERNAL_DETECTED,
+      callVendor,
+      env: {}
+    });
+    expect(result.mode).toBe('shadow');
+    expect(result.source).toBe('vendor');
+    expect(callVendor).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/moderation/ai-detector-mode.test.mjs
+++ b/src/moderation/ai-detector-mode.test.mjs
@@ -80,6 +80,13 @@ describe('ai-detector-mode - readGate', () => {
     expect(readGate({ AI_DETECTOR_GATE_WATERMARK_VISIBLE: 'nope' }, 'watermark_visible'))
       .toBe(0.8);
   });
+
+  it('defaults to 0.8 when the env var is outside 0..1', () => {
+    expect(readGate({ AI_DETECTOR_GATE_WATERMARK_VISIBLE: '1.5' }, 'watermark_visible'))
+      .toBe(0.8);
+    expect(readGate({ AI_DETECTOR_GATE_WATERMARK_VISIBLE: '-0.1' }, 'watermark_visible'))
+      .toBe(0.8);
+  });
 });
 
 describe('ai-detector-mode - dispatchSignal: shadow', () => {

--- a/src/moderation/ai-detector-resilience.test.mjs
+++ b/src/moderation/ai-detector-resilience.test.mjs
@@ -1,0 +1,507 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Tests for bounded retry, HTTP 429 Retry-After handling, and circuit breaker
+// ABOUTME: in the divine-ai-detector HTTP client
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  detectSignals,
+  parseRetryAfter,
+  STATE_CLOSED,
+  STATE_OPEN,
+  STATE_HALF_OPEN
+} from './ai-detector-client.mjs';
+import { createCircuitBreaker } from './ai-detector-circuit-breaker.mjs';
+
+// ---------------- helpers ----------------
+
+function makeResponse({ status = 200, body = {}, headers = {}, throwOnJson = false } = {}) {
+  const headerStore = {};
+  for (const [k, v] of Object.entries(headers)) headerStore[k.toLowerCase()] = v;
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: {
+      get: (name) => {
+        const k = String(name).toLowerCase();
+        return k in headerStore ? headerStore[k] : null;
+      }
+    },
+    json: async () => {
+      if (throwOnJson) throw new Error('Unexpected token');
+      return body;
+    }
+  };
+}
+
+/**
+ * Build a fetch that returns responses from a scripted sequence. Each element
+ * can be a response object or `{ throw: Error }` to simulate a network error,
+ * or `{ delayMs, ... }` to delay before resolving/throwing.
+ */
+function scriptedFetch(script) {
+  let i = 0;
+  return vi.fn(async (_url, init) => {
+    const step = script[Math.min(i, script.length - 1)];
+    i += 1;
+    if (step && step.delayMs) {
+      await new Promise((resolve, reject) => {
+        const t = setTimeout(resolve, step.delayMs);
+        if (init && init.signal) {
+          init.signal.addEventListener('abort', () => {
+            clearTimeout(t);
+            const err = new Error('aborted');
+            err.name = 'AbortError';
+            reject(err);
+          }, { once: true });
+        }
+      });
+    }
+    if (step && step.throw) throw step.throw;
+    return step.response || step;
+  });
+}
+
+function envBase() {
+  return { AI_DETECTOR_BASE_URL: 'https://svc' };
+}
+
+// A fresh breaker with a huge threshold so retry tests don't trip it.
+function inertBreaker() {
+  return createCircuitBreaker({ failureThreshold: 10_000, cooldownMs: 60_000 });
+}
+
+// ---------------- parseRetryAfter ----------------
+
+describe('parseRetryAfter', () => {
+  it('parses integer delta-seconds', () => {
+    expect(parseRetryAfter('3')).toBe(3000);
+    expect(parseRetryAfter('0')).toBe(0);
+  });
+
+  it('returns null for null / empty', () => {
+    expect(parseRetryAfter(null)).toBeNull();
+    expect(parseRetryAfter(undefined)).toBeNull();
+    expect(parseRetryAfter('')).toBeNull();
+    expect(parseRetryAfter('   ')).toBeNull();
+  });
+
+  it('returns null for unparseable strings', () => {
+    expect(parseRetryAfter('soon')).toBeNull();
+    expect(parseRetryAfter('not-a-date')).toBeNull();
+  });
+
+  it('parses HTTP-date form relative to now', () => {
+    const now = Date.parse('2026-04-17T12:00:00Z');
+    const in5s = 'Fri, 17 Apr 2026 12:00:05 GMT';
+    expect(parseRetryAfter(in5s, now)).toBe(5000);
+  });
+
+  it('returns 0 for an HTTP-date in the past', () => {
+    const now = Date.parse('2026-04-17T12:00:00Z');
+    const past = 'Thu, 21 Oct 2015 07:28:00 GMT';
+    expect(parseRetryAfter(past, now)).toBe(0);
+  });
+});
+
+// ---------------- Retry on transient errors ----------------
+
+describe('ai-detector-client retry', () => {
+  it('retries on 5xx and returns the successful response', async () => {
+    const okBody = {
+      sha256: 's', checked_at: 't', duration_ms: 12,
+      signals: { watermark_visible: { state: 'absent', model: 'v1' } }
+    };
+    const fetchImpl = scriptedFetch([
+      makeResponse({ status: 503 }),
+      makeResponse({ status: 200, body: okBody })
+    ]);
+
+    const result = await detectSignals(
+      { url: 'u' },
+      envBase(),
+      { fetchImpl, circuitBreaker: inertBreaker(), retryBackoffMs: [10, 30], timeoutMs: 5000 }
+    );
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(result.signals.watermark_visible.state).toBe('absent');
+    expect(result.circuit_state).toBe(STATE_CLOSED);
+  });
+
+  it('retries on network errors and succeeds on a later attempt', async () => {
+    const okBody = {
+      sha256: 's', checked_at: 't', duration_ms: 1,
+      signals: { watermark_visible: { state: 'absent', model: 'v1' } }
+    };
+    const fetchImpl = scriptedFetch([
+      { throw: new Error('ECONNRESET') },
+      makeResponse({ status: 200, body: okBody })
+    ]);
+
+    const result = await detectSignals(
+      { url: 'u' },
+      envBase(),
+      { fetchImpl, circuitBreaker: inertBreaker(), retryBackoffMs: [10, 30] }
+    );
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(result.signals.watermark_visible.state).toBe('absent');
+  });
+
+  it('does not retry on HTTP 404 (non-429 4xx)', async () => {
+    const fetchImpl = scriptedFetch([makeResponse({ status: 404 })]);
+    const result = await detectSignals(
+      { url: 'u' },
+      envBase(),
+      { fetchImpl, circuitBreaker: inertBreaker(), retryBackoffMs: [10, 30] }
+    );
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(result.signals.watermark_visible.state).toBe('error');
+    expect(result.signals.watermark_visible.error).toMatch(/HTTP 404/);
+  });
+
+  it('does not retry on malformed JSON', async () => {
+    const fetchImpl = scriptedFetch([makeResponse({ status: 200, throwOnJson: true })]);
+    const result = await detectSignals(
+      { url: 'u' },
+      envBase(),
+      { fetchImpl, circuitBreaker: inertBreaker(), retryBackoffMs: [10, 30] }
+    );
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(result.signals.watermark_visible.state).toBe('error');
+    expect(result.signals.watermark_visible.error).toMatch(/invalid JSON/i);
+  });
+
+  it('gives up after maxAttempts with a consistent transport_error', async () => {
+    const fetchImpl = scriptedFetch([
+      makeResponse({ status: 502 }),
+      makeResponse({ status: 502 }),
+      makeResponse({ status: 502 })
+    ]);
+    const result = await detectSignals(
+      { url: 'u' },
+      envBase(),
+      { fetchImpl, circuitBreaker: inertBreaker(), retryBackoffMs: [5, 10], timeoutMs: 5000 }
+    );
+
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    expect(result.signals.watermark_visible.state).toBe('error');
+    expect(result.signals.watermark_visible.error).toMatch(/HTTP 502/);
+  });
+
+  it('budget exhaustion: first slow attempt consumes most of the budget', async () => {
+    // timeoutMs=300. First attempt delays 250ms then errors (network). Second
+    // attempt must run with < 50ms budget, so we break before issuing it.
+    const fetchImpl = scriptedFetch([
+      { delayMs: 250, throw: new Error('ECONNRESET') },
+      makeResponse({ status: 200 }) // should never be reached
+    ]);
+    const result = await detectSignals(
+      { url: 'u' },
+      envBase(),
+      { fetchImpl, circuitBreaker: inertBreaker(), retryBackoffMs: [100, 300], timeoutMs: 300 }
+    );
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(result.signals.watermark_visible.state).toBe('error');
+  });
+});
+
+// ---------------- 429 Retry-After ----------------
+
+describe('ai-detector-client 429 Retry-After', () => {
+  it('honors a numeric Retry-After within budget', async () => {
+    const okBody = {
+      sha256: 's', checked_at: 't', duration_ms: 1,
+      signals: { watermark_visible: { state: 'absent', model: 'v1' } }
+    };
+    const fetchImpl = scriptedFetch([
+      makeResponse({ status: 429, headers: { 'Retry-After': '0' } }),
+      makeResponse({ status: 200, body: okBody })
+    ]);
+    const result = await detectSignals(
+      { url: 'u' },
+      envBase(),
+      { fetchImpl, circuitBreaker: inertBreaker(), retryBackoffMs: [1000, 3000], timeoutMs: 5000 }
+    );
+    // Retry-After: 0 means "retry immediately" — so we wait 0ms, not 1000ms.
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(result.signals.watermark_visible.state).toBe('absent');
+  });
+
+  it('gives up immediately when Retry-After exceeds remaining budget', async () => {
+    const fetchImpl = scriptedFetch([
+      makeResponse({ status: 429, headers: { 'Retry-After': '60' } }),
+      makeResponse({ status: 200 })
+    ]);
+    const result = await detectSignals(
+      { url: 'u' },
+      envBase(),
+      { fetchImpl, circuitBreaker: inertBreaker(), retryBackoffMs: [100, 300], timeoutMs: 5000 }
+    );
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(result.transport_error).toBe('429 Retry-After exceeds budget');
+    expect(result.signals.watermark_visible.error).toBe('429 Retry-After exceeds budget');
+  });
+
+  it('honors Retry-After HTTP-date form', async () => {
+    // Build a date ~2s from now.
+    const future = new Date(Date.now() + 2000).toUTCString();
+    const okBody = {
+      sha256: 's', checked_at: 't', duration_ms: 1,
+      signals: { watermark_visible: { state: 'detected', confidence: 0.9, model: 'v1' } }
+    };
+    const fetchImpl = scriptedFetch([
+      makeResponse({ status: 429, headers: { 'Retry-After': future } }),
+      makeResponse({ status: 200, body: okBody })
+    ]);
+    const result = await detectSignals(
+      { url: 'u' },
+      envBase(),
+      { fetchImpl, circuitBreaker: inertBreaker(), retryBackoffMs: [10, 30], timeoutMs: 5000 }
+    );
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(result.signals.watermark_visible.state).toBe('detected');
+  });
+
+  it('falls back to backoff when Retry-After is unparseable', async () => {
+    const okBody = {
+      sha256: 's', checked_at: 't', duration_ms: 1,
+      signals: { watermark_visible: { state: 'absent', model: 'v1' } }
+    };
+    const fetchImpl = scriptedFetch([
+      makeResponse({ status: 429, headers: { 'Retry-After': 'not-a-date' } }),
+      makeResponse({ status: 200, body: okBody })
+    ]);
+    const result = await detectSignals(
+      { url: 'u' },
+      envBase(),
+      { fetchImpl, circuitBreaker: inertBreaker(), retryBackoffMs: [10, 30], timeoutMs: 5000 }
+    );
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(result.signals.watermark_visible.state).toBe('absent');
+  });
+});
+
+// ---------------- Circuit breaker ----------------
+
+describe('ai-detector-circuit-breaker', () => {
+  it('starts CLOSED and allows calls', () => {
+    const cb = createCircuitBreaker();
+    expect(cb.getState()).toBe(STATE_CLOSED);
+    expect(cb.shouldAllow()).toBe(STATE_CLOSED);
+  });
+
+  it('opens after N consecutive failures', () => {
+    const cb = createCircuitBreaker({ failureThreshold: 3, cooldownMs: 10_000 });
+    cb.recordFailure();
+    cb.recordFailure();
+    expect(cb.getState()).toBe(STATE_CLOSED);
+    cb.recordFailure();
+    expect(cb.getState()).toBe(STATE_OPEN);
+    expect(cb.shouldAllow()).toBeNull();
+  });
+
+  it('resets consecutive failures on success', () => {
+    const cb = createCircuitBreaker({ failureThreshold: 3 });
+    cb.recordFailure();
+    cb.recordFailure();
+    cb.recordSuccess();
+    cb.recordFailure();
+    cb.recordFailure();
+    expect(cb.getState()).toBe(STATE_CLOSED); // would have opened without the reset
+  });
+
+  it('half-opens after cooldown, and a successful probe closes it', () => {
+    let t = 1_000_000;
+    const cb = createCircuitBreaker({
+      failureThreshold: 2,
+      cooldownMs: 5_000,
+      now: () => t
+    });
+    cb.recordFailure();
+    cb.recordFailure();
+    expect(cb.getState()).toBe(STATE_OPEN);
+    expect(cb.shouldAllow()).toBeNull();
+
+    // Advance past cooldown.
+    t += 6_000;
+    expect(cb.shouldAllow()).toBe(STATE_HALF_OPEN);
+    expect(cb.getState()).toBe(STATE_HALF_OPEN);
+
+    // Probe success -> CLOSED.
+    cb.recordSuccess();
+    expect(cb.getState()).toBe(STATE_CLOSED);
+    expect(cb.shouldAllow()).toBe(STATE_CLOSED);
+  });
+
+  it('re-opens on probe failure with a fresh cooldown', () => {
+    let t = 1_000_000;
+    const cb = createCircuitBreaker({
+      failureThreshold: 1,
+      cooldownMs: 5_000,
+      now: () => t
+    });
+    cb.recordFailure();
+    expect(cb.getState()).toBe(STATE_OPEN);
+
+    t += 6_000;
+    expect(cb.shouldAllow()).toBe(STATE_HALF_OPEN);
+    cb.recordFailure();
+    expect(cb.getState()).toBe(STATE_OPEN);
+    // Should still be blocked immediately after re-open.
+    expect(cb.shouldAllow()).toBeNull();
+
+    // And the new cooldown is measured from the probe-failure time.
+    t += 6_000;
+    expect(cb.shouldAllow()).toBe(STATE_HALF_OPEN);
+  });
+
+  it('allows only one probe in HALF_OPEN', () => {
+    let t = 1_000_000;
+    const cb = createCircuitBreaker({
+      failureThreshold: 1,
+      cooldownMs: 1_000,
+      now: () => t
+    });
+    cb.recordFailure();
+    t += 2_000;
+    expect(cb.shouldAllow()).toBe(STATE_HALF_OPEN);
+    // Second request before probe outcome is reported -> rejected.
+    expect(cb.shouldAllow()).toBeNull();
+  });
+
+  it('logs state transitions', () => {
+    const logs = [];
+    const log = (msg, ctx) => logs.push({ msg, ctx });
+    const cb = createCircuitBreaker({ failureThreshold: 2, cooldownMs: 1_000, log, now: () => 1_000_000 });
+    cb.recordFailure();
+    cb.recordFailure();
+    expect(logs.some(l => l.msg === 'ai-detector.circuit.open')).toBe(true);
+  });
+});
+
+// ---------------- Circuit breaker wired into detectSignals ----------------
+
+describe('detectSignals + circuit breaker', () => {
+  it('short-circuits when breaker is OPEN without invoking fetch', async () => {
+    const fetchImpl = vi.fn(async () => makeResponse({ status: 200 }));
+    const cb = createCircuitBreaker({ failureThreshold: 1, cooldownMs: 60_000 });
+    cb.recordFailure(); // trips OPEN
+
+    const result = await detectSignals(
+      { url: 'u' },
+      envBase(),
+      { fetchImpl, circuitBreaker: cb, retryBackoffMs: [10, 30] }
+    );
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(result.transport_error).toBe('circuit_open');
+    expect(result.circuit_state).toBe(STATE_OPEN);
+    expect(result.signals.watermark_visible.state).toBe('error');
+  });
+
+  it('records a single failure per detectSignals call even across retries', async () => {
+    // 5xx twice, then fail — we should see exactly one failure counted.
+    const cb = createCircuitBreaker({ failureThreshold: 100, cooldownMs: 60_000 });
+    const fetchImpl = scriptedFetch([
+      makeResponse({ status: 500 }),
+      makeResponse({ status: 500 }),
+      makeResponse({ status: 500 })
+    ]);
+
+    await detectSignals(
+      { url: 'u' },
+      envBase(),
+      { fetchImpl, circuitBreaker: cb, retryBackoffMs: [5, 10], timeoutMs: 2000 }
+    );
+
+    expect(cb.getConsecutiveFailures()).toBe(1);
+  });
+
+  it('records a single success per detectSignals call regardless of retries', async () => {
+    const okBody = {
+      sha256: 's', checked_at: 't', duration_ms: 1,
+      signals: { watermark_visible: { state: 'absent', model: 'v1' } }
+    };
+    const cb = createCircuitBreaker({ failureThreshold: 3, cooldownMs: 60_000 });
+    // Pre-load some failures; a single successful call should wipe them.
+    cb.recordFailure();
+    cb.recordFailure();
+
+    const fetchImpl = scriptedFetch([
+      makeResponse({ status: 503 }),
+      makeResponse({ status: 200, body: okBody })
+    ]);
+
+    const result = await detectSignals(
+      { url: 'u' },
+      envBase(),
+      { fetchImpl, circuitBreaker: cb, retryBackoffMs: [10, 30], timeoutMs: 5000 }
+    );
+
+    expect(result.signals.watermark_visible.state).toBe('absent');
+    expect(cb.getConsecutiveFailures()).toBe(0);
+    expect(cb.getState()).toBe(STATE_CLOSED);
+  });
+
+  it('opens after N consecutive failing detectSignals calls', async () => {
+    const cb = createCircuitBreaker({ failureThreshold: 3, cooldownMs: 60_000 });
+    // Each call: three 500s exhaust the retry loop, breaker records failure once.
+    const makeFetch = () => scriptedFetch([
+      makeResponse({ status: 500 }),
+      makeResponse({ status: 500 }),
+      makeResponse({ status: 500 })
+    ]);
+
+    const call = () => detectSignals(
+      { url: 'u' },
+      envBase(),
+      { fetchImpl: makeFetch(), circuitBreaker: cb, retryBackoffMs: [5, 10], timeoutMs: 2000 }
+    );
+
+    await call();
+    await call();
+    expect(cb.getState()).toBe(STATE_CLOSED);
+    await call();
+    expect(cb.getState()).toBe(STATE_OPEN);
+
+    // Next call short-circuits.
+    const sentinel = vi.fn(async () => makeResponse({ status: 200 }));
+    const result = await detectSignals(
+      { url: 'u' },
+      envBase(),
+      { fetchImpl: sentinel, circuitBreaker: cb, retryBackoffMs: [5, 10] }
+    );
+    expect(sentinel).not.toHaveBeenCalled();
+    expect(result.transport_error).toBe('circuit_open');
+  });
+
+  it('includes circuit_state on the happy path', async () => {
+    const okBody = {
+      sha256: 's', checked_at: 't', duration_ms: 1,
+      signals: { watermark_visible: { state: 'absent', model: 'v1' } }
+    };
+    const cb = createCircuitBreaker();
+    const fetchImpl = scriptedFetch([makeResponse({ status: 200, body: okBody })]);
+    const result = await detectSignals(
+      { url: 'u' },
+      envBase(),
+      { fetchImpl, circuitBreaker: cb }
+    );
+    expect(result.circuit_state).toBe(STATE_CLOSED);
+  });
+
+  it('does not trip the breaker when AI_DETECTOR_BASE_URL is missing', async () => {
+    const cb = createCircuitBreaker({ failureThreshold: 1, cooldownMs: 60_000 });
+    await detectSignals({ url: 'u' }, {}, { circuitBreaker: cb });
+    expect(cb.getState()).toBe(STATE_CLOSED);
+    expect(cb.getConsecutiveFailures()).toBe(0);
+  });
+});

--- a/src/moderation/logo_aggregator.mjs
+++ b/src/moderation/logo_aggregator.mjs
@@ -3,6 +3,15 @@
 //
 // ABOUTME: Aggregates per-frame logo detections into a single verdict
 // ABOUTME: Static pass: majority vote per (corner, class); fallback: class-only for moving watermarks
+//
+// TODO(divine-ai-detector): rename this module to `ai-detector-fusion.mjs`
+// once we add a second signal to fuse. The design doc
+// (docs/superpowers/plans/2026-04-17-divine-ai-detector-design.md
+// §"Worker-side changes") reframes this as "the Worker-side fusion layer that
+// combines multiple signals' confidence into a single ai_generated score."
+// For now the vote math here only fuses the four corners of a single
+// watermark_visible signal, so the old name is still accurate and a rename
+// would churn imports across the codebase without adding value.
 
 const CONFIDENCE_FLOOR = 0.7;
 const FRAME_SHARE_THRESHOLD = 0.5;

--- a/src/moderation/logo_detector.mjs
+++ b/src/moderation/logo_detector.mjs
@@ -14,7 +14,7 @@
 //
 // The stub `detectLogos` + `options.infer` test-injection path is preserved
 // for unit tests only. In production, callers should use
-// `envelopeToDetections(envelope, frameCount)` to adapt the service's
+// `envelopeToDetections(envelope)` to adapt the service's
 // per-signal `watermark_visible` envelope back into the per-frame/per-corner
 // shape that logo_aggregator.mjs consumes. This keeps the aggregator's vote
 // math stable during cutover.

--- a/src/moderation/logo_detector.mjs
+++ b/src/moderation/logo_detector.mjs
@@ -1,13 +1,23 @@
 // This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
 // If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 //
-// ABOUTME: Visible-watermark detector for consumer AI video generators
-// ABOUTME: Crops four 15% corners per frame and runs a stub classifier per crop
+// ABOUTME: Backwards-compat shim over ai-detector-client for the visible-watermark signal
+// ABOUTME: In-Worker inference is gone — this module now maps watermark_visible envelopes
 //
-// The actual ONNX model (Meta sparkle, Sora, Veo, Runway, Kling, Pika, Luma corner
-// logos) is loaded lazily via `loadModel()` + `runInference()`. Both are stubs
-// until the trained classifier is wired in through onnxruntime-web — tests drive
-// behaviour by injecting `options.infer`.
+// History: originally a stub ONNX classifier running 4x 15% corner crops per
+// frame inside the Worker. That inference has moved to the divine-ai-detector
+// service (see docs/superpowers/plans/2026-04-17-divine-ai-detector-design.md).
+// This file is kept as a compatibility layer so existing callers and tests
+// that still import { detectLogos, loadModel, runInference, cropCorner,
+// LOGO_CLASSES, CORNERS } continue to work. New code should prefer
+// ai-detector-client.mjs directly.
+//
+// The stub `detectLogos` + `options.infer` test-injection path is preserved
+// for unit tests only. In production, callers should use
+// `envelopeToDetections(envelope, frameCount)` to adapt the service's
+// per-signal `watermark_visible` envelope back into the per-frame/per-corner
+// shape that logo_aggregator.mjs consumes. This keeps the aggregator's vote
+// math stable during cutover.
 
 export const LOGO_CLASSES = [
   'clean',
@@ -25,6 +35,10 @@ export const CORNERS = ['TL', 'TR', 'BL', 'BR'];
 
 const CORNER_RATIO = 0.15;
 
+// Kept for backwards-compat. There is no local model anymore; the presence of
+// a non-empty URL just means "client is configured." `modelUrl` is treated as
+// a base URL to divine-ai-detector — the old ONNX URL shape is tolerated for
+// deprecated deployments (see ai-detector-client.mjs resolveBaseUrl).
 export async function loadModel(modelUrl) {
   if (!modelUrl) {
     return { modelUrl: null, ready: false };
@@ -33,7 +47,11 @@ export async function loadModel(modelUrl) {
 }
 
 export async function loadModelFromEnv(env) {
-  const url = env && env.LOGO_DETECTOR_MODEL_URL ? env.LOGO_DETECTOR_MODEL_URL : null;
+  // Prefer the new env var; fall back to the deprecated one so existing
+  // deployed configs keep working during rollout.
+  const url = env && (env.AI_DETECTOR_BASE_URL || env.LOGO_DETECTOR_MODEL_URL)
+    ? (env.AI_DETECTOR_BASE_URL || env.LOGO_DETECTOR_MODEL_URL)
+    : null;
   return loadModel(url);
 }
 
@@ -44,10 +62,14 @@ export function cropCorner(frame, corner) {
   return { frame, corner, ratio: CORNER_RATIO };
 }
 
+// Stub inference — only the unit tests still exercise this path now.
 export async function runInference(_crop, _model) {
   return { class: 'clean', confidence: 1.0 };
 }
 
+// Test-only synthesis path: emits four detections per frame, one per corner.
+// Production code should use detectSignals() from ai-detector-client.mjs and
+// then envelopeToDetections() to adapt to the aggregator's input shape.
 export async function detectLogos(frames, options = {}) {
   const { model = null, infer = runInference } = options;
   const detections = [];
@@ -61,6 +83,48 @@ export async function detectLogos(frames, options = {}) {
         class: result.class,
         confidence: result.confidence
       });
+    }
+  }
+  return detections;
+}
+
+/**
+ * Adapts a divine-ai-detector `watermark_visible` envelope back into the
+ * per-frame/per-corner detections shape that logo_aggregator.mjs consumes.
+ *
+ * The service reports aggregate counts (frames_flagged, total_frames) rather
+ * than per-frame/per-corner data, so this reconstructs detections that are
+ * vote-equivalent for the aggregator:
+ *
+ *   - `detected`: emit `frames_flagged` flagged frames (all in corner 'BL'
+ *     as a placeholder — aggregator's moving-watermark fallback ignores
+ *     corner) plus (total_frames - frames_flagged) clean frames.
+ *   - `absent` / `skipped`: emit `total_frames` clean frames.
+ *   - `error`: return null so callers can branch to vendor fallback.
+ *
+ * This is a shim. The long-term plan is for the Worker's fusion layer to
+ * consume envelopes directly without reconstructing detections.
+ */
+export function envelopeToDetections(envelope) {
+  if (!envelope || typeof envelope !== 'object') return null;
+  if (envelope.state === 'error') return null;
+
+  const total = Number.isFinite(envelope.total_frames) ? envelope.total_frames : 0;
+  const flagged = envelope.state === 'detected' && Number.isFinite(envelope.frames_flagged)
+    ? Math.min(envelope.frames_flagged, total)
+    : 0;
+  const cls = envelope.class || null;
+  const confidence = Number.isFinite(envelope.confidence) ? envelope.confidence : 0;
+
+  const detections = [];
+  for (let i = 0; i < total; i++) {
+    const isFlagged = i < flagged && cls;
+    for (const corner of CORNERS) {
+      if (isFlagged && corner === 'BL') {
+        detections.push({ frame_index: i, corner, class: cls, confidence });
+      } else {
+        detections.push({ frame_index: i, corner, class: 'clean', confidence: 1.0 });
+      }
     }
   }
   return detections;

--- a/src/moderation/logo_detector.test.mjs
+++ b/src/moderation/logo_detector.test.mjs
@@ -11,9 +11,11 @@ import {
   loadModelFromEnv,
   runInference,
   cropCorner,
+  envelopeToDetections,
   LOGO_CLASSES,
   CORNERS
 } from './logo_detector.mjs';
+import { aggregateLogoDetections } from './logo_aggregator.mjs';
 
 describe('logo_detector - constants', () => {
   it('exposes the nine classifier classes in a stable order', () => {
@@ -76,6 +78,83 @@ describe('logo_detector - loadModelFromEnv', () => {
     const model = await loadModelFromEnv(null);
     expect(model.ready).toBe(false);
     expect(model.modelUrl).toBeNull();
+  });
+
+  it('prefers AI_DETECTOR_BASE_URL over the deprecated LOGO_DETECTOR_MODEL_URL', async () => {
+    const env = {
+      AI_DETECTOR_BASE_URL: 'https://ai-detector.divine.video',
+      LOGO_DETECTOR_MODEL_URL: 'https://old.example/model.onnx'
+    };
+    const model = await loadModelFromEnv(env);
+    expect(model).toEqual({
+      modelUrl: 'https://ai-detector.divine.video',
+      ready: true
+    });
+  });
+
+  it('falls back to LOGO_DETECTOR_MODEL_URL for deployed configs that have not been rotated', async () => {
+    const env = { LOGO_DETECTOR_MODEL_URL: 'https://models.divine.video/logo-v1.onnx' };
+    const model = await loadModelFromEnv(env);
+    expect(model.ready).toBe(true);
+    expect(model.modelUrl).toBe('https://models.divine.video/logo-v1.onnx');
+  });
+});
+
+describe('logo_detector - envelopeToDetections', () => {
+  it('returns null for an error envelope so callers can fall through to vendor', () => {
+    expect(envelopeToDetections({ state: 'error', error: 'boom', model: 'v1' })).toBeNull();
+  });
+
+  it('returns null when given a null envelope', () => {
+    expect(envelopeToDetections(null)).toBeNull();
+  });
+
+  it('emits all-clean detections for an absent envelope with total_frames', () => {
+    const detections = envelopeToDetections({
+      state: 'absent', total_frames: 3, model: 'v1'
+    });
+    expect(detections).toHaveLength(12); // 3 frames × 4 corners
+    for (const d of detections) {
+      expect(d.class).toBe('clean');
+      expect(d.confidence).toBe(1.0);
+    }
+  });
+
+  it('emits flagged + clean detections for a detected envelope that aggregator agrees with', () => {
+    const envelope = {
+      state: 'detected',
+      class: 'meta_sparkle',
+      confidence: 0.9,
+      frames_flagged: 3,
+      total_frames: 4,
+      model: 'logo-v1.2.0'
+    };
+    const detections = envelopeToDetections(envelope);
+    expect(detections).toHaveLength(16);
+
+    const result = aggregateLogoDetections(detections);
+    expect(result.detected).toBe(true);
+    expect(result.class).toBe('meta_sparkle');
+    expect(result.frames_flagged).toBe(3);
+    expect(result.total_frames).toBe(4);
+  });
+
+  it('emits zero detections for a detected envelope with total_frames=0', () => {
+    const detections = envelopeToDetections({
+      state: 'detected', class: 'meta_sparkle', confidence: 0.9,
+      frames_flagged: 0, total_frames: 0, model: 'v1'
+    });
+    expect(detections).toEqual([]);
+  });
+
+  it('caps frames_flagged at total_frames to avoid aggregator double-counting', () => {
+    const detections = envelopeToDetections({
+      state: 'detected', class: 'meta_sparkle', confidence: 0.9,
+      frames_flagged: 99, total_frames: 4, model: 'v1'
+    });
+    const result = aggregateLogoDetections(detections);
+    expect(result.frames_flagged).toBe(4);
+    expect(result.total_frames).toBe(4);
   });
 });
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -85,11 +85,29 @@ AI_GENERATED_THRESHOLD_MEDIUM = "0.6" # Human review
 # Called from the pipeline before Hive — valid_ai_signed short-circuits Hive, valid_proofmode downgrades AI-QUARANTINE to REVIEW
 INQUISITOR_BASE_URL = "https://inquisitor.divine.video"
 
-# Visible-watermark detector (corner logo classifier for consumer AI generators:
-# Meta sparkle, Sora, Veo, Runway, Kling, Pika, Luma). Points at an ONNX model
-# served over HTTPS; loaded lazily in the Worker via onnxruntime-web. Empty
-# string = detector disabled (stub inference path returns clean).
+# divine-ai-detector service base URL. The Worker posts per-signal detection
+# requests to {AI_DETECTOR_BASE_URL}/detect and gets back per-signal envelopes
+# (see docs/superpowers/plans/2026-04-17-divine-ai-detector-design.md §API).
+# Empty string = client disabled; every signal resolves to an `error` envelope
+# and callers fall through to vendor (Hive / Reality Defender).
+AI_DETECTOR_BASE_URL = ""
+
+# DEPRECATED — kept so deployed configs that still set this don't break during
+# cutover. The client reads it as a fallback only when AI_DETECTOR_BASE_URL is
+# empty. Remove after every environment has been migrated.
 LOGO_DETECTOR_MODEL_URL = ""
+
+# Per-signal cutover mode: shadow | gated | preferred | sole (default shadow).
+# - shadow    : call vendor + internal, use vendor, log disagreement
+# - gated     : internal when confidence >= AI_DETECTOR_GATE_<SIGNAL>
+# - preferred : internal whenever state != error
+# - sole      : internal only, vendor not called
+# Flipping this is a runtime rollout decision, not a PR decision.
+AI_DETECTOR_MODE_WATERMARK_VISIBLE = "shadow"
+
+# Confidence gate used by `gated` mode. Spec: 0.8 is the Hive-equivalent high
+# threshold; 0.7 is moderate. Tune from shadow-mode agreement data.
+AI_DETECTOR_GATE_WATERMARK_VISIBLE = "0.8"
 
 # Relay Polling Configuration
 RELAY_POLLING_ENABLED = "true"                    # Enable/disable relay polling


### PR DESCRIPTION
## Summary

First follow-up to the [divine-ai-detector design doc](docs/superpowers/plans/2026-04-17-divine-ai-detector-design.md). Reshapes the Worker's logo-detection code into an HTTP client of the new Rust/Axum `divine-ai-detector` service, without changing any runtime behavior.

- **`src/moderation/ai-detector-client.mjs`** — thin HTTP client over `POST /detect`. Accepts `{url, mime_type, sha256, signals}`, returns the per-signal `SignalEnvelope` map. On fetch timeout, non-2xx, or malformed JSON it synthesizes an `error` envelope per requested signal so callers branch uniformly and fall through to vendor.
- **`src/moderation/ai-detector-mode.mjs`** — per-signal cutover dispatcher. Reads `AI_DETECTOR_MODE_<SIGNAL>` and `AI_DETECTOR_GATE_<SIGNAL>`. Implements all four modes from spec §"Cutover strategy":
  - `shadow` (default): call both, return vendor verdict, log both + disagreement.
  - `gated`: internal if `confidence >= GATE`, else vendor.
  - `preferred`: internal if `state != error`, else vendor.
  - `sole`: internal only, vendor never called.
- **`src/moderation/logo_detector.mjs`** — now a backwards-compat shim. Stub `detectLogos` + `options.infer` injection point stays for unit tests; production adds `envelopeToDetections(envelope)` which maps the service's `watermark_visible` envelope back into the per-frame/per-corner shape the aggregator already knows how to vote on.
- **`src/moderation/logo_aggregator.mjs`** — vote math unchanged; added TODO explaining why the `ai-detector-fusion.mjs` rename is deferred until a second signal ships.
- **`wrangler.toml`** — new `AI_DETECTOR_BASE_URL`, `AI_DETECTOR_MODE_WATERMARK_VISIBLE=shadow`, `AI_DETECTOR_GATE_WATERMARK_VISIBLE=0.8`. The old `LOGO_DETECTOR_MODEL_URL` stays with a `DEPRECATED` comment; the client reads it as a fallback so deployed configs keep working during rollout.

## Reshape decision: shim, not replace

Picked the backwards-compat shim path over deleting `logo_detector.mjs`:
- The existing 18 tests use `detectLogos(frames, {infer})` as a pure stub path — no production call site actually invokes `detectLogos` today, so keeping the API costs nothing.
- `envelopeToDetections()` adapts the new service's aggregate counts (`frames_flagged`, `total_frames`) back into the aggregator's input shape. A new test verifies an aggregate-equivalent round-trip: detected envelope → detections → `aggregateLogoDetections` gives the same class/counts.
- Aggregator rename `logo_aggregator.mjs` → `ai-detector-fusion.mjs` was **deferred**. Rationale in the file's top comment: vote math still only fuses one signal's four corners, so the old name is still accurate; renaming now just churns imports.

## Cutover modes

Every signal's current mode is a single env var. Default is `shadow` for every new signal — this PR ships `shadow`, so behavior is unchanged until ops flips a var.

| Mode | Internal called? | Vendor called? | Verdict returned |
|------|---|---|---|
| shadow | yes | yes | vendor |
| gated | yes | only if conf < GATE | internal if conf ≥ GATE, else vendor |
| preferred | yes | only on error/skipped | internal unless error |
| sole | yes | no | internal |

## Environment

- **New**: `AI_DETECTOR_BASE_URL=https://ai-detector.{env}.divine.video` required before anything but `shadow` mode works. Empty = every envelope is `error`.
- **New**: `AI_DETECTOR_MODE_WATERMARK_VISIBLE=shadow` (default).
- **New**: `AI_DETECTOR_GATE_WATERMARK_VISIBLE=0.8` (default).
- **Deprecated**: `LOGO_DETECTOR_MODEL_URL` — still read as a fallback; remove after every env has been migrated.

## Test plan

- [x] Client happy path (mocked fetch → detected envelope)
- [x] Client non-2xx → error envelope
- [x] Client network failure → error envelope
- [x] Client AbortController timeout → error envelope with `timeout after Nms`
- [x] Client env resolution (new var preferred, deprecated fallback, null env)
- [x] Mode dispatch: shadow calls both, returns vendor, flags disagreement
- [x] Mode dispatch: gated uses internal iff confidence ≥ gate, custom gate honored
- [x] Mode dispatch: preferred uses internal unless error
- [x] Mode dispatch: sole never calls vendor
- [x] Mode default = shadow when env empty
- [x] `envelopeToDetections` round-trips through `aggregateLogoDetections`
- [x] Existing 34 logo_detector + logo_aggregator tests unchanged in behavior
- [x] `npm test` — **762 pass, 0 fail** (was 716 before; +46 new)

## Don'ts honored

- No default mode change away from `shadow`.
- No existing tests broken.
- No deploy, no PR merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)