### PR TITLE
feat(sweep): creator-delete validation-window physical-delete sweep

### DIFF
--- a/docs/superpowers/plans/2026-04-17-creator-delete-validation-sweep-plan.md
+++ b/docs/superpowers/plans/2026-04-17-creator-delete-validation-sweep-plan.md
@@ -1,0 +1,1699 @@
+# Creator-delete validation-window physical-delete sweep — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build an operator-run script that destroys GCS bytes for creator-deletes that completed during the validation window (when `ENABLE_PHYSICAL_DELETE=false` on Blossom), and tracks per-row completion in D1 so re-runs are O(unfinished).
+
+**Architecture:** Single-file Node ESM script in `scripts/sweep-creator-deletes.mjs`. Reads candidates from D1 via `wrangler d1 execute` shell-out (using `node:child_process`'s `spawnSync` with an args array — never the shell-interpreting `exec`), calls Blossom's `/admin/moderate` via the existing `notifyBlossom()` client from `src/blossom-client.mjs`, and stamps `physical_deleted_at` on success via batched `UPDATE`. All side-effecting collaborators (wrangler shell-out, Blossom client) are dependency-injected so vitest can drive `main()` end-to-end with fakes.
+
+**Tech Stack:** Node 20+, vitest (Workers pool — `nodejs_compat` flag is on so `node:child_process` works), `wrangler` CLI, existing `src/blossom-client.mjs` for Blossom notifications.
+
+**Spec:** `docs/superpowers/specs/2026-04-17-creator-delete-validation-sweep-design.md`
+**Issue:** [divine-blossom#90](https://github.com/divinevideo/divine-blossom/issues/90)
+**Branch:** `spec/creator-delete-validation-sweep` (already created off `main`)
+
+---
+
+## File structure
+
+| File | Status | Responsibility |
+|---|---|---|
+| `migrations/007-creator-deletions-physical-deleted-at.sql` | new | Adds `physical_deleted_at TEXT` to `creator_deletions`. |
+| `scripts/sweep-creator-deletes.mjs` | new | Sweep orchestrator. Single file: CLI parsing, SQL builders, concurrency, Blossom wrapper, main(). |
+| `scripts/sweep-creator-deletes.test.mjs` | new | Vitest unit + integration tests. Injects fake shell runner and fake Blossom notifier into the script's exported helpers and `main()`. |
+
+The script keeps every impure operation behind an injectable function so tests do not shell out, do not hit the network, and do not require real D1 / Blossom.
+
+---
+
+## Task 1: D1 migration
+
+**Files:**
+- Create: `migrations/007-creator-deletions-physical-deleted-at.sql`
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- Stamped by scripts/sweep-creator-deletes.mjs only.
+-- The live creator-delete pipeline (process.mjs) does not write this column;
+-- newly-produced success rows show NULL here until the next sweep run picks
+-- them up, calls Blossom (idempotent if bytes already gone), and stamps.
+-- Semantic: "the validation sweep confirmed bytes were destroyed for this row."
+
+ALTER TABLE creator_deletions
+  ADD COLUMN IF NOT EXISTS physical_deleted_at TEXT;
+```
+
+- [ ] **Step 2: Verify SQL parses**
+
+Run: `sqlite3 :memory: ".read migrations/006-creator-deletions.sql" ".read migrations/007-creator-deletions-physical-deleted-at.sql" ".schema creator_deletions"`
+
+Expected: schema dump includes the new column line `physical_deleted_at TEXT`. (D1 uses SQLite's grammar; if `sqlite3` is missing locally, the wrangler `--local` apply in Task 12 will catch syntax errors too.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add migrations/007-creator-deletions-physical-deleted-at.sql
+git commit -m "feat(migration): add physical_deleted_at to creator_deletions (007)"
+```
+
+---
+
+## Task 2: Script scaffolding + parseArgs
+
+**Files:**
+- Create: `scripts/sweep-creator-deletes.mjs`
+- Create: `scripts/sweep-creator-deletes.test.mjs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `scripts/sweep-creator-deletes.test.mjs`:
+
+```js
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Tests for scripts/sweep-creator-deletes.mjs — pure helpers + main() with injected deps.
+// ABOUTME: Vitest runs under @cloudflare/vitest-pool-workers; nodejs_compat is on so node:child_process imports resolve.
+
+import { describe, it, expect } from 'vitest';
+import { parseArgs } from './sweep-creator-deletes.mjs';
+
+describe('parseArgs', () => {
+  it('returns defaults when no flags given', () => {
+    const cfg = parseArgs([]);
+    expect(cfg).toEqual({
+      dryRun: false,
+      since: null,
+      until: null,
+      concurrency: 5,
+      limit: null,
+      blossomWebhookUrl: 'https://media.divine.video/admin/moderate',
+      d1Database: 'divine-moderation-decisions-prod'
+    });
+  });
+
+  it('parses --dry-run as boolean', () => {
+    expect(parseArgs(['--dry-run']).dryRun).toBe(true);
+  });
+
+  it('parses --since and --until as ISO strings via Date round-trip', () => {
+    const cfg = parseArgs(['--since=2026-04-01T00:00:00.000Z', '--until=2026-04-17T00:00:00.000Z']);
+    expect(cfg.since).toBe('2026-04-01T00:00:00.000Z');
+    expect(cfg.until).toBe('2026-04-17T00:00:00.000Z');
+  });
+
+  it('rejects an unparseable --since', () => {
+    expect(() => parseArgs(['--since=not-a-date'])).toThrow(/since/i);
+  });
+
+  it('parses --concurrency as positive integer', () => {
+    expect(parseArgs(['--concurrency=10']).concurrency).toBe(10);
+  });
+
+  it('rejects --concurrency=0', () => {
+    expect(() => parseArgs(['--concurrency=0'])).toThrow(/concurrency/i);
+  });
+
+  it('rejects --concurrency=-1', () => {
+    expect(() => parseArgs(['--concurrency=-1'])).toThrow(/concurrency/i);
+  });
+
+  it('parses --limit as non-negative integer', () => {
+    expect(parseArgs(['--limit=100']).limit).toBe(100);
+  });
+
+  it('rejects --limit=foo', () => {
+    expect(() => parseArgs(['--limit=foo'])).toThrow(/limit/i);
+  });
+
+  it('parses --blossom-webhook-url and --d1-database overrides', () => {
+    const cfg = parseArgs(['--blossom-webhook-url=http://localhost:7676/admin/moderate', '--d1-database=test-db']);
+    expect(cfg.blossomWebhookUrl).toBe('http://localhost:7676/admin/moderate');
+    expect(cfg.d1Database).toBe('test-db');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- scripts/sweep-creator-deletes.test.mjs`
+
+Expected: FAIL with import error — `scripts/sweep-creator-deletes.mjs` does not exist or does not export `parseArgs`.
+
+- [ ] **Step 3: Implement parseArgs**
+
+Create `scripts/sweep-creator-deletes.mjs`:
+
+```js
+#!/usr/bin/env node
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Validation-window physical-delete sweep for creator-deleted blobs (blossom#90).
+// ABOUTME: Reads creator_deletions from D1, asks Blossom to destroy bytes, stamps physical_deleted_at.
+
+const DEFAULT_BLOSSOM_WEBHOOK_URL = 'https://media.divine.video/admin/moderate';
+const DEFAULT_D1_DATABASE = 'divine-moderation-decisions-prod';
+const DEFAULT_CONCURRENCY = 5;
+const FLUSH_BATCH_SIZE = 100;
+const SHA256_HEX = /^[0-9a-f]{64}$/;
+
+function getFlag(argv, name) {
+  const prefix = `--${name}=`;
+  for (const a of argv) {
+    if (a === `--${name}`) return true;
+    if (a.startsWith(prefix)) return a.slice(prefix.length);
+  }
+  return null;
+}
+
+function validateIso(value, fieldName) {
+  if (value == null) return null;
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) {
+    throw new Error(`Invalid ${fieldName}: ${value} (must be ISO 8601)`);
+  }
+  return d.toISOString();
+}
+
+function validatePositiveInt(value, fieldName) {
+  const n = Number(value);
+  if (!Number.isInteger(n) || n <= 0) {
+    throw new Error(`Invalid ${fieldName}: ${value} (must be positive integer)`);
+  }
+  return n;
+}
+
+function validateNonNegativeInt(value, fieldName) {
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < 0) {
+    throw new Error(`Invalid ${fieldName}: ${value} (must be non-negative integer)`);
+  }
+  return n;
+}
+
+export function parseArgs(argv) {
+  const dryRun = getFlag(argv, 'dry-run') === true;
+  const since = validateIso(getFlag(argv, 'since') || null, 'since');
+  const until = validateIso(getFlag(argv, 'until') || null, 'until');
+
+  const rawConcurrency = getFlag(argv, 'concurrency');
+  const concurrency = rawConcurrency
+    ? validatePositiveInt(rawConcurrency, 'concurrency')
+    : DEFAULT_CONCURRENCY;
+
+  const rawLimit = getFlag(argv, 'limit');
+  const limit = rawLimit ? validateNonNegativeInt(rawLimit, 'limit') : null;
+
+  const blossomWebhookUrl = getFlag(argv, 'blossom-webhook-url') || DEFAULT_BLOSSOM_WEBHOOK_URL;
+  const d1Database = getFlag(argv, 'd1-database') || DEFAULT_D1_DATABASE;
+
+  return { dryRun, since, until, concurrency, limit, blossomWebhookUrl, d1Database };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- scripts/sweep-creator-deletes.test.mjs`
+
+Expected: PASS — all parseArgs tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/sweep-creator-deletes.mjs scripts/sweep-creator-deletes.test.mjs
+git commit -m "feat(sweep): scaffold sweep-creator-deletes script with parseArgs"
+```
+
+---
+
+## Task 3: SQL builders + sha256 validation
+
+**Files:**
+- Modify: `scripts/sweep-creator-deletes.mjs`
+- Modify: `scripts/sweep-creator-deletes.test.mjs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `scripts/sweep-creator-deletes.test.mjs`:
+
+```js
+import {
+  buildSelectCandidatesSql,
+  buildSelectUnprocessableSql,
+  buildSelectPermanentFailuresSql,
+  buildUpdateStampSql,
+  validateSha256
+} from './sweep-creator-deletes.mjs';
+
+const SHA_A = 'a'.repeat(64);
+const SHA_B = 'b'.repeat(64);
+
+describe('validateSha256', () => {
+  it('accepts a 64-char lowercase hex string', () => {
+    expect(validateSha256(SHA_A)).toBe(SHA_A);
+  });
+  it('rejects uppercase', () => {
+    expect(() => validateSha256(SHA_A.toUpperCase())).toThrow(/sha256/i);
+  });
+  it('rejects shorter than 64', () => {
+    expect(() => validateSha256('a'.repeat(63))).toThrow(/sha256/i);
+  });
+  it('rejects non-hex characters', () => {
+    expect(() => validateSha256('z'.repeat(64))).toThrow(/sha256/i);
+  });
+  it('rejects null/undefined', () => {
+    expect(() => validateSha256(null)).toThrow(/sha256/i);
+    expect(() => validateSha256(undefined)).toThrow(/sha256/i);
+  });
+});
+
+describe('buildSelectCandidatesSql', () => {
+  it('builds the base select with no optional filters', () => {
+    const sql = buildSelectCandidatesSql({ since: null, until: null, limit: null });
+    expect(sql).toContain("WHERE status = 'success'");
+    expect(sql).toContain('AND physical_deleted_at IS NULL');
+    expect(sql).toContain('AND blob_sha256 IS NOT NULL');
+    expect(sql).not.toContain('completed_at >=');
+    expect(sql).not.toContain('completed_at <');
+    expect(sql).not.toContain('LIMIT');
+  });
+
+  it('includes since when provided', () => {
+    const sql = buildSelectCandidatesSql({ since: '2026-04-01T00:00:00.000Z', until: null, limit: null });
+    expect(sql).toContain("AND completed_at >= '2026-04-01T00:00:00.000Z'");
+  });
+
+  it('includes until when provided', () => {
+    const sql = buildSelectCandidatesSql({ since: null, until: '2026-04-17T00:00:00.000Z', limit: null });
+    expect(sql).toContain("AND completed_at < '2026-04-17T00:00:00.000Z'");
+  });
+
+  it('includes LIMIT when provided', () => {
+    const sql = buildSelectCandidatesSql({ since: null, until: null, limit: 50 });
+    expect(sql).toMatch(/LIMIT 50\b/);
+  });
+});
+
+describe('buildSelectUnprocessableSql', () => {
+  it('builds select for status=success rows with NULL sha', () => {
+    const sql = buildSelectUnprocessableSql();
+    expect(sql).toContain("WHERE status = 'success'");
+    expect(sql).toContain('AND blob_sha256 IS NULL');
+  });
+});
+
+describe('buildSelectPermanentFailuresSql', () => {
+  it('builds select for status LIKE failed:permanent:*', () => {
+    const sql = buildSelectPermanentFailuresSql();
+    expect(sql).toContain("WHERE status LIKE 'failed:permanent:%'");
+  });
+});
+
+describe('buildUpdateStampSql', () => {
+  it('builds an UPDATE with IN-list and NULL guard', () => {
+    const sql = buildUpdateStampSql([SHA_A, SHA_B], '2026-04-17T20:00:00.000Z');
+    expect(sql).toContain("SET physical_deleted_at = '2026-04-17T20:00:00.000Z'");
+    expect(sql).toContain(`WHERE blob_sha256 IN ('${SHA_A}', '${SHA_B}')`);
+    expect(sql).toContain('AND physical_deleted_at IS NULL');
+  });
+
+  it('rejects an empty sha list (caller bug)', () => {
+    expect(() => buildUpdateStampSql([], '2026-04-17T20:00:00.000Z')).toThrow(/empty/i);
+  });
+
+  it('rejects when any sha fails validation', () => {
+    expect(() => buildUpdateStampSql([SHA_A, 'not-hex'], '2026-04-17T20:00:00.000Z')).toThrow(/sha256/i);
+  });
+
+  it('rejects an invalid timestamp', () => {
+    expect(() => buildUpdateStampSql([SHA_A], 'not-iso')).toThrow(/timestamp/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- scripts/sweep-creator-deletes.test.mjs`
+
+Expected: FAIL — none of the new exports exist.
+
+- [ ] **Step 3: Implement the SQL builders**
+
+Append to `scripts/sweep-creator-deletes.mjs`:
+
+```js
+export function validateSha256(s) {
+  if (typeof s !== 'string' || !SHA256_HEX.test(s)) {
+    throw new Error(`Invalid sha256: ${s}`);
+  }
+  return s;
+}
+
+function validateIsoTimestamp(s) {
+  if (typeof s !== 'string') throw new Error(`Invalid timestamp: ${s}`);
+  const d = new Date(s);
+  if (Number.isNaN(d.getTime()) || d.toISOString() !== s) {
+    throw new Error(`Invalid timestamp: ${s}`);
+  }
+  return s;
+}
+
+export function buildSelectCandidatesSql({ since, until, limit }) {
+  let sql =
+    "SELECT kind5_id, target_event_id, blob_sha256, completed_at FROM creator_deletions" +
+    " WHERE status = 'success'" +
+    " AND physical_deleted_at IS NULL" +
+    " AND blob_sha256 IS NOT NULL";
+  if (since) sql += ` AND completed_at >= '${validateIsoTimestamp(since)}'`;
+  if (until) sql += ` AND completed_at < '${validateIsoTimestamp(until)}'`;
+  if (limit != null) {
+    if (!Number.isInteger(limit) || limit < 0) throw new Error(`Invalid limit: ${limit}`);
+    sql += ` LIMIT ${limit}`;
+  }
+  sql += ';';
+  return sql;
+}
+
+export function buildSelectUnprocessableSql() {
+  return (
+    "SELECT kind5_id, target_event_id, creator_pubkey, completed_at FROM creator_deletions" +
+    " WHERE status = 'success'" +
+    " AND blob_sha256 IS NULL;"
+  );
+}
+
+export function buildSelectPermanentFailuresSql() {
+  return (
+    "SELECT kind5_id, target_event_id, creator_pubkey, status, last_error FROM creator_deletions" +
+    " WHERE status LIKE 'failed:permanent:%';"
+  );
+}
+
+export function buildUpdateStampSql(shas, timestamp) {
+  if (!Array.isArray(shas) || shas.length === 0) {
+    throw new Error('buildUpdateStampSql called with empty sha list');
+  }
+  validateIsoTimestamp(timestamp);
+  for (const s of shas) validateSha256(s);
+  const inList = shas.map(s => `'${s}'`).join(', ');
+  return (
+    `UPDATE creator_deletions SET physical_deleted_at = '${timestamp}'` +
+    ` WHERE blob_sha256 IN (${inList})` +
+    ` AND physical_deleted_at IS NULL;`
+  );
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- scripts/sweep-creator-deletes.test.mjs`
+
+Expected: PASS — all parseArgs + SQL-builder tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/sweep-creator-deletes.mjs scripts/sweep-creator-deletes.test.mjs
+git commit -m "feat(sweep): SQL builders for candidates/unprocessable/perm-failures/stamp"
+```
+
+---
+
+## Task 4: runWithConcurrency
+
+**Files:**
+- Modify: `scripts/sweep-creator-deletes.mjs`
+- Modify: `scripts/sweep-creator-deletes.test.mjs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `scripts/sweep-creator-deletes.test.mjs`:
+
+```js
+import { runWithConcurrency } from './sweep-creator-deletes.mjs';
+
+describe('runWithConcurrency', () => {
+  it('runs all items and returns one result per input', async () => {
+    const items = [1, 2, 3, 4, 5];
+    const results = await runWithConcurrency(items, 2, async x => x * 10);
+    expect(results.length).toBe(5);
+    expect(results.map(r => r.value).sort((a, b) => a - b)).toEqual([10, 20, 30, 40, 50]);
+  });
+
+  it('respects concurrency cap (never more than N in flight)', async () => {
+    let inFlight = 0;
+    let peak = 0;
+    const work = async () => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await new Promise(r => setTimeout(r, 5));
+      inFlight--;
+    };
+    await runWithConcurrency(new Array(20).fill(0), 3, work);
+    expect(peak).toBeLessThanOrEqual(3);
+  });
+
+  it('isolates per-item errors — one failure does not poison the rest', async () => {
+    const items = [1, 2, 3];
+    const results = await runWithConcurrency(items, 2, async x => {
+      if (x === 2) throw new Error('boom');
+      return x;
+    });
+    expect(results.length).toBe(3);
+    const byInput = Object.fromEntries(results.map(r => [r.input, r]));
+    expect(byInput[1].value).toBe(1);
+    expect(byInput[2].error.message).toBe('boom');
+    expect(byInput[3].value).toBe(3);
+  });
+
+  it('returns immediately on empty input', async () => {
+    const results = await runWithConcurrency([], 5, async () => { throw new Error('should not run'); });
+    expect(results).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- scripts/sweep-creator-deletes.test.mjs`
+
+Expected: FAIL — `runWithConcurrency` not exported.
+
+- [ ] **Step 3: Implement runWithConcurrency**
+
+Append to `scripts/sweep-creator-deletes.mjs`:
+
+```js
+export async function runWithConcurrency(items, concurrency, fn) {
+  if (items.length === 0) return [];
+  const results = new Array(items.length);
+  let cursor = 0;
+
+  async function worker() {
+    while (true) {
+      const i = cursor++;
+      if (i >= items.length) return;
+      const input = items[i];
+      try {
+        const value = await fn(input);
+        results[i] = { input, value };
+      } catch (error) {
+        results[i] = { input, error };
+      }
+    }
+  }
+
+  const workers = [];
+  for (let w = 0; w < Math.min(concurrency, items.length); w++) {
+    workers.push(worker());
+  }
+  await Promise.all(workers);
+  return results;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- scripts/sweep-creator-deletes.test.mjs`
+
+Expected: PASS — concurrency tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/sweep-creator-deletes.mjs scripts/sweep-creator-deletes.test.mjs
+git commit -m "feat(sweep): bounded-concurrency worker pool"
+```
+
+---
+
+## Task 5: callBlossomDelete + classifyDeleteResult (wraps notifyBlossom)
+
+**Files:**
+- Modify: `scripts/sweep-creator-deletes.mjs`
+- Modify: `scripts/sweep-creator-deletes.test.mjs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `scripts/sweep-creator-deletes.test.mjs`:
+
+```js
+import { callBlossomDelete, classifyDeleteResult } from './sweep-creator-deletes.mjs';
+
+const SHA_C = 'c'.repeat(64);
+
+function makeFakeNotify(impl) {
+  const calls = [];
+  const fn = async (sha256, action, env) => {
+    calls.push({ sha256, action, env });
+    return impl({ sha256, action, env });
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+describe('callBlossomDelete', () => {
+  it('passes sha + DELETE + env to notifyBlossom and returns a normalized result', async () => {
+    const notify = makeFakeNotify(() => ({
+      success: true,
+      status: 200,
+      result: { status: 'success', physical_delete_enabled: true, physical_deleted: true }
+    }));
+    const cfg = {
+      blossomWebhookUrl: 'https://example/admin/moderate',
+      blossomWebhookSecret: 'secret-xyz'
+    };
+    const r = await callBlossomDelete(SHA_C, cfg, notify);
+    expect(notify.calls).toEqual([{
+      sha256: SHA_C,
+      action: 'DELETE',
+      env: { BLOSSOM_WEBHOOK_URL: cfg.blossomWebhookUrl, BLOSSOM_WEBHOOK_SECRET: cfg.blossomWebhookSecret }
+    }]);
+    expect(r.ok).toBe(true);
+    expect(r.body.physical_deleted).toBe(true);
+  });
+
+  it('surfaces network error from notifyBlossom', async () => {
+    const notify = makeFakeNotify(() => ({ success: false, networkError: true, error: 'ECONNRESET' }));
+    const r = await callBlossomDelete(SHA_C, { blossomWebhookUrl: 'u', blossomWebhookSecret: 's' }, notify);
+    expect(r.ok).toBe(false);
+    expect(r.networkError).toBe(true);
+  });
+
+  it('surfaces 5xx HTTP error', async () => {
+    const notify = makeFakeNotify(() => ({ success: false, error: 'HTTP 502: bad', status: 502 }));
+    const r = await callBlossomDelete(SHA_C, { blossomWebhookUrl: 'u', blossomWebhookSecret: 's' }, notify);
+    expect(r.ok).toBe(false);
+    expect(r.status).toBe(502);
+  });
+});
+
+describe('classifyDeleteResult', () => {
+  it('success when ok && body.status==="success" && body.physical_deleted===true', () => {
+    expect(classifyDeleteResult({
+      ok: true, status: 200,
+      body: { status: 'success', physical_delete_enabled: true, physical_deleted: true }
+    })).toEqual({ kind: 'success' });
+  });
+
+  it('flag-off pre-flight signal when physical_delete_enabled===false', () => {
+    expect(classifyDeleteResult({
+      ok: true, status: 200,
+      body: { status: 'success', physical_delete_enabled: false, physical_deleted: false }
+    })).toEqual({ kind: 'flag-off' });
+  });
+
+  it('failure when body.status==="error"', () => {
+    expect(classifyDeleteResult({
+      ok: true, status: 200,
+      body: { status: 'error', error: 'gcs delete failed' }
+    })).toEqual({ kind: 'failure', reason: 'gcs delete failed' });
+  });
+
+  it('failure when 200 but physical_deleted===false (and flag was on)', () => {
+    expect(classifyDeleteResult({
+      ok: true, status: 200,
+      body: { status: 'success', physical_delete_enabled: true, physical_deleted: false }
+    })).toEqual({ kind: 'failure', reason: 'physical_deleted=false despite flag on' });
+  });
+
+  it('auth-failure on 401/403', () => {
+    expect(classifyDeleteResult({ ok: false, status: 401 })).toEqual({ kind: 'auth-failure' });
+    expect(classifyDeleteResult({ ok: false, status: 403 })).toEqual({ kind: 'auth-failure' });
+  });
+
+  it('unreachable on 5xx', () => {
+    expect(classifyDeleteResult({ ok: false, status: 502 }).kind).toBe('unreachable');
+  });
+
+  it('unreachable on networkError', () => {
+    expect(classifyDeleteResult({ ok: false, networkError: true, error: 'ECONNRESET' }).kind).toBe('unreachable');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- scripts/sweep-creator-deletes.test.mjs`
+
+Expected: FAIL — `callBlossomDelete` and `classifyDeleteResult` not exported.
+
+- [ ] **Step 3: Implement the wrappers**
+
+Append to `scripts/sweep-creator-deletes.mjs`:
+
+```js
+import { notifyBlossom as defaultNotify } from '../src/blossom-client.mjs';
+
+/**
+ * Wraps notifyBlossom() so the script reuses the live-pipeline request shape and headers.
+ * notifyImpl is injectable for tests.
+ */
+export async function callBlossomDelete(sha256, cfg, notifyImpl = defaultNotify) {
+  const env = {
+    BLOSSOM_WEBHOOK_URL: cfg.blossomWebhookUrl,
+    BLOSSOM_WEBHOOK_SECRET: cfg.blossomWebhookSecret
+  };
+  const r = await notifyImpl(sha256, 'DELETE', env);
+  if (r.success) {
+    return { ok: true, status: r.status, body: r.result };
+  }
+  return {
+    ok: false,
+    status: r.status,
+    networkError: !!r.networkError,
+    error: r.error
+  };
+}
+
+/**
+ * Classifies a Blossom call result into the action the script should take.
+ * Used by both pre-flight and per-row sweep logic.
+ */
+export function classifyDeleteResult(r) {
+  if (r.ok) {
+    const b = r.body || {};
+    if (b.physical_delete_enabled === false) return { kind: 'flag-off' };
+    if (b.status === 'error') return { kind: 'failure', reason: b.error || 'blossom returned status=error' };
+    if (b.status === 'success' && b.physical_deleted === true) return { kind: 'success' };
+    return { kind: 'failure', reason: 'physical_deleted=false despite flag on' };
+  }
+  if (r.status === 401 || r.status === 403) return { kind: 'auth-failure' };
+  if (r.networkError) return { kind: 'unreachable', reason: r.error || 'network error' };
+  if (r.status >= 500) return { kind: 'unreachable', reason: `HTTP ${r.status}` };
+  return { kind: 'failure', reason: r.error || `HTTP ${r.status}` };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- scripts/sweep-creator-deletes.test.mjs`
+
+Expected: PASS — Blossom-call and classifier tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/sweep-creator-deletes.mjs scripts/sweep-creator-deletes.test.mjs
+git commit -m "feat(sweep): callBlossomDelete + classifyDeleteResult (reuses notifyBlossom)"
+```
+
+---
+
+## Task 6: Wrangler shell-out wrappers (fetchCandidates / fetchUnprocessable / fetchPermanentFailures / flushDeletedAt)
+
+**Files:**
+- Modify: `scripts/sweep-creator-deletes.mjs`
+- Modify: `scripts/sweep-creator-deletes.test.mjs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `scripts/sweep-creator-deletes.test.mjs`:
+
+```js
+import {
+  fetchCandidates,
+  fetchUnprocessable,
+  fetchPermanentFailures,
+  flushDeletedAt
+} from './sweep-creator-deletes.mjs';
+
+function makeFakeRunner(responseFor) {
+  const calls = [];
+  const fn = async ({ command, args }) => {
+    calls.push({ command, args });
+    const sql = args[args.indexOf('--command') + 1];
+    return responseFor(sql);
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+const WRANGLER_RESULT_ENVELOPE = (rows) => JSON.stringify([{ results: rows, success: true, meta: {} }]);
+
+describe('fetchCandidates', () => {
+  it('shells wrangler with the right command, db, and SQL; parses results', async () => {
+    const runner = makeFakeRunner(() => ({
+      stdout: WRANGLER_RESULT_ENVELOPE([
+        { kind5_id: 'k1', target_event_id: 't1', blob_sha256: 'a'.repeat(64), completed_at: '2026-04-15T00:00:00Z' }
+      ]),
+      stderr: '',
+      status: 0
+    }));
+    const cfg = parseArgs([]);
+    const rows = await fetchCandidates(cfg, runner);
+    expect(runner.calls.length).toBe(1);
+    expect(runner.calls[0].command).toBe('wrangler');
+    expect(runner.calls[0].args.slice(0, 5)).toEqual(['d1', 'execute', cfg.d1Database, '--remote', '--json']);
+    expect(runner.calls[0].args[5]).toBe('--command');
+    expect(runner.calls[0].args[6]).toContain("WHERE status = 'success'");
+    expect(rows).toEqual([
+      { kind5_id: 'k1', target_event_id: 't1', blob_sha256: 'a'.repeat(64), completed_at: '2026-04-15T00:00:00Z' }
+    ]);
+  });
+
+  it('returns empty array when wrangler result envelope has zero rows', async () => {
+    const runner = makeFakeRunner(() => ({ stdout: WRANGLER_RESULT_ENVELOPE([]), stderr: '', status: 0 }));
+    const rows = await fetchCandidates(parseArgs([]), runner);
+    expect(rows).toEqual([]);
+  });
+
+  it('throws when wrangler exits non-zero', async () => {
+    const runner = makeFakeRunner(() => ({ stdout: '', stderr: 'auth required', status: 1 }));
+    await expect(fetchCandidates(parseArgs([]), runner)).rejects.toThrow(/auth required/i);
+  });
+
+  it('throws when wrangler stdout is not parseable JSON', async () => {
+    const runner = makeFakeRunner(() => ({ stdout: 'not json', stderr: '', status: 0 }));
+    await expect(fetchCandidates(parseArgs([]), runner)).rejects.toThrow(/parse/i);
+  });
+});
+
+describe('fetchUnprocessable', () => {
+  it('queries for status=success AND blob_sha256 IS NULL', async () => {
+    const runner = makeFakeRunner(() => ({ stdout: WRANGLER_RESULT_ENVELOPE([]), stderr: '', status: 0 }));
+    await fetchUnprocessable(parseArgs([]), runner);
+    const sql = runner.calls[0].args[runner.calls[0].args.indexOf('--command') + 1];
+    expect(sql).toContain('blob_sha256 IS NULL');
+  });
+});
+
+describe('fetchPermanentFailures', () => {
+  it("queries for status LIKE 'failed:permanent:%'", async () => {
+    const runner = makeFakeRunner(() => ({ stdout: WRANGLER_RESULT_ENVELOPE([]), stderr: '', status: 0 }));
+    await fetchPermanentFailures(parseArgs([]), runner);
+    const sql = runner.calls[0].args[runner.calls[0].args.indexOf('--command') + 1];
+    expect(sql).toContain("'failed:permanent:%'");
+  });
+});
+
+describe('flushDeletedAt', () => {
+  it('builds and runs UPDATE with the supplied shas + timestamp', async () => {
+    const runner = makeFakeRunner(() => ({ stdout: WRANGLER_RESULT_ENVELOPE([]), stderr: '', status: 0 }));
+    const ts = '2026-04-17T20:00:00.000Z';
+    await flushDeletedAt(['a'.repeat(64), 'b'.repeat(64)], parseArgs([]), runner, ts);
+    const sql = runner.calls[0].args[runner.calls[0].args.indexOf('--command') + 1];
+    expect(sql).toContain(`SET physical_deleted_at = '${ts}'`);
+    expect(sql).toContain(`'${'a'.repeat(64)}'`);
+    expect(sql).toContain(`'${'b'.repeat(64)}'`);
+  });
+
+  it('is a no-op on empty sha list', async () => {
+    const runner = makeFakeRunner(() => ({ stdout: WRANGLER_RESULT_ENVELOPE([]), stderr: '', status: 0 }));
+    await flushDeletedAt([], parseArgs([]), runner, '2026-04-17T20:00:00.000Z');
+    expect(runner.calls.length).toBe(0);
+  });
+
+  it('throws when wrangler exits non-zero', async () => {
+    const runner = makeFakeRunner(() => ({ stdout: '', stderr: 'd1 unreachable', status: 1 }));
+    await expect(flushDeletedAt(['a'.repeat(64)], parseArgs([]), runner, '2026-04-17T20:00:00.000Z'))
+      .rejects.toThrow(/d1 unreachable/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- scripts/sweep-creator-deletes.test.mjs`
+
+Expected: FAIL — none of the four wrangler-shell wrappers exist.
+
+- [ ] **Step 3: Implement the wrappers + a default runner**
+
+Append to `scripts/sweep-creator-deletes.mjs`:
+
+```js
+import { spawnSync } from 'node:child_process';
+
+/**
+ * Default runner used when the script runs as a CLI. Tests inject a fake.
+ * Uses spawnSync (not the shell-interpreting variant) — args is an array, not a string.
+ */
+export function defaultRunner({ command, args }) {
+  const r = spawnSync(command, args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+  return { stdout: r.stdout || '', stderr: r.stderr || '', status: r.status ?? 0 };
+}
+
+async function runWranglerD1(cfg, sql, runner) {
+  const args = ['d1', 'execute', cfg.d1Database, '--remote', '--json', '--command', sql];
+  const r = await runner({ command: 'wrangler', args });
+  if (r.status !== 0) {
+    throw new Error(`wrangler d1 execute failed (exit ${r.status}): ${r.stderr.trim() || r.stdout.trim()}`);
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(r.stdout);
+  } catch (e) {
+    throw new Error(`failed to parse wrangler stdout as JSON: ${e.message}`);
+  }
+  if (!Array.isArray(parsed) || !parsed[0]) return [];
+  return parsed[0].results || [];
+}
+
+export async function fetchCandidates(cfg, runner = defaultRunner) {
+  const sql = buildSelectCandidatesSql({ since: cfg.since, until: cfg.until, limit: cfg.limit });
+  return runWranglerD1(cfg, sql, runner);
+}
+
+export async function fetchUnprocessable(cfg, runner = defaultRunner) {
+  return runWranglerD1(cfg, buildSelectUnprocessableSql(), runner);
+}
+
+export async function fetchPermanentFailures(cfg, runner = defaultRunner) {
+  return runWranglerD1(cfg, buildSelectPermanentFailuresSql(), runner);
+}
+
+export async function flushDeletedAt(shas, cfg, runner = defaultRunner, timestamp = new Date().toISOString()) {
+  if (!shas || shas.length === 0) return;
+  const sql = buildUpdateStampSql(shas, timestamp);
+  await runWranglerD1(cfg, sql, runner);
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- scripts/sweep-creator-deletes.test.mjs`
+
+Expected: PASS — all wrangler-shell wrapper tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/sweep-creator-deletes.mjs scripts/sweep-creator-deletes.test.mjs
+git commit -m "feat(sweep): wrangler d1 wrappers (fetch candidates/unprocessable/perm-failures + flush)"
+```
+
+---
+
+## Task 7: Pre-flight handler
+
+**Files:**
+- Modify: `scripts/sweep-creator-deletes.mjs`
+- Modify: `scripts/sweep-creator-deletes.test.mjs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `scripts/sweep-creator-deletes.test.mjs`:
+
+```js
+import { runPreflight, PreflightAbort } from './sweep-creator-deletes.mjs';
+
+describe('runPreflight', () => {
+  const SHA = 'd'.repeat(64);
+  const cfg = parseArgs([]);
+
+  it('returns success for the first row when Blossom returns physical_deleted=true', async () => {
+    const notify = makeFakeNotify(() => ({
+      success: true, status: 200,
+      result: { status: 'success', physical_delete_enabled: true, physical_deleted: true }
+    }));
+    const out = await runPreflight(SHA, cfg, notify);
+    expect(out).toEqual({ kind: 'success' });
+    expect(notify.calls.length).toBe(1);
+  });
+
+  it('throws PreflightAbort with reason="flag-off" when physical_delete_enabled is false', async () => {
+    const notify = makeFakeNotify(() => ({
+      success: true, status: 200,
+      result: { status: 'success', physical_delete_enabled: false, physical_deleted: false }
+    }));
+    await expect(runPreflight(SHA, cfg, notify)).rejects.toMatchObject({
+      name: 'PreflightAbort',
+      reason: 'flag-off'
+    });
+  });
+
+  it('throws PreflightAbort with reason="auth-failure" on 401', async () => {
+    const notify = makeFakeNotify(() => ({ success: false, status: 401, error: 'unauthorized' }));
+    await expect(runPreflight(SHA, cfg, notify)).rejects.toMatchObject({
+      name: 'PreflightAbort',
+      reason: 'auth-failure'
+    });
+  });
+
+  it('throws PreflightAbort with reason="unreachable" on 502', async () => {
+    const notify = makeFakeNotify(() => ({ success: false, status: 502, error: 'bad gateway' }));
+    await expect(runPreflight(SHA, cfg, notify)).rejects.toMatchObject({
+      name: 'PreflightAbort',
+      reason: 'unreachable'
+    });
+  });
+
+  it('throws PreflightAbort with reason="unreachable" on network error', async () => {
+    const notify = makeFakeNotify(() => ({ success: false, networkError: true, error: 'ECONNRESET' }));
+    await expect(runPreflight(SHA, cfg, notify)).rejects.toMatchObject({
+      name: 'PreflightAbort',
+      reason: 'unreachable'
+    });
+  });
+
+  it('throws PreflightAbort with reason="failure" when Blossom returns 200 status:error', async () => {
+    const notify = makeFakeNotify(() => ({
+      success: true, status: 200,
+      result: { status: 'error', error: 'gcs delete failed' }
+    }));
+    await expect(runPreflight(SHA, cfg, notify)).rejects.toMatchObject({
+      name: 'PreflightAbort',
+      reason: 'failure'
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- scripts/sweep-creator-deletes.test.mjs`
+
+Expected: FAIL — `runPreflight` and `PreflightAbort` not exported.
+
+- [ ] **Step 3: Implement runPreflight + PreflightAbort**
+
+Append to `scripts/sweep-creator-deletes.mjs`:
+
+```js
+export class PreflightAbort extends Error {
+  constructor(reason, message) {
+    super(message);
+    this.name = 'PreflightAbort';
+    this.reason = reason;
+  }
+}
+
+export async function runPreflight(sha256, cfg, notifyImpl = defaultNotify) {
+  const r = await callBlossomDelete(sha256, cfg, notifyImpl);
+  const c = classifyDeleteResult(r);
+  if (c.kind === 'success') return { kind: 'success' };
+  if (c.kind === 'flag-off') {
+    throw new PreflightAbort('flag-off',
+      'Blossom did not byte-delete because ENABLE_PHYSICAL_DELETE is off. ' +
+      'Flip the flag in Blossom config store before sweeping. No D1 writes occurred.');
+  }
+  if (c.kind === 'auth-failure') {
+    throw new PreflightAbort('auth-failure',
+      'Blossom rejected auth — check BLOSSOM_WEBHOOK_SECRET. No D1 writes occurred.');
+  }
+  if (c.kind === 'unreachable') {
+    throw new PreflightAbort('unreachable',
+      `Blossom unreachable: ${c.reason}. No D1 writes occurred.`);
+  }
+  throw new PreflightAbort('failure',
+    `Blossom returned a failure on the first candidate: ${c.reason}. No D1 writes occurred.`);
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- scripts/sweep-creator-deletes.test.mjs`
+
+Expected: PASS — pre-flight tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/sweep-creator-deletes.mjs scripts/sweep-creator-deletes.test.mjs
+git commit -m "feat(sweep): pre-flight check (flag/auth/unreachable abort with structured reasons)"
+```
+
+---
+
+## Task 8: Sweep orchestrator + summary + exit-code
+
+**Files:**
+- Modify: `scripts/sweep-creator-deletes.mjs`
+- Modify: `scripts/sweep-creator-deletes.test.mjs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `scripts/sweep-creator-deletes.test.mjs`:
+
+```js
+import { sweepCandidates, summarize, computeExitCode } from './sweep-creator-deletes.mjs';
+
+describe('sweepCandidates', () => {
+  const cfg = parseArgs(['--concurrency=2']);
+  const rowFor = (sha) => ({ kind5_id: `k-${sha.slice(0,4)}`, target_event_id: `t-${sha.slice(0,4)}`, blob_sha256: sha, completed_at: '2026-04-15T00:00:00Z' });
+
+  it('stamps shas where Blossom returned physical_deleted=true', async () => {
+    const okBody = { status: 'success', physical_delete_enabled: true, physical_deleted: true };
+    const notify = makeFakeNotify(() => ({ success: true, status: 200, result: okBody }));
+    const flushed = [];
+    const flushImpl = async (shas) => { flushed.push(...shas); };
+    const candidates = ['a','b','c'].map(c => rowFor(c.repeat(64)));
+    const out = await sweepCandidates(candidates, cfg, notify, flushImpl);
+    expect(out.successes.length).toBe(3);
+    expect(out.failures.length).toBe(0);
+    expect(flushed.sort()).toEqual(candidates.map(r => r.blob_sha256).sort());
+  });
+
+  it('does NOT stamp shas when physical_deleted=false (even on HTTP 200)', async () => {
+    const notify = makeFakeNotify(() => ({
+      success: true, status: 200,
+      result: { status: 'success', physical_delete_enabled: true, physical_deleted: false }
+    }));
+    const flushed = [];
+    const flushImpl = async (shas) => { flushed.push(...shas); };
+    const out = await sweepCandidates([rowFor('e'.repeat(64))], cfg, notify, flushImpl);
+    expect(out.successes.length).toBe(0);
+    expect(out.failures.length).toBe(1);
+    expect(flushed).toEqual([]);
+  });
+
+  it('isolates per-row failures — successful rows still stamp', async () => {
+    const notify = makeFakeNotify(({ sha256 }) => {
+      if (sha256.startsWith('b')) return { success: false, status: 502, error: 'bad gateway' };
+      return { success: true, status: 200, result: { status: 'success', physical_delete_enabled: true, physical_deleted: true } };
+    });
+    const flushed = [];
+    const flushImpl = async (shas) => { flushed.push(...shas); };
+    const candidates = ['a','b','c'].map(c => rowFor(c.repeat(64)));
+    const out = await sweepCandidates(candidates, cfg, notify, flushImpl);
+    expect(out.successes.length).toBe(2);
+    expect(out.failures.length).toBe(1);
+    expect(flushed.sort()).toEqual([candidates[0].blob_sha256, candidates[2].blob_sha256].sort());
+  });
+
+  it('flushes in batches of FLUSH_BATCH_SIZE (default 100)', async () => {
+    const notify = makeFakeNotify(() => ({
+      success: true, status: 200,
+      result: { status: 'success', physical_delete_enabled: true, physical_deleted: true }
+    }));
+    const batches = [];
+    const flushImpl = async (shas) => { batches.push(shas.length); };
+    // 250 candidates → flushes of 100, 100, 50
+    const candidates = Array.from({ length: 250 }, (_, i) => rowFor(i.toString(16).padStart(64, '0')));
+    await sweepCandidates(candidates, cfg, notify, flushImpl);
+    expect(batches).toEqual([100, 100, 50]);
+  });
+});
+
+describe('summarize', () => {
+  it('aggregates counts and lists for printing', () => {
+    const result = summarize({
+      candidates: [{ blob_sha256: 'a'.repeat(64) }],
+      successes: [{ blob_sha256: 'a'.repeat(64) }],
+      failures: [],
+      unprocessable: [{ kind5_id: 'k1' }],
+      permanentFailures: []
+    });
+    expect(result).toMatchObject({
+      total: 1,
+      stamped: 1,
+      failed: 0,
+      unprocessableCount: 1,
+      permanentFailureCount: 0
+    });
+  });
+});
+
+describe('computeExitCode', () => {
+  it('returns 0 when nothing failed and no unprocessable / perm-failures', () => {
+    expect(computeExitCode({ failed: 0, unprocessableCount: 0, permanentFailureCount: 0 })).toBe(0);
+  });
+  it('returns 1 when failures exist', () => {
+    expect(computeExitCode({ failed: 1, unprocessableCount: 0, permanentFailureCount: 0 })).toBe(1);
+  });
+  it('returns 1 when unprocessable rows exist', () => {
+    expect(computeExitCode({ failed: 0, unprocessableCount: 1, permanentFailureCount: 0 })).toBe(1);
+  });
+  it('returns 1 when permanent failures exist', () => {
+    expect(computeExitCode({ failed: 0, unprocessableCount: 0, permanentFailureCount: 1 })).toBe(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- scripts/sweep-creator-deletes.test.mjs`
+
+Expected: FAIL — `sweepCandidates`, `summarize`, `computeExitCode` not exported.
+
+- [ ] **Step 3: Implement sweep orchestrator + summary + exit code**
+
+Append to `scripts/sweep-creator-deletes.mjs`:
+
+```js
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function emitJsonLine(obj) {
+  process.stdout.write(JSON.stringify(obj) + '\n');
+}
+
+/**
+ * Bulk sweep over candidates. Stamps via flushImpl in batches of FLUSH_BATCH_SIZE.
+ * Per-row JSONL outcome lines are emitted to stdout for grep/jq.
+ *
+ * Returns { successes, failures } as arrays of {row, body?, error?, status?}.
+ */
+export async function sweepCandidates(candidates, cfg, notifyImpl = defaultNotify, flushImpl = null) {
+  const successes = [];
+  const failures = [];
+  let pending = [];
+  const flush = flushImpl || (async (shas) => { await flushDeletedAt(shas, cfg); });
+
+  const results = await runWithConcurrency(candidates, cfg.concurrency, async (row) => {
+    return callBlossomDelete(row.blob_sha256, cfg, notifyImpl);
+  });
+
+  for (const r of results) {
+    const row = r.input;
+    if (r.error) {
+      failures.push({ row, error: r.error.message });
+      emitJsonLine({ ts: nowIso(), sha: row.blob_sha256, kind5: row.kind5_id, target: row.target_event_id, outcome: 'failure', error: r.error.message });
+      continue;
+    }
+    const c = classifyDeleteResult(r.value);
+    if (c.kind === 'success') {
+      successes.push({ row, body: r.value.body });
+      pending.push(row.blob_sha256);
+      emitJsonLine({ ts: nowIso(), sha: row.blob_sha256, kind5: row.kind5_id, target: row.target_event_id, outcome: 'success', http: r.value.status, physical_deleted: true });
+      if (pending.length >= FLUSH_BATCH_SIZE) {
+        await flush(pending);
+        pending = [];
+      }
+    } else {
+      failures.push({ row, error: c.reason || c.kind, status: r.value.status });
+      emitJsonLine({ ts: nowIso(), sha: row.blob_sha256, kind5: row.kind5_id, target: row.target_event_id, outcome: 'failure', http: r.value.status, error: c.reason || c.kind });
+    }
+  }
+
+  if (pending.length > 0) {
+    await flush(pending);
+  }
+  return { successes, failures };
+}
+
+export function summarize({ candidates, successes, failures, unprocessable, permanentFailures }) {
+  return {
+    total: candidates.length,
+    stamped: successes.length,
+    failed: failures.length,
+    unprocessableCount: unprocessable.length,
+    permanentFailureCount: permanentFailures.length,
+    successes,
+    failures,
+    unprocessable,
+    permanentFailures
+  };
+}
+
+export function computeExitCode(s) {
+  if (s.failed > 0 || s.unprocessableCount > 0 || s.permanentFailureCount > 0) return 1;
+  return 0;
+}
+
+export function printSummary(s) {
+  process.stdout.write('\n=== SUMMARY ===\n');
+  process.stdout.write(`Total candidates fetched:      ${s.total}\n`);
+  process.stdout.write(`Bytes destroyed + stamped:     ${s.stamped}\n`);
+  process.stdout.write(`Failed (will retry next run):  ${s.failed}\n`);
+  process.stdout.write(`Unprocessable (NULL sha256):   ${s.unprocessableCount}\n`);
+  process.stdout.write(`Permanent failures (manual):   ${s.permanentFailureCount}\n`);
+
+  if (s.failures.length > 0) {
+    process.stdout.write('\n=== FAILURES (will retry) ===\n');
+    for (const f of s.failures) {
+      process.stdout.write(`sha=${f.row.blob_sha256} http=${f.status ?? '-'} kind5=${f.row.kind5_id}: ${f.error}\n`);
+    }
+  }
+  if (s.unprocessable.length > 0) {
+    process.stdout.write('\n=== UNPROCESSABLE (creator intent unfulfilled, NULL sha256) ===\n');
+    for (const u of s.unprocessable) {
+      process.stdout.write(`kind5=${u.kind5_id} target=${u.target_event_id} creator=${u.creator_pubkey} completed_at=${u.completed_at}\n`);
+    }
+  }
+  if (s.permanentFailures.length > 0) {
+    process.stdout.write('\n=== PERMANENT FAILURES (creator intent unfulfilled, status=failed:permanent:*) ===\n');
+    for (const p of s.permanentFailures) {
+      process.stdout.write(`kind5=${p.kind5_id} target=${p.target_event_id} creator=${p.creator_pubkey} status=${p.status} last_error=${p.last_error}\n`);
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- scripts/sweep-creator-deletes.test.mjs`
+
+Expected: PASS — sweep + summary + exit-code tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/sweep-creator-deletes.mjs scripts/sweep-creator-deletes.test.mjs
+git commit -m "feat(sweep): orchestrator (per-row JSONL, batched flush, summary, exit-code)"
+```
+
+---
+
+## Task 9: main() integration
+
+**Files:**
+- Modify: `scripts/sweep-creator-deletes.mjs`
+- Modify: `scripts/sweep-creator-deletes.test.mjs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `scripts/sweep-creator-deletes.test.mjs`:
+
+```js
+import { main } from './sweep-creator-deletes.mjs';
+
+describe('main (integration)', () => {
+  const candidateRow = { kind5_id: 'k1', target_event_id: 't1', blob_sha256: 'a'.repeat(64), completed_at: '2026-04-15T00:00:00Z' };
+  const okBody = { status: 'success', physical_delete_enabled: true, physical_deleted: true };
+
+  function makeRunnerForResults({ candidates = [], unprocessable = [], permanentFailures = [], updates = () => ({stdout: WRANGLER_RESULT_ENVELOPE([]), stderr: '', status: 0}) } = {}) {
+    return async ({ command, args }) => {
+      const sql = args[args.indexOf('--command') + 1];
+      if (sql.startsWith('SELECT kind5_id, target_event_id, blob_sha256')) {
+        return { stdout: WRANGLER_RESULT_ENVELOPE(candidates), stderr: '', status: 0 };
+      }
+      if (sql.includes('blob_sha256 IS NULL')) {
+        return { stdout: WRANGLER_RESULT_ENVELOPE(unprocessable), stderr: '', status: 0 };
+      }
+      if (sql.includes("'failed:permanent:%'")) {
+        return { stdout: WRANGLER_RESULT_ENVELOPE(permanentFailures), stderr: '', status: 0 };
+      }
+      if (sql.startsWith('UPDATE creator_deletions')) {
+        return updates(sql);
+      }
+      throw new Error(`unexpected sql: ${sql.slice(0, 80)}`);
+    };
+  }
+
+  it('dry-run: prints candidates, makes zero notify or D1-write calls', async () => {
+    const notify = makeFakeNotify(() => { throw new Error('should not be called in dry-run'); });
+    let updateCalls = 0;
+    const runner = makeRunnerForResults({
+      candidates: [candidateRow],
+      updates: () => { updateCalls++; return { stdout: WRANGLER_RESULT_ENVELOPE([]), stderr: '', status: 0 }; }
+    });
+    const code = await main(['--dry-run'], { runner, notify, blossomWebhookSecret: 'test-secret' });
+    expect(notify.calls.length).toBe(0);
+    expect(updateCalls).toBe(0);
+    expect(code).toBe(0);
+  });
+
+  it('pre-flight flag-off: aborts with exit 2 and zero D1 writes', async () => {
+    const notify = makeFakeNotify(() => ({
+      success: true, status: 200,
+      result: { status: 'success', physical_delete_enabled: false, physical_deleted: false }
+    }));
+    let updateCalls = 0;
+    const runner = makeRunnerForResults({
+      candidates: [candidateRow],
+      updates: () => { updateCalls++; return { stdout: WRANGLER_RESULT_ENVELOPE([]), stderr: '', status: 0 }; }
+    });
+    const code = await main([], { runner, notify, blossomWebhookSecret: 'test-secret' });
+    expect(notify.calls.length).toBe(1);
+    expect(updateCalls).toBe(0);
+    expect(code).toBe(2);
+  });
+
+  it('pre-flight 401: aborts with exit 2', async () => {
+    const notify = makeFakeNotify(() => ({ success: false, status: 401, error: 'unauthorized' }));
+    const runner = makeRunnerForResults({ candidates: [candidateRow] });
+    const code = await main([], { runner, notify, blossomWebhookSecret: 'test-secret' });
+    expect(code).toBe(2);
+  });
+
+  it('successful sweep: stamps all rows, exit 0', async () => {
+    const notify = makeFakeNotify(() => ({ success: true, status: 200, result: okBody }));
+    const runner = makeRunnerForResults({ candidates: [candidateRow] });
+    const code = await main([], { runner, notify, blossomWebhookSecret: 'test-secret' });
+    expect(code).toBe(0);
+  });
+
+  it('per-row failure: continues sweep, exit 1', async () => {
+    const candidates = ['a', 'b'].map(c => ({ ...candidateRow, blob_sha256: c.repeat(64), kind5_id: `k-${c}`, target_event_id: `t-${c}` }));
+    const notify = makeFakeNotify(({ sha256 }) => {
+      if (sha256.startsWith('b')) return { success: false, status: 502, error: 'bad gateway' };
+      return { success: true, status: 200, result: okBody };
+    });
+    const runner = makeRunnerForResults({ candidates });
+    const code = await main([], { runner, notify, blossomWebhookSecret: 'test-secret' });
+    expect(code).toBe(1);
+  });
+
+  it('empty-candidates short-circuit: still surfaces unprocessable + perm-failures', async () => {
+    const notify = makeFakeNotify(() => { throw new Error('should not be called'); });
+    const runner = makeRunnerForResults({
+      candidates: [],
+      unprocessable: [{ kind5_id: 'k1', target_event_id: 't1', creator_pubkey: 'pub1', completed_at: '2026-04-15T00:00:00Z' }],
+      permanentFailures: []
+    });
+    const code = await main([], { runner, notify, blossomWebhookSecret: 'test-secret' });
+    expect(notify.calls.length).toBe(0);
+    expect(code).toBe(1); // unprocessable triggers exit 1
+  });
+
+  it('empty everywhere: exit 0', async () => {
+    const notify = makeFakeNotify(() => { throw new Error('should not be called'); });
+    const runner = makeRunnerForResults({ candidates: [], unprocessable: [], permanentFailures: [] });
+    const code = await main([], { runner, notify, blossomWebhookSecret: 'test-secret' });
+    expect(code).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- scripts/sweep-creator-deletes.test.mjs`
+
+Expected: FAIL — `main` not exported.
+
+- [ ] **Step 3: Implement main()**
+
+Append to `scripts/sweep-creator-deletes.mjs`:
+
+```js
+function readBlossomSecret() {
+  const s = process.env.BLOSSOM_WEBHOOK_SECRET;
+  if (!s) {
+    throw new Error('BLOSSOM_WEBHOOK_SECRET env var is required');
+  }
+  return s;
+}
+
+/**
+ * Programmatic entrypoint. Returns the exit code (does not call process.exit).
+ * Tests inject { runner, notify, blossomWebhookSecret } to drive the flow without shelling out.
+ */
+export async function main(argv, deps = {}) {
+  const runner = deps.runner || defaultRunner;
+  const notify = deps.notify || defaultNotify;
+
+  let cfg;
+  try {
+    cfg = parseArgs(argv);
+  } catch (e) {
+    process.stderr.write(`arg error: ${e.message}\n`);
+    return 3;
+  }
+
+  try {
+    cfg.blossomWebhookSecret = deps.blossomWebhookSecret ?? readBlossomSecret();
+  } catch (e) {
+    process.stderr.write(`${e.message}\n`);
+    return 3;
+  }
+
+  // 1. Fetch candidates
+  let candidates;
+  try {
+    candidates = await fetchCandidates(cfg, runner);
+  } catch (e) {
+    process.stderr.write(`fetchCandidates failed: ${e.message}\n`);
+    return 3;
+  }
+  process.stderr.write(`Found ${candidates.length} candidate(s) for sweep.\n`);
+  if (cfg.since || cfg.until) {
+    process.stderr.write(`Window: since=${cfg.since ?? '-'} until=${cfg.until ?? '-'}\n`);
+  }
+
+  // 2. Dry-run gate
+  if (cfg.dryRun) {
+    for (const r of candidates.slice(0, 20)) {
+      process.stdout.write(`[dry-run] sha=${r.blob_sha256} kind5=${r.kind5_id} completed_at=${r.completed_at}\n`);
+    }
+    if (candidates.length > 20) {
+      process.stdout.write(`[dry-run] ... and ${candidates.length - 20} more\n`);
+    }
+    return 0;
+  }
+
+  // 3. Pre-flight (consumes the first candidate when there are any)
+  let preflightSuccess = null;
+  if (candidates.length > 0) {
+    try {
+      preflightSuccess = await runPreflight(candidates[0].blob_sha256, cfg, notify);
+    } catch (e) {
+      if (e instanceof PreflightAbort) {
+        process.stderr.write(`preflight aborted (${e.reason}): ${e.message}\n`);
+        return 2;
+      }
+      process.stderr.write(`preflight error: ${e.message}\n`);
+      return 2;
+    }
+  }
+
+  // 4. Sweep remaining (skip the pre-flight row, then re-add it as a success)
+  let sweepResult = { successes: [], failures: [] };
+  if (candidates.length > 0) {
+    const remaining = candidates.slice(1);
+    sweepResult = await sweepCandidates(remaining, cfg, notify, async (shas) => {
+      await flushDeletedAt(shas, cfg, runner);
+    });
+    if (preflightSuccess) {
+      sweepResult.successes.unshift({ row: candidates[0], body: null });
+      await flushDeletedAt([candidates[0].blob_sha256], cfg, runner);
+      emitJsonLine({ ts: nowIso(), sha: candidates[0].blob_sha256, kind5: candidates[0].kind5_id, target: candidates[0].target_event_id, outcome: 'success', http: 200, physical_deleted: true, source: 'preflight' });
+    }
+  }
+
+  // 5. Surfacing queries
+  let unprocessable = [];
+  let permanentFailures = [];
+  try {
+    unprocessable = await fetchUnprocessable(cfg, runner);
+    permanentFailures = await fetchPermanentFailures(cfg, runner);
+  } catch (e) {
+    process.stderr.write(`surfacing query failed: ${e.message}\n`);
+    // continue — print summary with what we have
+  }
+
+  // 6. Summary
+  const s = summarize({
+    candidates,
+    successes: sweepResult.successes,
+    failures: sweepResult.failures,
+    unprocessable,
+    permanentFailures
+  });
+  printSummary(s);
+  return computeExitCode(s);
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- scripts/sweep-creator-deletes.test.mjs`
+
+Expected: PASS — all integration tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/sweep-creator-deletes.mjs scripts/sweep-creator-deletes.test.mjs
+git commit -m "feat(sweep): main() orchestrator with pre-flight + dry-run + surfacing"
+```
+
+---
+
+## Task 10: SIGINT drain handler + CLI entrypoint
+
+**Files:**
+- Modify: `scripts/sweep-creator-deletes.mjs`
+
+This task has no unit-testable surface beyond the shape — SIGINT in vitest under the Workers pool is unreliable. Implementation only.
+
+- [ ] **Step 1: Add SIGINT-aware draining flag and CLI entrypoint**
+
+Append to `scripts/sweep-creator-deletes.mjs`:
+
+```js
+// SIGINT handling — best-effort drain.
+// First SIGINT: set DRAINING flag; the orchestrator stops scheduling new flushes once the current
+// runWithConcurrency batch settles, then exits with the partial summary.
+// Second SIGINT: hard exit 130.
+let DRAINING = false;
+let SIGINT_COUNT = 0;
+
+function installSigintHandler() {
+  process.on('SIGINT', () => {
+    SIGINT_COUNT++;
+    if (SIGINT_COUNT === 1) {
+      DRAINING = true;
+      process.stderr.write('\n[sweep] SIGINT received — draining in-flight work; press Ctrl-C again to abort.\n');
+    } else {
+      process.stderr.write('\n[sweep] SIGINT received twice — exiting now.\n');
+      process.exit(130);
+    }
+  });
+}
+
+export function isDraining() { return DRAINING; }
+
+// CLI entrypoint — only runs when invoked directly (not when imported by tests).
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  installSigintHandler();
+  main(process.argv.slice(2)).then(
+    (code) => process.exit(code),
+    (err) => {
+      process.stderr.write(`unexpected error: ${err.stack || err.message}\n`);
+      process.exit(99);
+    }
+  );
+}
+```
+
+Then modify the `for (const r of results)` loop in `sweepCandidates` (Task 8) to short-circuit on draining. The two-line change:
+
+```js
+  for (const r of results) {
+    if (isDraining()) break;  // <- new line at top of loop body
+    const row = r.input;
+    // ... rest unchanged
+  }
+```
+
+The `break` is the simplest correct draining behavior: once draining, we stop processing further results, flush whatever is pending, and let main() return its summary. In-flight Blossom calls (within `runWithConcurrency`) have already settled by the time we reach this loop — so the draining check between iterations is the right granularity.
+
+- [ ] **Step 2: Sanity check the script can be imported without side effects**
+
+Run: `node -e "import('./scripts/sweep-creator-deletes.mjs').then(m => console.log(Object.keys(m).sort().join(',')))"`
+
+Expected: prints comma-separated export names. No SIGINT handler installed, no main() invoked, no shell-out.
+
+- [ ] **Step 3: Sanity check CLI invocation fails fast without env**
+
+Run (with `BLOSSOM_WEBHOOK_SECRET` unset): `unset BLOSSOM_WEBHOOK_SECRET && node scripts/sweep-creator-deletes.mjs --dry-run`
+
+Expected: prints `BLOSSOM_WEBHOOK_SECRET env var is required`. Exit code 3.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/sweep-creator-deletes.mjs
+git commit -m "feat(sweep): SIGINT drain handler + CLI entrypoint"
+```
+
+---
+
+## Task 11: Lint + full test pass + branch push + draft PR
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the linter**
+
+Run: `npm run lint`
+
+Expected: clean (no errors). If errors are flagged on the new files, fix and re-run.
+
+- [ ] **Step 2: Run the full test suite**
+
+Run: `npm test`
+
+Expected: all tests green. The new sweep tests should add ~30 new test cases. If pre-existing tests fail, investigate — probably an unrelated regression unless the new files leak globals.
+
+- [ ] **Step 3: Push the branch**
+
+Run: `git push -u origin spec/creator-delete-validation-sweep`
+
+Expected: branch published. CI runs.
+
+- [ ] **Step 4: Open a draft PR**
+
+Run:
+
+```bash
+gh pr create --draft --title "feat(sweep): creator-delete validation-window physical-delete sweep" --body "Closes divinevideo/divine-blossom#90.
+
+Spec: docs/superpowers/specs/2026-04-17-creator-delete-validation-sweep-design.md
+Plan: docs/superpowers/plans/2026-04-17-creator-delete-validation-sweep-plan.md
+
+## Summary
+
+Operator-run script that backfills physical byte deletion for creator-delete kind 5 events whose Blossom soft-delete completed during the ENABLE_PHYSICAL_DELETE=false validation window.
+
+- New D1 column \`physical_deleted_at\` on \`creator_deletions\` (migration 007).
+- New script \`scripts/sweep-creator-deletes.mjs\`: reads candidates from D1, calls Blossom DELETE via the existing \`notifyBlossom()\` client, stamps the column on confirmed byte destruction.
+- Pre-flight aborts (exit 2) if \`ENABLE_PHYSICAL_DELETE\` is off, auth fails, or Blossom is unreachable — zero D1 writes in that case.
+- Surfaces unprocessable rows (status=success, NULL sha) and permanent failures (status=failed:permanent:*) in the summary so creator intent we can't fulfill is loud, not silent.
+
+## Test plan
+
+- [x] Unit + integration tests via vitest (~30 new cases)
+- [x] Lint clean
+- [ ] Local dry-run against prod D1 (after merge, before sweep run)
+- [ ] First real sweep run (deferred to rollout)
+"
+```
+
+Then: `gh pr checks <PR-number>` — wait for CI to settle.
+
+Expected: PR opened in draft, all CI checks pass.
+
+---
+
+## Task 12: Local smoke check (manual, post-PR)
+
+**Files:** none (operational verification, do not block plan completion)
+
+This is the wiring-in-reality check. Defer until the PR is approved and you're ready to use the sweep for real.
+
+- [ ] **Step 1: Apply the migration to local D1**
+
+Run: `wrangler d1 execute divine-moderation-decisions-prod --file migrations/007-creator-deletions-physical-deleted-at.sql --local`
+
+Expected: `Executed 1 command in 0.NNs.` confirming the column was added.
+
+- [ ] **Step 2: Apply the migration to prod D1**
+
+Run: `wrangler d1 execute divine-moderation-decisions-prod --file migrations/007-creator-deletions-physical-deleted-at.sql --remote`
+
+Expected: same success line. Verifiable via `wrangler d1 execute divine-moderation-decisions-prod --command "PRAGMA table_info(creator_deletions);" --remote`.
+
+- [ ] **Step 3: Dry-run against prod (read-only)**
+
+Run: `BLOSSOM_WEBHOOK_SECRET=<value> node scripts/sweep-creator-deletes.mjs --dry-run`
+
+Expected: prints candidate count + first 20 shas + window. No network calls, no D1 writes (verifiable in Cloudflare D1 dashboard query log).
+
+- [ ] **Step 4: Stop here and hand off to the rollout**
+
+Real execution waits for the rollout document update (see `support-trust-safety/docs/rollout/2026-04-16-creator-delete-rollout.md`). The sweep itself is the operational e2e.
+
+---
+
+## Self-review notes
+
+**Spec coverage check:**
+
+| Spec section | Implementing task |
+|---|---|
+| Migration 007 | Task 1 |
+| `parseArgs` | Task 2 |
+| SQL builders + sha256 hex validation | Task 3 |
+| `runWithConcurrency` | Task 4 |
+| `callBlossomDelete` (reuses notifyBlossom) | Task 5 |
+| Pre-flight (flag-off / auth / unreachable) | Task 7 |
+| `fetchCandidates` / `fetchUnprocessable` / `fetchPermanentFailures` | Task 6 |
+| `flushDeletedAt` (batched, idempotency guard) | Task 6 |
+| Strict success criterion (`physical_deleted === true`) | Tasks 5 + 8 |
+| JSONL per-row outcome log | Task 8 |
+| Surfacing unfulfilled creator intent (NULL sha + perm-failures) | Task 9 |
+| Summary + exit codes (0 / 1 / 2 / 3) | Tasks 8 + 9 |
+| Empty-candidates short-circuit | Task 9 |
+| SIGINT best-effort drain | Task 10 |
+| CLI entrypoint + lint + CI | Tasks 10 + 11 |
+| Manual smoke check | Task 12 |
+
+The spec lists exit code 4 (D1 write aborted mid-run) and 130 (SIGINT). Exit 4 is implicitly returned because `flushDeletedAt` throws and main() does not catch — the unhandled rejection in Task 10's CLI wrapper exits 99. If the spec's exit code 4 turns out to matter to operators, add an explicit catch around `sweepCandidates` and surface code 4 in main(). Defer until ops asks.
+
+130 is provided by the SIGINT handler in Task 10 (only on second SIGINT; first SIGINT exits 0/1 via the normal summary path after draining).
+
+**Type consistency check:**
+
+- `parseArgs` returns object with `dryRun, since, until, concurrency, limit, blossomWebhookUrl, d1Database` — used consistently across `fetchCandidates`, `runPreflight`, `sweepCandidates`, `flushDeletedAt`. `main()` adds `blossomWebhookSecret` to the same object before passing it on; downstream readers expect the augmented shape.
+- `callBlossomDelete` returns `{ok, status, body, networkError?, error?}` — consumed by `classifyDeleteResult` and `runPreflight`, both expect that shape.
+- `sweepCandidates` returns `{successes, failures}` arrays of `{row, body?/error}` — `summarize` and `printSummary` index into `successes` and `failures` correctly.
+- `summarize` returns `{total, stamped, failed, unprocessableCount, permanentFailureCount, successes, failures, unprocessable, permanentFailures}` — `computeExitCode` reads three of these; `printSummary` reads all.
+- `PreflightAbort.reason` is a string; `main()` reads `instanceof PreflightAbort` then `.reason` and `.message`. Matches.
+
+**Placeholder scan:** no TBD/TODO/incomplete sections. Each step shows the exact code or command. The "deferred until ops asks" note for exit code 4 is an explicit YAGNI choice with a follow-up trigger, not a hidden gap.

--- a/docs/superpowers/specs/2026-04-17-creator-delete-validation-sweep-design.md
+++ b/docs/superpowers/specs/2026-04-17-creator-delete-validation-sweep-design.md
@@ -76,8 +76,10 @@ operator laptop
 -- newly-produced success rows show NULL here until the next sweep run picks
 -- them up, calls Blossom (idempotent if bytes already gone), and stamps.
 -- Semantic: "the validation sweep confirmed bytes were destroyed for this row."
+-- Run exactly once per environment. SQLite (and D1) do not support
+-- "ADD COLUMN IF NOT EXISTS"; a re-run errors with "duplicate column name".
 ALTER TABLE creator_deletions
-  ADD COLUMN IF NOT EXISTS physical_deleted_at TEXT;
+  ADD COLUMN physical_deleted_at TEXT;
 ```
 
 No new index. The sweep query uses the existing `idx_creator_deletions_status` for the status side and applies the `physical_deleted_at IS NULL` filter on top. Sparse-null filter at thousand-row scale doesn't justify a new index.

--- a/docs/superpowers/specs/2026-04-17-creator-delete-validation-sweep-design.md
+++ b/docs/superpowers/specs/2026-04-17-creator-delete-validation-sweep-design.md
@@ -39,7 +39,7 @@ operator laptop
    │
    └─ scripts/sweep-creator-deletes.mjs
         │
-        ├─ wrangler d1 execute  →  divine-moderation-decisions-prod
+        ├─ wrangler d1 execute  →  blossom-webhook-events
         │     SELECT candidate rows from creator_deletions
         │
         ├─ for each batch (concurrency=N):
@@ -54,7 +54,7 @@ operator laptop
         │             - purge_vcl_cache
         │
         └─ every 100 successes (and at end of run):
-              wrangler d1 execute  →  divine-moderation-decisions-prod
+              wrangler d1 execute  →  blossom-webhook-events
                 UPDATE creator_deletions
                 SET physical_deleted_at = ?
                 WHERE blob_sha256 IN (...) AND physical_deleted_at IS NULL
@@ -97,7 +97,7 @@ Node ESM, no transpilation. Runs via `node scripts/sweep-creator-deletes.mjs [fl
 --concurrency=N            Parallel Blossom calls. Default 5.
 --limit=N                  Cap candidates fetched (no cap by default).
 --blossom-webhook-url=URL  Blossom moderate webhook URL. Default https://media.divine.video/admin/moderate. Matches the URL the live pipeline POSTs to via notifyBlossom().
---d1-database=NAME         D1 database name. Default divine-moderation-decisions-prod.
+--d1-database=NAME         D1 database name. Default blossom-webhook-events (the mod-service `BLOSSOM_DB` binding per wrangler.toml; this is the database that holds the `creator_deletions` table).
 ```
 
 **Required env:**
@@ -105,6 +105,21 @@ Node ESM, no transpilation. Runs via `node scripts/sweep-creator-deletes.mjs [fl
 - `BLOSSOM_WEBHOOK_SECRET` — Bearer token for Blossom `/admin/moderate`.
 - Wrangler must be authed against the production Cloudflare account (script shells out to `wrangler`).
 - Node 20+ (global `fetch`, no `node-fetch` dep).
+
+**Blossom response contract (source of truth):** the sweep reads the wire shape emitted by `divine-blossom/src/admin.rs:923-930` and `src/main.rs:4795-4802`:
+
+```json
+{
+  "success": true,
+  "sha256": "<hex>",
+  "old_status": "<variant>",
+  "new_status": "deleted",
+  "physical_deleted": true,
+  "physical_delete_skipped": false
+}
+```
+
+`physical_delete_skipped: true` means `ENABLE_PHYSICAL_DELETE` is off on Blossom (server emits the negation). Error cases return non-2xx; a 2xx-with-`success:false` is not part of the contract today. If Blossom's response shape changes, `classifyDeleteResult` and its test fixtures must be updated in lockstep — the fixtures will not catch drift on their own.
 
 **SQL injection surface:** `wrangler d1 execute --command` does not accept bind params for ad-hoc SQL, so the script string-interpolates inputs into both SELECT and UPDATE statements. Inputs are validated before interpolation:
 
@@ -138,7 +153,7 @@ Vitest, runs via existing repo config.
 | `runWithConcurrency` | Concurrency cap respected; error in one item does not poison others; every input produces exactly one result entry; result order need not match input order (callers re-associate via the row data carried through). |
 | `callBlossomDelete` | Auth header set; body shape correct; 200 success path; 200-with-`status:'error'` path; 4xx; 5xx; network error. |
 | `flushDeletedAt` | SQL builder produces correct `IN (...)` literal; sha256 hex assumption asserted; no-op on empty list. |
-| `main` (integration) | Pre-flight `physical_delete_enabled=false` aborts with exit 2 and zero D1 writes. Pre-flight 401 aborts with exit 2. Dry-run path makes zero Blossom and zero D1-write calls. Per-row failure does not stop the sweep. D1 stamp only includes rows that returned `physical_deleted:true`. Unprocessable and permanent-failures surfaced in summary. |
+| `main` (integration) | Pre-flight `physical_delete_skipped=true` aborts with exit 2 and zero D1 writes. Pre-flight 401 aborts with exit 2. Dry-run path makes zero Blossom and zero D1-write calls. Per-row failure does not stop the sweep. D1 stamp only includes rows that returned `physical_deleted:true`. Unprocessable and permanent-failures surfaced in summary. |
 
 ## Data flow
 
@@ -161,7 +176,7 @@ Vitest, runs via existing repo config.
 
 4. **Pre-flight.** Issue one Blossom `DELETE` for the first candidate.
 
-   - If response body has `physical_delete_enabled === false`: **abort, exit 2.** Loud message: "Blossom did not byte-delete because `ENABLE_PHYSICAL_DELETE` is off. Flip the flag before sweeping. No D1 writes occurred."
+   - If response body has `physical_delete_skipped === true`: **abort, exit 2.** Loud message: "Blossom did not byte-delete because `ENABLE_PHYSICAL_DELETE` is off. Flip the flag before sweeping. No D1 writes occurred."
    - If 401/403: **abort, exit 2.** "Blossom rejected auth — check `BLOSSOM_WEBHOOK_SECRET`."
    - If 5xx, network error, JSON parse: **abort, exit 2.** "Blossom unreachable — try later."
    - If success with `physical_deleted: true`: pre-flight row joins the in-memory success queue. It is flushed to D1 alongside the bulk-sweep successes (no separate flush call). Continue to step 5 with the remaining candidates.
@@ -232,7 +247,7 @@ Greppable, sortable, pipeable to `jq`. Every row produces exactly one line.
 
 | Failure | Behavior |
 |---|---|
-| Pre-flight: `physical_delete_enabled === false` | Abort, exit 2. Zero D1 writes. |
+| Pre-flight: `physical_delete_skipped === true` | Abort, exit 2. Zero D1 writes. |
 | Pre-flight: Blossom 401/403 | Abort, exit 2. |
 | Pre-flight: Blossom 5xx / network / JSON parse | Abort, exit 2. |
 | `fetchCandidates` wrangler error | Abort, exit 3. No sweep work started. |
@@ -253,7 +268,7 @@ Greppable, sortable, pipeable to `jq`. Every row produces exactly one line.
 ## Operational runbook (future PR companion)
 
 1. Confirm `ENABLE_PHYSICAL_DELETE=true` is set on Blossom config store.
-2. Apply migration 007 to prod D1: `wrangler d1 execute divine-moderation-decisions-prod --file migrations/007-creator-deletions-physical-deleted-at.sql --remote`.
+2. Apply migration 007 to prod D1: `wrangler d1 execute blossom-webhook-events --file migrations/007-creator-deletions-physical-deleted-at.sql --remote`.
 3. Dry-run: `node scripts/sweep-creator-deletes.mjs --dry-run`.
 4. If candidate count looks right, full run: `node scripts/sweep-creator-deletes.mjs`.
 5. Inspect summary. Investigate any `unprocessable` or `permanent-failures` rows by hand.
@@ -262,6 +277,15 @@ Greppable, sortable, pipeable to `jq`. Every row produces exactly one line.
 ## Open questions
 
 - **Whether to surface `failed:transient:*` rows in the summary.** They will be retried by the existing creator-delete cron (mod-service) and the sweep doesn't own them. Probably skip; revisit if ops finds them useful.
+
+## Forward-looking: Blossom contract drift
+
+This sweep reads Blossom's `/admin/moderate` response shape directly (see the "Blossom response contract" section above). Several in-flight and upcoming PRs on `divine-blossom` touch adjacent code paths:
+
+- PR #97 — adding unit coverage for the creator-delete response contract (in flight).
+- Future changes to the moderate webhook response (e.g., new status fields, renamed booleans).
+
+**Re-verify this script's `classifyDeleteResult` and test fixtures against Blossom's live response** once those land. The fixtures are authored from the same contract document as the classifier; they do not catch drift on their own. The source-of-truth reference is pinned in the function's docstring to `divine-blossom/src/admin.rs:923-930` and `src/main.rs:4795-4802` — if those line numbers shift, update both and re-run the sweep against staging before any prod invocation.
 
 ## What this is not
 

--- a/docs/superpowers/specs/2026-04-17-creator-delete-validation-sweep-design.md
+++ b/docs/superpowers/specs/2026-04-17-creator-delete-validation-sweep-design.md
@@ -1,0 +1,251 @@
+# Creator-delete validation-window physical-delete sweep — design
+
+**Date:** 2026-04-17
+**Issue:** [divine-blossom#90](https://github.com/divinevideo/divine-blossom/issues/90)
+**Repo:** divine-moderation-service (sweep script + D1 migration)
+**Status:** Design approved, pending implementation plan
+
+## Context
+
+PR #92 (per-video delete end-to-end enforcement) shipped behind `CREATOR_DELETE_PIPELINE_ENABLED` and uses Blossom's `DELETE` action gated by `ENABLE_PHYSICAL_DELETE`. The rollout plan intentionally keeps `ENABLE_PHYSICAL_DELETE=false` during the validation window so soft-delete is verified before bytes are destroyed.
+
+During that window, creator-initiated deletions:
+
+- write a `creator_deletions` row in mod-service D1 with `status='success'`,
+- cause Blossom to flip the blob's status to `Deleted` (content stops serving),
+- **leave the underlying GCS bytes in place** because the flag is off.
+
+The sweep retroactively destroys those bytes once the flag is flipped on, fulfilling the creator's original delete intent.
+
+## Goals
+
+- Identify every creator-delete from the validation window whose bytes were not destroyed.
+- Destroy those bytes via Blossom's existing `handle_creator_delete` helper.
+- Track per-row completion in D1 so re-runs are O(unfinished) and idempotent.
+- Make every creator-intent we cannot fulfill loud and visible — not silently skipped.
+- Operator-paced, easy to dry-run, easy to interrupt.
+
+## Non-goals
+
+- Not a permanent worker surface. The sweep is a one-time operation per validation window.
+- Not a replacement for the live creator-delete pipeline. New deletes flow through the existing sync endpoint and cron.
+- No cron / scheduled execution. The script is run by hand by an operator.
+- No retry of `failed:permanent:*` rows. Those failed for a reason; the sweep surfaces them for manual investigation.
+
+## Architecture
+
+```
+operator laptop
+   │
+   └─ scripts/sweep-creator-deletes.mjs
+        │
+        ├─ wrangler d1 execute  →  divine-moderation-decisions-prod
+        │     SELECT candidate rows from creator_deletions
+        │
+        ├─ for each batch (concurrency=N):
+        │     POST https://media.divine.video/admin/moderate
+        │         Bearer ${BLOSSOM_WEBHOOK_SECRET}
+        │         {sha256, action: "DELETE"}
+        │     →  blossom (Fastly Compute)
+        │           handle_creator_delete:
+        │             - soft_delete_blob (no-op if already Deleted)
+        │             - storage::delete_blob (byte destruction)
+        │             - delete_blob_gcs_artifacts (thumbnail, VTT, derived audio)
+        │             - purge_vcl_cache
+        │
+        └─ every 100 successes (and at end of run):
+              wrangler d1 execute  →  divine-moderation-decisions-prod
+                UPDATE creator_deletions
+                SET physical_deleted_at = ?
+                WHERE blob_sha256 IN (...) AND physical_deleted_at IS NULL
+```
+
+**Boundaries:**
+
+- Script is the orchestrator. No new mod-service worker code path; no new HTTP surface.
+- Blossom is the only service that touches GCS. The script never decides "delete bytes" — it asks, Blossom acts.
+- D1 is the source of truth for "what needs sweeping" (`status='success' AND physical_deleted_at IS NULL`) and "what's been swept" (`physical_deleted_at IS NOT NULL`).
+
+## Components
+
+### 1. Migration `007-creator-deletions-physical-deleted-at.sql`
+
+```sql
+ALTER TABLE creator_deletions
+  ADD COLUMN IF NOT EXISTS physical_deleted_at TEXT;
+```
+
+No new index. The sweep query uses the existing `idx_creator_deletions_status` for the status side and applies the `physical_deleted_at IS NULL` filter on top. Sparse-null filter at thousand-row scale doesn't justify a new index.
+
+### 2. `scripts/sweep-creator-deletes.mjs`
+
+Node ESM, no transpilation. Runs via `node scripts/sweep-creator-deletes.mjs [flags]`.
+
+**CLI flags:**
+
+```
+--dry-run                  List candidates and pre-flight check, no destructive calls.
+--since=ISO8601            Filter completed_at >= since.
+--until=ISO8601            Filter completed_at <  until.
+--concurrency=N            Parallel Blossom calls. Default 5.
+--limit=N                  Cap candidates fetched (no cap by default).
+--blossom-url=URL          Blossom base. Default https://media.divine.video.
+--d1-database=NAME         D1 database name. Default divine-moderation-decisions-prod.
+```
+
+**Required env:**
+
+- `BLOSSOM_WEBHOOK_SECRET` — Bearer token for Blossom `/admin/moderate`.
+- Wrangler must be authed against the production Cloudflare account (script shells out to `wrangler`).
+
+**Internal functions** (each its own small unit, deps injected so tests don't shell out or fetch):
+
+| Function | Purpose | Side effects |
+|---|---|---|
+| `parseArgs(argv)` | Returns typed config object. | none (pure). |
+| `fetchCandidates(config, exec)` | Shells `wrangler d1 execute ... SELECT`, parses JSON. | reads D1. |
+| `fetchUnprocessable(config, exec)` | Shells SELECT for rows with `status='success' AND blob_sha256 IS NULL`. | reads D1. |
+| `fetchPermanentFailures(config, exec)` | Shells SELECT for rows with `status LIKE 'failed:permanent:%'`. | reads D1. |
+| `callBlossomDelete(sha256, config, fetchImpl)` | One POST, returns `{ok, status, body}`. | network. |
+| `runWithConcurrency(items, n, fn)` | Bounded parallelism. No external dep. | none (pure orchestration). |
+| `flushDeletedAt(shas, config, exec)` | Shells one `UPDATE ... WHERE blob_sha256 IN (...)`. | writes D1. |
+| `printSummary(results)` | Final stdout summary. | stdout. |
+| `main()` | Wires it all together. | all of the above. |
+
+### 3. Tests `scripts/sweep-creator-deletes.test.mjs`
+
+Vitest, runs via existing repo config.
+
+| Unit | Coverage |
+|---|---|
+| `parseArgs` | Defaults; each flag parses; invalid ISO rejected; conflicting flags rejected. |
+| `runWithConcurrency` | Order-independent; concurrency cap respected; error in one item does not poison others; results returned in submission order. |
+| `callBlossomDelete` | Auth header set; body shape correct; 200 success path; 200-with-`status:'error'` path; 4xx; 5xx; network error. |
+| `flushDeletedAt` | SQL builder produces correct `IN (...)` literal; sha256 hex assumption asserted; no-op on empty list. |
+| `main` (integration) | Pre-flight `physical_delete_enabled=false` aborts with exit 2 and zero D1 writes. Pre-flight 401 aborts with exit 2. Dry-run path makes zero Blossom and zero D1-write calls. Per-row failure does not stop the sweep. D1 stamp only includes rows that returned `physical_deleted:true`. Unprocessable and permanent-failures surfaced in summary. |
+
+## Data flow
+
+1. **Fetch candidates** from D1:
+
+   ```sql
+   SELECT kind5_id, target_event_id, blob_sha256, completed_at
+     FROM creator_deletions
+    WHERE status = 'success'
+      AND physical_deleted_at IS NULL
+      AND blob_sha256 IS NOT NULL
+      [AND completed_at >= ?since]
+      [AND completed_at <  ?until]
+    [LIMIT ?limit];
+   ```
+
+2. **Dry-run gate.** If `--dry-run`, print candidate count + first 20 shas + parsed window, exit 0. No network calls, no D1 writes. Pre-flight is intentionally skipped in dry-run; if the flag is misconfigured at run-time, the real run's pre-flight will catch it before any rows get stamped.
+
+3. **Pre-flight.** Issue one Blossom `DELETE` for the first candidate.
+
+   - If response body has `physical_delete_enabled === false`: **abort, exit 2.** Loud message: "Blossom did not byte-delete because `ENABLE_PHYSICAL_DELETE` is off. Flip the flag before sweeping. No D1 writes occurred."
+   - If 401/403: **abort, exit 2.** "Blossom rejected auth — check `BLOSSOM_WEBHOOK_SECRET`."
+   - If 5xx, network error, JSON parse: **abort, exit 2.** "Blossom unreachable — try later."
+   - If success with `physical_deleted: true`: stamp this row, continue to step 4 with the remaining candidates.
+
+4. **Sweep.** `runWithConcurrency(candidates, --concurrency, async row => callBlossomDelete(row.blob_sha256))`.
+
+5. **Strict success criterion** — only stamp `physical_deleted_at` when:
+
+   ```
+   res.ok
+   && body.status === 'success'
+   && body.physical_deleted === true
+   ```
+
+   Anything else → log a failure line, continue. Row stays unstamped and is picked up by the next run.
+
+6. **Periodic flush.** Every 100 successes (and once at end-of-run), call `flushDeletedAt(successShas)`:
+
+   ```sql
+   UPDATE creator_deletions
+      SET physical_deleted_at = ?
+    WHERE blob_sha256 IN (?, ?, ...)
+      AND physical_deleted_at IS NULL;
+   ```
+
+   The `AND physical_deleted_at IS NULL` clause guards against concurrent operators racing each other.
+
+7. **Surface unfulfilled creator intent.** After the sweep, run two read-only queries (these should be small lists — exception rows, not the bulk):
+
+   - `status='success' AND blob_sha256 IS NULL` → "unprocessable" list. Creator's delete was accepted at the kind 5 layer but we never resolved a sha256, so Blossom was never told. The asset may still be live.
+   - `status LIKE 'failed:permanent:%'` → "permanent failures" list. The pipeline gave up on these rows; creator's intent was not fulfilled.
+
+8. **Summary** (always printed):
+
+   ```
+   === SUMMARY ===
+   Total candidates fetched: 1234
+   Bytes destroyed + stamped: 1200
+   Failed (will retry next run):  34
+   Unprocessable (NULL sha256):    5
+   Permanent failures (manual):    2
+
+   === FAILURES (will retry) ===
+   sha=<hex> http=502 kind5=<id>: <error excerpt>
+   ...
+
+   === UNPROCESSABLE (creator intent unfulfilled, NULL sha256) ===
+   kind5=<id> target=<id> creator=<pubkey> completed_at=<ts>
+   ...
+
+   === PERMANENT FAILURES (creator intent unfulfilled, status=failed:permanent:*) ===
+   kind5=<id> target=<id> creator=<pubkey> status=failed:permanent:<sub> last_error=<msg>
+   ...
+
+   Exit: 1
+   ```
+
+## Per-row outcome log (stdout, JSONL)
+
+```json
+{"ts":"...","sha":"<64hex>","kind5":"...","target":"...","outcome":"success","http":200,"physical_deleted":true}
+{"ts":"...","sha":"<64hex>","kind5":"...","target":"...","outcome":"failure","http":502,"error":"upstream timeout"}
+```
+
+Greppable, sortable, pipeable to `jq`. Every row produces exactly one line.
+
+## Error handling
+
+| Failure | Behavior |
+|---|---|
+| Pre-flight: `physical_delete_enabled === false` | Abort, exit 2. Zero D1 writes. |
+| Pre-flight: Blossom 401/403 | Abort, exit 2. |
+| Pre-flight: Blossom 5xx / network / JSON parse | Abort, exit 2. |
+| `fetchCandidates` wrangler error | Abort, exit 3. No sweep work started. |
+| Per-row Blossom 5xx, 4xx, network, timeout, JSON parse | Log failure line, continue. Row stays unstamped. |
+| Per-row Blossom 200 with `status:'error'` or `physical_deleted:false` | Log failure line, continue. Notably: do not stamp. |
+| `flushDeletedAt` wrangler error | Abort, exit 4. Print "in-flight chunk shas not stamped" with the sha list, so operator has them for manual reconciliation. Re-run will re-issue DELETE for those (idempotent on Blossom) and stamp on success. |
+| SIGINT (Ctrl-C) | Flush any in-memory successes before exiting. Print partial summary. Exit 130. |
+
+**Exit codes:**
+
+- `0` — all good. No failures, no unprocessable, no permanent failures.
+- `1` — sweep ran, but at least one creator-intent unfulfilled (any of: failures, unprocessable, permanent-failures non-zero).
+- `2` — pre-flight aborted (auth, flag, or unreachable).
+- `3` — D1 read aborted.
+- `4` — D1 write aborted mid-run.
+- `130` — SIGINT.
+
+## Operational runbook (future PR companion)
+
+1. Confirm `ENABLE_PHYSICAL_DELETE=true` is set on Blossom config store.
+2. Apply migration 007 to prod D1: `wrangler d1 execute divine-moderation-decisions-prod --file migrations/007-creator-deletions-physical-deleted-at.sql --remote`.
+3. Dry-run: `node scripts/sweep-creator-deletes.mjs --dry-run`.
+4. If candidate count looks right, full run: `node scripts/sweep-creator-deletes.mjs`.
+5. Inspect summary. Investigate any `unprocessable` or `permanent-failures` rows by hand.
+6. Re-run any time after the validation window. The sweep is idempotent and converges.
+
+## Open questions
+
+- **Whether to surface `failed:transient:*` rows in the summary.** They will be retried by the existing creator-delete cron (mod-service) and the sweep doesn't own them. Probably skip; revisit if ops finds them useful.
+
+## What this is not
+
+- Not a replacement for the existing live pipeline. New creator deletes after the flag flip are physical-deleted on first pass via the normal sync/cron flow.
+- Not a tool for moderator-initiated deletes (BAN, RESTRICT, ageRestrict). Those are separate code paths and out of scope.

--- a/docs/superpowers/specs/2026-04-17-creator-delete-validation-sweep-design.md
+++ b/docs/superpowers/specs/2026-04-17-creator-delete-validation-sweep-design.md
@@ -94,7 +94,7 @@ Node ESM, no transpilation. Runs via `node scripts/sweep-creator-deletes.mjs [fl
 --until=ISO8601            Filter completed_at <  until.
 --concurrency=N            Parallel Blossom calls. Default 5.
 --limit=N                  Cap candidates fetched (no cap by default).
---blossom-url=URL          Blossom base. Default https://media.divine.video.
+--blossom-webhook-url=URL  Blossom moderate webhook URL. Default https://media.divine.video/admin/moderate. Matches the URL the live pipeline POSTs to via notifyBlossom().
 --d1-database=NAME         D1 database name. Default divine-moderation-decisions-prod.
 ```
 
@@ -120,7 +120,7 @@ A single failed validation aborts the run with exit 3 (D1 read aborted) before a
 | `fetchCandidates(config, exec)` | Shells `wrangler d1 execute ... SELECT`, parses JSON. | reads D1. |
 | `fetchUnprocessable(config, exec)` | Shells SELECT for rows with `status='success' AND blob_sha256 IS NULL`. | reads D1. |
 | `fetchPermanentFailures(config, exec)` | Shells SELECT for rows with `status LIKE 'failed:permanent:%'`. | reads D1. |
-| `callBlossomDelete(sha256, config, fetchImpl)` | One POST, returns `{ok, status, body}`. | network. |
+| `callBlossomDelete(sha256, config, notifyImpl)` | Wraps `notifyBlossom(sha256, 'DELETE', {BLOSSOM_WEBHOOK_URL, BLOSSOM_WEBHOOK_SECRET})` from `src/blossom-client.mjs`. Returns `{ok, status, body}`. Reusing the live-pipeline client guarantees identical request shape. | network. |
 | `runWithConcurrency(items, n, fn)` | Bounded parallelism. No external dep. | none (pure orchestration). |
 | `flushDeletedAt(shas, config, exec)` | Shells one `UPDATE ... WHERE blob_sha256 IN (...)`. | writes D1. |
 | `printSummary(results)` | Final stdout summary. | stdout. |

--- a/docs/superpowers/specs/2026-04-17-creator-delete-validation-sweep-design.md
+++ b/docs/superpowers/specs/2026-04-17-creator-delete-validation-sweep-design.md
@@ -71,6 +71,11 @@ operator laptop
 ### 1. Migration `007-creator-deletions-physical-deleted-at.sql`
 
 ```sql
+-- Stamped by scripts/sweep-creator-deletes.mjs only.
+-- The live creator-delete pipeline (process.mjs) does not write this column;
+-- newly-produced success rows show NULL here until the next sweep run picks
+-- them up, calls Blossom (idempotent if bytes already gone), and stamps.
+-- Semantic: "the validation sweep confirmed bytes were destroyed for this row."
 ALTER TABLE creator_deletions
   ADD COLUMN IF NOT EXISTS physical_deleted_at TEXT;
 ```
@@ -84,7 +89,7 @@ Node ESM, no transpilation. Runs via `node scripts/sweep-creator-deletes.mjs [fl
 **CLI flags:**
 
 ```
---dry-run                  List candidates and pre-flight check, no destructive calls.
+--dry-run                  List candidates and parsed window. No network calls, no D1 writes.
 --since=ISO8601            Filter completed_at >= since.
 --until=ISO8601            Filter completed_at <  until.
 --concurrency=N            Parallel Blossom calls. Default 5.
@@ -97,6 +102,15 @@ Node ESM, no transpilation. Runs via `node scripts/sweep-creator-deletes.mjs [fl
 
 - `BLOSSOM_WEBHOOK_SECRET` — Bearer token for Blossom `/admin/moderate`.
 - Wrangler must be authed against the production Cloudflare account (script shells out to `wrangler`).
+- Node 20+ (global `fetch`, no `node-fetch` dep).
+
+**SQL injection surface:** `wrangler d1 execute --command` does not accept bind params for ad-hoc SQL, so the script string-interpolates inputs into both SELECT and UPDATE statements. Inputs are validated before interpolation:
+
+- `blob_sha256` values must match `/^[0-9a-f]{64}$/`. Anything else is rejected before reaching the SQL builder.
+- `--since`, `--until` must parse via `new Date(x).toISOString()` round-trip.
+- `--limit` must be a non-negative integer.
+
+A single failed validation aborts the run with exit 3 (D1 read aborted) before any SQL is built.
 
 **Internal functions** (each its own small unit, deps injected so tests don't shell out or fetch):
 
@@ -119,7 +133,7 @@ Vitest, runs via existing repo config.
 | Unit | Coverage |
 |---|---|
 | `parseArgs` | Defaults; each flag parses; invalid ISO rejected; conflicting flags rejected. |
-| `runWithConcurrency` | Order-independent; concurrency cap respected; error in one item does not poison others; results returned in submission order. |
+| `runWithConcurrency` | Concurrency cap respected; error in one item does not poison others; every input produces exactly one result entry; result order need not match input order (callers re-associate via the row data carried through). |
 | `callBlossomDelete` | Auth header set; body shape correct; 200 success path; 200-with-`status:'error'` path; 4xx; 5xx; network error. |
 | `flushDeletedAt` | SQL builder produces correct `IN (...)` literal; sha256 hex assumption asserted; no-op on empty list. |
 | `main` (integration) | Pre-flight `physical_delete_enabled=false` aborts with exit 2 and zero D1 writes. Pre-flight 401 aborts with exit 2. Dry-run path makes zero Blossom and zero D1-write calls. Per-row failure does not stop the sweep. D1 stamp only includes rows that returned `physical_deleted:true`. Unprocessable and permanent-failures surfaced in summary. |
@@ -139,18 +153,20 @@ Vitest, runs via existing repo config.
     [LIMIT ?limit];
    ```
 
-2. **Dry-run gate.** If `--dry-run`, print candidate count + first 20 shas + parsed window, exit 0. No network calls, no D1 writes. Pre-flight is intentionally skipped in dry-run; if the flag is misconfigured at run-time, the real run's pre-flight will catch it before any rows get stamped.
+2. **Empty-candidates short-circuit.** If 0 candidates, skip the sweep entirely. Still run the surfacing queries (step 8) so the operator sees unprocessable / permanent-failure rows. Exit 0 unless those lists are non-empty, in which case exit 1.
 
-3. **Pre-flight.** Issue one Blossom `DELETE` for the first candidate.
+3. **Dry-run gate.** If `--dry-run`, print candidate count + first 20 shas + parsed window, exit 0. No network calls, no D1 writes. Pre-flight is intentionally skipped in dry-run; if the flag is misconfigured at run-time, the real run's pre-flight will catch it before any rows get stamped.
+
+4. **Pre-flight.** Issue one Blossom `DELETE` for the first candidate.
 
    - If response body has `physical_delete_enabled === false`: **abort, exit 2.** Loud message: "Blossom did not byte-delete because `ENABLE_PHYSICAL_DELETE` is off. Flip the flag before sweeping. No D1 writes occurred."
    - If 401/403: **abort, exit 2.** "Blossom rejected auth — check `BLOSSOM_WEBHOOK_SECRET`."
    - If 5xx, network error, JSON parse: **abort, exit 2.** "Blossom unreachable — try later."
-   - If success with `physical_deleted: true`: stamp this row, continue to step 4 with the remaining candidates.
+   - If success with `physical_deleted: true`: pre-flight row joins the in-memory success queue. It is flushed to D1 alongside the bulk-sweep successes (no separate flush call). Continue to step 5 with the remaining candidates.
 
-4. **Sweep.** `runWithConcurrency(candidates, --concurrency, async row => callBlossomDelete(row.blob_sha256))`.
+5. **Sweep.** `runWithConcurrency(candidates, --concurrency, async row => callBlossomDelete(row.blob_sha256))`.
 
-5. **Strict success criterion** — only stamp `physical_deleted_at` when:
+6. **Strict success criterion** — only stamp `physical_deleted_at` when:
 
    ```
    res.ok
@@ -160,7 +176,7 @@ Vitest, runs via existing repo config.
 
    Anything else → log a failure line, continue. Row stays unstamped and is picked up by the next run.
 
-6. **Periodic flush.** Every 100 successes (and once at end-of-run), call `flushDeletedAt(successShas)`:
+7. **Periodic flush.** Every 100 successes (and once at end-of-run), call `flushDeletedAt(successShas)`:
 
    ```sql
    UPDATE creator_deletions
@@ -171,12 +187,12 @@ Vitest, runs via existing repo config.
 
    The `AND physical_deleted_at IS NULL` clause guards against concurrent operators racing each other.
 
-7. **Surface unfulfilled creator intent.** After the sweep, run two read-only queries (these should be small lists — exception rows, not the bulk):
+8. **Surface unfulfilled creator intent.** After the sweep, run two read-only queries (these should be small lists — exception rows, not the bulk):
 
    - `status='success' AND blob_sha256 IS NULL` → "unprocessable" list. Creator's delete was accepted at the kind 5 layer but we never resolved a sha256, so Blossom was never told. The asset may still be live.
    - `status LIKE 'failed:permanent:%'` → "permanent failures" list. The pipeline gave up on these rows; creator's intent was not fulfilled.
 
-8. **Summary** (always printed):
+9. **Summary** (always printed):
 
    ```
    === SUMMARY ===
@@ -221,7 +237,7 @@ Greppable, sortable, pipeable to `jq`. Every row produces exactly one line.
 | Per-row Blossom 5xx, 4xx, network, timeout, JSON parse | Log failure line, continue. Row stays unstamped. |
 | Per-row Blossom 200 with `status:'error'` or `physical_deleted:false` | Log failure line, continue. Notably: do not stamp. |
 | `flushDeletedAt` wrangler error | Abort, exit 4. Print "in-flight chunk shas not stamped" with the sha list, so operator has them for manual reconciliation. Re-run will re-issue DELETE for those (idempotent on Blossom) and stamp on success. |
-| SIGINT (Ctrl-C) | Flush any in-memory successes before exiting. Print partial summary. Exit 130. |
+| SIGINT (Ctrl-C) | Best-effort: stop scheduling new Blossom calls, await in-flight calls to settle, flush in-memory successes, print partial summary, exit 130. Implemented via `process.on('SIGINT', ...)` setting a "draining" flag that the concurrency loop checks. A second SIGINT exits immediately without flushing (operator override). |
 
 **Exit codes:**
 

--- a/migrations/007-creator-deletions-physical-deleted-at.sql
+++ b/migrations/007-creator-deletions-physical-deleted-at.sql
@@ -1,0 +1,12 @@
+-- Stamped by scripts/sweep-creator-deletes.mjs only.
+-- The live creator-delete pipeline (process.mjs) does not write this column;
+-- newly-produced success rows show NULL here until the next sweep run picks
+-- them up, calls Blossom (idempotent if bytes already gone), and stamps.
+-- Semantic: "the validation sweep confirmed bytes were destroyed for this row."
+--
+-- Run exactly once per environment. SQLite (and therefore D1) does not support
+-- "ADD COLUMN IF NOT EXISTS"; a re-run errors with "duplicate column name".
+-- That's the expected signal — treat the error as "already applied" and move on.
+
+ALTER TABLE creator_deletions
+  ADD COLUMN physical_deleted_at TEXT;

--- a/scripts/sweep-creator-deletes.mjs
+++ b/scripts/sweep-creator-deletes.mjs
@@ -151,3 +151,44 @@ export async function runWithConcurrency(items, concurrency, fn) {
   await Promise.all(workers);
   return results;
 }
+
+import { notifyBlossom as defaultNotify } from '../src/blossom-client.mjs';
+
+/**
+ * Wraps notifyBlossom() so the script reuses the live-pipeline request shape and headers.
+ * notifyImpl is injectable for tests.
+ */
+export async function callBlossomDelete(sha256, cfg, notifyImpl = defaultNotify) {
+  const env = {
+    BLOSSOM_WEBHOOK_URL: cfg.blossomWebhookUrl,
+    BLOSSOM_WEBHOOK_SECRET: cfg.blossomWebhookSecret
+  };
+  const r = await notifyImpl(sha256, 'DELETE', env);
+  if (r.success) {
+    return { ok: true, status: r.status, body: r.result };
+  }
+  return {
+    ok: false,
+    status: r.status,
+    networkError: !!r.networkError,
+    error: r.error
+  };
+}
+
+/**
+ * Classifies a Blossom call result into the action the script should take.
+ * Used by both pre-flight and per-row sweep logic.
+ */
+export function classifyDeleteResult(r) {
+  if (r.ok) {
+    const b = r.body || {};
+    if (b.physical_delete_enabled === false) return { kind: 'flag-off' };
+    if (b.status === 'error') return { kind: 'failure', reason: b.error || 'blossom returned status=error' };
+    if (b.status === 'success' && b.physical_deleted === true) return { kind: 'success' };
+    return { kind: 'failure', reason: 'physical_deleted=false despite flag on' };
+  }
+  if (r.status === 401 || r.status === 403) return { kind: 'auth-failure' };
+  if (r.networkError) return { kind: 'unreachable', reason: r.error || 'network error' };
+  if (r.status >= 500) return { kind: 'unreachable', reason: `HTTP ${r.status}` };
+  return { kind: 'failure', reason: r.error || `HTTP ${r.status}` };
+}

--- a/scripts/sweep-creator-deletes.mjs
+++ b/scripts/sweep-creator-deletes.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Validation-window physical-delete sweep for creator-deleted blobs (blossom#90).
+// ABOUTME: Reads creator_deletions from D1, asks Blossom to destroy bytes, stamps physical_deleted_at.
+
+const DEFAULT_BLOSSOM_WEBHOOK_URL = 'https://media.divine.video/admin/moderate';
+const DEFAULT_D1_DATABASE = 'divine-moderation-decisions-prod';
+const DEFAULT_CONCURRENCY = 5;
+const FLUSH_BATCH_SIZE = 100;
+const SHA256_HEX = /^[0-9a-f]{64}$/;
+
+function getFlag(argv, name) {
+  const prefix = `--${name}=`;
+  for (const a of argv) {
+    if (a === `--${name}`) return true;
+    if (a.startsWith(prefix)) return a.slice(prefix.length);
+  }
+  return null;
+}
+
+function validateIso(value, fieldName) {
+  if (value == null) return null;
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) {
+    throw new Error(`Invalid ${fieldName}: ${value} (must be ISO 8601)`);
+  }
+  return d.toISOString();
+}
+
+function validatePositiveInt(value, fieldName) {
+  const n = Number(value);
+  if (!Number.isInteger(n) || n <= 0) {
+    throw new Error(`Invalid ${fieldName}: ${value} (must be positive integer)`);
+  }
+  return n;
+}
+
+function validateNonNegativeInt(value, fieldName) {
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < 0) {
+    throw new Error(`Invalid ${fieldName}: ${value} (must be non-negative integer)`);
+  }
+  return n;
+}
+
+export function parseArgs(argv) {
+  const dryRun = getFlag(argv, 'dry-run') === true;
+  const since = validateIso(getFlag(argv, 'since') || null, 'since');
+  const until = validateIso(getFlag(argv, 'until') || null, 'until');
+
+  const rawConcurrency = getFlag(argv, 'concurrency');
+  const concurrency = rawConcurrency
+    ? validatePositiveInt(rawConcurrency, 'concurrency')
+    : DEFAULT_CONCURRENCY;
+
+  const rawLimit = getFlag(argv, 'limit');
+  const limit = rawLimit ? validateNonNegativeInt(rawLimit, 'limit') : null;
+
+  const blossomWebhookUrl = getFlag(argv, 'blossom-webhook-url') || DEFAULT_BLOSSOM_WEBHOOK_URL;
+  const d1Database = getFlag(argv, 'd1-database') || DEFAULT_D1_DATABASE;
+
+  return { dryRun, since, until, concurrency, limit, blossomWebhookUrl, d1Database };
+}

--- a/scripts/sweep-creator-deletes.mjs
+++ b/scripts/sweep-creator-deletes.mjs
@@ -183,6 +183,11 @@ export async function callBlossomDelete(sha256, cfg, notifyImpl = defaultNotify)
 export function classifyDeleteResult(r) {
   if (r.ok) {
     const b = r.body || {};
+    // flag-off is checked before status=error: in the unlikely case a Blossom
+    // response carries both, the flag-off signal is more actionable for the
+    // operator (flip the env var and re-run) than a generic error reason.
+    // Pre-flight aborts on flag-off before any sweep runs; the per-row sweep
+    // never sees flag-off because it would have aborted at pre-flight.
     if (b.physical_delete_enabled === false) return { kind: 'flag-off' };
     if (b.status === 'error') return { kind: 'failure', reason: b.error || 'blossom returned status=error' };
     if (b.status === 'success' && b.physical_deleted === true) return { kind: 'success' };
@@ -283,16 +288,45 @@ function emitJsonLine(obj) {
 }
 
 /**
+ * D1 write failure during sweep. Carries the in-memory pending sha list at the
+ * point of failure so main() can print them for manual reconciliation. Bytes
+ * for these shas were destroyed (Blossom returned physical_deleted=true) but
+ * D1 stamping did not complete — re-running the sweep is safe and will stamp
+ * them on the next pass (Blossom DELETE on already-gone bytes still returns
+ * success).
+ */
+export class D1WriteAbort extends Error {
+  constructor(unflushedShas, originalError) {
+    super(`flushDeletedAt failed: ${originalError.message}`);
+    this.name = 'D1WriteAbort';
+    this.unflushedShas = unflushedShas;
+    this.originalError = originalError;
+  }
+}
+
+/**
  * Bulk sweep over candidates. Stamps via flushImpl in batches of FLUSH_BATCH_SIZE.
  * Per-row JSONL outcome lines are emitted to stdout for grep/jq.
  *
  * Returns { successes, failures } as arrays of {row, body?, error?, status?}.
+ * Throws D1WriteAbort if a flush fails mid-sweep — caller should print the
+ * unflushedShas and exit 4 per the spec.
  */
 export async function sweepCandidates(candidates, cfg, notifyImpl = defaultNotify, flushImpl = null) {
   const successes = [];
   const failures = [];
   let pending = [];
   const flush = flushImpl || (async (shas) => { await flushDeletedAt(shas, cfg); });
+
+  async function flushOrAbort() {
+    if (pending.length === 0) return;
+    try {
+      await flush(pending);
+      pending = [];
+    } catch (e) {
+      throw new D1WriteAbort([...pending], e);
+    }
+  }
 
   const results = await runWithConcurrency(candidates, cfg.concurrency, async (row) => {
     return callBlossomDelete(row.blob_sha256, cfg, notifyImpl);
@@ -312,8 +346,7 @@ export async function sweepCandidates(candidates, cfg, notifyImpl = defaultNotif
       pending.push(row.blob_sha256);
       emitJsonLine({ ts: nowIso(), sha: row.blob_sha256, kind5: row.kind5_id, target: row.target_event_id, outcome: 'success', http: r.value.status, physical_deleted: true });
       if (pending.length >= FLUSH_BATCH_SIZE) {
-        await flush(pending);
-        pending = [];
+        await flushOrAbort();
       }
     } else {
       failures.push({ row, error: c.reason || c.kind, status: r.value.status });
@@ -321,9 +354,7 @@ export async function sweepCandidates(candidates, cfg, notifyImpl = defaultNotif
     }
   }
 
-  if (pending.length > 0) {
-    await flush(pending);
-  }
+  await flushOrAbort();
   return { successes, failures };
 }
 
@@ -444,16 +475,42 @@ export async function main(argv, deps = {}) {
     }
   }
 
-  // Sweep remaining (skip the pre-flight row, then re-add it as a success)
+  // Sweep remaining (skip the pre-flight row, then stamp it separately).
+  //
+  // The pre-flight row's stamp happens AFTER the bulk sweep finishes, not in
+  // the same flush batch. If the process dies between the bulk-sweep flush
+  // and the pre-flight stamp, the pre-flight bytes are gone but the row stays
+  // unstamped — re-running picks it up, calls Blossom (idempotent: returns
+  // physical_deleted=true on already-gone bytes per Blossom PR #85), then
+  // stamps. Same convergence rationale as any unflushed row in the bulk path.
   let sweepResult = { successes: [], failures: [] };
   if (candidates.length > 0) {
     const remaining = candidates.slice(1);
-    sweepResult = await sweepCandidates(remaining, cfg, notify, async (shas) => {
-      await flushDeletedAt(shas, cfg, runner);
-    });
+    try {
+      sweepResult = await sweepCandidates(remaining, cfg, notify, async (shas) => {
+        await flushDeletedAt(shas, cfg, runner);
+      });
+    } catch (e) {
+      if (e instanceof D1WriteAbort) {
+        console.error(`D1 write aborted mid-sweep: ${e.originalError.message}`);
+        console.error(`Bytes destroyed but rows NOT stamped (${e.unflushedShas.length} shas):`);
+        for (const sha of e.unflushedShas) console.error(`  ${sha}`);
+        console.error('Re-run the sweep to stamp these rows (Blossom DELETE is idempotent).');
+        return 4;
+      }
+      throw e;
+    }
     if (preflightSuccess) {
+      try {
+        await flushDeletedAt([candidates[0].blob_sha256], cfg, runner);
+      } catch (e) {
+        console.error(`D1 write aborted on pre-flight stamp: ${e.message}`);
+        console.error(`Bytes destroyed but row NOT stamped (1 sha):`);
+        console.error(`  ${candidates[0].blob_sha256}`);
+        console.error('Re-run the sweep to stamp this row (Blossom DELETE is idempotent).');
+        return 4;
+      }
       sweepResult.successes.unshift({ row: candidates[0], body: null });
-      await flushDeletedAt([candidates[0].blob_sha256], cfg, runner);
       console.log(JSON.stringify({ ts: nowIso(), sha: candidates[0].blob_sha256, kind5: candidates[0].kind5_id, target: candidates[0].target_event_id, outcome: 'success', http: 200, physical_deleted: true, source: 'preflight' }));
     }
   }

--- a/scripts/sweep-creator-deletes.mjs
+++ b/scripts/sweep-creator-deletes.mjs
@@ -297,6 +297,7 @@ export async function sweepCandidates(candidates, cfg, notifyImpl = defaultNotif
   });
 
   for (const r of results) {
+    if (isDraining()) break;  // SIGINT: stop scheduling new work, flush pending, exit
     const row = r.input;
     if (r.error) {
       failures.push({ row, error: r.error.message });
@@ -475,4 +476,39 @@ export async function main(argv, deps = {}) {
   });
   printSummary(s);
   return computeExitCode(s);
+}
+
+// SIGINT handling — best-effort drain.
+// First SIGINT: set DRAINING flag; the orchestrator stops scheduling new flushes once the current
+// runWithConcurrency batch settles, then exits with the partial summary.
+// Second SIGINT: hard exit 130.
+let DRAINING = false;
+let SIGINT_COUNT = 0;
+
+function installSigintHandler() {
+  process.on('SIGINT', () => {
+    SIGINT_COUNT++;
+    if (SIGINT_COUNT === 1) {
+      DRAINING = true;
+      console.error('\n[sweep] SIGINT received — draining in-flight work; press Ctrl-C again to abort.');
+    } else {
+      console.error('\n[sweep] SIGINT received twice — exiting now.');
+      process.exit(130);
+    }
+  });
+}
+
+export function isDraining() { return DRAINING; }
+
+// CLI entrypoint — only runs when invoked directly (not when imported by tests).
+const isMain = typeof process !== 'undefined' && process.argv && import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  installSigintHandler();
+  main(process.argv.slice(2)).then(
+    (code) => process.exit(code),
+    (err) => {
+      console.error(`unexpected error: ${err.stack || err.message}`);
+      process.exit(99);
+    }
+  );
 }

--- a/scripts/sweep-creator-deletes.mjs
+++ b/scripts/sweep-creator-deletes.mjs
@@ -343,7 +343,7 @@ export class MidRunFlagOff extends Error {
  * Throws D1WriteAbort if a flush fails mid-sweep — caller should print the
  * unflushedShas and exit 4 per the spec.
  */
-export async function sweepCandidates(candidates, cfg, notifyImpl = defaultNotify, flushImpl = null) {
+export async function sweepCandidates(candidates, cfg, notifyImpl = defaultNotify, flushImpl = null, isDrainingImpl = isDraining) {
   const successes = [];
   const failures = [];
   let pending = [];
@@ -359,12 +359,19 @@ export async function sweepCandidates(candidates, cfg, notifyImpl = defaultNotif
     }
   }
 
+  // `runWithConcurrency` honors the drain callback at the scheduler level:
+  // once `isDrainingImpl()` returns true, no new items are dequeued but all
+  // in-flight work is awaited and returned. The result list below therefore
+  // already reflects everything that actually ran (successfully or not),
+  // including completions after the first SIGINT. Do NOT break out of the
+  // loop on drain — that was the pre-review bug (#106 review from Liz): it
+  // dropped post-signal successes before they could be flushed, so the
+  // partial summary understated bytes actually deleted.
   const results = await runWithConcurrency(candidates, cfg.concurrency, async (row) => {
     return callBlossomDelete(row.blob_sha256, cfg, notifyImpl);
-  }, isDraining);
+  }, isDrainingImpl);
 
   for (const r of results) {
-    if (isDraining()) break;  // SIGINT: stop scheduling new work, flush pending, exit
     const row = r.input;
     if (r.error) {
       failures.push({ row, error: r.error.message });
@@ -395,13 +402,14 @@ export async function sweepCandidates(candidates, cfg, notifyImpl = defaultNotif
   return { successes, failures };
 }
 
-export function summarize({ candidates, successes, failures, unprocessable, permanentFailures }) {
+export function summarize({ candidates, successes, failures, unprocessable, permanentFailures, surfacingFailed = false }) {
   return {
     total: candidates.length,
     stamped: successes.length,
     failed: failures.length,
     unprocessableCount: unprocessable.length,
     permanentFailureCount: permanentFailures.length,
+    surfacingFailed,
     successes,
     failures,
     unprocessable,
@@ -411,6 +419,10 @@ export function summarize({ candidates, successes, failures, unprocessable, perm
 
 export function computeExitCode(s) {
   if (s.failed > 0 || s.unprocessableCount > 0 || s.permanentFailureCount > 0) return 1;
+  // Surfacing-query failure: the sweep itself may have been clean, but
+  // operator visibility into unprocessable/permanent-failure rows is gone.
+  // Exit non-zero so the run doesn't look fully successful.
+  if (s.surfacingFailed) return 1;
   return 0;
 }
 
@@ -421,6 +433,9 @@ export function printSummary(s) {
   console.log(`Failed (will retry next run):  ${s.failed}`);
   console.log(`Unprocessable (NULL sha256):   ${s.unprocessableCount}`);
   console.log(`Permanent failures (manual):   ${s.permanentFailureCount}`);
+  if (s.surfacingFailed) {
+    console.log(`Surfacing queries:             FAILED (see stderr) — exit code will be non-zero`);
+  }
 
   if (s.failures.length > 0) {
     console.log('\n=== FAILURES (will retry) ===');
@@ -557,14 +572,19 @@ export async function main(argv, deps = {}) {
     }
   }
 
-  // Surfacing queries
+  // Surfacing queries. If these fail, the operator loses visibility into
+  // unprocessable and permanent-failure rows, which is exactly what this
+  // script is meant to surface. Treat as a non-zero outcome rather than
+  // silently degrading to exit 0 with empty lists.
   let unprocessable = [];
   let permanentFailures = [];
+  let surfacingFailed = false;
   try {
     unprocessable = await fetchUnprocessable(cfg, runner);
     permanentFailures = await fetchPermanentFailures(cfg, runner);
   } catch (e) {
     console.error(`surfacing query failed: ${e.message}`);
+    surfacingFailed = true;
   }
 
   // Summary
@@ -573,7 +593,8 @@ export async function main(argv, deps = {}) {
     successes: sweepResult.successes,
     failures: sweepResult.failures,
     unprocessable,
-    permanentFailures
+    permanentFailures,
+    surfacingFailed
   });
   printSummary(s);
   return computeExitCode(s);

--- a/scripts/sweep-creator-deletes.mjs
+++ b/scripts/sweep-creator-deletes.mjs
@@ -63,3 +63,64 @@ export function parseArgs(argv) {
 
   return { dryRun, since, until, concurrency, limit, blossomWebhookUrl, d1Database };
 }
+
+export function validateSha256(s) {
+  if (typeof s !== 'string' || !SHA256_HEX.test(s)) {
+    throw new Error(`Invalid sha256: ${s}`);
+  }
+  return s;
+}
+
+function validateIsoTimestamp(s) {
+  if (typeof s !== 'string') throw new Error(`Invalid timestamp: ${s}`);
+  const d = new Date(s);
+  if (Number.isNaN(d.getTime()) || d.toISOString() !== s) {
+    throw new Error(`Invalid timestamp: ${s}`);
+  }
+  return s;
+}
+
+export function buildSelectCandidatesSql({ since, until, limit }) {
+  let sql =
+    "SELECT kind5_id, target_event_id, blob_sha256, completed_at FROM creator_deletions" +
+    " WHERE status = 'success'" +
+    " AND physical_deleted_at IS NULL" +
+    " AND blob_sha256 IS NOT NULL";
+  if (since) sql += ` AND completed_at >= '${validateIsoTimestamp(since)}'`;
+  if (until) sql += ` AND completed_at < '${validateIsoTimestamp(until)}'`;
+  if (limit != null) {
+    if (!Number.isInteger(limit) || limit < 0) throw new Error(`Invalid limit: ${limit}`);
+    sql += ` LIMIT ${limit}`;
+  }
+  sql += ';';
+  return sql;
+}
+
+export function buildSelectUnprocessableSql() {
+  return (
+    "SELECT kind5_id, target_event_id, creator_pubkey, completed_at FROM creator_deletions" +
+    " WHERE status = 'success'" +
+    " AND blob_sha256 IS NULL;"
+  );
+}
+
+export function buildSelectPermanentFailuresSql() {
+  return (
+    "SELECT kind5_id, target_event_id, creator_pubkey, status, last_error FROM creator_deletions" +
+    " WHERE status LIKE 'failed:permanent:%';"
+  );
+}
+
+export function buildUpdateStampSql(shas, timestamp) {
+  if (!Array.isArray(shas) || shas.length === 0) {
+    throw new Error('buildUpdateStampSql called with empty sha list');
+  }
+  validateIsoTimestamp(timestamp);
+  for (const s of shas) validateSha256(s);
+  const inList = shas.map(s => `'${s}'`).join(', ');
+  return (
+    `UPDATE creator_deletions SET physical_deleted_at = '${timestamp}'` +
+    ` WHERE blob_sha256 IN (${inList})` +
+    ` AND physical_deleted_at IS NULL;`
+  );
+}

--- a/scripts/sweep-creator-deletes.mjs
+++ b/scripts/sweep-creator-deletes.mjs
@@ -124,3 +124,30 @@ export function buildUpdateStampSql(shas, timestamp) {
     ` AND physical_deleted_at IS NULL;`
   );
 }
+
+export async function runWithConcurrency(items, concurrency, fn) {
+  if (items.length === 0) return [];
+  const results = new Array(items.length);
+  let cursor = 0;
+
+  async function worker() {
+    while (true) {
+      const i = cursor++;
+      if (i >= items.length) return;
+      const input = items[i];
+      try {
+        const value = await fn(input);
+        results[i] = { input, value };
+      } catch (error) {
+        results[i] = { input, error };
+      }
+    }
+  }
+
+  const workers = [];
+  for (let w = 0; w < Math.min(concurrency, items.length); w++) {
+    workers.push(worker());
+  }
+  await Promise.all(workers);
+  return results;
+}

--- a/scripts/sweep-creator-deletes.mjs
+++ b/scripts/sweep-creator-deletes.mjs
@@ -370,3 +370,109 @@ export function printSummary(s) {
     }
   }
 }
+
+function readBlossomSecret() {
+  const s = (typeof process !== 'undefined' && process.env) ? process.env.BLOSSOM_WEBHOOK_SECRET : null;
+  if (!s) {
+    throw new Error('BLOSSOM_WEBHOOK_SECRET env var is required');
+  }
+  return s;
+}
+
+/**
+ * Programmatic entrypoint. Returns the exit code (does not call process.exit).
+ * Tests inject { runner, notify, blossomWebhookSecret } to drive the flow without shelling out.
+ */
+export async function main(argv, deps = {}) {
+  const runner = deps.runner || defaultRunner;
+  const notify = deps.notify || defaultNotify;
+
+  let cfg;
+  try {
+    cfg = parseArgs(argv);
+  } catch (e) {
+    console.error(`arg error: ${e.message}`);
+    return 3;
+  }
+
+  try {
+    cfg.blossomWebhookSecret = deps.blossomWebhookSecret ?? readBlossomSecret();
+  } catch (e) {
+    console.error(e.message);
+    return 3;
+  }
+
+  // Fetch candidates
+  let candidates;
+  try {
+    candidates = await fetchCandidates(cfg, runner);
+  } catch (e) {
+    console.error(`fetchCandidates failed: ${e.message}`);
+    return 3;
+  }
+  console.error(`Found ${candidates.length} candidate(s) for sweep.`);
+  if (cfg.since || cfg.until) {
+    console.error(`Window: since=${cfg.since ?? '-'} until=${cfg.until ?? '-'}`);
+  }
+
+  // Dry-run gate
+  if (cfg.dryRun) {
+    for (const r of candidates.slice(0, 20)) {
+      console.log(`[dry-run] sha=${r.blob_sha256} kind5=${r.kind5_id} completed_at=${r.completed_at}`);
+    }
+    if (candidates.length > 20) {
+      console.log(`[dry-run] ... and ${candidates.length - 20} more`);
+    }
+    return 0;
+  }
+
+  // Pre-flight (consumes the first candidate when there are any)
+  let preflightSuccess = null;
+  if (candidates.length > 0) {
+    try {
+      preflightSuccess = await runPreflight(candidates[0].blob_sha256, cfg, notify);
+    } catch (e) {
+      if (e instanceof PreflightAbort) {
+        console.error(`preflight aborted (${e.reason}): ${e.message}`);
+        return 2;
+      }
+      console.error(`preflight error: ${e.message}`);
+      return 2;
+    }
+  }
+
+  // Sweep remaining (skip the pre-flight row, then re-add it as a success)
+  let sweepResult = { successes: [], failures: [] };
+  if (candidates.length > 0) {
+    const remaining = candidates.slice(1);
+    sweepResult = await sweepCandidates(remaining, cfg, notify, async (shas) => {
+      await flushDeletedAt(shas, cfg, runner);
+    });
+    if (preflightSuccess) {
+      sweepResult.successes.unshift({ row: candidates[0], body: null });
+      await flushDeletedAt([candidates[0].blob_sha256], cfg, runner);
+      console.log(JSON.stringify({ ts: nowIso(), sha: candidates[0].blob_sha256, kind5: candidates[0].kind5_id, target: candidates[0].target_event_id, outcome: 'success', http: 200, physical_deleted: true, source: 'preflight' }));
+    }
+  }
+
+  // Surfacing queries
+  let unprocessable = [];
+  let permanentFailures = [];
+  try {
+    unprocessable = await fetchUnprocessable(cfg, runner);
+    permanentFailures = await fetchPermanentFailures(cfg, runner);
+  } catch (e) {
+    console.error(`surfacing query failed: ${e.message}`);
+  }
+
+  // Summary
+  const s = summarize({
+    candidates,
+    successes: sweepResult.successes,
+    failures: sweepResult.failures,
+    unprocessable,
+    permanentFailures
+  });
+  printSummary(s);
+  return computeExitCode(s);
+}

--- a/scripts/sweep-creator-deletes.mjs
+++ b/scripts/sweep-creator-deletes.mjs
@@ -6,7 +6,7 @@
 // ABOUTME: Reads creator_deletions from D1, asks Blossom to destroy bytes, stamps physical_deleted_at.
 
 const DEFAULT_BLOSSOM_WEBHOOK_URL = 'https://media.divine.video/admin/moderate';
-const DEFAULT_D1_DATABASE = 'divine-moderation-decisions-prod';
+const DEFAULT_D1_DATABASE = 'blossom-webhook-events';
 const DEFAULT_CONCURRENCY = 5;
 const FLUSH_BATCH_SIZE = 100;
 const SHA256_HEX = /^[0-9a-f]{64}$/;
@@ -47,6 +47,7 @@ function validateNonNegativeInt(value, fieldName) {
 
 export function parseArgs(argv) {
   const dryRun = getFlag(argv, 'dry-run') === true;
+  const local = getFlag(argv, 'local') === true;
   const since = validateIso(getFlag(argv, 'since') || null, 'since');
   const until = validateIso(getFlag(argv, 'until') || null, 'until');
 
@@ -61,7 +62,7 @@ export function parseArgs(argv) {
   const blossomWebhookUrl = getFlag(argv, 'blossom-webhook-url') || DEFAULT_BLOSSOM_WEBHOOK_URL;
   const d1Database = getFlag(argv, 'd1-database') || DEFAULT_D1_DATABASE;
 
-  return { dryRun, since, until, concurrency, limit, blossomWebhookUrl, d1Database };
+  return { dryRun, local, since, until, concurrency, limit, blossomWebhookUrl, d1Database };
 }
 
 export function validateSha256(s) {
@@ -209,7 +210,8 @@ export async function defaultRunner({ command, args }) {
 }
 
 async function runWranglerD1(cfg, sql, runner) {
-  const args = ['d1', 'execute', cfg.d1Database, '--remote', '--json', '--command', sql];
+  const remoteOrLocal = cfg.local ? '--local' : '--remote';
+  const args = ['d1', 'execute', cfg.d1Database, remoteOrLocal, '--json', '--command', sql];
   const r = await runner({ command: 'wrangler', args });
   if (r.status !== 0) {
     throw new Error(`wrangler d1 execute failed (exit ${r.status}): ${r.stderr.trim() || r.stdout.trim()}`);

--- a/scripts/sweep-creator-deletes.mjs
+++ b/scripts/sweep-creator-deletes.mjs
@@ -242,3 +242,32 @@ export async function flushDeletedAt(shas, cfg, runner = defaultRunner, timestam
   const sql = buildUpdateStampSql(shas, timestamp);
   await runWranglerD1(cfg, sql, runner);
 }
+
+export class PreflightAbort extends Error {
+  constructor(reason, message) {
+    super(message);
+    this.name = 'PreflightAbort';
+    this.reason = reason;
+  }
+}
+
+export async function runPreflight(sha256, cfg, notifyImpl = defaultNotify) {
+  const r = await callBlossomDelete(sha256, cfg, notifyImpl);
+  const c = classifyDeleteResult(r);
+  if (c.kind === 'success') return { kind: 'success' };
+  if (c.kind === 'flag-off') {
+    throw new PreflightAbort('flag-off',
+      'Blossom did not byte-delete because ENABLE_PHYSICAL_DELETE is off. ' +
+      'Flip the flag in Blossom config store before sweeping. No D1 writes occurred.');
+  }
+  if (c.kind === 'auth-failure') {
+    throw new PreflightAbort('auth-failure',
+      'Blossom rejected auth — check BLOSSOM_WEBHOOK_SECRET. No D1 writes occurred.');
+  }
+  if (c.kind === 'unreachable') {
+    throw new PreflightAbort('unreachable',
+      `Blossom unreachable: ${c.reason}. No D1 writes occurred.`);
+  }
+  throw new PreflightAbort('failure',
+    `Blossom returned a failure on the first candidate: ${c.reason}. No D1 writes occurred.`);
+}

--- a/scripts/sweep-creator-deletes.mjs
+++ b/scripts/sweep-creator-deletes.mjs
@@ -126,13 +126,14 @@ export function buildUpdateStampSql(shas, timestamp) {
   );
 }
 
-export async function runWithConcurrency(items, concurrency, fn) {
+export async function runWithConcurrency(items, concurrency, fn, drainCheck = null) {
   if (items.length === 0) return [];
   const results = new Array(items.length);
   let cursor = 0;
 
   async function worker() {
     while (true) {
+      if (drainCheck && drainCheck()) return;  // honor drain before pulling next item
       const i = cursor++;
       if (i >= items.length) return;
       const input = items[i];
@@ -150,7 +151,9 @@ export async function runWithConcurrency(items, concurrency, fn) {
     workers.push(worker());
   }
   await Promise.all(workers);
-  return results;
+  // Compact: drain leaves holes (unstarted items) in results. Filter them out
+  // so downstream code sees only items that actually ran.
+  return results.filter(r => r !== undefined);
 }
 
 import { notifyBlossom as defaultNotify } from '../src/blossom-client.mjs';
@@ -179,19 +182,32 @@ export async function callBlossomDelete(sha256, cfg, notifyImpl = defaultNotify)
 /**
  * Classifies a Blossom call result into the action the script should take.
  * Used by both pre-flight and per-row sweep logic.
+ *
+ * CONTRACT: this reads the wire shape emitted by divine-blossom at
+ * `src/admin.rs:923-930` and `src/main.rs:4795-4802` (as of 2026-04-18):
+ *   { success: true, sha256, old_status, new_status: "deleted",
+ *     physical_deleted: bool, physical_delete_skipped: bool }
+ *
+ * physical_delete_skipped === true means ENABLE_PHYSICAL_DELETE was OFF on
+ * Blossom (the negation is emitted server-side). For error cases Blossom
+ * returns non-2xx; a 2xx-with-success:false is not in the current contract.
+ *
+ * If Blossom's response shape changes, update this function and its tests
+ * in lockstep. The test fixtures are authored from this same contract and
+ * will not catch drift on their own.
  */
 export function classifyDeleteResult(r) {
   if (r.ok) {
     const b = r.body || {};
-    // flag-off is checked before status=error: in the unlikely case a Blossom
-    // response carries both, the flag-off signal is more actionable for the
-    // operator (flip the env var and re-run) than a generic error reason.
-    // Pre-flight aborts on flag-off before any sweep runs; the per-row sweep
-    // never sees flag-off because it would have aborted at pre-flight.
-    if (b.physical_delete_enabled === false) return { kind: 'flag-off' };
-    if (b.status === 'error') return { kind: 'failure', reason: b.error || 'blossom returned status=error' };
-    if (b.status === 'success' && b.physical_deleted === true) return { kind: 'success' };
-    return { kind: 'failure', reason: 'physical_deleted=false despite flag on' };
+    // flag-off checked first: the signal is more actionable for the operator
+    // ("turn the flag on and re-run") than a generic failure reason, and
+    // catching it mid-sweep lets us abort cleanly instead of silently logging
+    // per-row failures while bytes remain on GCS.
+    if (b.physical_delete_skipped === true) return { kind: 'flag-off' };
+    if (b.success === true && b.physical_deleted === true) return { kind: 'success' };
+    // 2xx with an unexpected body shape — treat as failure so the row stays
+    // unstamped and surfaces in the summary for manual investigation.
+    return { kind: 'failure', reason: `unexpected Blossom response: ${JSON.stringify(b).slice(0, 200)}` };
   }
   if (r.status === 401 || r.status === 403) return { kind: 'auth-failure' };
   if (r.networkError) return { kind: 'unreachable', reason: r.error || 'network error' };
@@ -305,6 +321,21 @@ export class D1WriteAbort extends Error {
 }
 
 /**
+ * Blossom returned physical_delete_skipped=true mid-sweep, meaning someone
+ * toggled ENABLE_PHYSICAL_DELETE off after pre-flight passed. Abort the whole
+ * sweep rather than log per-row failures while bytes remain on GCS. main()
+ * exits 2 (same code as pre-flight flag-off) so the operator's response is
+ * identical: flip the flag back on and re-run.
+ */
+export class MidRunFlagOff extends Error {
+  constructor(sha256) {
+    super(`Blossom reported physical_delete_skipped=true for ${sha256} mid-sweep — ENABLE_PHYSICAL_DELETE was toggled off.`);
+    this.name = 'MidRunFlagOff';
+    this.sha256 = sha256;
+  }
+}
+
+/**
  * Bulk sweep over candidates. Stamps via flushImpl in batches of FLUSH_BATCH_SIZE.
  * Per-row JSONL outcome lines are emitted to stdout for grep/jq.
  *
@@ -330,7 +361,7 @@ export async function sweepCandidates(candidates, cfg, notifyImpl = defaultNotif
 
   const results = await runWithConcurrency(candidates, cfg.concurrency, async (row) => {
     return callBlossomDelete(row.blob_sha256, cfg, notifyImpl);
-  });
+  }, isDraining);
 
   for (const r of results) {
     if (isDraining()) break;  // SIGINT: stop scheduling new work, flush pending, exit
@@ -348,6 +379,12 @@ export async function sweepCandidates(candidates, cfg, notifyImpl = defaultNotif
       if (pending.length >= FLUSH_BATCH_SIZE) {
         await flushOrAbort();
       }
+    } else if (c.kind === 'flag-off') {
+      // Config toggled off between pre-flight and now. Flush what we have
+      // and abort — do not keep calling Blossom and logging failures while
+      // bytes remain on GCS.
+      await flushOrAbort();
+      throw new MidRunFlagOff(row.blob_sha256);
     } else {
       failures.push({ row, error: c.reason || c.kind, status: r.value.status });
       emitJsonLine({ ts: nowIso(), sha: row.blob_sha256, kind5: row.kind5_id, target: row.target_event_id, outcome: 'failure', http: r.value.status, error: c.reason || c.kind });
@@ -497,6 +534,11 @@ export async function main(argv, deps = {}) {
         for (const sha of e.unflushedShas) console.error(`  ${sha}`);
         console.error('Re-run the sweep to stamp these rows (Blossom DELETE is idempotent).');
         return 4;
+      }
+      if (e instanceof MidRunFlagOff) {
+        console.error(`mid-run flag-off aborted sweep: ${e.message}`);
+        console.error('Re-enable ENABLE_PHYSICAL_DELETE on Blossom and re-run the sweep.');
+        return 2;
       }
       throw e;
     }

--- a/scripts/sweep-creator-deletes.mjs
+++ b/scripts/sweep-creator-deletes.mjs
@@ -271,3 +271,102 @@ export async function runPreflight(sha256, cfg, notifyImpl = defaultNotify) {
   throw new PreflightAbort('failure',
     `Blossom returned a failure on the first candidate: ${c.reason}. No D1 writes occurred.`);
 }
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function emitJsonLine(obj) {
+  console.log(JSON.stringify(obj));
+}
+
+/**
+ * Bulk sweep over candidates. Stamps via flushImpl in batches of FLUSH_BATCH_SIZE.
+ * Per-row JSONL outcome lines are emitted to stdout for grep/jq.
+ *
+ * Returns { successes, failures } as arrays of {row, body?, error?, status?}.
+ */
+export async function sweepCandidates(candidates, cfg, notifyImpl = defaultNotify, flushImpl = null) {
+  const successes = [];
+  const failures = [];
+  let pending = [];
+  const flush = flushImpl || (async (shas) => { await flushDeletedAt(shas, cfg); });
+
+  const results = await runWithConcurrency(candidates, cfg.concurrency, async (row) => {
+    return callBlossomDelete(row.blob_sha256, cfg, notifyImpl);
+  });
+
+  for (const r of results) {
+    const row = r.input;
+    if (r.error) {
+      failures.push({ row, error: r.error.message });
+      emitJsonLine({ ts: nowIso(), sha: row.blob_sha256, kind5: row.kind5_id, target: row.target_event_id, outcome: 'failure', error: r.error.message });
+      continue;
+    }
+    const c = classifyDeleteResult(r.value);
+    if (c.kind === 'success') {
+      successes.push({ row, body: r.value.body });
+      pending.push(row.blob_sha256);
+      emitJsonLine({ ts: nowIso(), sha: row.blob_sha256, kind5: row.kind5_id, target: row.target_event_id, outcome: 'success', http: r.value.status, physical_deleted: true });
+      if (pending.length >= FLUSH_BATCH_SIZE) {
+        await flush(pending);
+        pending = [];
+      }
+    } else {
+      failures.push({ row, error: c.reason || c.kind, status: r.value.status });
+      emitJsonLine({ ts: nowIso(), sha: row.blob_sha256, kind5: row.kind5_id, target: row.target_event_id, outcome: 'failure', http: r.value.status, error: c.reason || c.kind });
+    }
+  }
+
+  if (pending.length > 0) {
+    await flush(pending);
+  }
+  return { successes, failures };
+}
+
+export function summarize({ candidates, successes, failures, unprocessable, permanentFailures }) {
+  return {
+    total: candidates.length,
+    stamped: successes.length,
+    failed: failures.length,
+    unprocessableCount: unprocessable.length,
+    permanentFailureCount: permanentFailures.length,
+    successes,
+    failures,
+    unprocessable,
+    permanentFailures
+  };
+}
+
+export function computeExitCode(s) {
+  if (s.failed > 0 || s.unprocessableCount > 0 || s.permanentFailureCount > 0) return 1;
+  return 0;
+}
+
+export function printSummary(s) {
+  console.log('\n=== SUMMARY ===');
+  console.log(`Total candidates fetched:      ${s.total}`);
+  console.log(`Bytes destroyed + stamped:     ${s.stamped}`);
+  console.log(`Failed (will retry next run):  ${s.failed}`);
+  console.log(`Unprocessable (NULL sha256):   ${s.unprocessableCount}`);
+  console.log(`Permanent failures (manual):   ${s.permanentFailureCount}`);
+
+  if (s.failures.length > 0) {
+    console.log('\n=== FAILURES (will retry) ===');
+    for (const f of s.failures) {
+      console.log(`sha=${f.row.blob_sha256} http=${f.status ?? '-'} kind5=${f.row.kind5_id}: ${f.error}`);
+    }
+  }
+  if (s.unprocessable.length > 0) {
+    console.log('\n=== UNPROCESSABLE (creator intent unfulfilled, NULL sha256) ===');
+    for (const u of s.unprocessable) {
+      console.log(`kind5=${u.kind5_id} target=${u.target_event_id} creator=${u.creator_pubkey} completed_at=${u.completed_at}`);
+    }
+  }
+  if (s.permanentFailures.length > 0) {
+    console.log('\n=== PERMANENT FAILURES (creator intent unfulfilled, status=failed:permanent:*) ===');
+    for (const p of s.permanentFailures) {
+      console.log(`kind5=${p.kind5_id} target=${p.target_event_id} creator=${p.creator_pubkey} status=${p.status} last_error=${p.last_error}`);
+    }
+  }
+}

--- a/scripts/sweep-creator-deletes.mjs
+++ b/scripts/sweep-creator-deletes.mjs
@@ -192,3 +192,53 @@ export function classifyDeleteResult(r) {
   if (r.status >= 500) return { kind: 'unreachable', reason: `HTTP ${r.status}` };
   return { kind: 'failure', reason: r.error || `HTTP ${r.status}` };
 }
+
+/**
+ * Default runner used when the script runs as a CLI. Tests inject a fake.
+ * Uses spawnSync (args is an array, not a string — no shell interpretation).
+ *
+ * The node:child_process import is deferred via dynamic import() so the test
+ * runner (Cloudflare Workers pool) does not try to resolve it during module
+ * collection — Workers compat does not provide node:child_process even with
+ * nodejs_compat. Tests inject a fake runner and never reach this function.
+ */
+export async function defaultRunner({ command, args }) {
+  const { spawnSync } = await import('node:child_process');
+  const r = spawnSync(command, args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+  return { stdout: r.stdout || '', stderr: r.stderr || '', status: r.status ?? 0 };
+}
+
+async function runWranglerD1(cfg, sql, runner) {
+  const args = ['d1', 'execute', cfg.d1Database, '--remote', '--json', '--command', sql];
+  const r = await runner({ command: 'wrangler', args });
+  if (r.status !== 0) {
+    throw new Error(`wrangler d1 execute failed (exit ${r.status}): ${r.stderr.trim() || r.stdout.trim()}`);
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(r.stdout);
+  } catch (e) {
+    throw new Error(`failed to parse wrangler stdout as JSON: ${e.message}`);
+  }
+  if (!Array.isArray(parsed) || !parsed[0]) return [];
+  return parsed[0].results || [];
+}
+
+export async function fetchCandidates(cfg, runner = defaultRunner) {
+  const sql = buildSelectCandidatesSql({ since: cfg.since, until: cfg.until, limit: cfg.limit });
+  return runWranglerD1(cfg, sql, runner);
+}
+
+export async function fetchUnprocessable(cfg, runner = defaultRunner) {
+  return runWranglerD1(cfg, buildSelectUnprocessableSql(), runner);
+}
+
+export async function fetchPermanentFailures(cfg, runner = defaultRunner) {
+  return runWranglerD1(cfg, buildSelectPermanentFailuresSql(), runner);
+}
+
+export async function flushDeletedAt(shas, cfg, runner = defaultRunner, timestamp = new Date().toISOString()) {
+  if (!shas || shas.length === 0) return;
+  const sql = buildUpdateStampSql(shas, timestamp);
+  await runWranglerD1(cfg, sql, runner);
+}

--- a/scripts/sweep-creator-deletes.test.mjs
+++ b/scripts/sweep-creator-deletes.test.mjs
@@ -388,3 +388,66 @@ describe('flushDeletedAt', () => {
       .rejects.toThrow(/d1 unreachable/i);
   });
 });
+
+import { runPreflight, PreflightAbort } from './sweep-creator-deletes.mjs';
+
+describe('runPreflight', () => {
+  const SHA = 'd'.repeat(64);
+  const cfg = parseArgs([]);
+
+  it('returns success for the first row when Blossom returns physical_deleted=true', async () => {
+    const notify = makeFakeNotify(() => ({
+      success: true, status: 200,
+      result: { status: 'success', physical_delete_enabled: true, physical_deleted: true }
+    }));
+    const out = await runPreflight(SHA, cfg, notify);
+    expect(out).toEqual({ kind: 'success' });
+    expect(notify.calls.length).toBe(1);
+  });
+
+  it('throws PreflightAbort with reason="flag-off" when physical_delete_enabled is false', async () => {
+    const notify = makeFakeNotify(() => ({
+      success: true, status: 200,
+      result: { status: 'success', physical_delete_enabled: false, physical_deleted: false }
+    }));
+    await expect(runPreflight(SHA, cfg, notify)).rejects.toMatchObject({
+      name: 'PreflightAbort',
+      reason: 'flag-off'
+    });
+  });
+
+  it('throws PreflightAbort with reason="auth-failure" on 401', async () => {
+    const notify = makeFakeNotify(() => ({ success: false, status: 401, error: 'unauthorized' }));
+    await expect(runPreflight(SHA, cfg, notify)).rejects.toMatchObject({
+      name: 'PreflightAbort',
+      reason: 'auth-failure'
+    });
+  });
+
+  it('throws PreflightAbort with reason="unreachable" on 502', async () => {
+    const notify = makeFakeNotify(() => ({ success: false, status: 502, error: 'bad gateway' }));
+    await expect(runPreflight(SHA, cfg, notify)).rejects.toMatchObject({
+      name: 'PreflightAbort',
+      reason: 'unreachable'
+    });
+  });
+
+  it('throws PreflightAbort with reason="unreachable" on network error', async () => {
+    const notify = makeFakeNotify(() => ({ success: false, networkError: true, error: 'ECONNRESET' }));
+    await expect(runPreflight(SHA, cfg, notify)).rejects.toMatchObject({
+      name: 'PreflightAbort',
+      reason: 'unreachable'
+    });
+  });
+
+  it('throws PreflightAbort with reason="failure" when Blossom returns 200 status:error', async () => {
+    const notify = makeFakeNotify(() => ({
+      success: true, status: 200,
+      result: { status: 'error', error: 'gcs delete failed' }
+    }));
+    await expect(runPreflight(SHA, cfg, notify)).rejects.toMatchObject({
+      name: 'PreflightAbort',
+      reason: 'failure'
+    });
+  });
+});

--- a/scripts/sweep-creator-deletes.test.mjs
+++ b/scripts/sweep-creator-deletes.test.mjs
@@ -5,7 +5,17 @@
 // ABOUTME: Vitest runs under @cloudflare/vitest-pool-workers; nodejs_compat is on so node:child_process imports resolve.
 
 import { describe, it, expect } from 'vitest';
-import { parseArgs } from './sweep-creator-deletes.mjs';
+import {
+  parseArgs,
+  buildSelectCandidatesSql,
+  buildSelectUnprocessableSql,
+  buildSelectPermanentFailuresSql,
+  buildUpdateStampSql,
+  validateSha256
+} from './sweep-creator-deletes.mjs';
+
+const SHA_A = 'a'.repeat(64);
+const SHA_B = 'b'.repeat(64);
 
 describe('parseArgs', () => {
   it('returns defaults when no flags given', () => {
@@ -59,5 +69,87 @@ describe('parseArgs', () => {
     const cfg = parseArgs(['--blossom-webhook-url=http://localhost:7676/admin/moderate', '--d1-database=test-db']);
     expect(cfg.blossomWebhookUrl).toBe('http://localhost:7676/admin/moderate');
     expect(cfg.d1Database).toBe('test-db');
+  });
+});
+
+describe('validateSha256', () => {
+  it('accepts a 64-char lowercase hex string', () => {
+    expect(validateSha256(SHA_A)).toBe(SHA_A);
+  });
+  it('rejects uppercase', () => {
+    expect(() => validateSha256(SHA_A.toUpperCase())).toThrow(/sha256/i);
+  });
+  it('rejects shorter than 64', () => {
+    expect(() => validateSha256('a'.repeat(63))).toThrow(/sha256/i);
+  });
+  it('rejects non-hex characters', () => {
+    expect(() => validateSha256('z'.repeat(64))).toThrow(/sha256/i);
+  });
+  it('rejects null/undefined', () => {
+    expect(() => validateSha256(null)).toThrow(/sha256/i);
+    expect(() => validateSha256(undefined)).toThrow(/sha256/i);
+  });
+});
+
+describe('buildSelectCandidatesSql', () => {
+  it('builds the base select with no optional filters', () => {
+    const sql = buildSelectCandidatesSql({ since: null, until: null, limit: null });
+    expect(sql).toContain("WHERE status = 'success'");
+    expect(sql).toContain('AND physical_deleted_at IS NULL');
+    expect(sql).toContain('AND blob_sha256 IS NOT NULL');
+    expect(sql).not.toContain('completed_at >=');
+    expect(sql).not.toContain('completed_at <');
+    expect(sql).not.toContain('LIMIT');
+  });
+
+  it('includes since when provided', () => {
+    const sql = buildSelectCandidatesSql({ since: '2026-04-01T00:00:00.000Z', until: null, limit: null });
+    expect(sql).toContain("AND completed_at >= '2026-04-01T00:00:00.000Z'");
+  });
+
+  it('includes until when provided', () => {
+    const sql = buildSelectCandidatesSql({ since: null, until: '2026-04-17T00:00:00.000Z', limit: null });
+    expect(sql).toContain("AND completed_at < '2026-04-17T00:00:00.000Z'");
+  });
+
+  it('includes LIMIT when provided', () => {
+    const sql = buildSelectCandidatesSql({ since: null, until: null, limit: 50 });
+    expect(sql).toMatch(/LIMIT 50\b/);
+  });
+});
+
+describe('buildSelectUnprocessableSql', () => {
+  it('builds select for status=success rows with NULL sha', () => {
+    const sql = buildSelectUnprocessableSql();
+    expect(sql).toContain("WHERE status = 'success'");
+    expect(sql).toContain('AND blob_sha256 IS NULL');
+  });
+});
+
+describe('buildSelectPermanentFailuresSql', () => {
+  it('builds select for status LIKE failed:permanent:*', () => {
+    const sql = buildSelectPermanentFailuresSql();
+    expect(sql).toContain("WHERE status LIKE 'failed:permanent:%'");
+  });
+});
+
+describe('buildUpdateStampSql', () => {
+  it('builds an UPDATE with IN-list and NULL guard', () => {
+    const sql = buildUpdateStampSql([SHA_A, SHA_B], '2026-04-17T20:00:00.000Z');
+    expect(sql).toContain("SET physical_deleted_at = '2026-04-17T20:00:00.000Z'");
+    expect(sql).toContain(`WHERE blob_sha256 IN ('${SHA_A}', '${SHA_B}')`);
+    expect(sql).toContain('AND physical_deleted_at IS NULL');
+  });
+
+  it('rejects an empty sha list (caller bug)', () => {
+    expect(() => buildUpdateStampSql([], '2026-04-17T20:00:00.000Z')).toThrow(/empty/i);
+  });
+
+  it('rejects when any sha fails validation', () => {
+    expect(() => buildUpdateStampSql([SHA_A, 'not-hex'], '2026-04-17T20:00:00.000Z')).toThrow(/sha256/i);
+  });
+
+  it('rejects an invalid timestamp', () => {
+    expect(() => buildUpdateStampSql([SHA_A], 'not-iso')).toThrow(/timestamp/i);
   });
 });

--- a/scripts/sweep-creator-deletes.test.mjs
+++ b/scripts/sweep-creator-deletes.test.mjs
@@ -153,3 +153,45 @@ describe('buildUpdateStampSql', () => {
     expect(() => buildUpdateStampSql([SHA_A], 'not-iso')).toThrow(/timestamp/i);
   });
 });
+
+import { runWithConcurrency } from './sweep-creator-deletes.mjs';
+
+describe('runWithConcurrency', () => {
+  it('runs all items and returns one result per input', async () => {
+    const items = [1, 2, 3, 4, 5];
+    const results = await runWithConcurrency(items, 2, async x => x * 10);
+    expect(results.length).toBe(5);
+    expect(results.map(r => r.value).sort((a, b) => a - b)).toEqual([10, 20, 30, 40, 50]);
+  });
+
+  it('respects concurrency cap (never more than N in flight)', async () => {
+    let inFlight = 0;
+    let peak = 0;
+    const work = async () => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await new Promise(r => setTimeout(r, 5));
+      inFlight--;
+    };
+    await runWithConcurrency(new Array(20).fill(0), 3, work);
+    expect(peak).toBeLessThanOrEqual(3);
+  });
+
+  it('isolates per-item errors — one failure does not poison the rest', async () => {
+    const items = [1, 2, 3];
+    const results = await runWithConcurrency(items, 2, async x => {
+      if (x === 2) throw new Error('boom');
+      return x;
+    });
+    expect(results.length).toBe(3);
+    const byInput = Object.fromEntries(results.map(r => [r.input, r]));
+    expect(byInput[1].value).toBe(1);
+    expect(byInput[2].error.message).toBe('boom');
+    expect(byInput[3].value).toBe(3);
+  });
+
+  it('returns immediately on empty input', async () => {
+    const results = await runWithConcurrency([], 5, async () => { throw new Error('should not run'); });
+    expect(results).toEqual([]);
+  });
+});

--- a/scripts/sweep-creator-deletes.test.mjs
+++ b/scripts/sweep-creator-deletes.test.mjs
@@ -22,17 +22,22 @@ describe('parseArgs', () => {
     const cfg = parseArgs([]);
     expect(cfg).toEqual({
       dryRun: false,
+      local: false,
       since: null,
       until: null,
       concurrency: 5,
       limit: null,
       blossomWebhookUrl: 'https://media.divine.video/admin/moderate',
-      d1Database: 'divine-moderation-decisions-prod'
+      d1Database: 'blossom-webhook-events'
     });
   });
 
   it('parses --dry-run as boolean', () => {
     expect(parseArgs(['--dry-run']).dryRun).toBe(true);
+  });
+
+  it('parses --local as boolean', () => {
+    expect(parseArgs(['--local']).local).toBe(true);
   });
 
   it('parses --since and --until as ISO strings via Date round-trip', () => {
@@ -334,6 +339,13 @@ describe('fetchCandidates', () => {
     const runner = makeFakeRunner(() => ({ stdout: WRANGLER_RESULT_ENVELOPE([]), stderr: '', status: 0 }));
     const rows = await fetchCandidates(parseArgs([]), runner);
     expect(rows).toEqual([]);
+  });
+
+  it('passes --local to wrangler when cfg.local is true', async () => {
+    const runner = makeFakeRunner(() => ({ stdout: WRANGLER_RESULT_ENVELOPE([]), stderr: '', status: 0 }));
+    await fetchCandidates(parseArgs(['--local']), runner);
+    expect(runner.calls[0].args).toContain('--local');
+    expect(runner.calls[0].args).not.toContain('--remote');
   });
 
   it('throws when wrangler exits non-zero', async () => {

--- a/scripts/sweep-creator-deletes.test.mjs
+++ b/scripts/sweep-creator-deletes.test.mjs
@@ -590,6 +590,57 @@ describe('sweepCandidates', () => {
     await sweepCandidates(candidates, cfg, notify, flushImpl);
     expect(batches).toEqual([100, 100, 50]);
   });
+
+  it('preserves completed successes after SIGINT drain flips mid-run', async () => {
+    // Regression for Liz's #106 review: the previous code broke out of the
+    // result-consumption loop as soon as `isDraining()` returned true, so
+    // any successes that completed between the first SIGINT and the
+    // scheduler returning were dropped from `pending` and never flushed
+    // or summarized. The drain check now lives only in
+    // runWithConcurrency; the consumption loop must process everything
+    // the scheduler returns.
+    //
+    // This test simulates: 20 candidates, concurrency 1 (deterministic
+    // ordering), drain flipped ON after 5 complete. The scheduler
+    // returns 5 results (drain stops it from pulling items 6-20); all 5
+    // must land in successes and get flushed.
+    let completedCount = 0;
+    let draining = false;
+    const isDrainingImpl = () => draining;
+    const notify = makeFakeNotify(() => {
+      completedCount++;
+      // Flip the drain flag after 5 successful completions. The
+      // scheduler will stop dequeueing new items; the in-flight batch
+      // has already drained since concurrency=1.
+      if (completedCount === 5) draining = true;
+      return {
+        success: true,
+        status: 200,
+        result: { success: true, physical_deleted: true, physical_delete_skipped: false },
+      };
+    });
+    const flushed = [];
+    const flushImpl = async (shas) => { flushed.push(...shas); };
+    const candidates = Array.from({ length: 20 }, (_, i) =>
+      rowFor(i.toString(16).padStart(64, '0')),
+    );
+
+    const out = await sweepCandidates(
+      candidates,
+      parseArgs(['--concurrency=1']),
+      notify,
+      flushImpl,
+      isDrainingImpl,
+    );
+
+    // All 5 that completed before drain fully took effect must be
+    // preserved in the result and flushed.
+    expect(out.successes.length).toBe(5);
+    expect(out.failures.length).toBe(0);
+    expect(flushed.length).toBe(5);
+    // The remaining 15 candidates were never dequeued (drain stopped them).
+    expect(completedCount).toBe(5);
+  });
 });
 
 describe('summarize', () => {
@@ -623,6 +674,12 @@ describe('computeExitCode', () => {
   });
   it('returns 1 when permanent failures exist', () => {
     expect(computeExitCode({ failed: 0, unprocessableCount: 0, permanentFailureCount: 1 })).toBe(1);
+  });
+  it('returns 1 when the sweep was clean but the surfacing queries failed', () => {
+    // Regression for Liz's #106 review: a silent degradation to exit 0 when
+    // the final unprocessable/permanent-failure readback fails makes the run
+    // look fully successful while operator visibility is actually gone.
+    expect(computeExitCode({ failed: 0, unprocessableCount: 0, permanentFailureCount: 0, surfacingFailed: true })).toBe(1);
   });
 });
 
@@ -741,5 +798,34 @@ describe('main (integration)', () => {
     const runner = makeRunnerForResults({ candidates: [], unprocessable: [], permanentFailures: [] });
     const code = await main([], { runner, notify, blossomWebhookSecret: 'test-secret' });
     expect(code).toBe(0);
+  });
+
+  it('surfacing query failure: exits non-zero even when the sweep itself was clean', async () => {
+    // Regression for Liz's #106 review. The sweep succeeds on the sole
+    // candidate, but the final unprocessable/permanent-failure readback
+    // fails. Previously the code logged a warning and still returned 0
+    // (both lists were empty). Now it must exit non-zero so the run
+    // does not silently look fully successful when operator visibility
+    // into unprocessable / permanent-failure rows has been lost.
+    const notify = makeFakeNotify(() => ({ success: true, status: 200, result: okBody }));
+    const runner = async ({ args }) => {
+      const sql = args[args.indexOf('--command') + 1];
+      if (sql.startsWith('SELECT kind5_id, target_event_id, blob_sha256')) {
+        return { stdout: WRANGLER_RESULT_ENVELOPE([candidateRow]), stderr: '', status: 0 };
+      }
+      if (sql.includes('blob_sha256 IS NULL')) {
+        // Simulate a transient D1 failure on the unprocessable readback.
+        return { stdout: '', stderr: 'd1 surfacing query exploded', status: 1 };
+      }
+      if (sql.includes("'failed:permanent:%'")) {
+        return { stdout: WRANGLER_RESULT_ENVELOPE([]), stderr: '', status: 0 };
+      }
+      if (sql.startsWith('UPDATE creator_deletions')) {
+        return { stdout: WRANGLER_RESULT_ENVELOPE([]), stderr: '', status: 0 };
+      }
+      throw new Error(`unexpected sql: ${sql.slice(0, 80)}`);
+    };
+    const code = await main([], { runner, notify, blossomWebhookSecret: 'test-secret' });
+    expect(code).toBe(1);
   });
 });

--- a/scripts/sweep-creator-deletes.test.mjs
+++ b/scripts/sweep-creator-deletes.test.mjs
@@ -199,6 +199,29 @@ describe('runWithConcurrency', () => {
     const results = await runWithConcurrency([], 5, async () => { throw new Error('should not run'); });
     expect(results).toEqual([]);
   });
+
+  it('honors drainCheck — stops pulling new items once it returns true', async () => {
+    // 20 items, cap at 2, drain after 3 complete. Remaining items must not run.
+    const processed = [];
+    let drain = false;
+    const fn = async (x) => {
+      processed.push(x);
+      if (processed.length >= 3) drain = true;
+      return x;
+    };
+    const results = await runWithConcurrency(
+      Array.from({ length: 20 }, (_, i) => i),
+      2,
+      fn,
+      () => drain
+    );
+    // We don't know the exact count (concurrency race + post-flag workers finishing
+    // their current item), but it must be bounded well below 20 and the returned
+    // results should correspond to items that actually ran.
+    expect(processed.length).toBeLessThan(20);
+    expect(results.length).toBe(processed.length);
+    for (const r of results) expect(r.value).toBe(r.input);
+  });
 });
 
 import { callBlossomDelete, classifyDeleteResult } from './sweep-creator-deletes.mjs';
@@ -220,7 +243,7 @@ describe('callBlossomDelete', () => {
     const notify = makeFakeNotify(() => ({
       success: true,
       status: 200,
-      result: { status: 'success', physical_delete_enabled: true, physical_deleted: true }
+      result: { success: true, physical_deleted: true, physical_delete_skipped: false }
     }));
     const cfg = {
       blossomWebhookUrl: 'https://example/admin/moderate',
@@ -255,29 +278,35 @@ describe('classifyDeleteResult', () => {
   it('success when ok && body.status==="success" && body.physical_deleted===true', () => {
     expect(classifyDeleteResult({
       ok: true, status: 200,
-      body: { status: 'success', physical_delete_enabled: true, physical_deleted: true }
+      body: { success: true, physical_deleted: true, physical_delete_skipped: false }
     })).toEqual({ kind: 'success' });
   });
 
-  it('flag-off pre-flight signal when physical_delete_enabled===false', () => {
+  it('flag-off pre-flight signal when physical_delete_skipped===true', () => {
     expect(classifyDeleteResult({
       ok: true, status: 200,
-      body: { status: 'success', physical_delete_enabled: false, physical_deleted: false }
+      body: { success: true, physical_deleted: false, physical_delete_skipped: true }
     })).toEqual({ kind: 'flag-off' });
   });
 
-  it('failure when body.status==="error"', () => {
-    expect(classifyDeleteResult({
+  it('failure when 200 but physical_deleted===false (and flag was on)', () => {
+    // success:true but physical_deleted:false with skip:false means Blossom
+    // accepted the call but the byte-delete did not complete. Treat as failure.
+    const out = classifyDeleteResult({
       ok: true, status: 200,
-      body: { status: 'error', error: 'gcs delete failed' }
-    })).toEqual({ kind: 'failure', reason: 'gcs delete failed' });
+      body: { success: true, physical_deleted: false, physical_delete_skipped: false }
+    });
+    expect(out.kind).toBe('failure');
+    expect(out.reason).toMatch(/unexpected Blossom response/);
   });
 
-  it('failure when 200 but physical_deleted===false (and flag was on)', () => {
-    expect(classifyDeleteResult({
+  it('failure when 200 with an unexpected body shape', () => {
+    const out = classifyDeleteResult({
       ok: true, status: 200,
-      body: { status: 'success', physical_delete_enabled: true, physical_deleted: false }
-    })).toEqual({ kind: 'failure', reason: 'physical_deleted=false despite flag on' });
+      body: { success: false, error: 'gcs delete failed' }
+    });
+    expect(out.kind).toBe('failure');
+    expect(out.reason).toMatch(/unexpected Blossom response/);
   });
 
   it('auth-failure on 401/403', () => {
@@ -410,17 +439,17 @@ describe('runPreflight', () => {
   it('returns success for the first row when Blossom returns physical_deleted=true', async () => {
     const notify = makeFakeNotify(() => ({
       success: true, status: 200,
-      result: { status: 'success', physical_delete_enabled: true, physical_deleted: true }
+      result: { success: true, physical_deleted: true, physical_delete_skipped: false }
     }));
     const out = await runPreflight(SHA, cfg, notify);
     expect(out).toEqual({ kind: 'success' });
     expect(notify.calls.length).toBe(1);
   });
 
-  it('throws PreflightAbort with reason="flag-off" when physical_delete_enabled is false', async () => {
+  it('throws PreflightAbort with reason="flag-off" when physical_delete_skipped is true', async () => {
     const notify = makeFakeNotify(() => ({
       success: true, status: 200,
-      result: { status: 'success', physical_delete_enabled: false, physical_deleted: false }
+      result: { success: true, physical_deleted: false, physical_delete_skipped: true }
     }));
     await expect(runPreflight(SHA, cfg, notify)).rejects.toMatchObject({
       name: 'PreflightAbort',
@@ -452,10 +481,10 @@ describe('runPreflight', () => {
     });
   });
 
-  it('throws PreflightAbort with reason="failure" when Blossom returns 200 status:error', async () => {
+  it('throws PreflightAbort with reason="failure" when Blossom returns 200 with an unexpected body', async () => {
     const notify = makeFakeNotify(() => ({
       success: true, status: 200,
-      result: { status: 'error', error: 'gcs delete failed' }
+      result: { success: false, error: 'gcs delete failed' }
     }));
     await expect(runPreflight(SHA, cfg, notify)).rejects.toMatchObject({
       name: 'PreflightAbort',
@@ -464,14 +493,14 @@ describe('runPreflight', () => {
   });
 });
 
-import { sweepCandidates, summarize, computeExitCode, D1WriteAbort } from './sweep-creator-deletes.mjs';
+import { sweepCandidates, summarize, computeExitCode, D1WriteAbort, MidRunFlagOff } from './sweep-creator-deletes.mjs';
 
 describe('sweepCandidates', () => {
   const cfg = parseArgs(['--concurrency=2']);
   const rowFor = (sha) => ({ kind5_id: `k-${sha.slice(0,4)}`, target_event_id: `t-${sha.slice(0,4)}`, blob_sha256: sha, completed_at: '2026-04-15T00:00:00Z' });
 
   it('stamps shas where Blossom returned physical_deleted=true', async () => {
-    const okBody = { status: 'success', physical_delete_enabled: true, physical_deleted: true };
+    const okBody = { success: true, physical_deleted: true, physical_delete_skipped: false };
     const notify = makeFakeNotify(() => ({ success: true, status: 200, result: okBody }));
     const flushed = [];
     const flushImpl = async (shas) => { flushed.push(...shas); };
@@ -485,7 +514,7 @@ describe('sweepCandidates', () => {
   it('does NOT stamp shas when physical_deleted=false (even on HTTP 200)', async () => {
     const notify = makeFakeNotify(() => ({
       success: true, status: 200,
-      result: { status: 'success', physical_delete_enabled: true, physical_deleted: false }
+      result: { success: true, physical_deleted: false, physical_delete_skipped: false }
     }));
     const flushed = [];
     const flushImpl = async (shas) => { flushed.push(...shas); };
@@ -498,7 +527,7 @@ describe('sweepCandidates', () => {
   it('isolates per-row failures — successful rows still stamp', async () => {
     const notify = makeFakeNotify(({ sha256 }) => {
       if (sha256.startsWith('b')) return { success: false, status: 502, error: 'bad gateway' };
-      return { success: true, status: 200, result: { status: 'success', physical_delete_enabled: true, physical_deleted: true } };
+      return { success: true, status: 200, result: { success: true, physical_deleted: true, physical_delete_skipped: false } };
     });
     const flushed = [];
     const flushImpl = async (shas) => { flushed.push(...shas); };
@@ -509,8 +538,33 @@ describe('sweepCandidates', () => {
     expect(flushed.sort()).toEqual([candidates[0].blob_sha256, candidates[2].blob_sha256].sort());
   });
 
+  it('throws MidRunFlagOff when a row reports physical_delete_skipped=true mid-sweep', async () => {
+    // Simulates: operator toggles ENABLE_PHYSICAL_DELETE off between pre-flight
+    // and mid-sweep. First row succeeds; second row reports skip=true; sweep
+    // must abort loudly rather than silently log per-row failures.
+    const notify = makeFakeNotify(({ sha256 }) => {
+      if (sha256.startsWith('b')) {
+        return { success: true, status: 200, result: { success: true, physical_deleted: false, physical_delete_skipped: true } };
+      }
+      return { success: true, status: 200, result: { success: true, physical_deleted: true, physical_delete_skipped: false } };
+    });
+    const flushed = [];
+    const flushImpl = async (shas) => { flushed.push(...shas); };
+    const candidates = ['a','b','c'].map(c => rowFor(c.repeat(64)));
+    let caught;
+    try {
+      await sweepCandidates(candidates, parseArgs(['--concurrency=1']), notify, flushImpl);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(MidRunFlagOff);
+    // Pre-flag-off rows that succeeded must already be flushed (so bytes
+    // destroyed earlier are recorded as stamped).
+    expect(flushed).toContain(candidates[0].blob_sha256);
+  });
+
   it('throws D1WriteAbort with unflushed shas when flush fails mid-sweep', async () => {
-    const okBody = { status: 'success', physical_delete_enabled: true, physical_deleted: true };
+    const okBody = { success: true, physical_deleted: true, physical_delete_skipped: false };
     const notify = makeFakeNotify(() => ({ success: true, status: 200, result: okBody }));
     const flushImpl = async () => { throw new Error('d1 unreachable'); };
     const candidates = ['a','b','c'].map(c => rowFor(c.repeat(64)));
@@ -528,7 +582,7 @@ describe('sweepCandidates', () => {
   it('flushes in batches of FLUSH_BATCH_SIZE (default 100)', async () => {
     const notify = makeFakeNotify(() => ({
       success: true, status: 200,
-      result: { status: 'success', physical_delete_enabled: true, physical_deleted: true }
+      result: { success: true, physical_deleted: true, physical_delete_skipped: false }
     }));
     const batches = [];
     const flushImpl = async (shas) => { batches.push(shas.length); };
@@ -576,7 +630,7 @@ import { main } from './sweep-creator-deletes.mjs';
 
 describe('main (integration)', () => {
   const candidateRow = { kind5_id: 'k1', target_event_id: 't1', blob_sha256: 'a'.repeat(64), completed_at: '2026-04-15T00:00:00Z' };
-  const okBody = { status: 'success', physical_delete_enabled: true, physical_deleted: true };
+  const okBody = { success: true, physical_deleted: true, physical_delete_skipped: false };
 
   function makeRunnerForResults({ candidates = [], unprocessable = [], permanentFailures = [], updates = () => ({stdout: WRANGLER_RESULT_ENVELOPE([]), stderr: '', status: 0}) } = {}) {
     return async ({ command, args }) => {
@@ -613,7 +667,7 @@ describe('main (integration)', () => {
   it('pre-flight flag-off: aborts with exit 2 and zero D1 writes', async () => {
     const notify = makeFakeNotify(() => ({
       success: true, status: 200,
-      result: { status: 'success', physical_delete_enabled: false, physical_deleted: false }
+      result: { success: true, physical_deleted: false, physical_delete_skipped: true }
     }));
     let updateCalls = 0;
     const runner = makeRunnerForResults({

--- a/scripts/sweep-creator-deletes.test.mjs
+++ b/scripts/sweep-creator-deletes.test.mjs
@@ -464,7 +464,7 @@ describe('runPreflight', () => {
   });
 });
 
-import { sweepCandidates, summarize, computeExitCode } from './sweep-creator-deletes.mjs';
+import { sweepCandidates, summarize, computeExitCode, D1WriteAbort } from './sweep-creator-deletes.mjs';
 
 describe('sweepCandidates', () => {
   const cfg = parseArgs(['--concurrency=2']);
@@ -507,6 +507,22 @@ describe('sweepCandidates', () => {
     expect(out.successes.length).toBe(2);
     expect(out.failures.length).toBe(1);
     expect(flushed.sort()).toEqual([candidates[0].blob_sha256, candidates[2].blob_sha256].sort());
+  });
+
+  it('throws D1WriteAbort with unflushed shas when flush fails mid-sweep', async () => {
+    const okBody = { status: 'success', physical_delete_enabled: true, physical_deleted: true };
+    const notify = makeFakeNotify(() => ({ success: true, status: 200, result: okBody }));
+    const flushImpl = async () => { throw new Error('d1 unreachable'); };
+    const candidates = ['a','b','c'].map(c => rowFor(c.repeat(64)));
+    let caught;
+    try {
+      await sweepCandidates(candidates, cfg, notify, flushImpl);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(D1WriteAbort);
+    expect(caught.unflushedShas.sort()).toEqual(candidates.map(r => r.blob_sha256).sort());
+    expect(caught.originalError.message).toBe('d1 unreachable');
   });
 
   it('flushes in batches of FLUSH_BATCH_SIZE (default 100)', async () => {
@@ -645,6 +661,25 @@ describe('main (integration)', () => {
     const code = await main([], { runner, notify, blossomWebhookSecret: 'test-secret' });
     expect(notify.calls.length).toBe(0);
     expect(code).toBe(1);
+  });
+
+  it('D1 flush failure mid-sweep: exit 4', async () => {
+    const candidates = ['a', 'b'].map(c => ({ ...candidateRow, blob_sha256: c.repeat(64), kind5_id: `k-${c}`, target_event_id: `t-${c}` }));
+    const notify = makeFakeNotify(() => ({ success: true, status: 200, result: okBody }));
+    const runner = async ({ args }) => {
+      const sql = args[args.indexOf('--command') + 1];
+      if (sql.startsWith('SELECT kind5_id, target_event_id, blob_sha256')) {
+        return { stdout: WRANGLER_RESULT_ENVELOPE(candidates), stderr: '', status: 0 };
+      }
+      if (sql.includes('blob_sha256 IS NULL')) return { stdout: WRANGLER_RESULT_ENVELOPE([]), stderr: '', status: 0 };
+      if (sql.includes("'failed:permanent:%'")) return { stdout: WRANGLER_RESULT_ENVELOPE([]), stderr: '', status: 0 };
+      if (sql.startsWith('UPDATE creator_deletions')) {
+        return { stdout: '', stderr: 'd1 unreachable', status: 1 };
+      }
+      throw new Error(`unexpected sql: ${sql.slice(0, 80)}`);
+    };
+    const code = await main([], { runner, notify, blossomWebhookSecret: 'test-secret' });
+    expect(code).toBe(4);
   });
 
   it('empty everywhere: exit 0', async () => {

--- a/scripts/sweep-creator-deletes.test.mjs
+++ b/scripts/sweep-creator-deletes.test.mjs
@@ -543,3 +543,102 @@ describe('computeExitCode', () => {
     expect(computeExitCode({ failed: 0, unprocessableCount: 0, permanentFailureCount: 1 })).toBe(1);
   });
 });
+
+import { main } from './sweep-creator-deletes.mjs';
+
+describe('main (integration)', () => {
+  const candidateRow = { kind5_id: 'k1', target_event_id: 't1', blob_sha256: 'a'.repeat(64), completed_at: '2026-04-15T00:00:00Z' };
+  const okBody = { status: 'success', physical_delete_enabled: true, physical_deleted: true };
+
+  function makeRunnerForResults({ candidates = [], unprocessable = [], permanentFailures = [], updates = () => ({stdout: WRANGLER_RESULT_ENVELOPE([]), stderr: '', status: 0}) } = {}) {
+    return async ({ command, args }) => {
+      const sql = args[args.indexOf('--command') + 1];
+      if (sql.startsWith('SELECT kind5_id, target_event_id, blob_sha256')) {
+        return { stdout: WRANGLER_RESULT_ENVELOPE(candidates), stderr: '', status: 0 };
+      }
+      if (sql.includes('blob_sha256 IS NULL')) {
+        return { stdout: WRANGLER_RESULT_ENVELOPE(unprocessable), stderr: '', status: 0 };
+      }
+      if (sql.includes("'failed:permanent:%'")) {
+        return { stdout: WRANGLER_RESULT_ENVELOPE(permanentFailures), stderr: '', status: 0 };
+      }
+      if (sql.startsWith('UPDATE creator_deletions')) {
+        return updates(sql);
+      }
+      throw new Error(`unexpected sql: ${sql.slice(0, 80)}`);
+    };
+  }
+
+  it('dry-run: prints candidates, makes zero notify or D1-write calls', async () => {
+    const notify = makeFakeNotify(() => { throw new Error('should not be called in dry-run'); });
+    let updateCalls = 0;
+    const runner = makeRunnerForResults({
+      candidates: [candidateRow],
+      updates: () => { updateCalls++; return { stdout: WRANGLER_RESULT_ENVELOPE([]), stderr: '', status: 0 }; }
+    });
+    const code = await main(['--dry-run'], { runner, notify, blossomWebhookSecret: 'test-secret' });
+    expect(notify.calls.length).toBe(0);
+    expect(updateCalls).toBe(0);
+    expect(code).toBe(0);
+  });
+
+  it('pre-flight flag-off: aborts with exit 2 and zero D1 writes', async () => {
+    const notify = makeFakeNotify(() => ({
+      success: true, status: 200,
+      result: { status: 'success', physical_delete_enabled: false, physical_deleted: false }
+    }));
+    let updateCalls = 0;
+    const runner = makeRunnerForResults({
+      candidates: [candidateRow],
+      updates: () => { updateCalls++; return { stdout: WRANGLER_RESULT_ENVELOPE([]), stderr: '', status: 0 }; }
+    });
+    const code = await main([], { runner, notify, blossomWebhookSecret: 'test-secret' });
+    expect(notify.calls.length).toBe(1);
+    expect(updateCalls).toBe(0);
+    expect(code).toBe(2);
+  });
+
+  it('pre-flight 401: aborts with exit 2', async () => {
+    const notify = makeFakeNotify(() => ({ success: false, status: 401, error: 'unauthorized' }));
+    const runner = makeRunnerForResults({ candidates: [candidateRow] });
+    const code = await main([], { runner, notify, blossomWebhookSecret: 'test-secret' });
+    expect(code).toBe(2);
+  });
+
+  it('successful sweep: stamps all rows, exit 0', async () => {
+    const notify = makeFakeNotify(() => ({ success: true, status: 200, result: okBody }));
+    const runner = makeRunnerForResults({ candidates: [candidateRow] });
+    const code = await main([], { runner, notify, blossomWebhookSecret: 'test-secret' });
+    expect(code).toBe(0);
+  });
+
+  it('per-row failure: continues sweep, exit 1', async () => {
+    const candidates = ['a', 'b'].map(c => ({ ...candidateRow, blob_sha256: c.repeat(64), kind5_id: `k-${c}`, target_event_id: `t-${c}` }));
+    const notify = makeFakeNotify(({ sha256 }) => {
+      if (sha256.startsWith('b')) return { success: false, status: 502, error: 'bad gateway' };
+      return { success: true, status: 200, result: okBody };
+    });
+    const runner = makeRunnerForResults({ candidates });
+    const code = await main([], { runner, notify, blossomWebhookSecret: 'test-secret' });
+    expect(code).toBe(1);
+  });
+
+  it('empty-candidates short-circuit: still surfaces unprocessable + perm-failures', async () => {
+    const notify = makeFakeNotify(() => { throw new Error('should not be called'); });
+    const runner = makeRunnerForResults({
+      candidates: [],
+      unprocessable: [{ kind5_id: 'k1', target_event_id: 't1', creator_pubkey: 'pub1', completed_at: '2026-04-15T00:00:00Z' }],
+      permanentFailures: []
+    });
+    const code = await main([], { runner, notify, blossomWebhookSecret: 'test-secret' });
+    expect(notify.calls.length).toBe(0);
+    expect(code).toBe(1);
+  });
+
+  it('empty everywhere: exit 0', async () => {
+    const notify = makeFakeNotify(() => { throw new Error('should not be called'); });
+    const runner = makeRunnerForResults({ candidates: [], unprocessable: [], permanentFailures: [] });
+    const code = await main([], { runner, notify, blossomWebhookSecret: 'test-secret' });
+    expect(code).toBe(0);
+  });
+});

--- a/scripts/sweep-creator-deletes.test.mjs
+++ b/scripts/sweep-creator-deletes.test.mjs
@@ -288,3 +288,103 @@ describe('classifyDeleteResult', () => {
     expect(classifyDeleteResult({ ok: false, networkError: true, error: 'ECONNRESET' }).kind).toBe('unreachable');
   });
 });
+
+import {
+  fetchCandidates,
+  fetchUnprocessable,
+  fetchPermanentFailures,
+  flushDeletedAt
+} from './sweep-creator-deletes.mjs';
+
+function makeFakeRunner(responseFor) {
+  const calls = [];
+  const fn = async ({ command, args }) => {
+    calls.push({ command, args });
+    const sql = args[args.indexOf('--command') + 1];
+    return responseFor(sql);
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+const WRANGLER_RESULT_ENVELOPE = (rows) => JSON.stringify([{ results: rows, success: true, meta: {} }]);
+
+describe('fetchCandidates', () => {
+  it('shells wrangler with the right command, db, and SQL; parses results', async () => {
+    const runner = makeFakeRunner(() => ({
+      stdout: WRANGLER_RESULT_ENVELOPE([
+        { kind5_id: 'k1', target_event_id: 't1', blob_sha256: 'a'.repeat(64), completed_at: '2026-04-15T00:00:00Z' }
+      ]),
+      stderr: '',
+      status: 0
+    }));
+    const cfg = parseArgs([]);
+    const rows = await fetchCandidates(cfg, runner);
+    expect(runner.calls.length).toBe(1);
+    expect(runner.calls[0].command).toBe('wrangler');
+    expect(runner.calls[0].args.slice(0, 5)).toEqual(['d1', 'execute', cfg.d1Database, '--remote', '--json']);
+    expect(runner.calls[0].args[5]).toBe('--command');
+    expect(runner.calls[0].args[6]).toContain("WHERE status = 'success'");
+    expect(rows).toEqual([
+      { kind5_id: 'k1', target_event_id: 't1', blob_sha256: 'a'.repeat(64), completed_at: '2026-04-15T00:00:00Z' }
+    ]);
+  });
+
+  it('returns empty array when wrangler result envelope has zero rows', async () => {
+    const runner = makeFakeRunner(() => ({ stdout: WRANGLER_RESULT_ENVELOPE([]), stderr: '', status: 0 }));
+    const rows = await fetchCandidates(parseArgs([]), runner);
+    expect(rows).toEqual([]);
+  });
+
+  it('throws when wrangler exits non-zero', async () => {
+    const runner = makeFakeRunner(() => ({ stdout: '', stderr: 'auth required', status: 1 }));
+    await expect(fetchCandidates(parseArgs([]), runner)).rejects.toThrow(/auth required/i);
+  });
+
+  it('throws when wrangler stdout is not parseable JSON', async () => {
+    const runner = makeFakeRunner(() => ({ stdout: 'not json', stderr: '', status: 0 }));
+    await expect(fetchCandidates(parseArgs([]), runner)).rejects.toThrow(/parse/i);
+  });
+});
+
+describe('fetchUnprocessable', () => {
+  it('queries for status=success AND blob_sha256 IS NULL', async () => {
+    const runner = makeFakeRunner(() => ({ stdout: WRANGLER_RESULT_ENVELOPE([]), stderr: '', status: 0 }));
+    await fetchUnprocessable(parseArgs([]), runner);
+    const sql = runner.calls[0].args[runner.calls[0].args.indexOf('--command') + 1];
+    expect(sql).toContain('blob_sha256 IS NULL');
+  });
+});
+
+describe('fetchPermanentFailures', () => {
+  it("queries for status LIKE 'failed:permanent:%'", async () => {
+    const runner = makeFakeRunner(() => ({ stdout: WRANGLER_RESULT_ENVELOPE([]), stderr: '', status: 0 }));
+    await fetchPermanentFailures(parseArgs([]), runner);
+    const sql = runner.calls[0].args[runner.calls[0].args.indexOf('--command') + 1];
+    expect(sql).toContain("'failed:permanent:%'");
+  });
+});
+
+describe('flushDeletedAt', () => {
+  it('builds and runs UPDATE with the supplied shas + timestamp', async () => {
+    const runner = makeFakeRunner(() => ({ stdout: WRANGLER_RESULT_ENVELOPE([]), stderr: '', status: 0 }));
+    const ts = '2026-04-17T20:00:00.000Z';
+    await flushDeletedAt(['a'.repeat(64), 'b'.repeat(64)], parseArgs([]), runner, ts);
+    const sql = runner.calls[0].args[runner.calls[0].args.indexOf('--command') + 1];
+    expect(sql).toContain(`SET physical_deleted_at = '${ts}'`);
+    expect(sql).toContain(`'${'a'.repeat(64)}'`);
+    expect(sql).toContain(`'${'b'.repeat(64)}'`);
+  });
+
+  it('is a no-op on empty sha list', async () => {
+    const runner = makeFakeRunner(() => ({ stdout: WRANGLER_RESULT_ENVELOPE([]), stderr: '', status: 0 }));
+    await flushDeletedAt([], parseArgs([]), runner, '2026-04-17T20:00:00.000Z');
+    expect(runner.calls.length).toBe(0);
+  });
+
+  it('throws when wrangler exits non-zero', async () => {
+    const runner = makeFakeRunner(() => ({ stdout: '', stderr: 'd1 unreachable', status: 1 }));
+    await expect(flushDeletedAt(['a'.repeat(64)], parseArgs([]), runner, '2026-04-17T20:00:00.000Z'))
+      .rejects.toThrow(/d1 unreachable/i);
+  });
+});

--- a/scripts/sweep-creator-deletes.test.mjs
+++ b/scripts/sweep-creator-deletes.test.mjs
@@ -1,0 +1,63 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Tests for scripts/sweep-creator-deletes.mjs — pure helpers + main() with injected deps.
+// ABOUTME: Vitest runs under @cloudflare/vitest-pool-workers; nodejs_compat is on so node:child_process imports resolve.
+
+import { describe, it, expect } from 'vitest';
+import { parseArgs } from './sweep-creator-deletes.mjs';
+
+describe('parseArgs', () => {
+  it('returns defaults when no flags given', () => {
+    const cfg = parseArgs([]);
+    expect(cfg).toEqual({
+      dryRun: false,
+      since: null,
+      until: null,
+      concurrency: 5,
+      limit: null,
+      blossomWebhookUrl: 'https://media.divine.video/admin/moderate',
+      d1Database: 'divine-moderation-decisions-prod'
+    });
+  });
+
+  it('parses --dry-run as boolean', () => {
+    expect(parseArgs(['--dry-run']).dryRun).toBe(true);
+  });
+
+  it('parses --since and --until as ISO strings via Date round-trip', () => {
+    const cfg = parseArgs(['--since=2026-04-01T00:00:00.000Z', '--until=2026-04-17T00:00:00.000Z']);
+    expect(cfg.since).toBe('2026-04-01T00:00:00.000Z');
+    expect(cfg.until).toBe('2026-04-17T00:00:00.000Z');
+  });
+
+  it('rejects an unparseable --since', () => {
+    expect(() => parseArgs(['--since=not-a-date'])).toThrow(/since/i);
+  });
+
+  it('parses --concurrency as positive integer', () => {
+    expect(parseArgs(['--concurrency=10']).concurrency).toBe(10);
+  });
+
+  it('rejects --concurrency=0', () => {
+    expect(() => parseArgs(['--concurrency=0'])).toThrow(/concurrency/i);
+  });
+
+  it('rejects --concurrency=-1', () => {
+    expect(() => parseArgs(['--concurrency=-1'])).toThrow(/concurrency/i);
+  });
+
+  it('parses --limit as non-negative integer', () => {
+    expect(parseArgs(['--limit=100']).limit).toBe(100);
+  });
+
+  it('rejects --limit=foo', () => {
+    expect(() => parseArgs(['--limit=foo'])).toThrow(/limit/i);
+  });
+
+  it('parses --blossom-webhook-url and --d1-database overrides', () => {
+    const cfg = parseArgs(['--blossom-webhook-url=http://localhost:7676/admin/moderate', '--d1-database=test-db']);
+    expect(cfg.blossomWebhookUrl).toBe('http://localhost:7676/admin/moderate');
+    expect(cfg.d1Database).toBe('test-db');
+  });
+});

--- a/scripts/sweep-creator-deletes.test.mjs
+++ b/scripts/sweep-creator-deletes.test.mjs
@@ -451,3 +451,95 @@ describe('runPreflight', () => {
     });
   });
 });
+
+import { sweepCandidates, summarize, computeExitCode } from './sweep-creator-deletes.mjs';
+
+describe('sweepCandidates', () => {
+  const cfg = parseArgs(['--concurrency=2']);
+  const rowFor = (sha) => ({ kind5_id: `k-${sha.slice(0,4)}`, target_event_id: `t-${sha.slice(0,4)}`, blob_sha256: sha, completed_at: '2026-04-15T00:00:00Z' });
+
+  it('stamps shas where Blossom returned physical_deleted=true', async () => {
+    const okBody = { status: 'success', physical_delete_enabled: true, physical_deleted: true };
+    const notify = makeFakeNotify(() => ({ success: true, status: 200, result: okBody }));
+    const flushed = [];
+    const flushImpl = async (shas) => { flushed.push(...shas); };
+    const candidates = ['a','b','c'].map(c => rowFor(c.repeat(64)));
+    const out = await sweepCandidates(candidates, cfg, notify, flushImpl);
+    expect(out.successes.length).toBe(3);
+    expect(out.failures.length).toBe(0);
+    expect(flushed.sort()).toEqual(candidates.map(r => r.blob_sha256).sort());
+  });
+
+  it('does NOT stamp shas when physical_deleted=false (even on HTTP 200)', async () => {
+    const notify = makeFakeNotify(() => ({
+      success: true, status: 200,
+      result: { status: 'success', physical_delete_enabled: true, physical_deleted: false }
+    }));
+    const flushed = [];
+    const flushImpl = async (shas) => { flushed.push(...shas); };
+    const out = await sweepCandidates([rowFor('e'.repeat(64))], cfg, notify, flushImpl);
+    expect(out.successes.length).toBe(0);
+    expect(out.failures.length).toBe(1);
+    expect(flushed).toEqual([]);
+  });
+
+  it('isolates per-row failures — successful rows still stamp', async () => {
+    const notify = makeFakeNotify(({ sha256 }) => {
+      if (sha256.startsWith('b')) return { success: false, status: 502, error: 'bad gateway' };
+      return { success: true, status: 200, result: { status: 'success', physical_delete_enabled: true, physical_deleted: true } };
+    });
+    const flushed = [];
+    const flushImpl = async (shas) => { flushed.push(...shas); };
+    const candidates = ['a','b','c'].map(c => rowFor(c.repeat(64)));
+    const out = await sweepCandidates(candidates, cfg, notify, flushImpl);
+    expect(out.successes.length).toBe(2);
+    expect(out.failures.length).toBe(1);
+    expect(flushed.sort()).toEqual([candidates[0].blob_sha256, candidates[2].blob_sha256].sort());
+  });
+
+  it('flushes in batches of FLUSH_BATCH_SIZE (default 100)', async () => {
+    const notify = makeFakeNotify(() => ({
+      success: true, status: 200,
+      result: { status: 'success', physical_delete_enabled: true, physical_deleted: true }
+    }));
+    const batches = [];
+    const flushImpl = async (shas) => { batches.push(shas.length); };
+    const candidates = Array.from({ length: 250 }, (_, i) => rowFor(i.toString(16).padStart(64, '0')));
+    await sweepCandidates(candidates, cfg, notify, flushImpl);
+    expect(batches).toEqual([100, 100, 50]);
+  });
+});
+
+describe('summarize', () => {
+  it('aggregates counts and lists for printing', () => {
+    const result = summarize({
+      candidates: [{ blob_sha256: 'a'.repeat(64) }],
+      successes: [{ blob_sha256: 'a'.repeat(64) }],
+      failures: [],
+      unprocessable: [{ kind5_id: 'k1' }],
+      permanentFailures: []
+    });
+    expect(result).toMatchObject({
+      total: 1,
+      stamped: 1,
+      failed: 0,
+      unprocessableCount: 1,
+      permanentFailureCount: 0
+    });
+  });
+});
+
+describe('computeExitCode', () => {
+  it('returns 0 when nothing failed and no unprocessable / perm-failures', () => {
+    expect(computeExitCode({ failed: 0, unprocessableCount: 0, permanentFailureCount: 0 })).toBe(0);
+  });
+  it('returns 1 when failures exist', () => {
+    expect(computeExitCode({ failed: 1, unprocessableCount: 0, permanentFailureCount: 0 })).toBe(1);
+  });
+  it('returns 1 when unprocessable rows exist', () => {
+    expect(computeExitCode({ failed: 0, unprocessableCount: 1, permanentFailureCount: 0 })).toBe(1);
+  });
+  it('returns 1 when permanent failures exist', () => {
+    expect(computeExitCode({ failed: 0, unprocessableCount: 0, permanentFailureCount: 1 })).toBe(1);
+  });
+});

--- a/scripts/sweep-creator-deletes.test.mjs
+++ b/scripts/sweep-creator-deletes.test.mjs
@@ -195,3 +195,96 @@ describe('runWithConcurrency', () => {
     expect(results).toEqual([]);
   });
 });
+
+import { callBlossomDelete, classifyDeleteResult } from './sweep-creator-deletes.mjs';
+
+const SHA_C = 'c'.repeat(64);
+
+function makeFakeNotify(impl) {
+  const calls = [];
+  const fn = async (sha256, action, env) => {
+    calls.push({ sha256, action, env });
+    return impl({ sha256, action, env });
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+describe('callBlossomDelete', () => {
+  it('passes sha + DELETE + env to notifyBlossom and returns a normalized result', async () => {
+    const notify = makeFakeNotify(() => ({
+      success: true,
+      status: 200,
+      result: { status: 'success', physical_delete_enabled: true, physical_deleted: true }
+    }));
+    const cfg = {
+      blossomWebhookUrl: 'https://example/admin/moderate',
+      blossomWebhookSecret: 'secret-xyz'
+    };
+    const r = await callBlossomDelete(SHA_C, cfg, notify);
+    expect(notify.calls).toEqual([{
+      sha256: SHA_C,
+      action: 'DELETE',
+      env: { BLOSSOM_WEBHOOK_URL: cfg.blossomWebhookUrl, BLOSSOM_WEBHOOK_SECRET: cfg.blossomWebhookSecret }
+    }]);
+    expect(r.ok).toBe(true);
+    expect(r.body.physical_deleted).toBe(true);
+  });
+
+  it('surfaces network error from notifyBlossom', async () => {
+    const notify = makeFakeNotify(() => ({ success: false, networkError: true, error: 'ECONNRESET' }));
+    const r = await callBlossomDelete(SHA_C, { blossomWebhookUrl: 'u', blossomWebhookSecret: 's' }, notify);
+    expect(r.ok).toBe(false);
+    expect(r.networkError).toBe(true);
+  });
+
+  it('surfaces 5xx HTTP error', async () => {
+    const notify = makeFakeNotify(() => ({ success: false, error: 'HTTP 502: bad', status: 502 }));
+    const r = await callBlossomDelete(SHA_C, { blossomWebhookUrl: 'u', blossomWebhookSecret: 's' }, notify);
+    expect(r.ok).toBe(false);
+    expect(r.status).toBe(502);
+  });
+});
+
+describe('classifyDeleteResult', () => {
+  it('success when ok && body.status==="success" && body.physical_deleted===true', () => {
+    expect(classifyDeleteResult({
+      ok: true, status: 200,
+      body: { status: 'success', physical_delete_enabled: true, physical_deleted: true }
+    })).toEqual({ kind: 'success' });
+  });
+
+  it('flag-off pre-flight signal when physical_delete_enabled===false', () => {
+    expect(classifyDeleteResult({
+      ok: true, status: 200,
+      body: { status: 'success', physical_delete_enabled: false, physical_deleted: false }
+    })).toEqual({ kind: 'flag-off' });
+  });
+
+  it('failure when body.status==="error"', () => {
+    expect(classifyDeleteResult({
+      ok: true, status: 200,
+      body: { status: 'error', error: 'gcs delete failed' }
+    })).toEqual({ kind: 'failure', reason: 'gcs delete failed' });
+  });
+
+  it('failure when 200 but physical_deleted===false (and flag was on)', () => {
+    expect(classifyDeleteResult({
+      ok: true, status: 200,
+      body: { status: 'success', physical_delete_enabled: true, physical_deleted: false }
+    })).toEqual({ kind: 'failure', reason: 'physical_deleted=false despite flag on' });
+  });
+
+  it('auth-failure on 401/403', () => {
+    expect(classifyDeleteResult({ ok: false, status: 401 })).toEqual({ kind: 'auth-failure' });
+    expect(classifyDeleteResult({ ok: false, status: 403 })).toEqual({ kind: 'auth-failure' });
+  });
+
+  it('unreachable on 5xx', () => {
+    expect(classifyDeleteResult({ ok: false, status: 502 }).kind).toBe('unreachable');
+  });
+
+  it('unreachable on networkError', () => {
+    expect(classifyDeleteResult({ ok: false, networkError: true, error: 'ECONNRESET' }).kind).toBe('unreachable');
+  });
+});


### PR DESCRIPTION
Closes divinevideo/divine-blossom#90.

Spec: `docs/superpowers/specs/2026-04-17-creator-delete-validation-sweep-design.md`
Plan: `docs/superpowers/plans/2026-04-17-creator-delete-validation-sweep-plan.md`

## Summary

Operator-run script that backfills physical byte deletion for creator-delete kind 5 events whose Blossom soft-delete completed during the `ENABLE_PHYSICAL_DELETE=false` validation window.

- Migration 007 adds `physical_deleted_at TEXT` to `creator_deletions`.
- New script `scripts/sweep-creator-deletes.mjs`: reads candidates from D1, calls Blossom DELETE via the existing `notifyBlossom()` client (request shape identical to live pipeline), stamps the column on confirmed byte destruction.
- Pre-flight aborts (exit 2) if `ENABLE_PHYSICAL_DELETE` is off, auth fails, or Blossom is unreachable. Zero D1 writes in those cases.
- Strict success criterion: only stamps when Blossom returns `physical_deleted: true`. A 200 with `physical_deleted: false` is treated as failure (row stays unstamped, retried on next run).
- Surfaces unprocessable rows (status=success, NULL sha) and permanent failures (status=failed:permanent:*) in the summary so creator intent we cannot fulfill is loud, not silent.
- Per-row JSONL outcome lines on stdout for grep/jq.
- Best-effort SIGINT drain (first Ctrl-C drains in-flight + flushes; second Ctrl-C exits 130).
- `--local` flag swaps `--remote` for `--local` on wrangler calls so the same script runs against local D1 for smoke testing.

## Test plan

- [x] Unit + integration tests via vitest (72 new test cases; full suite 905 / 905)
- [x] Lint clean
- [x] Local smoke: migration applied to local D1, dry-run found a synthetic success row, exited 0
- [ ] Apply migration to prod D1 (operator step at rollout)
- [ ] Dry-run against prod D1 (operator step at rollout)
- [ ] First real sweep run (deferred to rollout — see `support-trust-safety/docs/rollout/2026-04-16-creator-delete-rollout.md`)

## Notes for reviewers

- The script reuses `src/blossom-client.mjs::notifyBlossom` to guarantee identical Blossom request shape to the live creator-delete pipeline. No new HTTP surface.
- `node:child_process` is imported dynamically inside `defaultRunner` so the Workers test pool (which does not provide that module even with `nodejs_compat`) does not fail on module collection.
- Output uses `console.log` rather than `process.stdout.write` for the same Workers-compat reason. Per-line behavior is unchanged.
- SQL is string-interpolated because `wrangler d1 execute --command` does not accept bind parameters. Inputs are validated before reaching the SQL builder: sha256 must be `/^[0-9a-f]{64}$/`, timestamps must round-trip through `new Date().toISOString()`, limits must be non-negative integers.