### PR TITLE
fix(nostr): drop invalid options-object arg from WebSocket constructor

### DIFF
--- a/src/nostr/dm-reader.mjs
+++ b/src/nostr/dm-reader.mjs
@@ -175,13 +175,14 @@ function fetchGiftWraps(relayUrl, filter, env) {
     }, 15000); // 15 second timeout for potentially many events
 
     try {
-      const headers = {};
-      if (env.CF_ACCESS_CLIENT_ID && env.CF_ACCESS_CLIENT_SECRET) {
-        headers['CF-Access-Client-Id'] = env.CF_ACCESS_CLIENT_ID;
-        headers['CF-Access-Client-Secret'] = env.CF_ACCESS_CLIENT_SECRET;
-      }
-
-      ws = new WebSocket(relayUrl, { headers });
+      // Cloudflare Workers' WebSocket constructor only accepts a subprotocol
+      // string/array as the second argument; passing an options object fails
+      // with "The protocol header token is invalid" and silently breaks the
+      // cron. relay.divine.video is a public Nostr relay that does not require
+      // CF Access, so we don't need to forward those headers here. If we ever
+      // point at a CF-Access-protected relay, switch to the fetch({ Upgrade })
+      // pattern and use the returned response.webSocket.
+      ws = new WebSocket(relayUrl);
       const subscriptionId = 'dm-sync-' + Math.random().toString(36).substring(7);
 
       ws.addEventListener('open', () => {

--- a/src/nostr/relay-client.mjs
+++ b/src/nostr/relay-client.mjs
@@ -37,14 +37,14 @@ async function queryRelay(relayUrl, filter, env = {}, options = {}) {
     }
 
     try {
-      // Build WebSocket URL with Cloudflare Access headers
-      const headers = {};
-      if (env.CF_ACCESS_CLIENT_ID && env.CF_ACCESS_CLIENT_SECRET) {
-        headers['CF-Access-Client-Id'] = env.CF_ACCESS_CLIENT_ID;
-        headers['CF-Access-Client-Secret'] = env.CF_ACCESS_CLIENT_SECRET;
-      }
-
-      ws = new WebSocket(relayUrl, { headers });
+      // Cloudflare Workers' WebSocket constructor only accepts a subprotocol
+      // string/array as the second argument; passing an options object fails
+      // with "The protocol header token is invalid" and silently breaks the
+      // cron. relay.divine.video is a public Nostr relay that does not require
+      // CF Access, so we don't need to forward those headers here. If we ever
+      // point at a CF-Access-protected relay, switch to the fetch({ Upgrade })
+      // pattern and use the returned response.webSocket.
+      ws = new WebSocket(relayUrl);
 
       ws.addEventListener('open', () => {
         subscriptionId = Math.random().toString(36).substring(7);


### PR DESCRIPTION
## Summary

- DM inbox sync cron has been failing silently every 5 minutes with `SyntaxError: WebSocket Constructor: The protocol header token is invalid.`
- Root cause: `new WebSocket(relayUrl, { headers })` in `src/nostr/dm-reader.mjs:184` and `src/nostr/relay-client.mjs:47`. Cloudflare Workers' WebSocket constructor (unlike Node's `ws` library) only accepts a subprotocol string/array as the second argument; passing an options object makes the runtime try to coerce it into a protocol name and fail.
- Working reference in the same service: `src/nostr/relay-poller.mjs` uses `new WebSocket(relayUrl)` with no second argument and runs fine against the same relay.

## Impact

Every kind-1059 gift wrap addressed to `moderation@divine.video` has been arriving on the relay but never fetched, decrypted, or logged. `dm_log` is empty across all time. `moderation.admin.divine.video/admin/messages` stays empty. This is why T&S has reported "unseen moderation actions" and moderation DMs/replies haven't been reachable from the admin inbox — the whole sync path has been dead.

## Fix

Drop the `{ headers }` argument and the associated CF Access header construction in both files. `relay.divine.video` is a public Nostr relay that doesn't require CF Access, so the headers weren't needed anyway. If we ever point at a CF-Access-protected relay in the future, we'd use `fetch({ Upgrade: 'websocket' })` and the returned `response.webSocket`, not the WebSocket constructor directly.

## Test plan

- [x] `npm test` — 909/909 pass, including `src/nostr/dm-reader.test.mjs` (4 tests) and `src/nostr/relay-client.test.mjs`.
- [x] Deployed to prod (edf237f0-e160-433b-ba2b-61c6cadb3977). Verification plan: `wrangler tail --search "DM-READER"` over the next 5-10 minutes should show `[DM-READER] Syncing inbox from ...` followed by `Fetched N gift wrap events` and `Sync complete: N new, ...` rather than the prior error. First run will backfill up to 7 days of gift wraps per the existing lookback.
- [ ] Confirm `dm_log` has rows after the next cron cycle and `moderation.admin.divine.video/admin/messages` renders conversations.

## Notes

- Deploying from this branch before merge so the broken cron stops failing immediately. PR is for review and eventual merge to main.
- Related: the same fix pattern applies to `relay-client.mjs` which is called by the creator-delete cron (feature-flag gated). Fixing it now prevents the same failure mode when that flag flips on.