### PR TITLE
fix(admin+nostr): make moderation messages UI actually work (7 bundled fixes)

### DIFF
--- a/src/admin/messages.html
+++ b/src/admin/messages.html
@@ -507,10 +507,24 @@
       return hex.slice(0, 8) + '...' + hex.slice(-8);
     }
 
+    // SQLite's CURRENT_TIMESTAMP default writes "YYYY-MM-DD HH:MM:SS" in UTC
+    // with no timezone marker. Chrome parses that ambiguous format as local
+    // time, which flips recent rows into the future and makes relativeTime
+    // clamp to "just now" forever. Treat any SQLite-shaped string as UTC.
+    function parseTimestamp(ts) {
+      if (!ts) return NaN;
+      if (typeof ts === 'number') return ts * 1000;
+      if (typeof ts !== 'string') return new Date(ts).getTime();
+      // Already has explicit timezone (Z, +00:00, -05:00, etc.) — trust it.
+      if (/[zZ]$|[+-]\d{2}:?\d{2}$/.test(ts)) return new Date(ts).getTime();
+      // SQLite style: "YYYY-MM-DD HH:MM:SS" — force UTC interpretation.
+      return new Date(ts.replace(' ', 'T') + 'Z').getTime();
+    }
+
     function relativeTime(ts) {
-      if (!ts) return '';
+      const date = parseTimestamp(ts);
+      if (!Number.isFinite(date)) return '';
       const now = Date.now();
-      const date = typeof ts === 'number' ? ts * 1000 : new Date(ts).getTime();
       const diff = Math.max(0, now - date);
       const seconds = Math.floor(diff / 1000);
       if (seconds < 60) return 'just now';

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -2949,7 +2949,13 @@ async function runMigration() {
       const limit = parseInt(url.searchParams.get('limit') || '20');
       const offset = parseInt(url.searchParams.get('offset') || '0');
       const { getConversations } = await import('./nostr/dm-store.mjs');
-      const conversations = await getConversations(env.BLOSSOM_DB, { limit, offset });
+      const { getModeratorPubkey } = await import('./nostr/dm-reader.mjs');
+      // Pass moderatorPubkey so rows are augmented with participant_pubkey
+      // (the non-moderator side) + latest_message/message_type aliases that
+      // the admin messages UI expects. Without this, every conversation
+      // renders as "(unknown)" because the raw column names don't match.
+      const moderatorPubkey = env.NOSTR_PRIVATE_KEY ? getModeratorPubkey(env) : undefined;
+      const conversations = await getConversations(env.BLOSSOM_DB, { limit, offset, moderatorPubkey });
       return new Response(JSON.stringify(conversations), { headers: { 'Content-Type': 'application/json' } });
     }
 

--- a/src/nostr/dm-reader.mjs
+++ b/src/nostr/dm-reader.mjs
@@ -175,13 +175,14 @@ function fetchGiftWraps(relayUrl, filter, env) {
     }, 15000); // 15 second timeout for potentially many events
 
     try {
-      const headers = {};
-      if (env.CF_ACCESS_CLIENT_ID && env.CF_ACCESS_CLIENT_SECRET) {
-        headers['CF-Access-Client-Id'] = env.CF_ACCESS_CLIENT_ID;
-        headers['CF-Access-Client-Secret'] = env.CF_ACCESS_CLIENT_SECRET;
-      }
-
-      ws = new WebSocket(relayUrl, { headers });
+      // Cloudflare Workers' WebSocket constructor only accepts a subprotocol
+      // string/array as the second argument; passing an options object fails
+      // with "The protocol header token is invalid" and silently breaks the
+      // cron. relay.divine.video is a public Nostr relay that does not require
+      // CF Access, so we don't need to forward those headers here. If we ever
+      // point at a CF-Access-protected relay, switch to the fetch({ Upgrade })
+      // pattern and use the returned response.webSocket.
+      ws = new WebSocket(relayUrl);
       const subscriptionId = 'dm-sync-' + Math.random().toString(36).substring(7);
 
       ws.addEventListener('open', () => {

--- a/src/nostr/dm-reader.mjs
+++ b/src/nostr/dm-reader.mjs
@@ -89,8 +89,36 @@ export async function syncInbox(env) {
       const content = rumor.content;
       const createdAt = rumor.created_at;
 
-      // Compute conversation ID
-      const conversationId = computeConversationId(moderatorPubkey, senderPubkey);
+      // NIP-17 gift wraps reach the moderator's inbox in two shapes:
+      //   1. Inbound: someone writes to moderator. rumor.pubkey = them,
+      //      rumor's ['p'] tag = moderator.
+      //   2. Outbound self-copy: moderator writes to someone else, client
+      //      also wraps a copy addressed to moderator so sent messages
+      //      aren't lost. rumor.pubkey = moderator, rumor's ['p'] tag =
+      //      real recipient.
+      // Without handling (2), outgoing replies get stored with
+      // sender = recipient = moderator, which produces a separate
+      // conversation_id (moderator+moderator) and breaks threading.
+      const isOutgoing = senderPubkey === moderatorPubkey;
+      let counterpartyPubkey = null;
+      if (isOutgoing) {
+        // Find the real recipient in rumor tags: first 'p' tag whose value
+        // is not the moderator itself. Fall back to moderator if nothing
+        // else is tagged (should not happen in a valid kind-14 rumor).
+        const pTags = Array.isArray(rumor.tags)
+          ? rumor.tags.filter((t) => Array.isArray(t) && t[0] === 'p' && t[1])
+          : [];
+        const other = pTags.find((t) => t[1] !== moderatorPubkey);
+        counterpartyPubkey = other ? other[1] : moderatorPubkey;
+      } else {
+        counterpartyPubkey = senderPubkey;
+      }
+
+      const recipientPubkey = isOutgoing ? counterpartyPubkey : moderatorPubkey;
+      const direction = isOutgoing ? 'outgoing' : 'incoming';
+      // Compute conversation ID against the non-moderator side so inbound
+      // and outbound messages in the same thread share a conversation_id.
+      const conversationId = computeConversationId(moderatorPubkey, counterpartyPubkey);
 
       // Check if this is a structured conversation_report
       let relatedSha256 = null;
@@ -99,8 +127,10 @@ export async function syncInbox(env) {
         if (parsed && parsed.type === 'conversation_report' && parsed.sha256) {
           relatedSha256 = parsed.sha256;
 
-          // Also create entry in user_reports table if available
-          if (env.BLOSSOM_DB) {
+          // Also create entry in user_reports table if available.
+          // Skip for outgoing self-copies: the reporter is the counterparty,
+          // not the moderator (who is echoing their own sent message).
+          if (env.BLOSSOM_DB && !isOutgoing) {
             try {
               await env.BLOSSOM_DB.prepare(`
                 INSERT OR IGNORE INTO user_reports
@@ -123,14 +153,17 @@ export async function syncInbox(env) {
       }
 
       // Log to dm_log (dedup by nostr_event_id)
+      const messageType = relatedSha256
+        ? 'conversation_report'
+        : (isOutgoing ? 'moderator_reply' : 'creator_reply');
       const result = await logDm(env.BLOSSOM_DB, {
         conversationId,
         nostrEventId: giftWrap.id,
         senderPubkey,
-        recipientPubkey: moderatorPubkey,
+        recipientPubkey,
         content,
-        direction: 'incoming',
-        messageType: relatedSha256 ? 'conversation_report' : 'creator_reply',
+        direction,
+        messageType,
         sha256: relatedSha256
       });
 

--- a/src/nostr/dm-reader.mjs
+++ b/src/nostr/dm-reader.mjs
@@ -103,13 +103,22 @@ export async function syncInbox(env) {
       let counterpartyPubkey = null;
       if (isOutgoing) {
         // Find the real recipient in rumor tags: first 'p' tag whose value
-        // is not the moderator itself. Fall back to moderator if nothing
-        // else is tagged (should not happen in a valid kind-14 rumor).
+        // is not the moderator itself. A valid NIP-17 outgoing rumor must
+        // have one; if it doesn't, the gift wrap is malformed and we can't
+        // thread it correctly. Skip rather than store as a self-conversation
+        // that would later disappear from the admin UI.
         const pTags = Array.isArray(rumor.tags)
           ? rumor.tags.filter((t) => Array.isArray(t) && t[0] === 'p' && t[1])
           : [];
         const other = pTags.find((t) => t[1] !== moderatorPubkey);
-        counterpartyPubkey = other ? other[1] : moderatorPubkey;
+        if (!other) {
+          console.warn(
+            `[DM-READER] Outgoing rumor has no non-moderator 'p' tag; skipping event ${giftWrap.id}. rumor.tags=${JSON.stringify(rumor.tags || [])}`
+          );
+          errors++;
+          continue;
+        }
+        counterpartyPubkey = other[1];
       } else {
         counterpartyPubkey = senderPubkey;
       }

--- a/src/nostr/dm-store.mjs
+++ b/src/nostr/dm-store.mjs
@@ -44,7 +44,7 @@ export async function logDm(db, { conversationId, sha256, direction, senderPubke
   return { id: result.meta.last_row_id };
 }
 
-export async function getConversations(db, { limit = 20, offset = 0 } = {}) {
+export async function getConversations(db, { limit = 20, offset = 0, moderatorPubkey } = {}) {
   const rows = await db.prepare(`
     SELECT
       conversation_id,
@@ -62,7 +62,21 @@ export async function getConversations(db, { limit = 20, offset = 0 } = {}) {
     ORDER BY last_message_at DESC
     LIMIT ? OFFSET ?
   `).bind(limit, offset).all();
-  return rows.results || [];
+  const results = rows.results || [];
+
+  // The admin messages UI expects participant_pubkey (the other side of the
+  // conversation, not the moderator) plus latest_message / message_type
+  // aliases. We add those without removing the original columns so existing
+  // callers keep working.
+  if (!moderatorPubkey) return results;
+
+  return results.map((row) => ({
+    ...row,
+    participant_pubkey:
+      row.sender_pubkey === moderatorPubkey ? row.recipient_pubkey : row.sender_pubkey,
+    latest_message: row.last_message,
+    message_type: row.last_message_type,
+  }));
 }
 
 export async function getConversation(db, conversationId) {

--- a/src/nostr/dm-store.mjs
+++ b/src/nostr/dm-store.mjs
@@ -45,18 +45,27 @@ export async function logDm(db, { conversationId, sha256, direction, senderPubke
 }
 
 export async function getConversations(db, { limit = 20, offset = 0, moderatorPubkey } = {}) {
+  // An earlier revision of this query put MAX()/COUNT() in the outer SELECT
+  // without a GROUP BY, which SQLite collapses into a single aggregated row
+  // across the whole filtered set. That made every multi-conversation inbox
+  // render as exactly one sidebar item regardless of how many conversations
+  // actually existed. The subquery already picks the latest id per
+  // conversation, so we select those rows directly and compute
+  // message_count per conversation via a correlated subquery (bounded by
+  // LIMIT).
   const rows = await db.prepare(`
     SELECT
-      conversation_id,
-      MAX(created_at) as last_message_at,
-      COUNT(*) as message_count,
-      sender_pubkey,
-      recipient_pubkey,
-      content as last_message,
-      sha256 as last_sha256,
-      message_type as last_message_type
-    FROM dm_log
-    WHERE id IN (
+      dl.conversation_id,
+      dl.created_at as last_message_at,
+      dl.sender_pubkey,
+      dl.recipient_pubkey,
+      dl.direction as last_direction,
+      dl.content as last_message,
+      dl.sha256 as last_sha256,
+      dl.message_type as last_message_type,
+      (SELECT COUNT(*) FROM dm_log WHERE conversation_id = dl.conversation_id) as message_count
+    FROM dm_log dl
+    WHERE dl.id IN (
       SELECT MAX(id) FROM dm_log GROUP BY conversation_id
     )
     ORDER BY last_message_at DESC

--- a/src/nostr/dm-store.test.mjs
+++ b/src/nostr/dm-store.test.mjs
@@ -5,7 +5,8 @@
 // ABOUTME: Verifies D1-backed message logging, dedup, and conversation queries
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { computeConversationId, logDm, getConversations, getConversation, getConversationByPubkey } from './dm-store.mjs';
+import { env } from 'cloudflare:test';
+import { computeConversationId, logDm, getConversations, getConversation, getConversationByPubkey, initDmLogTable } from './dm-store.mjs';
 
 /**
  * Create a mock D1 database that tracks calls and stores data in-memory
@@ -327,6 +328,140 @@ describe('DM Store - getConversation', () => {
 
     const messages = await getConversation(emptyDb, 'nonexistent');
     expect(messages).toEqual([]);
+  });
+});
+
+// Regression suite against the real D1 (SQLite) runtime. The mocked
+// describe-blocks above fabricate getConversations() results, which would
+// not have caught the implicit-aggregate collapse bug: the outer SELECT
+// mixed MAX()/COUNT() with bare columns and no GROUP BY, so SQLite
+// collapsed the whole filtered set into a single row. Any inbox with N>1
+// conversations rendered as exactly one sidebar entry.
+describe('DM Store - getConversations against real D1', () => {
+  const db = env.BLOSSOM_DB;
+
+  const MODERATOR = 'f'.repeat(64);
+  const CREATOR_A = ('a'.repeat(63) + '1').slice(0, 64);
+  const CREATOR_B = ('a'.repeat(63) + '2').slice(0, 64);
+  const CREATOR_C = ('a'.repeat(63) + '3').slice(0, 64);
+
+  beforeEach(async () => {
+    await initDmLogTable(db);
+    await db.prepare('DELETE FROM dm_log').run();
+  });
+
+  it('returns one row per conversation, not one aggregated row across the inbox', async () => {
+    // 3 rows across 2 conversations ⇒ 2 conversations returned.
+    const convA = computeConversationId(MODERATOR, CREATOR_A);
+    const convB = computeConversationId(MODERATOR, CREATOR_B);
+
+    await logDm(db, {
+      conversationId: convA,
+      direction: 'incoming',
+      senderPubkey: CREATOR_A,
+      recipientPubkey: MODERATOR,
+      content: 'creator A says hi',
+      nostrEventId: 'evt-a-1',
+    });
+    await logDm(db, {
+      conversationId: convA,
+      direction: 'outgoing',
+      senderPubkey: MODERATOR,
+      recipientPubkey: CREATOR_A,
+      messageType: 'moderator_reply',
+      content: 'moderator replies to A',
+      nostrEventId: 'evt-a-2',
+    });
+    await logDm(db, {
+      conversationId: convB,
+      direction: 'incoming',
+      senderPubkey: CREATOR_B,
+      recipientPubkey: MODERATOR,
+      content: 'creator B says hi',
+      nostrEventId: 'evt-b-1',
+    });
+
+    const conversations = await getConversations(db, { limit: 20, offset: 0 });
+
+    expect(conversations).toHaveLength(2);
+
+    const ids = new Set(conversations.map(c => c.conversation_id));
+    expect(ids).toEqual(new Set([convA, convB]));
+
+    // Per-conversation message_count must be independent (2 for A, 1 for B).
+    const counts = Object.fromEntries(
+      conversations.map(c => [c.conversation_id, c.message_count]),
+    );
+    expect(counts[convA]).toBe(2);
+    expect(counts[convB]).toBe(1);
+  });
+
+  it('last_message for each conversation reflects its own most recent row', async () => {
+    const convA = computeConversationId(MODERATOR, CREATOR_A);
+    const convB = computeConversationId(MODERATOR, CREATOR_B);
+
+    await logDm(db, {
+      conversationId: convA,
+      direction: 'incoming',
+      senderPubkey: CREATOR_A,
+      recipientPubkey: MODERATOR,
+      content: 'first A message',
+      nostrEventId: 'evt-a-1',
+    });
+    await logDm(db, {
+      conversationId: convB,
+      direction: 'incoming',
+      senderPubkey: CREATOR_B,
+      recipientPubkey: MODERATOR,
+      content: 'only B message',
+      nostrEventId: 'evt-b-1',
+    });
+    await logDm(db, {
+      conversationId: convA,
+      direction: 'outgoing',
+      senderPubkey: MODERATOR,
+      recipientPubkey: CREATOR_A,
+      messageType: 'moderator_reply',
+      content: 'latest A message',
+      nostrEventId: 'evt-a-2',
+    });
+
+    const conversations = await getConversations(db, { limit: 20, offset: 0 });
+
+    expect(conversations).toHaveLength(2);
+    const byConv = Object.fromEntries(conversations.map(c => [c.conversation_id, c]));
+    expect(byConv[convA].last_message).toBe('latest A message');
+    expect(byConv[convB].last_message).toBe('only B message');
+  });
+
+  it('respects limit and offset', async () => {
+    for (const [creator, eventId, content] of [
+      [CREATOR_A, 'evt-a', 'from A'],
+      [CREATOR_B, 'evt-b', 'from B'],
+      [CREATOR_C, 'evt-c', 'from C'],
+    ]) {
+      await logDm(db, {
+        conversationId: computeConversationId(MODERATOR, creator),
+        direction: 'incoming',
+        senderPubkey: creator,
+        recipientPubkey: MODERATOR,
+        content,
+        nostrEventId: eventId,
+      });
+      // Stagger so created_at orders deterministically.
+      await new Promise(r => setTimeout(r, 15));
+    }
+
+    const page1 = await getConversations(db, { limit: 2, offset: 0 });
+    expect(page1).toHaveLength(2);
+
+    const page2 = await getConversations(db, { limit: 2, offset: 2 });
+    expect(page2).toHaveLength(1);
+  });
+
+  it('returns an empty array when dm_log is empty', async () => {
+    const conversations = await getConversations(db, { limit: 20, offset: 0 });
+    expect(conversations).toEqual([]);
   });
 });
 

--- a/src/nostr/dm-store.test.mjs
+++ b/src/nostr/dm-store.test.mjs
@@ -237,6 +237,47 @@ describe('DM Store - getConversations', () => {
     const conversations = await getConversations(emptyDb);
     expect(conversations).toEqual([]);
   });
+
+  it('augments rows with participant_pubkey, latest_message, message_type when moderatorPubkey is provided', async () => {
+    const moderator = '8'.repeat(64);
+    const userA = 'a'.repeat(64);
+    const userB = 'b'.repeat(64);
+
+    // Incoming: user -> moderator. participant should be the user.
+    await logDm(mockDb, {
+      conversationId: 'conv_in',
+      direction: 'incoming',
+      senderPubkey: userA,
+      recipientPubkey: moderator,
+      messageType: 'conversation_report',
+      content: 'Report from user A'
+    });
+
+    // Outgoing: moderator -> user. participant should still be the user.
+    await logDm(mockDb, {
+      conversationId: 'conv_out',
+      direction: 'outgoing',
+      senderPubkey: moderator,
+      recipientPubkey: userB,
+      messageType: 'moderator_reply',
+      content: 'Reply to user B'
+    });
+
+    const conversations = await getConversations(mockDb, { moderatorPubkey: moderator });
+
+    expect(conversations).toHaveLength(2);
+    for (const conv of conversations) {
+      // New fields the admin UI expects
+      expect(conv).toHaveProperty('participant_pubkey');
+      expect(conv).toHaveProperty('latest_message');
+      expect(conv).toHaveProperty('message_type');
+      // Participant must never be the moderator
+      expect(conv.participant_pubkey).not.toBe(moderator);
+      // Aliases must mirror the existing columns
+      expect(conv.latest_message).toBe(conv.last_message);
+      expect(conv.message_type).toBe(conv.last_message_type);
+    }
+  });
 });
 
 describe('DM Store - getConversation', () => {

--- a/src/nostr/profile-resolver.mjs
+++ b/src/nostr/profile-resolver.mjs
@@ -105,13 +105,13 @@ async function queryProfiles(pubkeys, env) {
     }, RELAY_TIMEOUT_MS);
 
     try {
-      const headers = {};
-      if (env.CF_ACCESS_CLIENT_ID && env.CF_ACCESS_CLIENT_SECRET) {
-        headers['CF-Access-Client-Id'] = env.CF_ACCESS_CLIENT_ID;
-        headers['CF-Access-Client-Secret'] = env.CF_ACCESS_CLIENT_SECRET;
-      }
-
-      ws = new WebSocket(DIVINE_RELAY, { headers });
+      // Cloudflare Workers' WebSocket constructor only accepts a subprotocol
+      // string/array as the second argument; passing an options object fails
+      // with "The protocol header token is invalid" and silently breaks
+      // profile resolution. relay.divine.video is a public Nostr relay that
+      // does not require CF Access, so we don't need to forward those
+      // headers here. Same fix as dm-reader.mjs and relay-client.mjs.
+      ws = new WebSocket(DIVINE_RELAY);
 
       ws.addEventListener('open', () => {
         const filter = { kinds: [0], authors: pubkeys, limit: pubkeys.length };

--- a/src/nostr/relay-client.mjs
+++ b/src/nostr/relay-client.mjs
@@ -37,14 +37,14 @@ async function queryRelay(relayUrl, filter, env = {}, options = {}) {
     }
 
     try {
-      // Build WebSocket URL with Cloudflare Access headers
-      const headers = {};
-      if (env.CF_ACCESS_CLIENT_ID && env.CF_ACCESS_CLIENT_SECRET) {
-        headers['CF-Access-Client-Id'] = env.CF_ACCESS_CLIENT_ID;
-        headers['CF-Access-Client-Secret'] = env.CF_ACCESS_CLIENT_SECRET;
-      }
-
-      ws = new WebSocket(relayUrl, { headers });
+      // Cloudflare Workers' WebSocket constructor only accepts a subprotocol
+      // string/array as the second argument; passing an options object fails
+      // with "The protocol header token is invalid" and silently breaks the
+      // cron. relay.divine.video is a public Nostr relay that does not require
+      // CF Access, so we don't need to forward those headers here. If we ever
+      // point at a CF-Access-protected relay, switch to the fetch({ Upgrade })
+      // pattern and use the returned response.webSocket.
+      ws = new WebSocket(relayUrl);
 
       ws.addEventListener('open', () => {
         subscriptionId = Math.random().toString(36).substring(7);


### PR DESCRIPTION
## Summary

The admin messages page at `moderation.admin.divine.video/admin/messages` was broken end-to-end. This PR bundles seven independent fixes across the Nostr DM sync path and the admin UI.

## Fixes

**1. `dm-reader` WebSocket constructor rejected invalid options arg** (`aa4f090`)
`new WebSocket(url, { headers })` threw in the Cloudflare Workers runtime, so the DM reader never connected and `dm_log` stayed empty. Dropped the options argument. Previously tracked as #108; folded in here since #108 has no consumer without the rest of this bundle.

**2. `getConversations` SELECT collapsed everything to one row** (`2ad9a73`)
The outer SELECT used `MAX(created_at)` and `COUNT(*)` without an explicit `GROUP BY`. SQLite collapses that to a single aggregated row across the whole filtered set, so every multi-conversation inbox rendered as exactly one sidebar item regardless of how many conversations existed. Reproduced with `dm_log` holding 3 rows across 2 `conversation_id`s — the query returned 1 row. Fixed by selecting row columns directly from the `WHERE id IN (...)` filtered set and computing `message_count` per conversation via a correlated subquery. Regression test added in `3b451f8` (runs against real D1 via `cloudflare:test`, not the mock).

**3. Backend/frontend field-name mismatch** (`f7edcb3`)
`getConversations` returned `sender_pubkey` / `recipient_pubkey` / `last_message` / `last_message_type`; the frontend in `messages.html` looked for `participant_pubkey` / `pubkey` / `latest_message` / `preview` / `message_type` / `latest_message_type`. No field name matched, so every row rendered as `(unknown) (no messages)` and clicking 404'd because the selected pubkey was empty. Added an optional `moderatorPubkey` parameter to `getConversations`; when provided, each row is augmented with `participant_pubkey` (the non-moderator side) plus `latest_message` / `message_type` aliases. Original columns preserved for existing callers. Handler at `/admin/api/messages` now passes `getModeratorPubkey(env)` to the store.

**4. NIP-17 outgoing self-copies broke threading** (`0de92fc`, `dm-reader.mjs`)
NIP-17 clients wrap outgoing messages twice: once addressed to the recipient, once addressed to the sender so sent messages aren't lost. When the moderator's sync pulls in the self-copy (`#p=moderator`), the inner `rumor.pubkey` is the moderator themselves. The previous code hardcoded `recipientPubkey = moderatorPubkey`, which produced rows with `sender = recipient = moderator` and a separate `conversation_id = sha256(moderator+moderator)`, so outgoing replies ended up in their own orphaned thread. Fixed by detecting self-copies (`rumor.pubkey === moderatorPubkey`), reading the real recipient from the first non-moderator `['p', …]` tag in `rumor.tags`, setting `direction = 'outgoing'` and `messageType = 'moderator_reply'`, and computing `conversation_id` against the counterparty so inbound + outbound collapse into one thread. Also skip the `user_reports` insert for outgoing self-copies since the reporter is the counterparty, not the moderator echoing their own sent message.

**5. SQLite timestamp parsed as local time** (`0de92fc`, `messages.html`)
SQLite's `CURRENT_TIMESTAMP` default writes `"YYYY-MM-DD HH:MM:SS"` in UTC with no timezone marker. Chrome parses that ambiguous format as **local** time, which flips recent rows into the future and makes `relativeTime`'s `Math.max(0, now - date)` clamp to `0` — rendering every timestamp as "just now" regardless of actual age. Added a `parseTimestamp` helper that appends `'Z'` when no explicit timezone is present, forcing UTC interpretation.

**6. Profile resolver had the same WebSocket ctor bug as dm-reader** (`37d7fa6`)
`profile-resolver.mjs` passed `{ headers }` to `new WebSocket()` — same pattern as fix #1 above. Profile resolution was failing silently for every pubkey, so `fetchProfiles` always returned empty and the UI fell back to truncated hex for every display name. Dropped the options object. Operator note: 1-hour negative cache in KV means already-attempted pubkeys may need their `profile:<hex>` keys purged after deploy to force a re-resolve; we did that for the two pubkeys currently in-inbox.

**7. Malformed outgoing rumors silently corrupted `dm_log`** (`1595f1a`, `dm-reader.mjs`)
Companion to fix #4: when `rumor.pubkey === moderatorPubkey` but no non-moderator `['p', …]` tag was present, the previous code fell back to `counterpartyPubkey = moderatorPubkey`, writing a self-conversation row (sender = recipient = moderator) that the UI's `participant_pubkey` logic then resolved back to the moderator and effectively hid. `errors++` was not incremented, nothing was logged. Now we `console.warn` and increment `errors`, matching the empty-rumor handling a few lines above. Surfaces bad data in `wrangler tail` rather than dropping it on the floor.

## Previously stacked on #108 — now consolidated

#108 was a 1-commit WebSocket constructor fix with no standalone consumer. It's folded in here (commit `aa4f090`) and #108 has been closed. One PR, one review, one merge.

## Test plan

- [x] `npm test` — 914/914 pass across 57 test files.
- [x] Deployed to prod (`db640396-66ca-4562-86d4-2c9511478f53`).
- [x] Manual verification end-to-end:
  - Hard-reloaded `/admin/messages` with the deploy live.
  - Sidebar now shows one sidebar item per actual conversation (not one aggregated row).
  - Participant pubkey resolves to name / NIP-05 via kind-0 lookup, not truncated hex.
  - Message direction correct: incoming bubbles left, moderator replies bubble right.
  - Relative timestamps accurate ("13m ago", "47m ago") instead of "just now".
- [x] One-off `UPDATE` on a pre-fix `dm_log` row (id=2) to merge its orphan `conversation_id` into the correct thread. Single row changed, all others untouched.