### PR TITLE
feat(e2e): creator-delete end-to-end test (mod-service#101)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,20 @@
+# Moderation Service Documentation Map
+
+This directory is the index for repository documentation. Current docs first, historical context second.
+
+## Current
+
+- [README.md](../README.md) — service overview, setup, architecture
+- [CLAUDE.md](../CLAUDE.md) — working notes for AI-assisted development
+- [CHANGELOG.md](../CHANGELOG.md) — release history
+- [CONTENT_MODERATION.md](../CONTENT_MODERATION.md) — moderation pipeline reference
+- [docs/integrations/](integrations/) — cross-service contracts (creator-delete, etc.)
+
+## Historical
+
+- [docs/superpowers/](superpowers/README.md) — per-PR planning and design artifacts, preserved for context
+- [docs/plans/](plans/) — legacy planning docs (pre-superpowers convention)
+
+## Source-of-truth rule
+
+When docs and code disagree, trust the code. Historical docs describe intent at a point in time and are not maintained after the linked PR ships.

--- a/docs/superpowers/README.md
+++ b/docs/superpowers/README.md
@@ -1,0 +1,18 @@
+# docs/superpowers — historical planning and design
+
+This directory holds per-PR planning and design artifacts. They are preserved for context, not maintained as current documentation.
+
+## Convention
+
+- `plans/YYYY-MM-DD-<slug>.md` — implementation plans. Typically written before the PR and reflect intent at that point in time.
+- `specs/YYYY-MM-DD-<slug>.md` — design specs. Longer-lived than plans but still point-in-time.
+- No expectation of ongoing maintenance after the linked PR ships.
+- When a doc here and the code disagree, the code wins. Use these as archival context only.
+
+## Why keep them at all
+
+They remain useful for "why did we pick this approach" retrospection, for handoff between contributors, and as context for AI-assisted work. Keeping them in-repo means `git grep` and local tooling find them without GitHub round-trips.
+
+## When to archive differently
+
+If a design doc is durable and meant to evolve with the code (architecture reference rather than PR scaffolding), put it at `docs/` top level instead.

--- a/docs/superpowers/plans/2026-04-20-creator-delete-e2e-test-plan.md
+++ b/docs/superpowers/plans/2026-04-20-creator-delete-e2e-test-plan.md
@@ -1,0 +1,2090 @@
+# Creator-delete end-to-end test — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build an operator-run Node script that exercises the full creator-delete pipeline end-to-end (sync and cron paths) against real staging relay + prod Blossom + prod mod-service, with active cleanup that returns prod systems to their pre-run state.
+
+**Architecture:** Single-file ESM script in `scripts/e2e-creator-delete.mjs` with injectable side effects (fetch, wrangler shell-out, Blossom notify) so vitest can drive pure and orchestrator-level tests without network. Reuses existing `nostr-tools` (already a dep) for keypair generation, event signing, and WebSocket publishing. Reuses `notifyBlossom` / NIP-98 signing patterns from the live pipeline where practical.
+
+**Tech Stack:** Node 20+, vitest (Workers pool — `nodejs_compat` flag is on so `node:child_process` works), `wrangler` CLI, `nostr-tools` (`pure`, `relay`, `nip19`), `@noble/hashes/sha256`.
+
+**Spec:** `docs/superpowers/specs/2026-04-18-creator-delete-e2e-test-design.md`
+**Issue:** [divinevideo/divine-moderation-service#101](https://github.com/divinevideo/divine-moderation-service/issues/101)
+**Branch:** `spec/creator-delete-e2e-test` (already created off `main`)
+
+---
+
+## File structure
+
+| File | Status | Responsibility |
+|---|---|---|
+| `scripts/e2e-creator-delete.mjs` | new | Orchestrator. CLI, helpers, scenarios, main. ~500 lines. |
+| `scripts/e2e-creator-delete.test.mjs` | new | Vitest unit tests for pure helpers + main() via injected deps. |
+| `scripts/sign-nip98.mjs` | modify | Factor inline signing into an exported `signNip98Header(sk, url, method)` helper so the e2e script imports rather than duplicates. |
+
+All impure operations live behind injectable functions so tests neither shell out nor hit the network.
+
+---
+
+## Task 1: Refactor sign-nip98.mjs to export a reusable helper
+
+**Files:**
+- Modify: `scripts/sign-nip98.mjs`
+- Test: `scripts/sign-nip98.test.mjs` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `scripts/sign-nip98.test.mjs`:
+
+```js
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Tests for the exported NIP-98 signing helper consumed by e2e and ad-hoc scripts.
+
+import { describe, it, expect } from 'vitest';
+import { generateSecretKey, getPublicKey, verifyEvent } from 'nostr-tools/pure';
+import { signNip98Header } from './sign-nip98.mjs';
+
+describe('signNip98Header', () => {
+  it('returns a Nostr-scheme Authorization header with a base64-encoded signed kind-27235 event', () => {
+    const sk = generateSecretKey();
+    const header = signNip98Header(sk, 'https://example/api', 'POST');
+    expect(header.startsWith('Nostr ')).toBe(true);
+    const eventJson = Buffer.from(header.slice('Nostr '.length), 'base64').toString('utf8');
+    const event = JSON.parse(eventJson);
+    expect(event.kind).toBe(27235);
+    expect(event.tags).toEqual(expect.arrayContaining([['u', 'https://example/api'], ['method', 'POST']]));
+    expect(event.pubkey).toBe(getPublicKey(sk));
+    expect(verifyEvent(event)).toBe(true);
+  });
+
+  it('normalizes method to uppercase', () => {
+    const sk = generateSecretKey();
+    const header = signNip98Header(sk, 'https://example', 'get');
+    const event = JSON.parse(Buffer.from(header.slice('Nostr '.length), 'base64').toString('utf8'));
+    expect(event.tags).toEqual(expect.arrayContaining([['method', 'GET']]));
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -- scripts/sign-nip98.test.mjs`
+
+Expected: FAIL — `signNip98Header` is not exported.
+
+- [ ] **Step 3: Refactor the CLI script to export the helper**
+
+Replace the body of `scripts/sign-nip98.mjs` with:
+
+```js
+#!/usr/bin/env node
+// Sign a NIP-98 Authorization header for testing creator-delete endpoints.
+// Usage (CLI): node scripts/sign-nip98.mjs --nsec <hex> --url <url> --method <POST|GET>
+// Usage (import): import { signNip98Header } from './sign-nip98.mjs'
+
+import { generateSecretKey, getPublicKey, finalizeEvent } from 'nostr-tools/pure';
+import { hexToBytes } from '@noble/hashes/utils';
+
+/**
+ * Sign a NIP-98 Authorization header. Returns the full "Nostr <base64>" header value.
+ * Importable from other scripts; see CLI entry point below for standalone use.
+ */
+export function signNip98Header(sk, url, method) {
+  const event = finalizeEvent({
+    kind: 27235,
+    created_at: Math.floor(Date.now() / 1000),
+    tags: [['u', url], ['method', method.toUpperCase()]],
+    content: ''
+  }, sk);
+  return `Nostr ${Buffer.from(JSON.stringify(event)).toString('base64')}`;
+}
+
+// CLI entrypoint — skipped when imported by tests.
+const isMain = typeof process !== 'undefined' && process.argv && import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const args = process.argv.slice(2);
+  const getArg = (name) => {
+    const idx = args.indexOf(`--${name}`);
+    return idx >= 0 && args[idx + 1] ? args[idx + 1] : null;
+  };
+
+  const nsecHex = getArg('nsec');
+  const sk = nsecHex ? hexToBytes(nsecHex) : generateSecretKey();
+  if (!nsecHex) {
+    console.error(`No --nsec provided. Generated ephemeral key. Pubkey: ${getPublicKey(sk)}`);
+  }
+
+  const url = getArg('url');
+  const method = (getArg('method') || 'POST').toUpperCase();
+
+  if (!url) {
+    console.error('Usage: node scripts/sign-nip98.mjs --nsec <hex> --url <url> [--method POST]');
+    process.exit(1);
+  }
+
+  console.log(signNip98Header(sk, url, method));
+  console.error(`Pubkey: ${getPublicKey(sk)}`);
+  console.error(`URL: ${url}`);
+  console.error(`Method: ${method}`);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- scripts/sign-nip98.test.mjs`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/sign-nip98.mjs scripts/sign-nip98.test.mjs
+git commit -m "refactor(sign-nip98): export signNip98Header helper for reuse"
+```
+
+---
+
+## Task 2: Scaffold the e2e script + parseArgs
+
+**Files:**
+- Create: `scripts/e2e-creator-delete.mjs`
+- Create: `scripts/e2e-creator-delete.test.mjs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `scripts/e2e-creator-delete.test.mjs`:
+
+```js
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Tests for scripts/e2e-creator-delete.mjs — pure helpers + main() with injected deps.
+// ABOUTME: Vitest runs under @cloudflare/vitest-pool-workers; nodejs_compat is on.
+
+import { describe, it, expect } from 'vitest';
+import { parseArgs } from './e2e-creator-delete.mjs';
+
+describe('parseArgs', () => {
+  it('returns defaults when no flags given', () => {
+    const cfg = parseArgs([]);
+    expect(cfg).toEqual({
+      scenario: 'both',
+      stagingRelay: 'wss://relay.staging.divine.video',
+      funnelcakeApi: 'https://funnelcake.staging.dvines.org',
+      blossomBase: 'https://media.divine.video',
+      modServiceBase: 'https://moderation-api.divine.video',
+      d1Database: 'blossom-webhook-events',
+      cronWaitSeconds: 180,
+      skipCleanup: false
+    });
+  });
+
+  it('parses --scenario=sync', () => {
+    expect(parseArgs(['--scenario=sync']).scenario).toBe('sync');
+  });
+
+  it('parses --scenario=cron', () => {
+    expect(parseArgs(['--scenario=cron']).scenario).toBe('cron');
+  });
+
+  it('rejects unknown scenario', () => {
+    expect(() => parseArgs(['--scenario=foo'])).toThrow(/scenario/i);
+  });
+
+  it('parses --skip-cleanup as boolean', () => {
+    expect(parseArgs(['--skip-cleanup']).skipCleanup).toBe(true);
+  });
+
+  it('parses --cron-wait-seconds as positive integer', () => {
+    expect(parseArgs(['--cron-wait-seconds=240']).cronWaitSeconds).toBe(240);
+  });
+
+  it('rejects --cron-wait-seconds=0', () => {
+    expect(() => parseArgs(['--cron-wait-seconds=0'])).toThrow(/cron-wait/i);
+  });
+
+  it('parses URL overrides', () => {
+    const cfg = parseArgs([
+      '--staging-relay=wss://localhost:7777',
+      '--funnelcake-api=http://localhost:8080',
+      '--blossom-base=http://localhost:7676',
+      '--mod-service-base=http://localhost:8787'
+    ]);
+    expect(cfg.stagingRelay).toBe('wss://localhost:7777');
+    expect(cfg.funnelcakeApi).toBe('http://localhost:8080');
+    expect(cfg.blossomBase).toBe('http://localhost:7676');
+    expect(cfg.modServiceBase).toBe('http://localhost:8787');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- scripts/e2e-creator-delete.test.mjs`
+
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Create the script with parseArgs**
+
+Create `scripts/e2e-creator-delete.mjs`:
+
+```js
+#!/usr/bin/env node
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: End-to-end test for the creator-delete pipeline (mod-service#101).
+// ABOUTME: Operator-run. Exercises sync + cron paths against staging relay + prod Blossom + prod mod-service.
+
+const DEFAULT_STAGING_RELAY = 'wss://relay.staging.divine.video';
+const DEFAULT_FUNNELCAKE_API = 'https://funnelcake.staging.dvines.org';
+const DEFAULT_BLOSSOM_BASE = 'https://media.divine.video';
+const DEFAULT_MOD_SERVICE_BASE = 'https://moderation-api.divine.video';
+const DEFAULT_D1_DATABASE = 'blossom-webhook-events';
+const DEFAULT_CRON_WAIT_SECONDS = 180;
+const SHA256_HEX = /^[0-9a-f]{64}$/;
+
+function getFlag(argv, name) {
+  const prefix = `--${name}=`;
+  for (const a of argv) {
+    if (a === `--${name}`) return true;
+    if (a.startsWith(prefix)) return a.slice(prefix.length);
+  }
+  return null;
+}
+
+function validatePositiveInt(value, fieldName) {
+  const n = Number(value);
+  if (!Number.isInteger(n) || n <= 0) {
+    throw new Error(`Invalid ${fieldName}: ${value} (must be positive integer)`);
+  }
+  return n;
+}
+
+export function parseArgs(argv) {
+  const rawScenario = getFlag(argv, 'scenario');
+  const scenario = rawScenario === null || rawScenario === true ? 'both' : rawScenario;
+  if (!['sync', 'cron', 'both'].includes(scenario)) {
+    throw new Error(`Invalid scenario: ${scenario} (must be sync|cron|both)`);
+  }
+
+  const rawCron = getFlag(argv, 'cron-wait-seconds');
+  const cronWaitSeconds = rawCron
+    ? validatePositiveInt(rawCron, 'cron-wait-seconds')
+    : DEFAULT_CRON_WAIT_SECONDS;
+
+  return {
+    scenario,
+    stagingRelay: getFlag(argv, 'staging-relay') || DEFAULT_STAGING_RELAY,
+    funnelcakeApi: getFlag(argv, 'funnelcake-api') || DEFAULT_FUNNELCAKE_API,
+    blossomBase: getFlag(argv, 'blossom-base') || DEFAULT_BLOSSOM_BASE,
+    modServiceBase: getFlag(argv, 'mod-service-base') || DEFAULT_MOD_SERVICE_BASE,
+    d1Database: getFlag(argv, 'd1-database') || DEFAULT_D1_DATABASE,
+    cronWaitSeconds,
+    skipCleanup: getFlag(argv, 'skip-cleanup') === true
+  };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- scripts/e2e-creator-delete.test.mjs`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/e2e-creator-delete.mjs scripts/e2e-creator-delete.test.mjs
+git commit -m "feat(e2e): scaffold creator-delete e2e script with parseArgs"
+```
+
+---
+
+## Task 3: generateTestKey + generateSyntheticBlob
+
+**Files:**
+- Modify: `scripts/e2e-creator-delete.mjs`
+- Modify: `scripts/e2e-creator-delete.test.mjs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `scripts/e2e-creator-delete.test.mjs`:
+
+```js
+import { generateTestKey, generateSyntheticBlob } from './e2e-creator-delete.mjs';
+import { getPublicKey } from 'nostr-tools/pure';
+import { bytesToHex, sha256 as sha256Hash } from '@noble/hashes/sha256';
+
+describe('generateTestKey', () => {
+  it('returns a fresh nsec + hex pubkey each call', () => {
+    const a = generateTestKey();
+    const b = generateTestKey();
+    expect(a.sk).not.toEqual(b.sk);
+    expect(a.pubkey).toMatch(/^[0-9a-f]{64}$/);
+    expect(a.pubkey).toBe(getPublicKey(a.sk));
+  });
+});
+
+describe('generateSyntheticBlob', () => {
+  it('returns exactly 1024 bytes', () => {
+    const { bytes } = generateSyntheticBlob();
+    expect(bytes).toBeInstanceOf(Uint8Array);
+    expect(bytes.length).toBe(1024);
+  });
+
+  it('returns a sha256 that matches the bytes', () => {
+    const { bytes, sha256 } = generateSyntheticBlob();
+    const computed = bytesToHex(sha256Hash(bytes));
+    expect(sha256).toBe(computed);
+  });
+
+  it('produces a different sha256 on each call', () => {
+    const a = generateSyntheticBlob();
+    const b = generateSyntheticBlob();
+    expect(a.sha256).not.toBe(b.sha256);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- scripts/e2e-creator-delete.test.mjs`
+
+Expected: FAIL — helpers not exported.
+
+- [ ] **Step 3: Implement the helpers**
+
+Append to `scripts/e2e-creator-delete.mjs`:
+
+```js
+import { generateSecretKey, getPublicKey } from 'nostr-tools/pure';
+import { sha256 as sha256Hash, bytesToHex } from '@noble/hashes/sha256';
+import { randomBytes } from '@noble/hashes/utils';
+
+export function generateTestKey() {
+  const sk = generateSecretKey();
+  return { sk, pubkey: getPublicKey(sk) };
+}
+
+// Minimal ISO-BMFF ftyp box so the payload at least looks like MP4 to a casual
+// inspector. 1024 bytes total: 32-byte header + 992 bytes of random payload so
+// each run has a unique sha256.
+export function generateSyntheticBlob() {
+  const header = new Uint8Array([
+    // box size (32 bytes)
+    0x00, 0x00, 0x00, 0x20,
+    // 'ftyp'
+    0x66, 0x74, 0x79, 0x70,
+    // major brand 'isom'
+    0x69, 0x73, 0x6f, 0x6d,
+    // minor version (0x00000200)
+    0x00, 0x00, 0x02, 0x00,
+    // compatible brands: 'isom', 'iso2', 'avc1', 'mp41'
+    0x69, 0x73, 0x6f, 0x6d,
+    0x69, 0x73, 0x6f, 0x32,
+    0x61, 0x76, 0x63, 0x31,
+    0x6d, 0x70, 0x34, 0x31
+  ]);
+  const payload = randomBytes(992);
+  const bytes = new Uint8Array(1024);
+  bytes.set(header, 0);
+  bytes.set(payload, 32);
+  const sha256 = bytesToHex(sha256Hash(bytes));
+  return { bytes, sha256 };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- scripts/e2e-creator-delete.test.mjs`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/e2e-creator-delete.mjs scripts/e2e-creator-delete.test.mjs
+git commit -m "feat(e2e): generateTestKey + generateSyntheticBlob (1KB pseudo-mp4)"
+```
+
+---
+
+## Task 4: buildKind34236Event (contract-grounded)
+
+**Files:**
+- Modify: `scripts/e2e-creator-delete.mjs`
+- Modify: `scripts/e2e-creator-delete.test.mjs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `scripts/e2e-creator-delete.test.mjs`:
+
+```js
+import { buildKind34236Event } from './e2e-creator-delete.mjs';
+import { verifyEvent } from 'nostr-tools/pure';
+
+describe('buildKind34236Event', () => {
+  const cfg = parseArgs([]);
+  const SHA = 'a'.repeat(64);
+
+  it('returns a signed kind 34236 event with all required tags', () => {
+    const { sk } = generateTestKey();
+    const event = buildKind34236Event(sk, SHA, cfg);
+    expect(event.kind).toBe(34236);
+    expect(verifyEvent(event)).toBe(true);
+
+    const tagNames = event.tags.map(t => t[0]);
+    expect(tagNames).toContain('d');
+    expect(tagNames).toContain('title');
+    expect(tagNames).toContain('imeta');
+    expect(tagNames).toContain('thumb');
+  });
+
+  it('imeta tag contains space-delimited url/x/m items (Funnelcake contract)', () => {
+    const { sk } = generateTestKey();
+    const event = buildKind34236Event(sk, SHA, cfg);
+    const imeta = event.tags.find(t => t[0] === 'imeta');
+    expect(imeta).toBeDefined();
+
+    // validate_imeta_format: each non-first item must contain a space
+    for (const item of imeta.slice(1)) {
+      expect(item).toMatch(/\s/);
+    }
+
+    // Required keys for our test blob
+    const itemsByKey = Object.fromEntries(
+      imeta.slice(1).map(item => {
+        const idx = item.indexOf(' ');
+        return [item.slice(0, idx), item.slice(idx + 1)];
+      })
+    );
+    expect(itemsByKey.url).toMatch(/^https?:\/\//);
+    expect(itemsByKey.x).toBe(SHA);
+    expect(itemsByKey.m).toBe('video/mp4');
+  });
+
+  it('d tag is unique across calls (prevents addressable-event collision)', () => {
+    const { sk: sk1 } = generateTestKey();
+    const { sk: sk2 } = generateTestKey();
+    const e1 = buildKind34236Event(sk1, SHA, cfg);
+    const e2 = buildKind34236Event(sk2, SHA, cfg);
+    const d1 = e1.tags.find(t => t[0] === 'd')[1];
+    const d2 = e2.tags.find(t => t[0] === 'd')[1];
+    expect(d1).not.toBe(d2);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- scripts/e2e-creator-delete.test.mjs`
+
+Expected: FAIL — `buildKind34236Event` not exported.
+
+- [ ] **Step 3: Implement**
+
+Append to `scripts/e2e-creator-delete.mjs`:
+
+```js
+import { finalizeEvent } from 'nostr-tools/pure';
+
+/**
+ * Build and sign a kind 34236 event that passes Funnelcake's validation at
+ * divine-funnelcake/crates/relay/src/relay.rs:1023-1087.
+ *
+ * Required: d (unique), title, imeta with url+x+m (each space-delimited item
+ * per validate_imeta_format), and a thumb-equivalent. Thumb URL does not need
+ * to resolve.
+ */
+export function buildKind34236Event(sk, sha256, cfg) {
+  const blobUrl = `${cfg.blossomBase}/${sha256}`;
+  const thumbUrl = `${cfg.blossomBase}/${sha256}.jpg`;
+  // Unique d tag per run: timestamp + random suffix ensures no collision across
+  // concurrent or rapid-fire test runs with the same key (not our normal case
+  // but cheap to defend against).
+  const dTag = `e2e-test-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+
+  return finalizeEvent({
+    kind: 34236,
+    created_at: Math.floor(Date.now() / 1000),
+    tags: [
+      ['d', dTag],
+      ['title', 'creator-delete e2e test video'],
+      ['imeta', `url ${blobUrl}`, `x ${sha256}`, `m video/mp4`],
+      ['thumb', thumbUrl]
+    ],
+    content: 'Synthetic 1KB test blob published by scripts/e2e-creator-delete.mjs'
+  }, sk);
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- scripts/e2e-creator-delete.test.mjs`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/e2e-creator-delete.mjs scripts/e2e-creator-delete.test.mjs
+git commit -m "feat(e2e): buildKind34236Event with Funnelcake-contract-grounded tags"
+```
+
+---
+
+## Task 5: classifyByteProbeResponse
+
+**Files:**
+- Modify: `scripts/e2e-creator-delete.mjs`
+- Modify: `scripts/e2e-creator-delete.test.mjs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `scripts/e2e-creator-delete.test.mjs`:
+
+```js
+import { classifyByteProbeResponse } from './e2e-creator-delete.mjs';
+
+describe('classifyByteProbeResponse', () => {
+  it('404 → bytes_gone (flag was on)', () => {
+    expect(classifyByteProbeResponse(404)).toEqual({
+      kind: 'bytes_gone',
+      flagStateInferred: 'on'
+    });
+  });
+
+  it('200 → bytes_present (flag was off)', () => {
+    expect(classifyByteProbeResponse(200)).toEqual({
+      kind: 'bytes_present',
+      flagStateInferred: 'off'
+    });
+  });
+
+  it('410 also counts as bytes_gone (some CDNs serve 410 for deleted)', () => {
+    expect(classifyByteProbeResponse(410)).toEqual({
+      kind: 'bytes_gone',
+      flagStateInferred: 'on'
+    });
+  });
+
+  it('other statuses → unknown (assertion failure)', () => {
+    expect(classifyByteProbeResponse(500).kind).toBe('unknown');
+    expect(classifyByteProbeResponse(403).kind).toBe('unknown');
+    expect(classifyByteProbeResponse(0).kind).toBe('unknown');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- scripts/e2e-creator-delete.test.mjs`
+
+Expected: FAIL — `classifyByteProbeResponse` not exported.
+
+- [ ] **Step 3: Implement**
+
+Append to `scripts/e2e-creator-delete.mjs`:
+
+```js
+/**
+ * Classify a GET https://media.divine.video/<sha256> response after the
+ * pipeline has completed. 404/410 → bytes physically deleted (ENABLE_PHYSICAL_DELETE
+ * was on). 200 → bytes still present (flag was off, soft-delete state). Both
+ * are acceptable pass conditions for the script; the kind is recorded in the
+ * JSONL output. Anything else is treated as an unexpected state.
+ */
+export function classifyByteProbeResponse(status) {
+  if (status === 404 || status === 410) return { kind: 'bytes_gone', flagStateInferred: 'on' };
+  if (status === 200) return { kind: 'bytes_present', flagStateInferred: 'off' };
+  return { kind: 'unknown', status };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- scripts/e2e-creator-delete.test.mjs`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/e2e-creator-delete.mjs scripts/e2e-creator-delete.test.mjs
+git commit -m "feat(e2e): classifyByteProbeResponse infers flag state from GET /<sha>"
+```
+
+---
+
+## Task 6: Default runner + cleanupD1Row
+
+**Files:**
+- Modify: `scripts/e2e-creator-delete.mjs`
+- Modify: `scripts/e2e-creator-delete.test.mjs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `scripts/e2e-creator-delete.test.mjs`:
+
+```js
+import { cleanupD1Row } from './e2e-creator-delete.mjs';
+
+function makeFakeRunner(responseFor) {
+  const calls = [];
+  const fn = async ({ command, args }) => {
+    calls.push({ command, args });
+    const sql = args[args.indexOf('--command') + 1];
+    return responseFor(sql);
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+const WRANGLER_OK = JSON.stringify([{ results: [], success: true, meta: {} }]);
+
+describe('cleanupD1Row', () => {
+  const cfg = parseArgs([]);
+  const KIND5 = 'a'.repeat(64);
+  const TARGET = 'b'.repeat(64);
+
+  it('runs wrangler d1 execute with a DELETE matching the composite primary key', async () => {
+    const runner = makeFakeRunner(() => ({ stdout: WRANGLER_OK, stderr: '', status: 0 }));
+    await cleanupD1Row(KIND5, TARGET, cfg, runner);
+    expect(runner.calls.length).toBe(1);
+    expect(runner.calls[0].args.slice(0, 5)).toEqual(['d1', 'execute', cfg.d1Database, '--remote', '--json']);
+    const sql = runner.calls[0].args[runner.calls[0].args.indexOf('--command') + 1];
+    expect(sql).toContain('DELETE FROM creator_deletions');
+    expect(sql).toContain(`kind5_id = '${KIND5}'`);
+    expect(sql).toContain(`target_event_id = '${TARGET}'`);
+  });
+
+  it('throws when wrangler exits non-zero', async () => {
+    const runner = makeFakeRunner(() => ({ stdout: '', stderr: 'd1 unreachable', status: 1 }));
+    await expect(cleanupD1Row(KIND5, TARGET, cfg, runner)).rejects.toThrow(/d1 unreachable/i);
+  });
+
+  it('rejects kind5 or target that is not 64-char hex (prevents SQL interpolation risk)', async () => {
+    const runner = makeFakeRunner(() => ({ stdout: WRANGLER_OK, stderr: '', status: 0 }));
+    await expect(cleanupD1Row('not-hex', TARGET, cfg, runner)).rejects.toThrow(/kind5_id/i);
+    await expect(cleanupD1Row(KIND5, 'not-hex', cfg, runner)).rejects.toThrow(/target_event_id/i);
+    expect(runner.calls.length).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- scripts/e2e-creator-delete.test.mjs`
+
+Expected: FAIL — `cleanupD1Row` not exported.
+
+- [ ] **Step 3: Implement the runner + cleanup**
+
+Append to `scripts/e2e-creator-delete.mjs`:
+
+```js
+/**
+ * Default runner used when the script runs as a CLI. Tests inject a fake.
+ * Uses spawnSync (args is an array, not a string — no shell interpretation).
+ * The node:child_process import is deferred via dynamic import() so the
+ * Cloudflare Workers vitest pool does not try to resolve it at module-load
+ * time (nodejs_compat does not expose child_process there).
+ */
+export async function defaultRunner({ command, args }) {
+  const { spawnSync } = await import('node:child_process');
+  const r = spawnSync(command, args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+  return { stdout: r.stdout || '', stderr: r.stderr || '', status: r.status ?? 0 };
+}
+
+function validateHex64(value, fieldName) {
+  if (typeof value !== 'string' || !SHA256_HEX.test(value)) {
+    throw new Error(`Invalid ${fieldName}: ${value} (must be 64-char lowercase hex)`);
+  }
+  return value;
+}
+
+export async function cleanupD1Row(kind5_id, target_event_id, cfg, runner = defaultRunner) {
+  validateHex64(kind5_id, 'kind5_id');
+  validateHex64(target_event_id, 'target_event_id');
+  const sql = `DELETE FROM creator_deletions WHERE kind5_id = '${kind5_id}' AND target_event_id = '${target_event_id}';`;
+  const args = ['d1', 'execute', cfg.d1Database, '--remote', '--json', '--command', sql];
+  const r = await runner({ command: 'wrangler', args });
+  if (r.status !== 0) {
+    throw new Error(`wrangler d1 execute failed (exit ${r.status}): ${r.stderr.trim() || r.stdout.trim()}`);
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- scripts/e2e-creator-delete.test.mjs`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/e2e-creator-delete.mjs scripts/e2e-creator-delete.test.mjs
+git commit -m "feat(e2e): defaultRunner + cleanupD1Row with hex validation"
+```
+
+---
+
+## Task 7: cleanupBlossomVanish
+
+**Files:**
+- Modify: `scripts/e2e-creator-delete.mjs`
+- Modify: `scripts/e2e-creator-delete.test.mjs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `scripts/e2e-creator-delete.test.mjs`:
+
+```js
+import { cleanupBlossomVanish } from './e2e-creator-delete.mjs';
+
+function makeFakeFetch(impl) {
+  const calls = [];
+  const fn = async (url, init) => {
+    calls.push({ url, init });
+    return impl({ url, init });
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+describe('cleanupBlossomVanish', () => {
+  const cfg = { ...parseArgs([]), blossomWebhookSecret: 'test-secret' };
+  const PUBKEY = 'f'.repeat(64);
+
+  it('POSTs to /admin/api/vanish with bearer auth and pubkey+reason body', async () => {
+    const fetchImpl = makeFakeFetch(async () => ({
+      ok: true, status: 200,
+      json: async () => ({ vanished: true, pubkey: PUBKEY, reason: 'e2e-test cleanup', fully_deleted: 1, unlinked: 0, errors: 0 })
+    }));
+    const out = await cleanupBlossomVanish(PUBKEY, cfg, fetchImpl);
+    expect(fetchImpl.calls.length).toBe(1);
+    const call = fetchImpl.calls[0];
+    expect(call.url).toBe(`${cfg.blossomBase}/admin/api/vanish`);
+    expect(call.init.method).toBe('POST');
+    expect(call.init.headers.Authorization).toBe('Bearer test-secret');
+    expect(call.init.headers['Content-Type']).toBe('application/json');
+    const body = JSON.parse(call.init.body);
+    expect(body.pubkey).toBe(PUBKEY);
+    expect(body.reason).toBe('e2e-test cleanup');
+    expect(out).toEqual({ fullyDeleted: 1, unlinked: 0, errors: 0 });
+  });
+
+  it('throws on HTTP 4xx/5xx', async () => {
+    const fetchImpl = makeFakeFetch(async () => ({ ok: false, status: 500, text: async () => 'bad gateway' }));
+    await expect(cleanupBlossomVanish(PUBKEY, cfg, fetchImpl)).rejects.toThrow(/500/);
+  });
+
+  it('throws when vanish body reports errors > 0', async () => {
+    const fetchImpl = makeFakeFetch(async () => ({
+      ok: true, status: 200,
+      json: async () => ({ vanished: true, pubkey: PUBKEY, fully_deleted: 0, unlinked: 0, errors: 1 })
+    }));
+    await expect(cleanupBlossomVanish(PUBKEY, cfg, fetchImpl)).rejects.toThrow(/errors/);
+  });
+
+  it('tolerates fully_deleted:0 unlinked:0 (blob already gone from a previous cleanup)', async () => {
+    const fetchImpl = makeFakeFetch(async () => ({
+      ok: true, status: 200,
+      json: async () => ({ vanished: true, pubkey: PUBKEY, fully_deleted: 0, unlinked: 0, errors: 0 })
+    }));
+    const out = await cleanupBlossomVanish(PUBKEY, cfg, fetchImpl);
+    expect(out).toEqual({ fullyDeleted: 0, unlinked: 0, errors: 0 });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- scripts/e2e-creator-delete.test.mjs`
+
+Expected: FAIL — `cleanupBlossomVanish` not exported.
+
+- [ ] **Step 3: Implement**
+
+Append to `scripts/e2e-creator-delete.mjs`:
+
+```js
+/**
+ * Fully purge the single blob owned by the test pubkey.
+ *
+ * Uses POST /admin/api/vanish (verified at divine-blossom/src/main.rs:209 →
+ * handle_admin_vanish, src/main.rs:3975 → execute_vanish). For a fresh
+ * ephemeral pubkey that owns exactly one blob, this is surgical: full GCS +
+ * KV + VCL purge of the test blob and nothing else.
+ *
+ * Expects a successful vanish to return { vanished: true, fully_deleted, unlinked, errors }.
+ * fully_deleted:0 is acceptable (pipeline may have already purged the blob).
+ * errors > 0 indicates Blossom couldn't fully process; surface as failure.
+ */
+export async function cleanupBlossomVanish(testPubkey, cfg, fetchImpl = fetch) {
+  const res = await fetchImpl(`${cfg.blossomBase}/admin/api/vanish`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${cfg.blossomWebhookSecret}`
+    },
+    body: JSON.stringify({ pubkey: testPubkey, reason: 'e2e-test cleanup' })
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Blossom vanish failed: HTTP ${res.status}: ${text}`);
+  }
+  const body = await res.json();
+  const out = {
+    fullyDeleted: body.fully_deleted ?? 0,
+    unlinked: body.unlinked ?? 0,
+    errors: body.errors ?? 0
+  };
+  if (out.errors > 0) {
+    throw new Error(`Blossom vanish reported errors:${out.errors} fully_deleted:${out.fullyDeleted} unlinked:${out.unlinked}`);
+  }
+  return out;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- scripts/e2e-creator-delete.test.mjs`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/e2e-creator-delete.mjs scripts/e2e-creator-delete.test.mjs
+git commit -m "feat(e2e): cleanupBlossomVanish — full GCS+KV+VCL purge for test pubkey"
+```
+
+---
+
+## Task 8: uploadToBlossom (BUD-02 with BUD-01 auth)
+
+**Files:**
+- Modify: `scripts/e2e-creator-delete.mjs`
+- Modify: `scripts/e2e-creator-delete.test.mjs`
+
+Note: BUD-02 upload endpoint is `PUT /upload` with `Authorization: Nostr <base64>` where the base64-decoded event is a signed kind 24242 "upload" authorization event (BUD-01). The existing `scripts/publish-test-video.mjs` does this; we replicate the pattern.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `scripts/e2e-creator-delete.test.mjs`:
+
+```js
+import { uploadToBlossom, buildBud01UploadAuth } from './e2e-creator-delete.mjs';
+
+describe('buildBud01UploadAuth', () => {
+  const SHA = 'a'.repeat(64);
+  it('returns a Nostr-scheme header with kind 24242 event containing t=upload and x=sha', () => {
+    const { sk } = generateTestKey();
+    const header = buildBud01UploadAuth(sk, SHA);
+    expect(header.startsWith('Nostr ')).toBe(true);
+    const eventJson = Buffer.from(header.slice('Nostr '.length), 'base64').toString('utf8');
+    const event = JSON.parse(eventJson);
+    expect(event.kind).toBe(24242);
+    expect(event.tags).toEqual(expect.arrayContaining([['t', 'upload'], ['x', SHA]]));
+  });
+});
+
+describe('uploadToBlossom', () => {
+  const cfg = parseArgs([]);
+  const SHA = 'a'.repeat(64);
+
+  it('PUTs the bytes to /upload with BUD-01 auth and returns the parsed response', async () => {
+    const fetchImpl = makeFakeFetch(async () => ({
+      ok: true, status: 200,
+      json: async () => ({ url: `${cfg.blossomBase}/${SHA}`, sha256: SHA, size: 1024 })
+    }));
+    const { sk } = generateTestKey();
+    const bytes = new Uint8Array(1024);
+    const out = await uploadToBlossom(bytes, SHA, sk, cfg, fetchImpl);
+    expect(fetchImpl.calls.length).toBe(1);
+    expect(fetchImpl.calls[0].url).toBe(`${cfg.blossomBase}/upload`);
+    expect(fetchImpl.calls[0].init.method).toBe('PUT');
+    expect(fetchImpl.calls[0].init.headers.Authorization.startsWith('Nostr ')).toBe(true);
+    expect(fetchImpl.calls[0].init.body).toBe(bytes);
+    expect(out).toEqual({ url: `${cfg.blossomBase}/${SHA}`, sha256: SHA });
+  });
+
+  it('throws on non-2xx', async () => {
+    const fetchImpl = makeFakeFetch(async () => ({ ok: false, status: 413, text: async () => 'too large' }));
+    const { sk } = generateTestKey();
+    await expect(uploadToBlossom(new Uint8Array(1), SHA, sk, cfg, fetchImpl)).rejects.toThrow(/413/);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- scripts/e2e-creator-delete.test.mjs`
+
+Expected: FAIL — helpers not exported.
+
+- [ ] **Step 3: Implement**
+
+Append to `scripts/e2e-creator-delete.mjs`:
+
+```js
+/**
+ * BUD-01 upload authorization. Signed kind 24242 event with:
+ *   - t tag: "upload"
+ *   - x tag: sha256 of the payload
+ *   - expiration tag: unix timestamp (5 minutes from now)
+ */
+export function buildBud01UploadAuth(sk, sha256) {
+  const expiration = Math.floor(Date.now() / 1000) + 300;
+  const event = finalizeEvent({
+    kind: 24242,
+    created_at: Math.floor(Date.now() / 1000),
+    tags: [
+      ['t', 'upload'],
+      ['x', sha256],
+      ['expiration', String(expiration)]
+    ],
+    content: 'creator-delete e2e test upload'
+  }, sk);
+  return `Nostr ${Buffer.from(JSON.stringify(event)).toString('base64')}`;
+}
+
+export async function uploadToBlossom(bytes, sha256, sk, cfg, fetchImpl = fetch) {
+  const res = await fetchImpl(`${cfg.blossomBase}/upload`, {
+    method: 'PUT',
+    headers: {
+      Authorization: buildBud01UploadAuth(sk, sha256),
+      'Content-Type': 'video/mp4',
+      'Content-Length': String(bytes.length)
+    },
+    body: bytes
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Blossom upload failed: HTTP ${res.status}: ${text}`);
+  }
+  const body = await res.json();
+  return { url: body.url || `${cfg.blossomBase}/${sha256}`, sha256 };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- scripts/e2e-creator-delete.test.mjs`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/e2e-creator-delete.mjs scripts/e2e-creator-delete.test.mjs
+git commit -m "feat(e2e): uploadToBlossom (BUD-02 PUT with BUD-01 auth)"
+```
+
+---
+
+## Task 9: WebSocket publishing + Funnelcake indexing poll
+
+**Files:**
+- Modify: `scripts/e2e-creator-delete.mjs`
+- Modify: `scripts/e2e-creator-delete.test.mjs`
+
+Note: the actual WebSocket work is side-effecting and awkward to unit-test without a fake. We expose `publishEvent` (low-level WS publish) with an injectable connection factory, plus `waitForIndexing` which is pure-ish (HTTP polling with an injectable fetch).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `scripts/e2e-creator-delete.test.mjs`:
+
+```js
+import { waitForIndexing } from './e2e-creator-delete.mjs';
+
+describe('waitForIndexing', () => {
+  const cfg = parseArgs([]);
+  const EVENT_ID = 'a'.repeat(64);
+
+  it('resolves immediately when fetch returns 200 on first attempt', async () => {
+    let calls = 0;
+    const fetchImpl = async () => {
+      calls++;
+      return { ok: true, status: 200, json: async () => ({ id: EVENT_ID }) };
+    };
+    await waitForIndexing(EVENT_ID, cfg, { fetchImpl, timeoutMs: 5000, pollIntervalMs: 10 });
+    expect(calls).toBe(1);
+  });
+
+  it('polls until 200, tolerates 404 during indexing lag', async () => {
+    let calls = 0;
+    const fetchImpl = async () => {
+      calls++;
+      if (calls < 3) return { ok: false, status: 404, text: async () => 'not found' };
+      return { ok: true, status: 200, json: async () => ({ id: EVENT_ID }) };
+    };
+    await waitForIndexing(EVENT_ID, cfg, { fetchImpl, timeoutMs: 5000, pollIntervalMs: 10 });
+    expect(calls).toBe(3);
+  });
+
+  it('throws after timeout', async () => {
+    const fetchImpl = async () => ({ ok: false, status: 404, text: async () => 'not found' });
+    await expect(
+      waitForIndexing(EVENT_ID, cfg, { fetchImpl, timeoutMs: 50, pollIntervalMs: 10 })
+    ).rejects.toThrow(/timeout|not indexed/i);
+  });
+
+  it('throws immediately on non-404 HTTP error', async () => {
+    const fetchImpl = async () => ({ ok: false, status: 500, text: async () => 'server error' });
+    await expect(
+      waitForIndexing(EVENT_ID, cfg, { fetchImpl, timeoutMs: 5000, pollIntervalMs: 10 })
+    ).rejects.toThrow(/500/);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- scripts/e2e-creator-delete.test.mjs`
+
+Expected: FAIL — `waitForIndexing` not exported.
+
+- [ ] **Step 3: Implement waitForIndexing + publish helpers**
+
+Append to `scripts/e2e-creator-delete.mjs`:
+
+```js
+/**
+ * Poll Funnelcake REST GET /api/event/{id} until 200 or timeout.
+ * Catches ClickHouse batch-flush + MergeTree dedup propagation lag.
+ */
+export async function waitForIndexing(eventId, cfg, opts = {}) {
+  const fetchImpl = opts.fetchImpl || fetch;
+  const timeoutMs = opts.timeoutMs ?? 30000;
+  const pollIntervalMs = opts.pollIntervalMs ?? 1000;
+  const deadline = Date.now() + timeoutMs;
+  const url = `${cfg.funnelcakeApi}/api/event/${eventId}`;
+  let polls = 0;
+  while (Date.now() < deadline) {
+    polls++;
+    const res = await fetchImpl(url, { method: 'GET' });
+    if (res.ok) return { polls };
+    if (res.status !== 404) {
+      const text = await res.text();
+      throw new Error(`Funnelcake /api/event/${eventId} HTTP ${res.status}: ${text}`);
+    }
+    await new Promise(r => setTimeout(r, pollIntervalMs));
+  }
+  throw new Error(`timeout after ${timeoutMs}ms: event ${eventId} not indexed by Funnelcake`);
+}
+
+/**
+ * Publish a signed Nostr event to a relay over WebSocket. Resolves with the
+ * event id on OK=true; throws on relay rejection or timeout.
+ *
+ * The WebSocket lives only for the duration of the publish. The ws library
+ * is imported dynamically so the Workers test pool doesn't trip on it at
+ * module-load time.
+ */
+export async function publishEvent(event, relayUrl, opts = {}) {
+  const timeoutMs = opts.timeoutMs ?? 10000;
+  const WsCtor = opts.WebSocket || (await import('ws')).WebSocket;
+  return await new Promise((resolve, reject) => {
+    const ws = new WsCtor(relayUrl);
+    const timer = setTimeout(() => {
+      try { ws.close(); } catch {}
+      reject(new Error(`publish timeout after ${timeoutMs}ms: ${event.id}`));
+    }, timeoutMs);
+
+    ws.on('open', () => {
+      ws.send(JSON.stringify(['EVENT', event]));
+    });
+    ws.on('message', (data) => {
+      const msg = JSON.parse(data.toString());
+      if (msg[0] === 'OK' && msg[1] === event.id) {
+        clearTimeout(timer);
+        try { ws.close(); } catch {}
+        if (msg[2] === true) {
+          resolve(event.id);
+        } else {
+          reject(new Error(`relay rejected ${event.id}: ${msg[3] || 'unknown'}`));
+        }
+      }
+    });
+    ws.on('error', (err) => {
+      clearTimeout(timer);
+      reject(new Error(`WebSocket error: ${err.message}`));
+    });
+  });
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- scripts/e2e-creator-delete.test.mjs`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/e2e-creator-delete.mjs scripts/e2e-creator-delete.test.mjs
+git commit -m "feat(e2e): waitForIndexing (Funnelcake poll) + publishEvent (WS)"
+```
+
+---
+
+## Task 10: callSyncEndpoint + pollStatus
+
+**Files:**
+- Modify: `scripts/e2e-creator-delete.mjs`
+- Modify: `scripts/e2e-creator-delete.test.mjs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `scripts/e2e-creator-delete.test.mjs`:
+
+```js
+import { callSyncEndpoint, pollStatus } from './e2e-creator-delete.mjs';
+
+describe('callSyncEndpoint', () => {
+  const cfg = parseArgs([]);
+
+  it('POSTs to /api/creator-delete/sync with NIP-98 Authorization + kind 5 body', async () => {
+    const fetchImpl = makeFakeFetch(async () => ({ ok: true, status: 202, json: async () => ({ accepted: true }) }));
+    const { sk } = generateTestKey();
+    const kind5 = { id: 'a'.repeat(64), kind: 5, pubkey: 'f'.repeat(64), tags: [], content: '', created_at: 0, sig: '00' };
+    await callSyncEndpoint(sk, kind5, cfg, fetchImpl);
+    expect(fetchImpl.calls.length).toBe(1);
+    const call = fetchImpl.calls[0];
+    expect(call.url).toBe(`${cfg.modServiceBase}/api/creator-delete/sync`);
+    expect(call.init.method).toBe('POST');
+    expect(call.init.headers.Authorization.startsWith('Nostr ')).toBe(true);
+    expect(JSON.parse(call.init.body)).toEqual(kind5);
+  });
+
+  it('throws on 4xx/5xx', async () => {
+    const fetchImpl = makeFakeFetch(async () => ({ ok: false, status: 400, text: async () => 'bad request' }));
+    const { sk } = generateTestKey();
+    const kind5 = { id: 'a'.repeat(64), kind: 5, pubkey: 'f'.repeat(64), tags: [], content: '', created_at: 0, sig: '00' };
+    await expect(callSyncEndpoint(sk, kind5, cfg, fetchImpl)).rejects.toThrow(/400/);
+  });
+});
+
+describe('pollStatus', () => {
+  const cfg = parseArgs([]);
+  const KIND5 = 'a'.repeat(64);
+
+  it('resolves with the terminal success body', async () => {
+    let calls = 0;
+    const fetchImpl = async () => {
+      calls++;
+      if (calls < 3) return { ok: true, status: 200, json: async () => ({ status: 'accepted' }) };
+      return { ok: true, status: 200, json: async () => ({ status: 'success', blob_sha256: 'a'.repeat(64) }) };
+    };
+    const { sk } = generateTestKey();
+    const out = await pollStatus(sk, KIND5, cfg, { fetchImpl, timeoutMs: 5000, pollIntervalMs: 10 });
+    expect(out.status).toBe('success');
+    expect(calls).toBe(3);
+  });
+
+  it('resolves when status reaches a failed:* terminal (returns the body for caller to assert on)', async () => {
+    const fetchImpl = async () => ({ ok: true, status: 200, json: async () => ({ status: 'failed:permanent:target_not_found' }) });
+    const { sk } = generateTestKey();
+    const out = await pollStatus(sk, KIND5, cfg, { fetchImpl, timeoutMs: 5000, pollIntervalMs: 10 });
+    expect(out.status).toBe('failed:permanent:target_not_found');
+  });
+
+  it('throws on timeout if no terminal status is reached', async () => {
+    const fetchImpl = async () => ({ ok: true, status: 200, json: async () => ({ status: 'accepted' }) });
+    const { sk } = generateTestKey();
+    await expect(
+      pollStatus(sk, KIND5, cfg, { fetchImpl, timeoutMs: 40, pollIntervalMs: 10 })
+    ).rejects.toThrow(/timeout/i);
+  });
+
+  it('throws on non-2xx', async () => {
+    const fetchImpl = async () => ({ ok: false, status: 401, text: async () => 'unauthorized' });
+    const { sk } = generateTestKey();
+    await expect(
+      pollStatus(sk, KIND5, cfg, { fetchImpl, timeoutMs: 5000, pollIntervalMs: 10 })
+    ).rejects.toThrow(/401/);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- scripts/e2e-creator-delete.test.mjs`
+
+Expected: FAIL — helpers not exported.
+
+- [ ] **Step 3: Implement**
+
+Append to `scripts/e2e-creator-delete.mjs`:
+
+```js
+import { signNip98Header } from './sign-nip98.mjs';
+
+export async function callSyncEndpoint(sk, kind5Event, cfg, fetchImpl = fetch) {
+  const url = `${cfg.modServiceBase}/api/creator-delete/sync`;
+  const res = await fetchImpl(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: signNip98Header(sk, url, 'POST')
+    },
+    body: JSON.stringify(kind5Event)
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`sync endpoint HTTP ${res.status}: ${text}`);
+  }
+  return await res.json();
+}
+
+/**
+ * Poll the status endpoint until the row reaches a terminal status
+ * (success OR failed:*). Returns the final body so the caller can distinguish.
+ *
+ * Re-signs NIP-98 per poll so the signature stays fresh and the `u` tag always
+ * matches the request URL exactly (see PR #104 URL-normalization fix).
+ */
+export async function pollStatus(sk, kind5Id, cfg, opts = {}) {
+  const fetchImpl = opts.fetchImpl || fetch;
+  const timeoutMs = opts.timeoutMs ?? 60000;
+  const pollIntervalMs = opts.pollIntervalMs ?? 2000;
+  const url = `${cfg.modServiceBase}/api/creator-delete/status/${kind5Id}`;
+  const deadline = Date.now() + timeoutMs;
+  let polls = 0;
+  while (Date.now() < deadline) {
+    polls++;
+    const res = await fetchImpl(url, {
+      method: 'GET',
+      headers: { Authorization: signNip98Header(sk, url, 'GET') }
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`status endpoint HTTP ${res.status}: ${text}`);
+    }
+    const body = await res.json();
+    if (body.status === 'success' || (typeof body.status === 'string' && body.status.startsWith('failed:'))) {
+      return { ...body, polls };
+    }
+    await new Promise(r => setTimeout(r, pollIntervalMs));
+  }
+  throw new Error(`timeout after ${timeoutMs}ms: kind5 ${kind5Id} did not reach terminal status. Common cause: CREATOR_DELETE_PIPELINE_ENABLED may be unset on the prod worker.`);
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- scripts/e2e-creator-delete.test.mjs`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/e2e-creator-delete.mjs scripts/e2e-creator-delete.test.mjs
+git commit -m "feat(e2e): callSyncEndpoint + pollStatus (NIP-98 re-signed per poll)"
+```
+
+---
+
+## Task 11: assertD1AndBlossomState
+
+**Files:**
+- Modify: `scripts/e2e-creator-delete.mjs`
+- Modify: `scripts/e2e-creator-delete.test.mjs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `scripts/e2e-creator-delete.test.mjs`:
+
+```js
+import { assertD1AndBlossomState } from './e2e-creator-delete.mjs';
+
+describe('assertD1AndBlossomState', () => {
+  const cfg = parseArgs([]);
+  const KIND5 = 'a'.repeat(64);
+  const TARGET = 'b'.repeat(64);
+  const SHA = 'c'.repeat(64);
+
+  const makeD1Row = (overrides) => JSON.stringify([{
+    results: [{ kind5_id: KIND5, target_event_id: TARGET, blob_sha256: SHA, status: 'success', ...overrides }],
+    success: true, meta: {}
+  }]);
+
+  it('passes when D1 row status=success and Blossom returns 404 (bytes gone)', async () => {
+    const runner = makeFakeRunner(() => ({ stdout: makeD1Row(), stderr: '', status: 0 }));
+    const fetchImpl = makeFakeFetch(async () => ({ ok: false, status: 404, text: async () => 'not found' }));
+    const out = await assertD1AndBlossomState(KIND5, SHA, cfg, { runner, fetchImpl });
+    expect(out.d1Status).toBe('success');
+    expect(out.byteProbe).toMatchObject({ kind: 'bytes_gone', flagStateInferred: 'on' });
+  });
+
+  it('passes when D1 row status=success and Blossom returns 200 (bytes present, flag off)', async () => {
+    const runner = makeFakeRunner(() => ({ stdout: makeD1Row(), stderr: '', status: 0 }));
+    const fetchImpl = makeFakeFetch(async () => ({ ok: true, status: 200, text: async () => 'bytes' }));
+    const out = await assertD1AndBlossomState(KIND5, SHA, cfg, { runner, fetchImpl });
+    expect(out.byteProbe).toMatchObject({ kind: 'bytes_present', flagStateInferred: 'off' });
+  });
+
+  it('fails when D1 row is missing', async () => {
+    const runner = makeFakeRunner(() => ({ stdout: JSON.stringify([{ results: [], success: true, meta: {} }]), stderr: '', status: 0 }));
+    const fetchImpl = makeFakeFetch(async () => ({ ok: false, status: 404, text: async () => '' }));
+    await expect(assertD1AndBlossomState(KIND5, SHA, cfg, { runner, fetchImpl })).rejects.toThrow(/D1 row not found/i);
+  });
+
+  it('fails when D1 row status is not success', async () => {
+    const runner = makeFakeRunner(() => ({ stdout: makeD1Row({ status: 'failed:transient:timeout' }), stderr: '', status: 0 }));
+    const fetchImpl = makeFakeFetch(async () => ({ ok: false, status: 404, text: async () => '' }));
+    await expect(assertD1AndBlossomState(KIND5, SHA, cfg, { runner, fetchImpl })).rejects.toThrow(/status=failed:transient:timeout/i);
+  });
+
+  it('fails when byte probe returns unknown status', async () => {
+    const runner = makeFakeRunner(() => ({ stdout: makeD1Row(), stderr: '', status: 0 }));
+    const fetchImpl = makeFakeFetch(async () => ({ ok: false, status: 500, text: async () => 'server error' }));
+    await expect(assertD1AndBlossomState(KIND5, SHA, cfg, { runner, fetchImpl })).rejects.toThrow(/byte probe returned unknown/i);
+  });
+
+  it('fails when sha256 on the D1 row does not match the expected sha', async () => {
+    const wrongSha = 'e'.repeat(64);
+    const runner = makeFakeRunner(() => ({ stdout: makeD1Row({ blob_sha256: wrongSha }), stderr: '', status: 0 }));
+    const fetchImpl = makeFakeFetch(async () => ({ ok: false, status: 404, text: async () => '' }));
+    await expect(assertD1AndBlossomState(KIND5, SHA, cfg, { runner, fetchImpl })).rejects.toThrow(/blob_sha256 mismatch/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- scripts/e2e-creator-delete.test.mjs`
+
+Expected: FAIL — `assertD1AndBlossomState` not exported.
+
+- [ ] **Step 3: Implement**
+
+Append to `scripts/e2e-creator-delete.mjs`:
+
+```js
+export async function assertD1AndBlossomState(kind5Id, expectedSha, cfg, deps = {}) {
+  validateHex64(kind5Id, 'kind5_id');
+  validateHex64(expectedSha, 'expectedSha');
+
+  const runner = deps.runner || defaultRunner;
+  const fetchImpl = deps.fetchImpl || fetch;
+
+  // (a) D1 row check
+  const sql = `SELECT kind5_id, target_event_id, blob_sha256, status FROM creator_deletions WHERE kind5_id = '${kind5Id}';`;
+  const args = ['d1', 'execute', cfg.d1Database, '--remote', '--json', '--command', sql];
+  const r = await runner({ command: 'wrangler', args });
+  if (r.status !== 0) {
+    throw new Error(`wrangler d1 execute failed (exit ${r.status}): ${r.stderr.trim() || r.stdout.trim()}`);
+  }
+  const parsed = JSON.parse(r.stdout);
+  const rows = (parsed?.[0]?.results) || [];
+  if (rows.length === 0) {
+    throw new Error(`D1 row not found for kind5_id=${kind5Id}`);
+  }
+  const row = rows[0];
+  if (row.status !== 'success') {
+    throw new Error(`expected D1 status='success', got status=${row.status}`);
+  }
+  if (row.blob_sha256 !== expectedSha) {
+    throw new Error(`blob_sha256 mismatch: D1 has ${row.blob_sha256}, expected ${expectedSha}`);
+  }
+
+  // (b) Blossom byte probe
+  const probe = await fetchImpl(`${cfg.blossomBase}/${expectedSha}`, { method: 'GET' });
+  const byteProbe = classifyByteProbeResponse(probe.status);
+  if (byteProbe.kind === 'unknown') {
+    throw new Error(`Blossom byte probe returned unknown status: ${probe.status}`);
+  }
+
+  return { d1Status: row.status, byteProbe };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- scripts/e2e-creator-delete.test.mjs`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/e2e-creator-delete.mjs scripts/e2e-creator-delete.test.mjs
+git commit -m "feat(e2e): assertD1AndBlossomState (D1 + byte probe)"
+```
+
+---
+
+## Task 12: Scenario functions
+
+**Files:**
+- Modify: `scripts/e2e-creator-delete.mjs`
+- Modify: `scripts/e2e-creator-delete.test.mjs`
+
+Scenario functions glue the helpers into a pipeline. They are tested via injected deps for every side effect: `runner` (wrangler), `fetchImpl`, `publishImpl` (for WS), and `notifyImpl` (reserved for future).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `scripts/e2e-creator-delete.test.mjs`:
+
+```js
+import { runSyncScenario, runCronScenario } from './e2e-creator-delete.mjs';
+
+describe('runSyncScenario', () => {
+  const cfg = { ...parseArgs([]), blossomWebhookSecret: 'test-secret' };
+
+  function makeDeps({ uploadResult, publishEventIds, statusBody, d1Row, byteProbeStatus, vanishResult }) {
+    const published = [];
+    return {
+      uploadToBlossom: async () => uploadResult,
+      publishEvent: async (event) => {
+        published.push(event);
+        return publishEventIds.shift() || event.id;
+      },
+      waitForIndexing: async () => ({ polls: 1 }),
+      callSyncEndpoint: async () => ({ accepted: true }),
+      pollStatus: async () => statusBody,
+      runner: makeFakeRunner((sql) => {
+        if (sql.startsWith('SELECT')) {
+          return { stdout: JSON.stringify([{ results: [d1Row], success: true, meta: {} }]), stderr: '', status: 0 };
+        }
+        if (sql.startsWith('DELETE')) {
+          return { stdout: JSON.stringify([{ results: [], success: true, meta: {} }]), stderr: '', status: 0 };
+        }
+        throw new Error('unexpected sql: ' + sql.slice(0, 80));
+      }),
+      fetchImpl: makeFakeFetch(async ({ url }) => {
+        if (url.endsWith('/admin/api/vanish')) {
+          return { ok: true, status: 200, json: async () => vanishResult };
+        }
+        // byte probe
+        return { ok: byteProbeStatus === 200, status: byteProbeStatus, text: async () => '' };
+      }),
+      published
+    };
+  }
+
+  it('passes end-to-end with flag-on path (byte probe 404)', async () => {
+    const SHA = 'a'.repeat(64);
+    const deps = makeDeps({
+      uploadResult: { sha256: SHA, url: `${cfg.blossomBase}/${SHA}` },
+      publishEventIds: [],
+      statusBody: { status: 'success', blob_sha256: SHA, polls: 4 },
+      d1Row: { kind5_id: '', target_event_id: '', blob_sha256: SHA, status: 'success' },
+      byteProbeStatus: 404,
+      vanishResult: { vanished: true, fully_deleted: 1, unlinked: 0, errors: 0 }
+    });
+    const result = await runSyncScenario(cfg, deps);
+    expect(result.outcome).toBe('pass');
+    expect(result.cleanup.blossom.fullyDeleted).toBe(1);
+    expect(result.cleanup.d1.ok).toBe(true);
+  });
+
+  it('fails when pollStatus returns a failed:* terminal, but cleanup still runs', async () => {
+    const SHA = 'a'.repeat(64);
+    const deps = makeDeps({
+      uploadResult: { sha256: SHA, url: `${cfg.blossomBase}/${SHA}` },
+      publishEventIds: [],
+      statusBody: { status: 'failed:permanent:target_not_found' },
+      d1Row: { kind5_id: '', target_event_id: '', blob_sha256: SHA, status: 'failed:permanent:target_not_found' },
+      byteProbeStatus: 200,
+      vanishResult: { vanished: true, fully_deleted: 1, unlinked: 0, errors: 0 }
+    });
+    const result = await runSyncScenario(cfg, deps);
+    expect(result.outcome).toBe('fail');
+    expect(result.cleanup.blossom.fullyDeleted).toBe(1);
+  });
+
+  it('skips cleanup when cfg.skipCleanup is true', async () => {
+    const SHA = 'a'.repeat(64);
+    const cfgNoCleanup = { ...cfg, skipCleanup: true };
+    const deps = makeDeps({
+      uploadResult: { sha256: SHA, url: `${cfg.blossomBase}/${SHA}` },
+      publishEventIds: [],
+      statusBody: { status: 'success', blob_sha256: SHA },
+      d1Row: { kind5_id: '', target_event_id: '', blob_sha256: SHA, status: 'success' },
+      byteProbeStatus: 404,
+      vanishResult: { vanished: true, fully_deleted: 1, unlinked: 0, errors: 0 }
+    });
+    const result = await runSyncScenario(cfgNoCleanup, deps);
+    expect(result.outcome).toBe('pass');
+    expect(result.cleanup).toEqual({ skipped: true });
+  });
+});
+
+describe('runCronScenario', () => {
+  const cfg = { ...parseArgs([]), blossomWebhookSecret: 'test-secret' };
+
+  it('does NOT call the sync endpoint; relies on pollStatus for cron-triggered D1 update', async () => {
+    const SHA = 'a'.repeat(64);
+    let syncCalls = 0;
+    const deps = {
+      uploadToBlossom: async () => ({ sha256: SHA, url: `${cfg.blossomBase}/${SHA}` }),
+      publishEvent: async (event) => event.id,
+      waitForIndexing: async () => ({ polls: 1 }),
+      callSyncEndpoint: async () => { syncCalls++; return { accepted: true }; },
+      pollStatus: async () => ({ status: 'success', blob_sha256: SHA }),
+      runner: makeFakeRunner((sql) => {
+        if (sql.startsWith('SELECT')) return { stdout: JSON.stringify([{ results: [{ kind5_id: '', target_event_id: '', blob_sha256: SHA, status: 'success' }], success: true, meta: {} }]), stderr: '', status: 0 };
+        return { stdout: JSON.stringify([{ results: [], success: true, meta: {} }]), stderr: '', status: 0 };
+      }),
+      fetchImpl: makeFakeFetch(async ({ url }) => {
+        if (url.endsWith('/admin/api/vanish')) return { ok: true, status: 200, json: async () => ({ vanished: true, fully_deleted: 1, unlinked: 0, errors: 0 }) };
+        return { ok: false, status: 404, text: async () => '' };
+      })
+    };
+    const result = await runCronScenario(cfg, deps);
+    expect(syncCalls).toBe(0);
+    expect(result.outcome).toBe('pass');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- scripts/e2e-creator-delete.test.mjs`
+
+Expected: FAIL — `runSyncScenario` / `runCronScenario` not exported.
+
+- [ ] **Step 3: Implement**
+
+Append to `scripts/e2e-creator-delete.mjs`:
+
+```js
+function nowIso() { return new Date().toISOString(); }
+
+function emit(obj) { console.log(JSON.stringify(obj)); }
+
+async function runScenario(name, cfg, deps, opts) {
+  const { sk, pubkey } = (deps.generateTestKey || generateTestKey)();
+  const blob = (deps.generateSyntheticBlob || generateSyntheticBlob)();
+  const started = Date.now();
+  let kind5Id = null;
+  let target = null;
+  let assertResult = null;
+  let outcome = 'pass';
+  let failureReason = null;
+
+  try {
+    // 1. Upload
+    const upload = await (deps.uploadToBlossom || uploadToBlossom)(blob.bytes, blob.sha256, sk, cfg, deps.fetchImpl);
+    emit({ ts: nowIso(), scenario: name, step: 'upload', ok: true, sha256: blob.sha256, bytes: blob.bytes.length });
+
+    // 2. Publish kind 34236
+    const event = buildKind34236Event(sk, blob.sha256, cfg);
+    target = await (deps.publishEvent || publishEvent)(event, cfg.stagingRelay);
+    emit({ ts: nowIso(), scenario: name, step: 'publish_kind34236', ok: true, event_id: target });
+
+    // 3. Wait for Funnelcake to index it
+    const indexing = await (deps.waitForIndexing || waitForIndexing)(target, cfg, { fetchImpl: deps.fetchImpl });
+    emit({ ts: nowIso(), scenario: name, step: 'wait_indexing', ok: true, polls: indexing.polls });
+
+    // 4. Publish kind 5
+    const kind5Event = finalizeEvent({
+      kind: 5,
+      created_at: Math.floor(Date.now() / 1000),
+      tags: [['e', target], ['k', '34236'], ['client', 'diVine']],
+      content: 'e2e test delete'
+    }, sk);
+    kind5Id = await (deps.publishEvent || publishEvent)(kind5Event, cfg.stagingRelay);
+    emit({ ts: nowIso(), scenario: name, step: 'publish_kind5', ok: true, kind5_id: kind5Id });
+
+    // 5. Sync (sync scenario only)
+    if (opts.callSync) {
+      await (deps.callSyncEndpoint || callSyncEndpoint)(sk, kind5Event, cfg, deps.fetchImpl);
+      emit({ ts: nowIso(), scenario: name, step: 'call_sync', ok: true });
+    }
+
+    // 6. Poll status
+    const pollOpts = {
+      fetchImpl: deps.fetchImpl,
+      timeoutMs: opts.statusTimeoutMs,
+      pollIntervalMs: opts.statusPollIntervalMs
+    };
+    const status = await (deps.pollStatus || pollStatus)(sk, kind5Id, cfg, pollOpts);
+    emit({ ts: nowIso(), scenario: name, step: 'poll_status', ok: status.status === 'success', terminal_status: status.status, polls: status.polls });
+    if (status.status !== 'success') {
+      throw new Error(`pipeline failed: ${status.status}`);
+    }
+
+    // 7. Assert D1 + Blossom state
+    assertResult = await (deps.assertD1AndBlossomState || assertD1AndBlossomState)(kind5Id, blob.sha256, cfg, { runner: deps.runner, fetchImpl: deps.fetchImpl });
+    emit({ ts: nowIso(), scenario: name, step: 'assert_d1_and_blossom', ok: true, d1_status: assertResult.d1Status, byte_probe: assertResult.byteProbe.kind });
+  } catch (err) {
+    outcome = 'fail';
+    failureReason = err.message;
+    emit({ ts: nowIso(), scenario: name, step: 'failure', ok: false, error: err.message });
+  }
+
+  // 8. Cleanup (always, unless --skip-cleanup)
+  let cleanup = null;
+  if (cfg.skipCleanup) {
+    cleanup = { skipped: true };
+    emit({ ts: nowIso(), scenario: name, step: 'cleanup', ok: true, skipped: true });
+  } else {
+    cleanup = { blossom: null, d1: null };
+    try {
+      cleanup.blossom = await (deps.cleanupBlossomVanish || cleanupBlossomVanish)(pubkey, cfg, deps.fetchImpl);
+      emit({ ts: nowIso(), scenario: name, step: 'cleanup_blossom', ok: true, ...cleanup.blossom });
+    } catch (err) {
+      cleanup.blossom = { ok: false, error: err.message };
+      emit({ ts: nowIso(), scenario: name, step: 'cleanup_blossom', ok: false, error: err.message });
+    }
+    if (kind5Id && target) {
+      try {
+        await (deps.cleanupD1Row || cleanupD1Row)(kind5Id, target, cfg, deps.runner);
+        cleanup.d1 = { ok: true };
+        emit({ ts: nowIso(), scenario: name, step: 'cleanup_d1', ok: true });
+      } catch (err) {
+        cleanup.d1 = { ok: false, error: err.message };
+        emit({ ts: nowIso(), scenario: name, step: 'cleanup_d1', ok: false, error: err.message });
+      }
+    } else {
+      cleanup.d1 = { ok: true, skipped: 'no kind5/target' };
+    }
+  }
+
+  const totalDurationMs = Date.now() - started;
+  emit({ ts: nowIso(), scenario: name, outcome, total_duration_ms: totalDurationMs });
+  return { outcome, failureReason, cleanup, pubkey, sha256: blob.sha256, kind5Id, target, totalDurationMs };
+}
+
+export async function runSyncScenario(cfg, deps = {}) {
+  return runScenario('sync', cfg, deps, { callSync: true, statusTimeoutMs: 60000, statusPollIntervalMs: 2000 });
+}
+
+export async function runCronScenario(cfg, deps = {}) {
+  return runScenario('cron', cfg, deps, { callSync: false, statusTimeoutMs: cfg.cronWaitSeconds * 1000, statusPollIntervalMs: 3000 });
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- scripts/e2e-creator-delete.test.mjs`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/e2e-creator-delete.mjs scripts/e2e-creator-delete.test.mjs
+git commit -m "feat(e2e): runSyncScenario + runCronScenario (orchestrators with always-cleanup)"
+```
+
+---
+
+## Task 13: printSummary + computeExitCode + main()
+
+**Files:**
+- Modify: `scripts/e2e-creator-delete.mjs`
+- Modify: `scripts/e2e-creator-delete.test.mjs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `scripts/e2e-creator-delete.test.mjs`:
+
+```js
+import { computeExitCode, main } from './e2e-creator-delete.mjs';
+
+describe('computeExitCode', () => {
+  it('0 when all scenarios pass and all cleanups ok', () => {
+    expect(computeExitCode([
+      { outcome: 'pass', cleanup: { blossom: { errors: 0 }, d1: { ok: true } } },
+      { outcome: 'pass', cleanup: { blossom: { errors: 0 }, d1: { ok: true } } }
+    ])).toBe(0);
+  });
+
+  it('1 when any scenario fails, regardless of cleanup', () => {
+    expect(computeExitCode([
+      { outcome: 'fail', cleanup: { blossom: { errors: 0 }, d1: { ok: true } } }
+    ])).toBe(1);
+  });
+
+  it('3 when scenarios pass but a cleanup failed', () => {
+    expect(computeExitCode([
+      { outcome: 'pass', cleanup: { blossom: { errors: 0 }, d1: { ok: false, error: 'x' } } }
+    ])).toBe(3);
+  });
+
+  it('1 (takes precedence) when a scenario fails AND cleanup failed', () => {
+    expect(computeExitCode([
+      { outcome: 'fail', cleanup: { blossom: { ok: false, error: 'x' }, d1: { ok: false, error: 'y' } } }
+    ])).toBe(1);
+  });
+
+  it('0 when scenarios pass and cleanup was skipped', () => {
+    expect(computeExitCode([
+      { outcome: 'pass', cleanup: { skipped: true } }
+    ])).toBe(0);
+  });
+});
+
+describe('main (integration)', () => {
+  const baseDeps = {
+    uploadToBlossom: async () => ({ sha256: 'a'.repeat(64), url: 'u' }),
+    publishEvent: async (event) => event.id,
+    waitForIndexing: async () => ({ polls: 1 }),
+    callSyncEndpoint: async () => ({ accepted: true }),
+    pollStatus: async () => ({ status: 'success', blob_sha256: 'a'.repeat(64) }),
+    assertD1AndBlossomState: async () => ({ d1Status: 'success', byteProbe: { kind: 'bytes_gone', flagStateInferred: 'on' } }),
+    cleanupBlossomVanish: async () => ({ fullyDeleted: 1, unlinked: 0, errors: 0 }),
+    cleanupD1Row: async () => {},
+    blossomWebhookSecret: 'test-secret'
+  };
+
+  it('exits 0 on a passing both-scenarios run', async () => {
+    const code = await main(['--scenario=both'], baseDeps);
+    expect(code).toBe(0);
+  });
+
+  it('exits 1 when pollStatus reports failed:*', async () => {
+    const deps = { ...baseDeps, pollStatus: async () => ({ status: 'failed:permanent:target_not_found' }) };
+    const code = await main(['--scenario=sync'], deps);
+    expect(code).toBe(1);
+  });
+
+  it('exits 2 on missing BLOSSOM_WEBHOOK_SECRET', async () => {
+    const deps = { ...baseDeps, blossomWebhookSecret: null, env: {} };
+    const code = await main(['--scenario=sync'], deps);
+    expect(code).toBe(2);
+  });
+
+  it('exits 2 on invalid --scenario', async () => {
+    const code = await main(['--scenario=invalid'], baseDeps);
+    expect(code).toBe(2);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- scripts/e2e-creator-delete.test.mjs`
+
+Expected: FAIL — `main` / `computeExitCode` not exported.
+
+- [ ] **Step 3: Implement**
+
+Append to `scripts/e2e-creator-delete.mjs`:
+
+```js
+export function computeExitCode(results) {
+  const anyFailed = results.some(r => r.outcome === 'fail');
+  if (anyFailed) return 1;
+  const anyCleanupFailed = results.some(r => {
+    if (r.cleanup?.skipped) return false;
+    if (r.cleanup?.blossom?.ok === false) return true;
+    if (r.cleanup?.blossom?.errors > 0) return true;
+    if (r.cleanup?.d1?.ok === false) return true;
+    return false;
+  });
+  if (anyCleanupFailed) return 3;
+  return 0;
+}
+
+export function printSummary(results) {
+  process.stderr.write('\n=== E2E SUMMARY ===\n');
+  for (const r of results) {
+    const seconds = (r.totalDurationMs / 1000).toFixed(1);
+    const label = r.outcome.toUpperCase();
+    const detail = r.outcome === 'fail' ? `  (${r.failureReason})` : '';
+    process.stderr.write(`Scenario: ${r.scenario.padEnd(6)}${label}  ${seconds}s${detail}\n`);
+  }
+
+  const artifacts = results.filter(r => !r.cleanup?.skipped);
+  if (artifacts.length > 0) {
+    process.stderr.write('\n=== ARTIFACTS (cleaned) ===\n');
+    for (const r of artifacts) {
+      const blossom = r.cleanup?.blossom?.ok === false
+        ? `vanish=FAILED:${r.cleanup.blossom.error}`
+        : `vanish=fully_deleted:${r.cleanup.blossom?.fullyDeleted ?? '?'}`;
+      const d1 = r.cleanup?.d1?.ok === false ? `d1=FAILED:${r.cleanup.d1.error}` : 'd1=cleaned';
+      process.stderr.write(`sha=${r.sha256}  kind5=${r.kind5Id || '-'}  ${blossom}  ${d1}  (${r.scenario})\n`);
+    }
+  }
+
+  const manual = results.filter(r => {
+    if (r.cleanup?.skipped) return false;
+    return r.cleanup?.blossom?.ok === false || r.cleanup?.d1?.ok === false;
+  });
+  process.stderr.write('\n=== MANUAL CLEANUP NEEDED ===\n');
+  if (manual.length === 0) {
+    process.stderr.write('(none)\n');
+  } else {
+    for (const r of manual) {
+      if (r.cleanup?.blossom?.ok === false) {
+        process.stderr.write(`sha=${r.sha256} pubkey=${r.pubkey} (${r.scenario})\n`);
+        process.stderr.write(`  curl -X POST -H "Authorization: Bearer $BLOSSOM_WEBHOOK_SECRET" \\\n`);
+        process.stderr.write(`       ${DEFAULT_BLOSSOM_BASE}/admin/api/vanish \\\n`);
+        process.stderr.write(`       -d '{"pubkey":"${r.pubkey}","reason":"e2e-test manual cleanup"}'\n`);
+      }
+      if (r.cleanup?.d1?.ok === false) {
+        process.stderr.write(`  wrangler d1 execute ${DEFAULT_D1_DATABASE} --remote \\\n`);
+        process.stderr.write(`       --command "DELETE FROM creator_deletions WHERE kind5_id='${r.kind5Id}' AND target_event_id='${r.target}';"\n`);
+      }
+    }
+  }
+
+  const code = computeExitCode(results);
+  process.stderr.write(`\nExit: ${code}\n`);
+}
+
+function readBlossomSecret(deps) {
+  if (deps.blossomWebhookSecret) return deps.blossomWebhookSecret;
+  const env = deps.env || (typeof process !== 'undefined' ? process.env : {});
+  const s = env.BLOSSOM_WEBHOOK_SECRET;
+  if (!s) throw new Error('BLOSSOM_WEBHOOK_SECRET env var is required');
+  return s;
+}
+
+export async function main(argv, deps = {}) {
+  let cfg;
+  try {
+    cfg = parseArgs(argv);
+  } catch (e) {
+    process.stderr.write(`arg error: ${e.message}\n`);
+    return 2;
+  }
+
+  try {
+    cfg.blossomWebhookSecret = readBlossomSecret(deps);
+  } catch (e) {
+    process.stderr.write(`${e.message}\n`);
+    return 2;
+  }
+
+  const results = [];
+  if (cfg.scenario === 'sync' || cfg.scenario === 'both') {
+    const r = await runSyncScenario(cfg, deps);
+    results.push({ ...r, scenario: 'sync' });
+  }
+  if (cfg.scenario === 'cron' || cfg.scenario === 'both') {
+    const r = await runCronScenario(cfg, deps);
+    results.push({ ...r, scenario: 'cron' });
+  }
+
+  printSummary(results);
+  return computeExitCode(results);
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- scripts/e2e-creator-delete.test.mjs`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/e2e-creator-delete.mjs scripts/e2e-creator-delete.test.mjs
+git commit -m "feat(e2e): main() + printSummary + computeExitCode"
+```
+
+---
+
+## Task 14: CLI entrypoint + lint + full test
+
+**Files:**
+- Modify: `scripts/e2e-creator-delete.mjs`
+
+- [ ] **Step 1: Add the CLI entrypoint**
+
+Append to `scripts/e2e-creator-delete.mjs`:
+
+```js
+// CLI entrypoint — runs only when invoked directly (not when imported by tests).
+const isMain = typeof process !== 'undefined' && process.argv && import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  main(process.argv.slice(2)).then(
+    (code) => process.exit(code),
+    (err) => {
+      process.stderr.write(`unexpected error: ${err.stack || err.message}\n`);
+      process.exit(99);
+    }
+  );
+}
+```
+
+- [ ] **Step 2: Sanity check imports work**
+
+Run:
+
+```bash
+node -e "import('./scripts/e2e-creator-delete.mjs').then(m => console.log(Object.keys(m).sort().join(',')))"
+```
+
+Expected output (order may vary): `assertD1AndBlossomState,buildBud01UploadAuth,buildKind34236Event,callSyncEndpoint,classifyByteProbeResponse,cleanupBlossomVanish,cleanupD1Row,computeExitCode,defaultRunner,generateSyntheticBlob,generateTestKey,main,parseArgs,pollStatus,printSummary,publishEvent,runCronScenario,runSyncScenario,uploadToBlossom,waitForIndexing`
+
+- [ ] **Step 3: Sanity check CLI fails fast on missing env**
+
+Run: `unset BLOSSOM_WEBHOOK_SECRET; node scripts/e2e-creator-delete.mjs --scenario=sync; echo "exit=$?"`
+
+Expected: prints `BLOSSOM_WEBHOOK_SECRET env var is required` and `exit=2`.
+
+- [ ] **Step 4: Sanity check --scenario validation**
+
+Run: `BLOSSOM_WEBHOOK_SECRET=x node scripts/e2e-creator-delete.mjs --scenario=invalid; echo "exit=$?"`
+
+Expected: prints `arg error: Invalid scenario: invalid (must be sync|cron|both)` and `exit=2`.
+
+- [ ] **Step 5: Run lint**
+
+Run: `npm run lint`
+
+Expected: clean.
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `npm test`
+
+Expected: all tests green. ~40 new test cases added across `sign-nip98.test.mjs` + `e2e-creator-delete.test.mjs`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/e2e-creator-delete.mjs
+git commit -m "feat(e2e): CLI entrypoint + pre-flight arg/env diagnostics"
+```
+
+---
+
+## Task 15: Push branch + draft PR
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Push**
+
+Run: `git push -u origin spec/creator-delete-e2e-test`
+
+- [ ] **Step 2: Open draft PR**
+
+Run:
+
+```bash
+gh pr create --draft --title "feat(e2e): creator-delete end-to-end test (mod-service#101)" --body "$(cat <<'EOF'
+Closes #101.
+
+Spec: docs/superpowers/specs/2026-04-18-creator-delete-e2e-test-design.md
+Plan: docs/superpowers/plans/2026-04-20-creator-delete-e2e-test-plan.md
+
+## Summary
+
+Operator-run script that exercises the full creator-delete pipeline end-to-end:
+- Uploads a synthetic 1KB blob to prod Blossom (BUD-02)
+- Publishes kind 34236 to staging relay; polls Funnelcake until indexed
+- Runs the sync scenario (kind 5 + sync endpoint call) and the cron scenario (kind 5 only) against the prod mod-service worker
+- Asserts D1 `creator_deletions` row reached status='success' and Blossom returned either 404 (flag on, bytes gone) or 200 (flag off, soft-delete)
+- Cleans up in a \`finally\`: \`/admin/api/vanish\` for the test pubkey (full GCS+KV+VCL purge for the one blob it owns) and a DELETE on the D1 row(s)
+- Prints JSONL per step on stdout; summary + manual-cleanup instructions on stderr
+
+Adopts the \`docs/superpowers/\` historical-framing policy from divine-blossom PR #91 as part of this branch.
+
+## Test plan
+
+- [x] ~40 unit tests for pure helpers + main() integration with injected deps
+- [x] Lint clean
+- [ ] Run the script against staging-relay + prod-blossom + prod-mod-service after merge, during rollout validation
+
+## Notes for reviewers
+
+- WebSocket publish uses \`ws\` (transitive dep via nostr-tools + wrangler). If resolution breaks on a future package bump, add \`ws\` to \`devDependencies\` explicitly.
+- Contract grounding: \`buildKind34236Event\` tests are pinned to divine-funnelcake/crates/relay/src/relay.rs:1023-1087 (video tag validation rules). \`cleanupBlossomVanish\` response shape pinned to divine-blossom/src/main.rs:209,3975.
+- The script does not pre-flight \`CREATOR_DELETE_PIPELINE_ENABLED\` on the prod worker; on polling timeout it surfaces a hint pointing at that flag as the most likely cause.
+EOF
+)"
+```
+
+- [ ] **Step 3: Check CI**
+
+Run: `gh pr checks <PR-number>`
+
+Expected: all checks pass.
+
+---
+
+## Task 16: Local smoke check (deferred until rollout window)
+
+**Files:** none (operational verification)
+
+This validates the script against real services. Deferred until the upstream creator-delete PRs (blossom #97, mod-service #106) land and a rollout window is scheduled.
+
+- [ ] **Step 1: Export env**
+
+```bash
+export BLOSSOM_WEBHOOK_SECRET=<prod-webhook-secret>
+wrangler whoami   # confirm prod CF account
+```
+
+- [ ] **Step 2: Dry run logic check** — run only the sync scenario with `--skip-cleanup` on a branch where the prod worker's flag is known-on:
+
+```bash
+node scripts/e2e-creator-delete.mjs --scenario=sync --skip-cleanup | tee /tmp/e2e-sync.jsonl
+```
+
+Expected: exit 0, `assert_d1_and_blossom` step ok, `byte_probe: "bytes_gone"`, artifacts visible in Blossom admin (pubkey owns one blob, status=Deleted). Operator manually runs the printed vanish + wrangler commands to clean up.
+
+- [ ] **Step 3: Full run**
+
+```bash
+node scripts/e2e-creator-delete.mjs
+```
+
+Expected: both scenarios pass, summary shows cleaned artifacts and `(none)` under manual-cleanup, exit 0. Capture stdout JSONL + stderr summary to a worklog entry as evidence.
+
+- [ ] **Step 4: Worklog entry**
+
+Paste the stderr summary + the final ~10 lines of JSONL into `.context/worklog/YYYY-MM-DD.md` as evidence of a green e2e run.
+
+---
+
+## Self-review notes
+
+**Spec coverage check:**
+
+| Spec section | Implementing task |
+|---|---|
+| Ephemeral key generation | Task 3 (`generateTestKey`) |
+| Synthetic 1KB blob generation | Task 3 (`generateSyntheticBlob`) |
+| Kind 34236 event construction (Funnelcake contract) | Task 4 (`buildKind34236Event`) + contract tests |
+| Flag-state inference via byte probe | Task 5 (`classifyByteProbeResponse`) |
+| Wrangler D1 write for cleanup | Task 6 (`defaultRunner`, `cleanupD1Row`) |
+| Blossom vanish cleanup | Task 7 (`cleanupBlossomVanish`) |
+| Blossom upload (BUD-02 + BUD-01) | Task 8 (`uploadToBlossom`, `buildBud01UploadAuth`) |
+| Funnelcake indexing poll | Task 9 (`waitForIndexing`) |
+| WebSocket publish | Task 9 (`publishEvent`) |
+| Mod-service sync endpoint call | Task 10 (`callSyncEndpoint`) |
+| Mod-service status polling (re-signed NIP-98) | Task 10 (`pollStatus`) |
+| D1 + Blossom post-pipeline assertions | Task 11 (`assertD1AndBlossomState`) |
+| Sync scenario orchestration | Task 12 (`runSyncScenario`) |
+| Cron scenario orchestration (180s default wait) | Task 12 (`runCronScenario`) |
+| Per-step JSONL output | Task 12 (`emit` helper) |
+| Summary + exit codes + manual-cleanup instructions | Task 13 (`printSummary`, `computeExitCode`) |
+| CLI entrypoint + env validation | Task 14 |
+| Lint + test + PR | Tasks 14-15 |
+| Real-environment smoke check | Task 16 (deferred to rollout) |
+
+All spec sections map to a task. The SIGINT drain described in the spec's error-handling table is intentionally left as "script exits on Ctrl-C, cleanup runs in scenario `finally` blocks to the extent Node runtime permits." No explicit SIGINT handler like sweep's double-Ctrl-C pattern — this script is short-lived enough that an operator Ctrl-C is rare and the finally blocks are sufficient. If ops runs into this, add a handler in a follow-up.
+
+**Placeholder scan:** no TBD/TODO in any task. Every step has exact code or exact commands.
+
+**Type consistency check:**
+
+- `generateTestKey` returns `{sk, pubkey}` — used as `{sk}` or `{sk, pubkey}` consistently in Tasks 4, 5, 7, 8, 10, 11, 12.
+- `generateSyntheticBlob` returns `{bytes, sha256}` — used with that shape in Task 8, 12.
+- `classifyByteProbeResponse` returns `{kind, flagStateInferred}` or `{kind: 'unknown', status}` — consumed in Task 11 (assert) and Task 12 (JSONL emit).
+- `cleanupBlossomVanish` returns `{fullyDeleted, unlinked, errors}` — consumed by `runScenario` cleanup block and `printSummary`.
+- `runSyncScenario` / `runCronScenario` return `{outcome, failureReason, cleanup, pubkey, sha256, kind5Id, target, totalDurationMs}` — consumed by `computeExitCode` and `printSummary`. `runScenario` also sets `scenario` downstream in `main()`.
+- `runner` signature `{command, args} → {stdout, stderr, status}` — consistent between `defaultRunner`, `cleanupD1Row`, and `assertD1AndBlossomState`.
+- `fetchImpl` signature mirrors `fetch` — consistent across Tasks 7, 8, 10, 11, 12.
+
+**SIGINT:** deliberately omitted. See above.
+
+**Known risks:** `ws` as transitive dep (noted in PR description); prod-worker flag pre-flight not possible without a new endpoint (accepted trade-off from brainstorming).

--- a/docs/superpowers/specs/2026-04-18-creator-delete-e2e-test-design.md
+++ b/docs/superpowers/specs/2026-04-18-creator-delete-e2e-test-design.md
@@ -1,0 +1,299 @@
+# Creator-delete end-to-end test — design
+
+**Date:** 2026-04-18
+**Issue:** [divinevideo/divine-moderation-service#101](https://github.com/divinevideo/divine-moderation-service/issues/101)
+**Repo:** divine-moderation-service (new script + tests)
+**Status:** Design approved, pending implementation plan
+
+## Context
+
+PR #92 shipped creator-delete end-to-end enforcement with strong unit and integration coverage, but the full-pipeline e2e was deferred: a throwaway-key kind 34236 event did not persist to queryable state quickly enough for the in-house e2e attempt to complete. Issue #101 asks for a repeatable e2e test that exercises the real path from Nostr delete event through moderation-service to Blossom's deleted state — either sync or cron path, isolated, repeatable, without affecting production user content.
+
+Investigation into Funnelcake's ingest code (`divine-funnelcake/crates/relay/src/relay.rs:844-1391`) and REST read path (`crates/api/src/handlers.rs:5322` → `crates/clickhouse/src/client.rs:1484`) confirmed there is no creator-registration gate. Ephemeral keys *are* indexed into ClickHouse once the normal video tag validation and batch-write pass. The previous e2e-failure attributions were likely ClickHouse batch-flush + ReplacingMergeTree dedup propagation latency, not a pubkey whitelist.
+
+That opens up a cleaner shape: operator-run script with ephemeral keys, targeted against a mix of staging (relay) and prod (Blossom + mod-service worker) so that Nostr events stay out of prod user feeds while the media and pipeline are exercised for real.
+
+## Goals
+
+- Prove the full route from kind 5 publish through mod-service to Blossom's deleted state.
+- Cover both pipeline paths: direct sync endpoint and cron pickup.
+- Repeatable on demand, no human orchestration beyond invoking the script.
+- Leave production Blossom and D1 in the same state after each run as before it, via active cleanup.
+- Surface real regression signal when Blossom or mod-service pipeline code changes.
+
+## Non-goals
+
+- Not a CI-automated test. Hitting real prod Blossom on every commit is unsafe and generates audit-log noise.
+- Not a replacement for unit tests. The in-script unit tests cover pure helpers; the e2e itself is an integration gate.
+- Not a load or stress test. One sync + one cron scenario per run.
+- Not intended to validate account-level vanish (NIP-62) or moderator-initiated deletes.
+- Not designed to work when the prod worker's `CREATOR_DELETE_PIPELINE_ENABLED` is off. If that flag is unset, the test will fail with a polling timeout; operator verifies and re-runs.
+
+## Environment targeting
+
+| Layer | Target | Why |
+|---|---|---|
+| Nostr relay (publish + fetch) | `wss://relay.staging.divine.video` (staging Funnelcake) | Keeps test kind 34236 / kind 5 events out of prod user feeds. |
+| Media server (upload + state check + cleanup) | `https://media.divine.video` (prod Blossom) | No staging Blossom exists; prod is the only real target for the media path. |
+| mod-service worker (sync endpoint + cron) | `https://moderation-api.divine.video` (prod) | The live pipeline runs on the prod worker; "staging mod-service" is not deployed. |
+| D1 (state check + cleanup) | `blossom-webhook-events` on prod via `wrangler --remote` | Same D1 binding the live pipeline writes. |
+
+The mixed posture is the trade-off: prod Blossom + prod D1 unavoidable because no staging instances exist for them. Staging relay keeps the Nostr artifacts out of prod feeds. Active cleanup returns prod Blossom and prod D1 to their pre-run state.
+
+## Architecture
+
+```
+operator laptop
+   │
+   └─ scripts/e2e-creator-delete.mjs  [--scenario=sync|cron|both]
+        │
+        ├─ generateTestKey()                       fresh ephemeral secp256k1; in-memory only
+        ├─ generateSyntheticBlob()                 1KB bytes, unique sha256
+        │
+        ├─ uploadToBlossom(bytes)         ─→ https://media.divine.video (PUT /upload, BUD-02)
+        ├─ publishKind34236(sk, sha256)   ─→ wss://relay.staging.divine.video
+        ├─ waitForIndexing(event_id)      ─→ poll https://funnelcake.staging..../api/event/{id}
+        │
+        ├─ SCENARIO sync:
+        │   ├─ publishKind5(sk, target_event_id)   ─→ staging relay
+        │   ├─ callSyncEndpoint(sk, kind5_event)   ─→ prod mod-service /api/creator-delete/sync
+        │   ├─ pollStatus(kind5_id)                ─→ prod mod-service /api/creator-delete/status/{id}
+        │   └─ assertD1AndBlossomState
+        │
+        ├─ SCENARIO cron (independent key + blob):
+        │   ├─ publishKind5(sk, target_event_id)   ─→ staging relay (no sync call)
+        │   ├─ waitForCronPickup (poll status ≤180s)
+        │   └─ assertD1AndBlossomState
+        │
+        └─ CLEANUP (always, even on failure; best-effort):
+            ├─ cleanupBlossomVanish(pubkey)        ─→ POST /admin/api/vanish (full purge)
+            └─ cleanupD1Row(kind5_id, target_id)   ─→ wrangler d1 execute --remote DELETE
+```
+
+**Boundaries:**
+
+- Script is the orchestrator. No new mod-service or Blossom code.
+- Each scenario uses its own ephemeral key + fresh blob — no cross-contamination.
+- Cleanup uses `/admin/api/vanish` (verified in `divine-blossom/src/main.rs:209, 3975`), which for a pubkey owning one blob surgically purges GCS + KV + VCL for that single blob.
+
+## Components
+
+### `scripts/e2e-creator-delete.mjs`
+
+Single-file Node ESM, no transpilation. Operator-run: `node scripts/e2e-creator-delete.mjs [flags]`.
+
+**CLI flags:**
+
+```
+--scenario=sync|cron|both     Which scenarios to run. Default: both.
+--staging-relay=URL           Default: wss://relay.staging.divine.video
+--funnelcake-api=URL          Default: https://funnelcake.staging.dvines.org
+--blossom-base=URL            Default: https://media.divine.video
+--mod-service-base=URL        Default: https://moderation-api.divine.video
+--d1-database=NAME            Default: blossom-webhook-events (prod)
+--cron-wait-seconds=N         Default: 180 (derived from 1-minute cron interval)
+--skip-cleanup                Leave artifacts in place for post-failure inspection.
+--help
+```
+
+**Required env:**
+
+- `BLOSSOM_WEBHOOK_SECRET` — Bearer for Blossom `/admin/api/vanish` during cleanup.
+- Wrangler authed against the prod Cloudflare account.
+- Node 20+ (global `fetch`).
+
+**Blossom response contract (verified 2026-04-18):**
+
+The admin vanish endpoint (`divine-blossom/src/main.rs:209` → `handle_admin_vanish`, `src/main.rs:3975` → `execute_vanish`) returns:
+
+```json
+{
+  "vanished": true,
+  "pubkey": "<hex>",
+  "reason": "<string>",
+  "fully_deleted": 1,
+  "unlinked": 0,
+  "errors": 0
+}
+```
+
+The creator-delete moderate endpoint's response contract is pinned in `scripts/sweep-creator-deletes.mjs::classifyDeleteResult` — reads `success`, `physical_deleted`, `physical_delete_skipped` (from `divine-blossom/src/admin.rs:923-930`). The e2e script uses the same contract.
+
+**Internal functions** (each small, side effects isolated for unit testing):
+
+| Function | Purpose | Side effects |
+|---|---|---|
+| `parseArgs(argv)` | Typed config. | none (pure). |
+| `generateTestKey()` | Fresh secp256k1 keypair per scenario, in-memory only. | none. |
+| `generateSyntheticBlob()` | 1KB deterministic-looking pseudo-mp4 with unique sha256. | none. |
+| `uploadToBlossom(bytes, sk, cfg)` | BUD-02 PUT `/upload` signed with BUD-01 auth. Returns `{sha256, url}`. | network. |
+| `buildKind34236Event(sk, sha256, cfg)` | Pure: constructs the unsigned event JSON with all required video tags, signs, returns `{id, sig, ...}`. Tags: `d` (unique per test), `title`, `imeta` with space-delimited `url <blossom-url>` + `x <sha256>` + `m video/mp4`, and a `thumb` tag (synthetic URL; does not need to resolve per Funnelcake's check). Contract-grounded against `divine-funnelcake/crates/relay/src/relay.rs:1023-1087` + `validate_imeta_format` at the same file (each imeta item must contain a space). | none. |
+| `publishKind34236(event, cfg)` | WebSocket publish of the pre-built event to the staging relay. Returns event_id on OK, throws on relay rejection. 10s timeout. | network. |
+| `publishKind5(sk, target_event_id, cfg)` | WebSocket publish. Returns kind5_id. 10s timeout. | network. |
+| `waitForIndexing(event_id, cfg, timeoutMs=30000)` | Poll Funnelcake REST GET `/api/event/{event_id}` every 1s until 200 or timeout. | network. |
+| `signNip98(sk, url, method, payloadHash?)` | Reuses or imports from `scripts/sign-nip98.mjs`. | none. |
+| `callSyncEndpoint(sk, kind5_event, cfg)` | POST mod-service `/api/creator-delete/sync`, NIP-98-authed. 30s timeout. | network. |
+| `pollStatus(sk, kind5_id, cfg, timeoutMs)` | GET mod-service `/api/creator-delete/status/{kind5_id}`, NIP-98-authed (re-signs per poll). 2s interval (sync) or 3s interval (cron). | network. |
+| `classifyByteProbeResponse(httpStatus)` | Pure: 404 → `{kind: 'bytes_gone', flag_state_inferred: 'on'}`, 200 → `{kind: 'bytes_present', flag_state_inferred: 'off'}`, other → `{kind: 'unknown', status}` (treated as assertion failure). | none. |
+| `assertD1AndBlossomState(kind5_id, sha256, testPubkey, cfg)` | (a) Query D1 via wrangler to fetch the `creator_deletions` row; assert `status='success'`, `blob_sha256` matches. (b) GET `https://media.divine.video/<sha256>` (10s timeout); run `classifyByteProbeResponse(status)`; pass on `bytes_gone` OR `bytes_present`, fail on `unknown`. | reads D1, reads Blossom. |
+| `cleanupBlossomVanish(testPubkey, cfg)` | POST `/admin/api/vanish` with Bearer auth, reason `"e2e-test cleanup"`. Log `fully_deleted`/`unlinked`/`errors`. 30s timeout. | writes prod Blossom. |
+| `cleanupD1Row(kind5_id, target_event_id, cfg)` | `wrangler d1 execute --remote --command "DELETE FROM creator_deletions WHERE kind5_id=? AND target_event_id=?"`. 30s timeout. | writes prod D1. |
+| `runSyncScenario(cfg)` | Full sync flow with cleanup in a `finally`. | all of the above. |
+| `runCronScenario(cfg)` | Full cron flow (no sync call, longer wait) with cleanup in a `finally`. | all of the above. |
+| `printSummary(results)` | Per-scenario pass/fail + timing + any manual-cleanup remnants. stderr. | stderr. |
+| `main(argv)` | Wires it all together. | all. |
+
+### `scripts/e2e-creator-delete.test.mjs`
+
+Vitest, runs under the existing repo config. Covers pure/injectable helpers only — the e2e itself is validated by running the script.
+
+| Unit | Coverage |
+|---|---|
+| `parseArgs` | Defaults, each flag, bad URL strings rejected. |
+| `generateSyntheticBlob` | Output is exactly 1024 bytes, sha256 matches bytes, consecutive calls produce different hashes. |
+| `buildKind34236Event` | All required tags present (`d`, `title`, `imeta` with `url`/`x`/`m`, thumbnail); imeta parses via regex matching Funnelcake's `validate_imeta_format`; event id matches computed sha256(canonicalized fields). Contract-grounded against `divine-funnelcake/crates/relay/src/relay.rs:1023-1087`. |
+| `signNip98` | Expected payload shape, valid signature (verify with nostr-tools). |
+| `classifyByteProbeResponse` | 404 → `{kind: 'bytes_gone'}`, 200 → `{kind: 'bytes_present'}`, other statuses → `{kind: 'unknown', status}`. |
+| `cleanupBlossomVanish` / `cleanupD1Row` | Injected fetch/runner stubs; verify correct endpoint/body/args shape; verify graceful handling of `fully_deleted:0` vs `fully_deleted:1` responses. |
+
+## Data flow
+
+### Scenario A: sync
+
+1. `generateTestKey()` → fresh secp256k1 keypair.
+2. `generateSyntheticBlob()` → `{bytes, sha256}`.
+3. `uploadToBlossom(bytes, sk, cfg)` → prod Blossom (BUD-02).
+4. `buildKind34236Event(sk, sha256, cfg)` → signed event object. `publishKind34236(event, cfg)` → staging relay. 10s WS timeout.
+5. `waitForIndexing(event_id, cfg, 30000)` → poll Funnelcake REST every 1s until 200.
+6. `publishKind5(sk, target_event_id, cfg)` → staging relay. Returns kind5_id.
+7. `callSyncEndpoint(sk, kind5_event, cfg)` — NIP-98 signed, 30s timeout. Expect 202 Accepted (or 200 if terminal on the fast path).
+8. `pollStatus(sk, kind5_id, cfg, 60000)` — every 2s, NIP-98 re-signed per poll. Succeeds on `body.status === 'success'`. Fails on any `failed:*` terminal or timeout.
+9. `assertD1AndBlossomState(kind5_id, sha256, testPubkey, cfg)` — D1 row + Blossom byte probe.
+10. **Cleanup (always in `finally`):**
+    - `cleanupBlossomVanish(testPubkey, cfg)` — full purge of testPubkey's one blob.
+    - `cleanupD1Row(kind5_id, target_event_id, cfg)` — DELETE the two D1 rows.
+11. Record outcome.
+
+### Scenario B: cron
+
+Identical to A except step 7 is replaced with:
+
+7'. **No sync call.** Wait for cron to pick up kind 5 from the staging relay.
+8'. `pollStatus(sk, kind5_id, cfg, 180000)` — every 3s, NIP-98 re-signed per poll. 180s total derived from 1-minute cron interval: worst-case next-fire (60s) + processing (10s) + one transient-retry cycle (60s + 10s) + 30s margin. Succeeds on `body.status === 'success'`. Fails on any `failed:*` terminal or timeout.
+
+On timeout, error message includes: *"Common cause: `CREATOR_DELETE_PIPELINE_ENABLED` may be unset on the prod worker. Verify via `wrangler secret list` or check the worker's deployment config."*
+
+**Running both:** sequential. Each scenario has its own ephemeral key and blob. A failure in A does not prevent B from running; the summary reports each independently.
+
+## Per-step JSONL output (stdout)
+
+One line per step, greppable, pipeable to `jq`:
+
+```json
+{"ts":"2026-04-18T...","scenario":"sync","step":"generate_key","ok":true,"pubkey":"<hex>","duration_ms":2}
+{"ts":"...","scenario":"sync","step":"upload","ok":true,"sha256":"...","bytes":1024,"duration_ms":340}
+{"ts":"...","scenario":"sync","step":"publish_kind34236","ok":true,"event_id":"...","duration_ms":820}
+{"ts":"...","scenario":"sync","step":"wait_indexing","ok":true,"polled_times":3,"duration_ms":2800}
+{"ts":"...","scenario":"sync","step":"publish_kind5","ok":true,"kind5_id":"...","duration_ms":730}
+{"ts":"...","scenario":"sync","step":"call_sync","ok":true,"http":202,"duration_ms":410}
+{"ts":"...","scenario":"sync","step":"poll_status","ok":true,"terminal_status":"success","polled_times":4,"duration_ms":3200}
+{"ts":"...","scenario":"sync","step":"assert_d1","ok":true,"d1_status":"success","duration_ms":850}
+{"ts":"...","scenario":"sync","step":"assert_blossom","ok":true,"bytes_probe":"404","flag_state_inferred":"on","duration_ms":200}
+{"ts":"...","scenario":"sync","step":"cleanup_blossom","ok":true,"fully_deleted":1,"unlinked":0,"errors":0,"duration_ms":310}
+{"ts":"...","scenario":"sync","step":"cleanup_d1","ok":true,"duration_ms":920}
+{"ts":"...","scenario":"sync","outcome":"pass","total_duration_ms":10612}
+```
+
+## Error handling
+
+| Stage | Failure | Cleanup attempted? | Exit impact |
+|---|---|---|---|
+| Pre-flight (env, wrangler auth, CLI args) | Any | No — nothing created yet | exit 2 |
+| `uploadToBlossom` 4xx/5xx/network/timeout | Scenario fails | No — upload incomplete | exit 1 |
+| `publishKind34236` WS timeout or relay rejection | Scenario fails | Blob cleanup runs | exit 1 |
+| `waitForIndexing` 30s timeout | Scenario fails | Blob + relay-event cleanup attempted; relay stays | exit 1 |
+| `publishKind5` WS timeout | Scenario fails | Blob cleanup runs | exit 1 |
+| `callSyncEndpoint` 4xx/5xx/timeout | Scenario fails | Blob + D1 cleanup run | exit 1 |
+| `pollStatus` timeout or `failed:*` terminal | Scenario fails (include `CREATOR_DELETE_PIPELINE_ENABLED` hint on timeout) | Blob + D1 cleanup run | exit 1 |
+| `assertD1AndBlossomState` mismatch | Scenario fails | Blob + D1 cleanup run | exit 1 |
+| `cleanupBlossomVanish` fails (404, 5xx, auth) | Print manual-cleanup curl; continue to D1 cleanup | — | exit 3 (or OR'd with 1) |
+| `cleanupD1Row` fails (wrangler non-zero) | Print manual-cleanup wrangler command | — | exit 3 |
+| SIGINT | Finally blocks attempt cleanup; on 2nd SIGINT, hard exit | Best-effort | exit 130 |
+
+**Exit codes:**
+
+- `0` — all requested scenarios passed; all cleanup succeeded.
+- `1` — at least one scenario failed. Cleanup was attempted.
+- `2` — pre-flight aborted (env, auth, args).
+- `3` — scenarios passed but at least one cleanup failed. Prod has residual test artifacts; summary lists them.
+- `130` — SIGINT.
+
+If both `1` and `3` apply, `1` takes precedence in the exit code; the summary still itemizes cleanup failures.
+
+## Summary format (stderr)
+
+```
+=== E2E SUMMARY ===
+Scenario: sync    PASS   10.6s
+Scenario: cron    PASS   183.4s
+
+=== ARTIFACTS (cleaned) ===
+sha=<sha>  kind5=<id>  vanish=fully_deleted:1  d1=cleaned  (sync)
+sha=<sha>  kind5=<id>  vanish=fully_deleted:1  d1=cleaned  (cron)
+
+=== MANUAL CLEANUP NEEDED ===
+(none)
+
+Exit: 0
+```
+
+On partial failure:
+
+```
+=== E2E SUMMARY ===
+Scenario: sync    PASS   10.6s
+Scenario: cron    FAIL   121.3s  (poll_status timeout — check CREATOR_DELETE_PIPELINE_ENABLED on prod worker)
+
+=== ARTIFACTS (cleaned) ===
+sha=<sha>  kind5=<id>  vanish=fully_deleted:1  d1=cleaned  (sync)
+
+=== MANUAL CLEANUP NEEDED ===
+sha=<sha>  kind5=<id>  (cron)
+  curl -X POST -H "Authorization: Bearer $BLOSSOM_WEBHOOK_SECRET" \
+       https://media.divine.video/admin/api/vanish \
+       -d '{"pubkey":"<pubkey>","reason":"e2e-test manual cleanup"}'
+  wrangler d1 execute blossom-webhook-events --remote \
+       --command "DELETE FROM creator_deletions WHERE kind5_id='<id>' AND target_event_id='<id>';"
+
+Exit: 1
+```
+
+## Operational runbook
+
+1. Ensure `BLOSSOM_WEBHOOK_SECRET` is exported in the shell.
+2. Confirm wrangler is authed against the prod Cloudflare account (`wrangler whoami`).
+3. Run: `node scripts/e2e-creator-delete.mjs` (default: both scenarios).
+4. Confirm `Exit: 0` and `=== MANUAL CLEANUP NEEDED === (none)` in the stderr summary.
+5. On failure: inspect the JSONL stdout (`jq -s 'map(select(.outcome=="fail"))' < run.log`), then act on any "MANUAL CLEANUP NEEDED" lines in the stderr summary.
+
+**Expected runtime:** sync ~15s, cron ~180s (worst case), both together ~200s.
+
+**Audit-log note:** each run emits Blossom audit entries for `upload`, `creator_delete`, and `admin_vanish`, and mod-service console logs for the pipeline run. The `admin_vanish` `reason` field is always `"e2e-test cleanup"` for easy grep. Audit-log readers should filter on this string to distinguish e2e runs from operator actions.
+
+## Forward-looking
+
+The Blossom response contract (verified at `divine-blossom/src/admin.rs:923-930` and `src/main.rs:4795-4802`) drives the byte-probe + vanish-response interpretation in this script. If that contract changes (in-flight PR #97 adds coverage; future PRs may add fields or rename booleans), the script's `classifyByteProbeResponse` and cleanup response assertions must be reverified in lockstep.
+
+The Funnelcake video-tag validation contract (`divine-funnelcake/crates/relay/src/relay.rs:1023-1087`) drives `buildKind34236Event`. Same drift caveat applies; the contract test in `scripts/e2e-creator-delete.test.mjs` is the first line of defense.
+
+Once PR #106 (creator-delete validation-window sweep) and any open Blossom PRs land, re-run this e2e test as part of rollout validation. A green run from this script is a stronger signal for the pipeline being production-healthy than unit tests alone.
+
+## Open questions
+
+(none — all known ambiguities resolved during brainstorming)
+
+## What this is not
+
+- Not a CI-automated test. Operator-run only.
+- Not a tool for validating per-blob admin deletes or moderator-initiated actions (BAN, RESTRICT, etc.).
+- Not a load test or chaos-engineering tool.

--- a/scripts/e2e-creator-delete.mjs
+++ b/scripts/e2e-creator-delete.mjs
@@ -368,3 +368,50 @@ export async function pollStatus(sk, kind5Id, cfg, opts = {}) {
   }
   throw new Error(`timeout after ${timeoutMs}ms: kind5 ${kind5Id} did not reach terminal status. Common cause: CREATOR_DELETE_PIPELINE_ENABLED may be unset on the prod worker.`);
 }
+
+/**
+ * Verify that the pipeline completed successfully:
+ * - D1 row exists with status='success'
+ * - blob_sha256 matches the expected value
+ * - Blossom byte probe indicates the final state (bytes_gone or bytes_present)
+ *
+ * Returns { d1Status, byteProbe } for caller to record in JSONL output.
+ * byteProbe.kind is 'bytes_gone' (flag was on) or 'bytes_present' (flag was off).
+ * Both are acceptable final states; the test records which one actually occurred.
+ */
+export async function assertD1AndBlossomState(kind5Id, expectedSha, cfg, deps = {}) {
+  validateHex64(kind5Id, 'kind5_id');
+  validateHex64(expectedSha, 'expectedSha');
+
+  const runner = deps.runner || defaultRunner;
+  const fetchImpl = deps.fetchImpl || fetch;
+
+  // (a) D1 row check
+  const sql = `SELECT kind5_id, target_event_id, blob_sha256, status FROM creator_deletions WHERE kind5_id = '${kind5Id}';`;
+  const args = ['d1', 'execute', cfg.d1Database, '--remote', '--json', '--command', sql];
+  const r = await runner({ command: 'wrangler', args });
+  if (r.status !== 0) {
+    throw new Error(`wrangler d1 execute failed (exit ${r.status}): ${r.stderr.trim() || r.stdout.trim()}`);
+  }
+  const parsed = JSON.parse(r.stdout);
+  const rows = (parsed?.[0]?.results) || [];
+  if (rows.length === 0) {
+    throw new Error(`D1 row not found for kind5_id=${kind5Id}`);
+  }
+  const row = rows[0];
+  if (row.status !== 'success') {
+    throw new Error(`expected D1 status='success', got status=${row.status}`);
+  }
+  if (row.blob_sha256 !== expectedSha) {
+    throw new Error(`blob_sha256 mismatch: D1 has ${row.blob_sha256}, expected ${expectedSha}`);
+  }
+
+  // (b) Blossom byte probe
+  const probe = await fetchImpl(`${cfg.blossomBase}/${expectedSha}`, { method: 'GET' });
+  const byteProbe = classifyByteProbeResponse(probe.status);
+  if (byteProbe.kind === 'unknown') {
+    throw new Error(`Blossom byte probe returned unknown status: ${probe.status}`);
+  }
+
+  return { d1Status: row.status, byteProbe };
+}

--- a/scripts/e2e-creator-delete.mjs
+++ b/scripts/e2e-creator-delete.mjs
@@ -316,3 +316,55 @@ export async function publishEvent(event, relayUrl, opts = {}) {
     });
   });
 }
+
+import { signNip98Header } from './sign-nip98.mjs';
+
+export async function callSyncEndpoint(sk, kind5Event, cfg, fetchImpl = fetch) {
+  const url = `${cfg.modServiceBase}/api/creator-delete/sync`;
+  const res = await fetchImpl(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: signNip98Header(sk, url, 'POST')
+    },
+    body: JSON.stringify(kind5Event)
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`sync endpoint HTTP ${res.status}: ${text}`);
+  }
+  return await res.json();
+}
+
+/**
+ * Poll the status endpoint until the row reaches a terminal status
+ * (success OR failed:*). Returns the final body so the caller can distinguish.
+ *
+ * Re-signs NIP-98 per poll so the signature stays fresh and the `u` tag always
+ * matches the request URL exactly (see PR #104 URL-normalization fix).
+ */
+export async function pollStatus(sk, kind5Id, cfg, opts = {}) {
+  const fetchImpl = opts.fetchImpl || fetch;
+  const timeoutMs = opts.timeoutMs ?? 60000;
+  const pollIntervalMs = opts.pollIntervalMs ?? 2000;
+  const url = `${cfg.modServiceBase}/api/creator-delete/status/${kind5Id}`;
+  const deadline = Date.now() + timeoutMs;
+  let polls = 0;
+  while (Date.now() < deadline) {
+    polls++;
+    const res = await fetchImpl(url, {
+      method: 'GET',
+      headers: { Authorization: signNip98Header(sk, url, 'GET') }
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`status endpoint HTTP ${res.status}: ${text}`);
+    }
+    const body = await res.json();
+    if (body.status === 'success' || (typeof body.status === 'string' && body.status.startsWith('failed:'))) {
+      return { ...body, polls };
+    }
+    await new Promise(r => setTimeout(r, pollIntervalMs));
+  }
+  throw new Error(`timeout after ${timeoutMs}ms: kind5 ${kind5Id} did not reach terminal status. Common cause: CREATOR_DELETE_PIPELINE_ENABLED may be unset on the prod worker.`);
+}

--- a/scripts/e2e-creator-delete.mjs
+++ b/scripts/e2e-creator-delete.mjs
@@ -250,7 +250,16 @@ export async function uploadToBlossom(bytes, sha256, sk, cfg, fetchImpl = fetch)
     throw new Error(`Blossom upload failed: HTTP ${res.status}: ${text}`);
   }
   const body = await res.json();
-  return { url: body.url || `${cfg.blossomBase}/${sha256}`, sha256 };
+  // Return the server-confirmed sha, not the caller-provided value.
+  // Any mismatch between them means either our local hash is wrong or
+  // Blossom rehashed the bytes under a different content type; either
+  // case should surface loudly rather than silently propagate the
+  // caller's claim through the rest of the pipeline. A missing
+  // body.sha256 is also a contract break worth raising here.
+  if (!body.sha256 || typeof body.sha256 !== 'string') {
+    throw new Error(`Blossom upload response missing sha256 field: ${JSON.stringify(body)}`);
+  }
+  return { url: body.url || `${cfg.blossomBase}/${body.sha256}`, sha256: body.sha256 };
 }
 
 /**
@@ -290,29 +299,45 @@ export async function publishEvent(event, relayUrl, opts = {}) {
   const WsCtor = opts.WebSocket || (await import('ws')).WebSocket;
   return await new Promise((resolve, reject) => {
     const ws = new WsCtor(relayUrl);
-    const timer = setTimeout(() => {
+    let settled = false;
+
+    // Centralize socket teardown and promise settlement so every exit
+    // path (OK=true, OK=false, error, close, timeout) releases the
+    // socket exactly once and no later handlers mutate the outcome.
+    const done = (fn) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
       try { ws.close(); } catch {}
-      reject(new Error(`publish timeout after ${timeoutMs}ms: ${event.id}`));
+      fn();
+    };
+
+    const timer = setTimeout(() => {
+      done(() => reject(new Error(`publish timeout after ${timeoutMs}ms: ${event.id}`)));
     }, timeoutMs);
 
     ws.on('open', () => {
       ws.send(JSON.stringify(['EVENT', event]));
     });
     ws.on('message', (data) => {
-      const msg = JSON.parse(data.toString());
+      let msg;
+      try { msg = JSON.parse(data.toString()); } catch { return; }
       if (msg[0] === 'OK' && msg[1] === event.id) {
-        clearTimeout(timer);
-        try { ws.close(); } catch {}
         if (msg[2] === true) {
-          resolve(event.id);
+          done(() => resolve(event.id));
         } else {
-          reject(new Error(`relay rejected ${event.id}: ${msg[3] || 'unknown'}`));
+          done(() => reject(new Error(`relay rejected ${event.id}: ${msg[3] || 'unknown'}`)));
         }
       }
     });
     ws.on('error', (err) => {
-      clearTimeout(timer);
-      reject(new Error(`WebSocket error: ${err.message}`));
+      done(() => reject(new Error(`WebSocket error: ${err.message}`)));
+    });
+    // Early-close handler: if the relay disconnects before sending OK,
+    // surface a concrete publish failure instead of waiting for the
+    // generic timeout. If we already resolved/rejected, this is a no-op.
+    ws.on('close', (code, reason) => {
+      done(() => reject(new Error(`WebSocket closed before OK for ${event.id} (code=${code}${reason ? `, reason=${reason}` : ''})`)));
     });
   });
 }
@@ -543,7 +568,12 @@ export function computeExitCode(results) {
   return 0;
 }
 
-export function printSummary(results) {
+export function printSummary(results, cfg = {}) {
+  // Fall back to defaults only when cfg is absent (e.g. older callers).
+  // The live main() flow always passes cfg so the manual-cleanup
+  // commands render against the target the script actually ran against.
+  const blossomBase = cfg.blossomBase || DEFAULT_BLOSSOM_BASE;
+  const d1Database = cfg.d1Database || DEFAULT_D1_DATABASE;
   console.error('\n=== E2E SUMMARY ===');
   for (const r of results) {
     const seconds = (r.totalDurationMs / 1000).toFixed(1);
@@ -576,11 +606,11 @@ export function printSummary(results) {
       if (r.cleanup?.blossom?.ok === false) {
         console.error(`sha=${r.sha256} pubkey=${r.pubkey} (${r.scenario})`);
         console.error(`  curl -X POST -H "Authorization: Bearer $BLOSSOM_WEBHOOK_SECRET" \\`);
-        console.error(`       ${DEFAULT_BLOSSOM_BASE}/admin/api/vanish \\`);
+        console.error(`       ${blossomBase}/admin/api/vanish \\`);
         console.error(`       -d '{"pubkey":"${r.pubkey}","reason":"e2e-test manual cleanup"}'`);
       }
       if (r.cleanup?.d1?.ok === false) {
-        console.error(`  wrangler d1 execute ${DEFAULT_D1_DATABASE} --remote \\`);
+        console.error(`  wrangler d1 execute ${d1Database} --remote \\`);
         console.error(`       --command "DELETE FROM creator_deletions WHERE kind5_id='${r.kind5Id}' AND target_event_id='${r.target}';"`);
       }
     }
@@ -607,11 +637,17 @@ export async function main(argv, deps = {}) {
     return 2;
   }
 
-  try {
-    cfg.blossomWebhookSecret = readBlossomSecret(deps);
-  } catch (e) {
-    console.error(e.message);
-    return 2;
+  // BLOSSOM_WEBHOOK_SECRET only gates /admin/api/vanish cleanup. The
+  // documented --skip-cleanup inspection mode intentionally leaves
+  // artifacts in place, so requiring the secret there made the
+  // no-cleanup path depend on a prod admin credential it never used.
+  if (!cfg.skipCleanup) {
+    try {
+      cfg.blossomWebhookSecret = readBlossomSecret(deps);
+    } catch (e) {
+      console.error(e.message);
+      return 2;
+    }
   }
 
   const results = [];
@@ -624,7 +660,7 @@ export async function main(argv, deps = {}) {
     results.push({ ...r, scenario: 'cron' });
   }
 
-  printSummary(results);
+  printSummary(results, cfg);
   return computeExitCode(results);
 }
 

--- a/scripts/e2e-creator-delete.mjs
+++ b/scripts/e2e-creator-delete.mjs
@@ -528,3 +528,102 @@ export async function runSyncScenario(cfg, deps = {}) {
 export async function runCronScenario(cfg, deps = {}) {
   return runScenario('cron', cfg, deps, { callSync: false, statusTimeoutMs: cfg.cronWaitSeconds * 1000, statusPollIntervalMs: 3000 });
 }
+
+export function computeExitCode(results) {
+  const anyFailed = results.some(r => r.outcome === 'fail');
+  if (anyFailed) return 1;
+  const anyCleanupFailed = results.some(r => {
+    if (r.cleanup?.skipped) return false;
+    if (r.cleanup?.blossom?.ok === false) return true;
+    if (r.cleanup?.blossom?.errors > 0) return true;
+    if (r.cleanup?.d1?.ok === false) return true;
+    return false;
+  });
+  if (anyCleanupFailed) return 3;
+  return 0;
+}
+
+export function printSummary(results) {
+  console.error('\n=== E2E SUMMARY ===');
+  for (const r of results) {
+    const seconds = (r.totalDurationMs / 1000).toFixed(1);
+    const label = r.outcome.toUpperCase();
+    const detail = r.outcome === 'fail' ? `  (${r.failureReason})` : '';
+    console.error(`Scenario: ${r.scenario.padEnd(6)}${label}  ${seconds}s${detail}`);
+  }
+
+  const artifacts = results.filter(r => !r.cleanup?.skipped);
+  if (artifacts.length > 0) {
+    console.error('\n=== ARTIFACTS (cleaned) ===');
+    for (const r of artifacts) {
+      const blossom = r.cleanup?.blossom?.ok === false
+        ? `vanish=FAILED:${r.cleanup.blossom.error}`
+        : `vanish=fully_deleted:${r.cleanup.blossom?.fullyDeleted ?? '?'}`;
+      const d1 = r.cleanup?.d1?.ok === false ? `d1=FAILED:${r.cleanup.d1.error}` : 'd1=cleaned';
+      console.error(`sha=${r.sha256}  kind5=${r.kind5Id || '-'}  ${blossom}  ${d1}  (${r.scenario})`);
+    }
+  }
+
+  const manual = results.filter(r => {
+    if (r.cleanup?.skipped) return false;
+    return r.cleanup?.blossom?.ok === false || r.cleanup?.d1?.ok === false;
+  });
+  console.error('\n=== MANUAL CLEANUP NEEDED ===');
+  if (manual.length === 0) {
+    console.error('(none)');
+  } else {
+    for (const r of manual) {
+      if (r.cleanup?.blossom?.ok === false) {
+        console.error(`sha=${r.sha256} pubkey=${r.pubkey} (${r.scenario})`);
+        console.error(`  curl -X POST -H "Authorization: Bearer $BLOSSOM_WEBHOOK_SECRET" \\`);
+        console.error(`       ${DEFAULT_BLOSSOM_BASE}/admin/api/vanish \\`);
+        console.error(`       -d '{"pubkey":"${r.pubkey}","reason":"e2e-test manual cleanup"}'`);
+      }
+      if (r.cleanup?.d1?.ok === false) {
+        console.error(`  wrangler d1 execute ${DEFAULT_D1_DATABASE} --remote \\`);
+        console.error(`       --command "DELETE FROM creator_deletions WHERE kind5_id='${r.kind5Id}' AND target_event_id='${r.target}';"`);
+      }
+    }
+  }
+
+  const code = computeExitCode(results);
+  console.error(`\nExit: ${code}`);
+}
+
+function readBlossomSecret(deps) {
+  if (deps.blossomWebhookSecret) return deps.blossomWebhookSecret;
+  const env = deps.env || (typeof process !== 'undefined' ? process.env : {});
+  const s = env.BLOSSOM_WEBHOOK_SECRET;
+  if (!s) throw new Error('BLOSSOM_WEBHOOK_SECRET env var is required');
+  return s;
+}
+
+export async function main(argv, deps = {}) {
+  let cfg;
+  try {
+    cfg = parseArgs(argv);
+  } catch (e) {
+    console.error(`arg error: ${e.message}`);
+    return 2;
+  }
+
+  try {
+    cfg.blossomWebhookSecret = readBlossomSecret(deps);
+  } catch (e) {
+    console.error(e.message);
+    return 2;
+  }
+
+  const results = [];
+  if (cfg.scenario === 'sync' || cfg.scenario === 'both') {
+    const r = await runSyncScenario(cfg, deps);
+    results.push({ ...r, scenario: 'sync' });
+  }
+  if (cfg.scenario === 'cron' || cfg.scenario === 'both') {
+    const r = await runCronScenario(cfg, deps);
+    results.push({ ...r, scenario: 'cron' });
+  }
+
+  printSummary(results);
+  return computeExitCode(results);
+}

--- a/scripts/e2e-creator-delete.mjs
+++ b/scripts/e2e-creator-delete.mjs
@@ -187,6 +187,9 @@ export async function cleanupD1Row(kind5_id, target_event_id, cfg, runner = defa
  * errors > 0 indicates Blossom couldn't fully process; surface as failure.
  */
 export async function cleanupBlossomVanish(testPubkey, cfg, fetchImpl = fetch) {
+  if (!cfg.blossomWebhookSecret) {
+    throw new Error('cleanupBlossomVanish: cfg.blossomWebhookSecret is required');
+  }
   const res = await fetchImpl(`${cfg.blossomBase}/admin/api/vanish`, {
     method: 'POST',
     headers: {

--- a/scripts/e2e-creator-delete.mjs
+++ b/scripts/e2e-creator-delete.mjs
@@ -129,3 +129,16 @@ export function buildKind34236Event(sk, sha256, cfg) {
     content: 'Synthetic 1KB test blob published by scripts/e2e-creator-delete.mjs'
   }, sk);
 }
+
+/**
+ * Classify a GET https://media.divine.video/<sha256> response after the
+ * pipeline has completed. 404/410 → bytes physically deleted (ENABLE_PHYSICAL_DELETE
+ * was on). 200 → bytes still present (flag was off, soft-delete state). Both
+ * are acceptable pass conditions for the script; the kind is recorded in the
+ * JSONL output. Anything else is treated as an unexpected state.
+ */
+export function classifyByteProbeResponse(status) {
+  if (status === 404 || status === 410) return { kind: 'bytes_gone', flagStateInferred: 'on' };
+  if (status === 200) return { kind: 'bytes_present', flagStateInferred: 'off' };
+  return { kind: 'unknown', status };
+}

--- a/scripts/e2e-creator-delete.mjs
+++ b/scripts/e2e-creator-delete.mjs
@@ -213,3 +213,42 @@ export async function cleanupBlossomVanish(testPubkey, cfg, fetchImpl = fetch) {
   }
   return out;
 }
+
+/**
+ * BUD-01 upload authorization. Signed kind 24242 event with:
+ *   - t tag: "upload"
+ *   - x tag: sha256 of the payload
+ *   - expiration tag: unix timestamp (5 minutes from now)
+ */
+export function buildBud01UploadAuth(sk, sha256) {
+  const expiration = Math.floor(Date.now() / 1000) + 300;
+  const event = finalizeEvent({
+    kind: 24242,
+    created_at: Math.floor(Date.now() / 1000),
+    tags: [
+      ['t', 'upload'],
+      ['x', sha256],
+      ['expiration', String(expiration)]
+    ],
+    content: 'creator-delete e2e test upload'
+  }, sk);
+  return `Nostr ${Buffer.from(JSON.stringify(event)).toString('base64')}`;
+}
+
+export async function uploadToBlossom(bytes, sha256, sk, cfg, fetchImpl = fetch) {
+  const res = await fetchImpl(`${cfg.blossomBase}/upload`, {
+    method: 'PUT',
+    headers: {
+      Authorization: buildBud01UploadAuth(sk, sha256),
+      'Content-Type': 'video/mp4',
+      'Content-Length': String(bytes.length)
+    },
+    body: bytes
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Blossom upload failed: HTTP ${res.status}: ${text}`);
+  }
+  const body = await res.json();
+  return { url: body.url || `${cfg.blossomBase}/${sha256}`, sha256 };
+}

--- a/scripts/e2e-creator-delete.mjs
+++ b/scripts/e2e-creator-delete.mjs
@@ -65,7 +65,7 @@ export function parseArgs(argv) {
   };
 }
 
-import { generateSecretKey, getPublicKey } from 'nostr-tools/pure';
+import { generateSecretKey, getPublicKey, finalizeEvent } from 'nostr-tools/pure';
 import { sha256 as sha256Hash } from '@noble/hashes/sha256';
 import { bytesToHex, randomBytes } from '@noble/hashes/utils';
 
@@ -99,4 +99,33 @@ export function generateSyntheticBlob() {
   bytes.set(payload, 32);
   const sha256 = bytesToHex(sha256Hash(bytes));
   return { bytes, sha256 };
+}
+
+/**
+ * Build and sign a kind 34236 event that passes Funnelcake's validation at
+ * divine-funnelcake/crates/relay/src/relay.rs:1023-1087.
+ *
+ * Required: d (unique), title, imeta with url+x+m (each space-delimited item
+ * per validate_imeta_format), and a thumb-equivalent. Thumb URL does not need
+ * to resolve.
+ */
+export function buildKind34236Event(sk, sha256, cfg) {
+  const blobUrl = `${cfg.blossomBase}/${sha256}`;
+  const thumbUrl = `${cfg.blossomBase}/${sha256}.jpg`;
+  // Unique d tag per run: timestamp + random suffix ensures no collision across
+  // concurrent or rapid-fire test runs with the same key (not our normal case
+  // but cheap to defend against).
+  const dTag = `e2e-test-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+
+  return finalizeEvent({
+    kind: 34236,
+    created_at: Math.floor(Date.now() / 1000),
+    tags: [
+      ['d', dTag],
+      ['title', 'creator-delete e2e test video'],
+      ['imeta', `url ${blobUrl}`, `x ${sha256}`, `m video/mp4`],
+      ['thumb', thumbUrl]
+    ],
+    content: 'Synthetic 1KB test blob published by scripts/e2e-creator-delete.mjs'
+  }, sk);
 }

--- a/scripts/e2e-creator-delete.mjs
+++ b/scripts/e2e-creator-delete.mjs
@@ -64,3 +64,39 @@ export function parseArgs(argv) {
     skipCleanup: getFlag(argv, 'skip-cleanup') === true
   };
 }
+
+import { generateSecretKey, getPublicKey } from 'nostr-tools/pure';
+import { sha256 as sha256Hash } from '@noble/hashes/sha256';
+import { bytesToHex, randomBytes } from '@noble/hashes/utils';
+
+export function generateTestKey() {
+  const sk = generateSecretKey();
+  return { sk, pubkey: getPublicKey(sk) };
+}
+
+// Minimal ISO-BMFF ftyp box so the payload at least looks like MP4 to a casual
+// inspector. 1024 bytes total: 32-byte header + 992 bytes of random payload so
+// each run has a unique sha256.
+export function generateSyntheticBlob() {
+  const header = new Uint8Array([
+    // box size (32 bytes)
+    0x00, 0x00, 0x00, 0x20,
+    // 'ftyp'
+    0x66, 0x74, 0x79, 0x70,
+    // major brand 'isom'
+    0x69, 0x73, 0x6f, 0x6d,
+    // minor version (0x00000200)
+    0x00, 0x00, 0x02, 0x00,
+    // compatible brands: 'isom', 'iso2', 'avc1', 'mp41'
+    0x69, 0x73, 0x6f, 0x6d,
+    0x69, 0x73, 0x6f, 0x32,
+    0x61, 0x76, 0x63, 0x31,
+    0x6d, 0x70, 0x34, 0x31
+  ]);
+  const payload = randomBytes(992);
+  const bytes = new Uint8Array(1024);
+  bytes.set(header, 0);
+  bytes.set(payload, 32);
+  const sha256 = bytesToHex(sha256Hash(bytes));
+  return { bytes, sha256 };
+}

--- a/scripts/e2e-creator-delete.mjs
+++ b/scripts/e2e-creator-delete.mjs
@@ -22,6 +22,11 @@ function getFlag(argv, name) {
   return null;
 }
 
+function requireValue(raw, fieldName) {
+  if (raw === true) throw new Error(`--${fieldName} requires a value (use --${fieldName}=<value>)`);
+  return raw;
+}
+
 function validatePositiveInt(value, fieldName) {
   const n = Number(value);
   if (!Number.isInteger(n) || n <= 0) {
@@ -32,23 +37,29 @@ function validatePositiveInt(value, fieldName) {
 
 export function parseArgs(argv) {
   const rawScenario = getFlag(argv, 'scenario');
-  const scenario = rawScenario === null || rawScenario === true ? 'both' : rawScenario;
+  const scenario = rawScenario === null ? 'both' : requireValue(rawScenario, 'scenario');
   if (!['sync', 'cron', 'both'].includes(scenario)) {
     throw new Error(`Invalid scenario: ${scenario} (must be sync|cron|both)`);
   }
 
   const rawCron = getFlag(argv, 'cron-wait-seconds');
   const cronWaitSeconds = rawCron
-    ? validatePositiveInt(rawCron, 'cron-wait-seconds')
+    ? validatePositiveInt(requireValue(rawCron, 'cron-wait-seconds'), 'cron-wait-seconds')
     : DEFAULT_CRON_WAIT_SECONDS;
+
+  const stagingRelay = getFlag(argv, 'staging-relay');
+  const funnelcakeApi = getFlag(argv, 'funnelcake-api');
+  const blossomBase = getFlag(argv, 'blossom-base');
+  const modServiceBase = getFlag(argv, 'mod-service-base');
+  const d1Database = getFlag(argv, 'd1-database');
 
   return {
     scenario,
-    stagingRelay: getFlag(argv, 'staging-relay') || DEFAULT_STAGING_RELAY,
-    funnelcakeApi: getFlag(argv, 'funnelcake-api') || DEFAULT_FUNNELCAKE_API,
-    blossomBase: getFlag(argv, 'blossom-base') || DEFAULT_BLOSSOM_BASE,
-    modServiceBase: getFlag(argv, 'mod-service-base') || DEFAULT_MOD_SERVICE_BASE,
-    d1Database: getFlag(argv, 'd1-database') || DEFAULT_D1_DATABASE,
+    stagingRelay: stagingRelay ? requireValue(stagingRelay, 'staging-relay') : DEFAULT_STAGING_RELAY,
+    funnelcakeApi: funnelcakeApi ? requireValue(funnelcakeApi, 'funnelcake-api') : DEFAULT_FUNNELCAKE_API,
+    blossomBase: blossomBase ? requireValue(blossomBase, 'blossom-base') : DEFAULT_BLOSSOM_BASE,
+    modServiceBase: modServiceBase ? requireValue(modServiceBase, 'mod-service-base') : DEFAULT_MOD_SERVICE_BASE,
+    d1Database: d1Database ? requireValue(d1Database, 'd1-database') : DEFAULT_D1_DATABASE,
     cronWaitSeconds,
     skipCleanup: getFlag(argv, 'skip-cleanup') === true
   };

--- a/scripts/e2e-creator-delete.mjs
+++ b/scripts/e2e-creator-delete.mjs
@@ -415,3 +415,116 @@ export async function assertD1AndBlossomState(kind5Id, expectedSha, cfg, deps = 
 
   return { d1Status: row.status, byteProbe };
 }
+
+function nowIso() { return new Date().toISOString(); }
+
+function emit(obj) { console.log(JSON.stringify(obj)); }
+
+async function runScenario(name, cfg, deps, opts) {
+  const { sk, pubkey } = (deps.generateTestKey || generateTestKey)();
+  const blob = (deps.generateSyntheticBlob || generateSyntheticBlob)();
+  const started = Date.now();
+  let kind5Id = null;
+  let target = null;
+  let assertResult = null;
+  let outcome = 'pass';
+  let failureReason = null;
+  // Hoisted so it is accessible in cleanup and return after the try block.
+  // Upload.sha256 (server-confirmed) is the canonical sha; falls back to blob.sha256
+  // if upload hasn't run yet (shouldn't happen in normal flow).
+  let blobSha256 = blob.sha256;
+
+  try {
+    // 1. Upload
+    const upload = await (deps.uploadToBlossom || uploadToBlossom)(blob.bytes, blob.sha256, sk, cfg, deps.fetchImpl);
+    // Use upload.sha256 (server-confirmed) as the canonical sha for all downstream assertions.
+    // This ensures injected uploadToBlossom can control which sha flows through the scenario.
+    blobSha256 = upload.sha256;
+    emit({ ts: nowIso(), scenario: name, step: 'upload', ok: true, sha256: blobSha256, bytes: blob.bytes.length });
+
+    // 2. Publish kind 34236
+    const event = buildKind34236Event(sk, blobSha256, cfg);
+    target = await (deps.publishEvent || publishEvent)(event, cfg.stagingRelay);
+    emit({ ts: nowIso(), scenario: name, step: 'publish_kind34236', ok: true, event_id: target });
+
+    // 3. Wait for Funnelcake to index it
+    const indexing = await (deps.waitForIndexing || waitForIndexing)(target, cfg, { fetchImpl: deps.fetchImpl });
+    emit({ ts: nowIso(), scenario: name, step: 'wait_indexing', ok: true, polls: indexing.polls });
+
+    // 4. Publish kind 5
+    const kind5Event = finalizeEvent({
+      kind: 5,
+      created_at: Math.floor(Date.now() / 1000),
+      tags: [['e', target], ['k', '34236'], ['client', 'diVine']],
+      content: 'e2e test delete'
+    }, sk);
+    kind5Id = await (deps.publishEvent || publishEvent)(kind5Event, cfg.stagingRelay);
+    emit({ ts: nowIso(), scenario: name, step: 'publish_kind5', ok: true, kind5_id: kind5Id });
+
+    // 5. Sync (sync scenario only)
+    if (opts.callSync) {
+      await (deps.callSyncEndpoint || callSyncEndpoint)(sk, kind5Event, cfg, deps.fetchImpl);
+      emit({ ts: nowIso(), scenario: name, step: 'call_sync', ok: true });
+    }
+
+    // 6. Poll status
+    const pollOpts = {
+      fetchImpl: deps.fetchImpl,
+      timeoutMs: opts.statusTimeoutMs,
+      pollIntervalMs: opts.statusPollIntervalMs
+    };
+    const status = await (deps.pollStatus || pollStatus)(sk, kind5Id, cfg, pollOpts);
+    emit({ ts: nowIso(), scenario: name, step: 'poll_status', ok: status.status === 'success', terminal_status: status.status, polls: status.polls });
+    if (status.status !== 'success') {
+      throw new Error(`pipeline failed: ${status.status}`);
+    }
+
+    // 7. Assert D1 + Blossom state
+    assertResult = await (deps.assertD1AndBlossomState || assertD1AndBlossomState)(kind5Id, blobSha256, cfg, { runner: deps.runner, fetchImpl: deps.fetchImpl });
+    emit({ ts: nowIso(), scenario: name, step: 'assert_d1_and_blossom', ok: true, d1_status: assertResult.d1Status, byte_probe: assertResult.byteProbe.kind });
+  } catch (err) {
+    outcome = 'fail';
+    failureReason = err.message;
+    emit({ ts: nowIso(), scenario: name, step: 'failure', ok: false, error: err.message });
+  }
+
+  // 8. Cleanup (always, unless --skip-cleanup)
+  let cleanup = null;
+  if (cfg.skipCleanup) {
+    cleanup = { skipped: true };
+    emit({ ts: nowIso(), scenario: name, step: 'cleanup', ok: true, skipped: true });
+  } else {
+    cleanup = { blossom: null, d1: null };
+    try {
+      cleanup.blossom = await (deps.cleanupBlossomVanish || cleanupBlossomVanish)(pubkey, cfg, deps.fetchImpl);
+      emit({ ts: nowIso(), scenario: name, step: 'cleanup_blossom', ok: true, ...cleanup.blossom });
+    } catch (err) {
+      cleanup.blossom = { ok: false, error: err.message };
+      emit({ ts: nowIso(), scenario: name, step: 'cleanup_blossom', ok: false, error: err.message });
+    }
+    if (kind5Id && target) {
+      try {
+        await (deps.cleanupD1Row || cleanupD1Row)(kind5Id, target, cfg, deps.runner);
+        cleanup.d1 = { ok: true };
+        emit({ ts: nowIso(), scenario: name, step: 'cleanup_d1', ok: true });
+      } catch (err) {
+        cleanup.d1 = { ok: false, error: err.message };
+        emit({ ts: nowIso(), scenario: name, step: 'cleanup_d1', ok: false, error: err.message });
+      }
+    } else {
+      cleanup.d1 = { ok: true, skipped: 'no kind5/target' };
+    }
+  }
+
+  const totalDurationMs = Date.now() - started;
+  emit({ ts: nowIso(), scenario: name, outcome, total_duration_ms: totalDurationMs });
+  return { outcome, failureReason, cleanup, pubkey, sha256: blobSha256, kind5Id, target, totalDurationMs };
+}
+
+export async function runSyncScenario(cfg, deps = {}) {
+  return runScenario('sync', cfg, deps, { callSync: true, statusTimeoutMs: 60000, statusPollIntervalMs: 2000 });
+}
+
+export async function runCronScenario(cfg, deps = {}) {
+  return runScenario('cron', cfg, deps, { callSync: false, statusTimeoutMs: cfg.cronWaitSeconds * 1000, statusPollIntervalMs: 3000 });
+}

--- a/scripts/e2e-creator-delete.mjs
+++ b/scripts/e2e-creator-delete.mjs
@@ -252,3 +252,67 @@ export async function uploadToBlossom(bytes, sha256, sk, cfg, fetchImpl = fetch)
   const body = await res.json();
   return { url: body.url || `${cfg.blossomBase}/${sha256}`, sha256 };
 }
+
+/**
+ * Poll Funnelcake REST GET /api/event/{id} until 200 or timeout.
+ * Catches ClickHouse batch-flush + MergeTree dedup propagation lag.
+ */
+export async function waitForIndexing(eventId, cfg, opts = {}) {
+  const fetchImpl = opts.fetchImpl || fetch;
+  const timeoutMs = opts.timeoutMs ?? 30000;
+  const pollIntervalMs = opts.pollIntervalMs ?? 1000;
+  const deadline = Date.now() + timeoutMs;
+  const url = `${cfg.funnelcakeApi}/api/event/${eventId}`;
+  let polls = 0;
+  while (Date.now() < deadline) {
+    polls++;
+    const res = await fetchImpl(url, { method: 'GET' });
+    if (res.ok) return { polls };
+    if (res.status !== 404) {
+      const text = await res.text();
+      throw new Error(`Funnelcake /api/event/${eventId} HTTP ${res.status}: ${text}`);
+    }
+    await new Promise(r => setTimeout(r, pollIntervalMs));
+  }
+  throw new Error(`timeout after ${timeoutMs}ms: event ${eventId} not indexed by Funnelcake`);
+}
+
+/**
+ * Publish a signed Nostr event to a relay over WebSocket. Resolves with the
+ * event id on OK=true; throws on relay rejection or timeout.
+ *
+ * The WebSocket lives only for the duration of the publish. The ws library
+ * is imported dynamically so the Workers test pool doesn't trip on it at
+ * module-load time.
+ */
+export async function publishEvent(event, relayUrl, opts = {}) {
+  const timeoutMs = opts.timeoutMs ?? 10000;
+  const WsCtor = opts.WebSocket || (await import('ws')).WebSocket;
+  return await new Promise((resolve, reject) => {
+    const ws = new WsCtor(relayUrl);
+    const timer = setTimeout(() => {
+      try { ws.close(); } catch {}
+      reject(new Error(`publish timeout after ${timeoutMs}ms: ${event.id}`));
+    }, timeoutMs);
+
+    ws.on('open', () => {
+      ws.send(JSON.stringify(['EVENT', event]));
+    });
+    ws.on('message', (data) => {
+      const msg = JSON.parse(data.toString());
+      if (msg[0] === 'OK' && msg[1] === event.id) {
+        clearTimeout(timer);
+        try { ws.close(); } catch {}
+        if (msg[2] === true) {
+          resolve(event.id);
+        } else {
+          reject(new Error(`relay rejected ${event.id}: ${msg[3] || 'unknown'}`));
+        }
+      }
+    });
+    ws.on('error', (err) => {
+      clearTimeout(timer);
+      reject(new Error(`WebSocket error: ${err.message}`));
+    });
+  });
+}

--- a/scripts/e2e-creator-delete.mjs
+++ b/scripts/e2e-creator-delete.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: End-to-end test for the creator-delete pipeline (mod-service#101).
+// ABOUTME: Operator-run. Exercises sync + cron paths against staging relay + prod Blossom + prod mod-service.
+
+const DEFAULT_STAGING_RELAY = 'wss://relay.staging.divine.video';
+const DEFAULT_FUNNELCAKE_API = 'https://funnelcake.staging.dvines.org';
+const DEFAULT_BLOSSOM_BASE = 'https://media.divine.video';
+const DEFAULT_MOD_SERVICE_BASE = 'https://moderation-api.divine.video';
+const DEFAULT_D1_DATABASE = 'blossom-webhook-events';
+const DEFAULT_CRON_WAIT_SECONDS = 180;
+const SHA256_HEX = /^[0-9a-f]{64}$/;
+
+function getFlag(argv, name) {
+  const prefix = `--${name}=`;
+  for (const a of argv) {
+    if (a === `--${name}`) return true;
+    if (a.startsWith(prefix)) return a.slice(prefix.length);
+  }
+  return null;
+}
+
+function validatePositiveInt(value, fieldName) {
+  const n = Number(value);
+  if (!Number.isInteger(n) || n <= 0) {
+    throw new Error(`Invalid ${fieldName}: ${value} (must be positive integer)`);
+  }
+  return n;
+}
+
+export function parseArgs(argv) {
+  const rawScenario = getFlag(argv, 'scenario');
+  const scenario = rawScenario === null || rawScenario === true ? 'both' : rawScenario;
+  if (!['sync', 'cron', 'both'].includes(scenario)) {
+    throw new Error(`Invalid scenario: ${scenario} (must be sync|cron|both)`);
+  }
+
+  const rawCron = getFlag(argv, 'cron-wait-seconds');
+  const cronWaitSeconds = rawCron
+    ? validatePositiveInt(rawCron, 'cron-wait-seconds')
+    : DEFAULT_CRON_WAIT_SECONDS;
+
+  return {
+    scenario,
+    stagingRelay: getFlag(argv, 'staging-relay') || DEFAULT_STAGING_RELAY,
+    funnelcakeApi: getFlag(argv, 'funnelcake-api') || DEFAULT_FUNNELCAKE_API,
+    blossomBase: getFlag(argv, 'blossom-base') || DEFAULT_BLOSSOM_BASE,
+    modServiceBase: getFlag(argv, 'mod-service-base') || DEFAULT_MOD_SERVICE_BASE,
+    d1Database: getFlag(argv, 'd1-database') || DEFAULT_D1_DATABASE,
+    cronWaitSeconds,
+    skipCleanup: getFlag(argv, 'skip-cleanup') === true
+  };
+}

--- a/scripts/e2e-creator-delete.mjs
+++ b/scripts/e2e-creator-delete.mjs
@@ -173,3 +173,40 @@ export async function cleanupD1Row(kind5_id, target_event_id, cfg, runner = defa
     throw new Error(`wrangler d1 execute failed (exit ${r.status}): ${r.stderr.trim() || r.stdout.trim()}`);
   }
 }
+
+/**
+ * Fully purge the single blob owned by the test pubkey.
+ *
+ * Uses POST /admin/api/vanish (verified at divine-blossom/src/main.rs:209 →
+ * handle_admin_vanish, src/main.rs:3975 → execute_vanish). For a fresh
+ * ephemeral pubkey that owns exactly one blob, this is surgical: full GCS +
+ * KV + VCL purge of the test blob and nothing else.
+ *
+ * Expects a successful vanish to return { vanished: true, fully_deleted, unlinked, errors }.
+ * fully_deleted:0 is acceptable (pipeline may have already purged the blob).
+ * errors > 0 indicates Blossom couldn't fully process; surface as failure.
+ */
+export async function cleanupBlossomVanish(testPubkey, cfg, fetchImpl = fetch) {
+  const res = await fetchImpl(`${cfg.blossomBase}/admin/api/vanish`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${cfg.blossomWebhookSecret}`
+    },
+    body: JSON.stringify({ pubkey: testPubkey, reason: 'e2e-test cleanup' })
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Blossom vanish failed: HTTP ${res.status}: ${text}`);
+  }
+  const body = await res.json();
+  const out = {
+    fullyDeleted: body.fully_deleted ?? 0,
+    unlinked: body.unlinked ?? 0,
+    errors: body.errors ?? 0
+  };
+  if (out.errors > 0) {
+    throw new Error(`Blossom vanish reported errors:${out.errors} fully_deleted:${out.fullyDeleted} unlinked:${out.unlinked}`);
+  }
+  return out;
+}

--- a/scripts/e2e-creator-delete.mjs
+++ b/scripts/e2e-creator-delete.mjs
@@ -142,3 +142,34 @@ export function classifyByteProbeResponse(status) {
   if (status === 200) return { kind: 'bytes_present', flagStateInferred: 'off' };
   return { kind: 'unknown', status };
 }
+
+/**
+ * Default runner used when the script runs as a CLI. Tests inject a fake.
+ * Uses spawnSync (args is an array, not a string — no shell interpretation).
+ * The node:child_process import is deferred via dynamic import() so the
+ * Cloudflare Workers vitest pool does not try to resolve it at module-load
+ * time (nodejs_compat does not expose child_process there).
+ */
+export async function defaultRunner({ command, args }) {
+  const { spawnSync } = await import('node:child_process');
+  const r = spawnSync(command, args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+  return { stdout: r.stdout || '', stderr: r.stderr || '', status: r.status ?? 0 };
+}
+
+function validateHex64(value, fieldName) {
+  if (typeof value !== 'string' || !SHA256_HEX.test(value)) {
+    throw new Error(`Invalid ${fieldName}: ${value} (must be 64-char lowercase hex)`);
+  }
+  return value;
+}
+
+export async function cleanupD1Row(kind5_id, target_event_id, cfg, runner = defaultRunner) {
+  validateHex64(kind5_id, 'kind5_id');
+  validateHex64(target_event_id, 'target_event_id');
+  const sql = `DELETE FROM creator_deletions WHERE kind5_id = '${kind5_id}' AND target_event_id = '${target_event_id}';`;
+  const args = ['d1', 'execute', cfg.d1Database, '--remote', '--json', '--command', sql];
+  const r = await runner({ command: 'wrangler', args });
+  if (r.status !== 0) {
+    throw new Error(`wrangler d1 execute failed (exit ${r.status}): ${r.stderr.trim() || r.stdout.trim()}`);
+  }
+}

--- a/scripts/e2e-creator-delete.mjs
+++ b/scripts/e2e-creator-delete.mjs
@@ -627,3 +627,15 @@ export async function main(argv, deps = {}) {
   printSummary(results);
   return computeExitCode(results);
 }
+
+// CLI entrypoint — runs only when invoked directly (not when imported by tests).
+const isMain = typeof process !== 'undefined' && process.argv && import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  main(process.argv.slice(2)).then(
+    (code) => process.exit(code),
+    (err) => {
+      process.stderr.write(`unexpected error: ${err.stack || err.message}\n`);
+      process.exit(99);
+    }
+  );
+}

--- a/scripts/e2e-creator-delete.test.mjs
+++ b/scripts/e2e-creator-delete.test.mjs
@@ -58,4 +58,24 @@ describe('parseArgs', () => {
     expect(cfg.blossomBase).toBe('http://localhost:7676');
     expect(cfg.modServiceBase).toBe('http://localhost:8787');
   });
+
+  it('rejects --cron-wait-seconds=abc (non-numeric)', () => {
+    expect(() => parseArgs(['--cron-wait-seconds=abc'])).toThrow(/cron-wait/i);
+  });
+
+  it('rejects --cron-wait-seconds=-10 (negative)', () => {
+    expect(() => parseArgs(['--cron-wait-seconds=-10'])).toThrow(/cron-wait/i);
+  });
+
+  it('rejects --cron-wait-seconds=1.5 (non-integer)', () => {
+    expect(() => parseArgs(['--cron-wait-seconds=1.5'])).toThrow(/cron-wait/i);
+  });
+
+  it('rejects flags that expect a value but are passed without = (e.g., --cron-wait-seconds)', () => {
+    expect(() => parseArgs(['--cron-wait-seconds'])).toThrow(/requires a value/i);
+  });
+
+  it('rejects --staging-relay without a value', () => {
+    expect(() => parseArgs(['--staging-relay'])).toThrow(/requires a value/i);
+  });
 });

--- a/scripts/e2e-creator-delete.test.mjs
+++ b/scripts/e2e-creator-delete.test.mjs
@@ -199,3 +199,47 @@ describe('classifyByteProbeResponse', () => {
     expect(classifyByteProbeResponse(0).kind).toBe('unknown');
   });
 });
+
+import { cleanupD1Row } from './e2e-creator-delete.mjs';
+
+function makeFakeRunner(responseFor) {
+  const calls = [];
+  const fn = async ({ command, args }) => {
+    calls.push({ command, args });
+    const sql = args[args.indexOf('--command') + 1];
+    return responseFor(sql);
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+const WRANGLER_OK = JSON.stringify([{ results: [], success: true, meta: {} }]);
+
+describe('cleanupD1Row', () => {
+  const cfg = parseArgs([]);
+  const KIND5 = 'a'.repeat(64);
+  const TARGET = 'b'.repeat(64);
+
+  it('runs wrangler d1 execute with a DELETE matching the composite primary key', async () => {
+    const runner = makeFakeRunner(() => ({ stdout: WRANGLER_OK, stderr: '', status: 0 }));
+    await cleanupD1Row(KIND5, TARGET, cfg, runner);
+    expect(runner.calls.length).toBe(1);
+    expect(runner.calls[0].args.slice(0, 5)).toEqual(['d1', 'execute', cfg.d1Database, '--remote', '--json']);
+    const sql = runner.calls[0].args[runner.calls[0].args.indexOf('--command') + 1];
+    expect(sql).toContain('DELETE FROM creator_deletions');
+    expect(sql).toContain(`kind5_id = '${KIND5}'`);
+    expect(sql).toContain(`target_event_id = '${TARGET}'`);
+  });
+
+  it('throws when wrangler exits non-zero', async () => {
+    const runner = makeFakeRunner(() => ({ stdout: '', stderr: 'd1 unreachable', status: 1 }));
+    await expect(cleanupD1Row(KIND5, TARGET, cfg, runner)).rejects.toThrow(/d1 unreachable/i);
+  });
+
+  it('rejects kind5 or target that is not 64-char hex (prevents SQL interpolation risk)', async () => {
+    const runner = makeFakeRunner(() => ({ stdout: WRANGLER_OK, stderr: '', status: 0 }));
+    await expect(cleanupD1Row('not-hex', TARGET, cfg, runner)).rejects.toThrow(/kind5_id/i);
+    await expect(cleanupD1Row(KIND5, 'not-hex', cfg, runner)).rejects.toThrow(/target_event_id/i);
+    expect(runner.calls.length).toBe(0);
+  });
+});

--- a/scripts/e2e-creator-delete.test.mjs
+++ b/scripts/e2e-creator-delete.test.mjs
@@ -391,3 +391,70 @@ describe('waitForIndexing', () => {
     ).rejects.toThrow(/500/);
   });
 });
+
+import { callSyncEndpoint, pollStatus } from './e2e-creator-delete.mjs';
+
+describe('callSyncEndpoint', () => {
+  const cfg = parseArgs([]);
+
+  it('POSTs to /api/creator-delete/sync with NIP-98 Authorization + kind 5 body', async () => {
+    const fetchImpl = makeFakeFetch(async () => ({ ok: true, status: 202, json: async () => ({ accepted: true }) }));
+    const { sk } = generateTestKey();
+    const kind5 = { id: 'a'.repeat(64), kind: 5, pubkey: 'f'.repeat(64), tags: [], content: '', created_at: 0, sig: '00' };
+    await callSyncEndpoint(sk, kind5, cfg, fetchImpl);
+    expect(fetchImpl.calls.length).toBe(1);
+    const call = fetchImpl.calls[0];
+    expect(call.url).toBe(`${cfg.modServiceBase}/api/creator-delete/sync`);
+    expect(call.init.method).toBe('POST');
+    expect(call.init.headers.Authorization.startsWith('Nostr ')).toBe(true);
+    expect(JSON.parse(call.init.body)).toEqual(kind5);
+  });
+
+  it('throws on 4xx/5xx', async () => {
+    const fetchImpl = makeFakeFetch(async () => ({ ok: false, status: 400, text: async () => 'bad request' }));
+    const { sk } = generateTestKey();
+    const kind5 = { id: 'a'.repeat(64), kind: 5, pubkey: 'f'.repeat(64), tags: [], content: '', created_at: 0, sig: '00' };
+    await expect(callSyncEndpoint(sk, kind5, cfg, fetchImpl)).rejects.toThrow(/400/);
+  });
+});
+
+describe('pollStatus', () => {
+  const cfg = parseArgs([]);
+  const KIND5 = 'a'.repeat(64);
+
+  it('resolves with the terminal success body', async () => {
+    let calls = 0;
+    const fetchImpl = async () => {
+      calls++;
+      if (calls < 3) return { ok: true, status: 200, json: async () => ({ status: 'accepted' }) };
+      return { ok: true, status: 200, json: async () => ({ status: 'success', blob_sha256: 'a'.repeat(64) }) };
+    };
+    const { sk } = generateTestKey();
+    const out = await pollStatus(sk, KIND5, cfg, { fetchImpl, timeoutMs: 5000, pollIntervalMs: 10 });
+    expect(out.status).toBe('success');
+    expect(calls).toBe(3);
+  });
+
+  it('resolves when status reaches a failed:* terminal (returns the body for caller to assert on)', async () => {
+    const fetchImpl = async () => ({ ok: true, status: 200, json: async () => ({ status: 'failed:permanent:target_not_found' }) });
+    const { sk } = generateTestKey();
+    const out = await pollStatus(sk, KIND5, cfg, { fetchImpl, timeoutMs: 5000, pollIntervalMs: 10 });
+    expect(out.status).toBe('failed:permanent:target_not_found');
+  });
+
+  it('throws on timeout if no terminal status is reached', async () => {
+    const fetchImpl = async () => ({ ok: true, status: 200, json: async () => ({ status: 'accepted' }) });
+    const { sk } = generateTestKey();
+    await expect(
+      pollStatus(sk, KIND5, cfg, { fetchImpl, timeoutMs: 40, pollIntervalMs: 10 })
+    ).rejects.toThrow(/timeout/i);
+  });
+
+  it('throws on non-2xx', async () => {
+    const fetchImpl = async () => ({ ok: false, status: 401, text: async () => 'unauthorized' });
+    const { sk } = generateTestKey();
+    await expect(
+      pollStatus(sk, KIND5, cfg, { fetchImpl, timeoutMs: 5000, pollIntervalMs: 10 })
+    ).rejects.toThrow(/401/);
+  });
+});

--- a/scripts/e2e-creator-delete.test.mjs
+++ b/scripts/e2e-creator-delete.test.mjs
@@ -114,3 +114,57 @@ describe('generateSyntheticBlob', () => {
     expect(a.sha256).not.toBe(b.sha256);
   });
 });
+
+import { buildKind34236Event } from './e2e-creator-delete.mjs';
+import { verifyEvent } from 'nostr-tools/pure';
+
+describe('buildKind34236Event', () => {
+  const cfg = parseArgs([]);
+  const SHA = 'a'.repeat(64);
+
+  it('returns a signed kind 34236 event with all required tags', () => {
+    const { sk } = generateTestKey();
+    const event = buildKind34236Event(sk, SHA, cfg);
+    expect(event.kind).toBe(34236);
+    expect(verifyEvent(event)).toBe(true);
+
+    const tagNames = event.tags.map(t => t[0]);
+    expect(tagNames).toContain('d');
+    expect(tagNames).toContain('title');
+    expect(tagNames).toContain('imeta');
+    expect(tagNames).toContain('thumb');
+  });
+
+  it('imeta tag contains space-delimited url/x/m items (Funnelcake contract)', () => {
+    const { sk } = generateTestKey();
+    const event = buildKind34236Event(sk, SHA, cfg);
+    const imeta = event.tags.find(t => t[0] === 'imeta');
+    expect(imeta).toBeDefined();
+
+    // validate_imeta_format: each non-first item must contain a space
+    for (const item of imeta.slice(1)) {
+      expect(item).toMatch(/\s/);
+    }
+
+    // Required keys for our test blob
+    const itemsByKey = Object.fromEntries(
+      imeta.slice(1).map(item => {
+        const idx = item.indexOf(' ');
+        return [item.slice(0, idx), item.slice(idx + 1)];
+      })
+    );
+    expect(itemsByKey.url).toMatch(/^https?:\/\//);
+    expect(itemsByKey.x).toBe(SHA);
+    expect(itemsByKey.m).toBe('video/mp4');
+  });
+
+  it('d tag is unique across calls (prevents addressable-event collision)', () => {
+    const { sk: sk1 } = generateTestKey();
+    const { sk: sk2 } = generateTestKey();
+    const e1 = buildKind34236Event(sk1, SHA, cfg);
+    const e2 = buildKind34236Event(sk2, SHA, cfg);
+    const d1 = e1.tags.find(t => t[0] === 'd')[1];
+    const d2 = e2.tags.find(t => t[0] === 'd')[1];
+    expect(d1).not.toBe(d2);
+  });
+});

--- a/scripts/e2e-creator-delete.test.mjs
+++ b/scripts/e2e-creator-delete.test.mjs
@@ -349,3 +349,45 @@ describe('uploadToBlossom', () => {
     await expect(uploadToBlossom(new Uint8Array(1), SHA, sk, cfg, fetchImpl)).rejects.toThrow(/413/);
   });
 });
+
+import { waitForIndexing } from './e2e-creator-delete.mjs';
+
+describe('waitForIndexing', () => {
+  const cfg = parseArgs([]);
+  const EVENT_ID = 'a'.repeat(64);
+
+  it('resolves immediately when fetch returns 200 on first attempt', async () => {
+    let calls = 0;
+    const fetchImpl = async () => {
+      calls++;
+      return { ok: true, status: 200, json: async () => ({ id: EVENT_ID }) };
+    };
+    await waitForIndexing(EVENT_ID, cfg, { fetchImpl, timeoutMs: 5000, pollIntervalMs: 10 });
+    expect(calls).toBe(1);
+  });
+
+  it('polls until 200, tolerates 404 during indexing lag', async () => {
+    let calls = 0;
+    const fetchImpl = async () => {
+      calls++;
+      if (calls < 3) return { ok: false, status: 404, text: async () => 'not found' };
+      return { ok: true, status: 200, json: async () => ({ id: EVENT_ID }) };
+    };
+    await waitForIndexing(EVENT_ID, cfg, { fetchImpl, timeoutMs: 5000, pollIntervalMs: 10 });
+    expect(calls).toBe(3);
+  });
+
+  it('throws after timeout', async () => {
+    const fetchImpl = async () => ({ ok: false, status: 404, text: async () => 'not found' });
+    await expect(
+      waitForIndexing(EVENT_ID, cfg, { fetchImpl, timeoutMs: 50, pollIntervalMs: 10 })
+    ).rejects.toThrow(/timeout|not indexed/i);
+  });
+
+  it('throws immediately on non-404 HTTP error', async () => {
+    const fetchImpl = async () => ({ ok: false, status: 500, text: async () => 'server error' });
+    await expect(
+      waitForIndexing(EVENT_ID, cfg, { fetchImpl, timeoutMs: 5000, pollIntervalMs: 10 })
+    ).rejects.toThrow(/500/);
+  });
+});

--- a/scripts/e2e-creator-delete.test.mjs
+++ b/scripts/e2e-creator-delete.test.mjs
@@ -458,3 +458,57 @@ describe('pollStatus', () => {
     ).rejects.toThrow(/401/);
   });
 });
+
+import { assertD1AndBlossomState } from './e2e-creator-delete.mjs';
+
+describe('assertD1AndBlossomState', () => {
+  const cfg = parseArgs([]);
+  const KIND5 = 'a'.repeat(64);
+  const TARGET = 'b'.repeat(64);
+  const SHA = 'c'.repeat(64);
+
+  const makeD1Row = (overrides) => JSON.stringify([{
+    results: [{ kind5_id: KIND5, target_event_id: TARGET, blob_sha256: SHA, status: 'success', ...overrides }],
+    success: true, meta: {}
+  }]);
+
+  it('passes when D1 row status=success and Blossom returns 404 (bytes gone)', async () => {
+    const runner = makeFakeRunner(() => ({ stdout: makeD1Row(), stderr: '', status: 0 }));
+    const fetchImpl = makeFakeFetch(async () => ({ ok: false, status: 404, text: async () => 'not found' }));
+    const out = await assertD1AndBlossomState(KIND5, SHA, cfg, { runner, fetchImpl });
+    expect(out.d1Status).toBe('success');
+    expect(out.byteProbe).toMatchObject({ kind: 'bytes_gone', flagStateInferred: 'on' });
+  });
+
+  it('passes when D1 row status=success and Blossom returns 200 (bytes present, flag off)', async () => {
+    const runner = makeFakeRunner(() => ({ stdout: makeD1Row(), stderr: '', status: 0 }));
+    const fetchImpl = makeFakeFetch(async () => ({ ok: true, status: 200, text: async () => 'bytes' }));
+    const out = await assertD1AndBlossomState(KIND5, SHA, cfg, { runner, fetchImpl });
+    expect(out.byteProbe).toMatchObject({ kind: 'bytes_present', flagStateInferred: 'off' });
+  });
+
+  it('fails when D1 row is missing', async () => {
+    const runner = makeFakeRunner(() => ({ stdout: JSON.stringify([{ results: [], success: true, meta: {} }]), stderr: '', status: 0 }));
+    const fetchImpl = makeFakeFetch(async () => ({ ok: false, status: 404, text: async () => '' }));
+    await expect(assertD1AndBlossomState(KIND5, SHA, cfg, { runner, fetchImpl })).rejects.toThrow(/D1 row not found/i);
+  });
+
+  it('fails when D1 row status is not success', async () => {
+    const runner = makeFakeRunner(() => ({ stdout: makeD1Row({ status: 'failed:transient:timeout' }), stderr: '', status: 0 }));
+    const fetchImpl = makeFakeFetch(async () => ({ ok: false, status: 404, text: async () => '' }));
+    await expect(assertD1AndBlossomState(KIND5, SHA, cfg, { runner, fetchImpl })).rejects.toThrow(/status=failed:transient:timeout/i);
+  });
+
+  it('fails when byte probe returns unknown status', async () => {
+    const runner = makeFakeRunner(() => ({ stdout: makeD1Row(), stderr: '', status: 0 }));
+    const fetchImpl = makeFakeFetch(async () => ({ ok: false, status: 500, text: async () => 'server error' }));
+    await expect(assertD1AndBlossomState(KIND5, SHA, cfg, { runner, fetchImpl })).rejects.toThrow(/byte probe returned unknown/i);
+  });
+
+  it('fails when sha256 on the D1 row does not match the expected sha', async () => {
+    const wrongSha = 'e'.repeat(64);
+    const runner = makeFakeRunner(() => ({ stdout: makeD1Row({ blob_sha256: wrongSha }), stderr: '', status: 0 }));
+    const fetchImpl = makeFakeFetch(async () => ({ ok: false, status: 404, text: async () => '' }));
+    await expect(assertD1AndBlossomState(KIND5, SHA, cfg, { runner, fetchImpl })).rejects.toThrow(/blob_sha256 mismatch/i);
+  });
+});

--- a/scripts/e2e-creator-delete.test.mjs
+++ b/scripts/e2e-creator-delete.test.mjs
@@ -512,3 +512,114 @@ describe('assertD1AndBlossomState', () => {
     await expect(assertD1AndBlossomState(KIND5, SHA, cfg, { runner, fetchImpl })).rejects.toThrow(/blob_sha256 mismatch/i);
   });
 });
+
+import { runSyncScenario, runCronScenario } from './e2e-creator-delete.mjs';
+
+describe('runSyncScenario', () => {
+  const cfg = { ...parseArgs([]), blossomWebhookSecret: 'test-secret' };
+
+  function makeDeps({ uploadResult, publishEventIds, statusBody, d1Row, byteProbeStatus, vanishResult }) {
+    const published = [];
+    return {
+      uploadToBlossom: async () => uploadResult,
+      publishEvent: async (event) => {
+        published.push(event);
+        return publishEventIds.shift() || event.id;
+      },
+      waitForIndexing: async () => ({ polls: 1 }),
+      callSyncEndpoint: async () => ({ accepted: true }),
+      pollStatus: async () => statusBody,
+      runner: makeFakeRunner((sql) => {
+        if (sql.startsWith('SELECT')) {
+          return { stdout: JSON.stringify([{ results: [d1Row], success: true, meta: {} }]), stderr: '', status: 0 };
+        }
+        if (sql.startsWith('DELETE')) {
+          return { stdout: JSON.stringify([{ results: [], success: true, meta: {} }]), stderr: '', status: 0 };
+        }
+        throw new Error('unexpected sql: ' + sql.slice(0, 80));
+      }),
+      fetchImpl: makeFakeFetch(async ({ url }) => {
+        if (url.endsWith('/admin/api/vanish')) {
+          return { ok: true, status: 200, json: async () => vanishResult };
+        }
+        // byte probe
+        return { ok: byteProbeStatus === 200, status: byteProbeStatus, text: async () => '' };
+      }),
+      published
+    };
+  }
+
+  it('passes end-to-end with flag-on path (byte probe 404)', async () => {
+    const SHA = 'a'.repeat(64);
+    const deps = makeDeps({
+      uploadResult: { sha256: SHA, url: `${cfg.blossomBase}/${SHA}` },
+      publishEventIds: [],
+      statusBody: { status: 'success', blob_sha256: SHA, polls: 4 },
+      d1Row: { kind5_id: '', target_event_id: '', blob_sha256: SHA, status: 'success' },
+      byteProbeStatus: 404,
+      vanishResult: { vanished: true, fully_deleted: 1, unlinked: 0, errors: 0 }
+    });
+    const result = await runSyncScenario(cfg, deps);
+    expect(result.outcome).toBe('pass');
+    expect(result.cleanup.blossom.fullyDeleted).toBe(1);
+    expect(result.cleanup.d1.ok).toBe(true);
+  });
+
+  it('fails when pollStatus returns a failed:* terminal, but cleanup still runs', async () => {
+    const SHA = 'a'.repeat(64);
+    const deps = makeDeps({
+      uploadResult: { sha256: SHA, url: `${cfg.blossomBase}/${SHA}` },
+      publishEventIds: [],
+      statusBody: { status: 'failed:permanent:target_not_found' },
+      d1Row: { kind5_id: '', target_event_id: '', blob_sha256: SHA, status: 'failed:permanent:target_not_found' },
+      byteProbeStatus: 200,
+      vanishResult: { vanished: true, fully_deleted: 1, unlinked: 0, errors: 0 }
+    });
+    const result = await runSyncScenario(cfg, deps);
+    expect(result.outcome).toBe('fail');
+    expect(result.cleanup.blossom.fullyDeleted).toBe(1);
+  });
+
+  it('skips cleanup when cfg.skipCleanup is true', async () => {
+    const SHA = 'a'.repeat(64);
+    const cfgNoCleanup = { ...cfg, skipCleanup: true };
+    const deps = makeDeps({
+      uploadResult: { sha256: SHA, url: `${cfg.blossomBase}/${SHA}` },
+      publishEventIds: [],
+      statusBody: { status: 'success', blob_sha256: SHA },
+      d1Row: { kind5_id: '', target_event_id: '', blob_sha256: SHA, status: 'success' },
+      byteProbeStatus: 404,
+      vanishResult: { vanished: true, fully_deleted: 1, unlinked: 0, errors: 0 }
+    });
+    const result = await runSyncScenario(cfgNoCleanup, deps);
+    expect(result.outcome).toBe('pass');
+    expect(result.cleanup).toEqual({ skipped: true });
+  });
+});
+
+describe('runCronScenario', () => {
+  const cfg = { ...parseArgs([]), blossomWebhookSecret: 'test-secret' };
+
+  it('does NOT call the sync endpoint; relies on pollStatus for cron-triggered D1 update', async () => {
+    const SHA = 'a'.repeat(64);
+    let syncCalls = 0;
+    const deps = {
+      uploadToBlossom: async () => ({ sha256: SHA, url: `${cfg.blossomBase}/${SHA}` }),
+      publishEvent: async (event) => event.id,
+      waitForIndexing: async () => ({ polls: 1 }),
+      callSyncEndpoint: async () => { syncCalls++; return { accepted: true }; },
+      pollStatus: async () => ({ status: 'success', blob_sha256: SHA }),
+      runner: makeFakeRunner((sql) => {
+        if (sql.startsWith('SELECT')) return { stdout: JSON.stringify([{ results: [{ kind5_id: '', target_event_id: '', blob_sha256: SHA, status: 'success' }], success: true, meta: {} }]), stderr: '', status: 0 };
+        return { stdout: JSON.stringify([{ results: [], success: true, meta: {} }]), stderr: '', status: 0 };
+      }),
+      fetchImpl: makeFakeFetch(async ({ url }) => {
+        if (url.endsWith('/admin/api/vanish')) return { ok: true, status: 200, json: async () => ({ vanished: true, fully_deleted: 1, unlinked: 0, errors: 0 }) };
+        return { ok: false, status: 404, text: async () => '' };
+      })
+    };
+    const result = await runCronScenario(cfg, deps);
+    expect(syncCalls).toBe(0);
+    expect(result.outcome).toBe('pass');
+  });
+});

--- a/scripts/e2e-creator-delete.test.mjs
+++ b/scripts/e2e-creator-delete.test.mjs
@@ -307,3 +307,45 @@ describe('cleanupBlossomVanish', () => {
     expect(fetchImpl.calls.length).toBe(0);
   });
 });
+
+import { uploadToBlossom, buildBud01UploadAuth } from './e2e-creator-delete.mjs';
+
+describe('buildBud01UploadAuth', () => {
+  const SHA = 'a'.repeat(64);
+  it('returns a Nostr-scheme header with kind 24242 event containing t=upload and x=sha', () => {
+    const { sk } = generateTestKey();
+    const header = buildBud01UploadAuth(sk, SHA);
+    expect(header.startsWith('Nostr ')).toBe(true);
+    const eventJson = Buffer.from(header.slice('Nostr '.length), 'base64').toString('utf8');
+    const event = JSON.parse(eventJson);
+    expect(event.kind).toBe(24242);
+    expect(event.tags).toEqual(expect.arrayContaining([['t', 'upload'], ['x', SHA]]));
+  });
+});
+
+describe('uploadToBlossom', () => {
+  const cfg = parseArgs([]);
+  const SHA = 'a'.repeat(64);
+
+  it('PUTs the bytes to /upload with BUD-01 auth and returns the parsed response', async () => {
+    const fetchImpl = makeFakeFetch(async () => ({
+      ok: true, status: 200,
+      json: async () => ({ url: `${cfg.blossomBase}/${SHA}`, sha256: SHA, size: 1024 })
+    }));
+    const { sk } = generateTestKey();
+    const bytes = new Uint8Array(1024);
+    const out = await uploadToBlossom(bytes, SHA, sk, cfg, fetchImpl);
+    expect(fetchImpl.calls.length).toBe(1);
+    expect(fetchImpl.calls[0].url).toBe(`${cfg.blossomBase}/upload`);
+    expect(fetchImpl.calls[0].init.method).toBe('PUT');
+    expect(fetchImpl.calls[0].init.headers.Authorization.startsWith('Nostr ')).toBe(true);
+    expect(fetchImpl.calls[0].init.body).toBe(bytes);
+    expect(out).toEqual({ url: `${cfg.blossomBase}/${SHA}`, sha256: SHA });
+  });
+
+  it('throws on non-2xx', async () => {
+    const fetchImpl = makeFakeFetch(async () => ({ ok: false, status: 413, text: async () => 'too large' }));
+    const { sk } = generateTestKey();
+    await expect(uploadToBlossom(new Uint8Array(1), SHA, sk, cfg, fetchImpl)).rejects.toThrow(/413/);
+  });
+});

--- a/scripts/e2e-creator-delete.test.mjs
+++ b/scripts/e2e-creator-delete.test.mjs
@@ -299,4 +299,11 @@ describe('cleanupBlossomVanish', () => {
     const out = await cleanupBlossomVanish(PUBKEY, cfg, fetchImpl);
     expect(out).toEqual({ fullyDeleted: 0, unlinked: 0, errors: 0 });
   });
+
+  it('throws when cfg.blossomWebhookSecret is missing', async () => {
+    const fetchImpl = makeFakeFetch(async () => ({ ok: true, status: 200, json: async () => ({ fully_deleted: 1, unlinked: 0, errors: 0 }) }));
+    const cfgNoSecret = { ...parseArgs([]) };
+    await expect(cleanupBlossomVanish(PUBKEY, cfgNoSecret, fetchImpl)).rejects.toThrow(/blossomWebhookSecret/);
+    expect(fetchImpl.calls.length).toBe(0);
+  });
 });

--- a/scripts/e2e-creator-delete.test.mjs
+++ b/scripts/e2e-creator-delete.test.mjs
@@ -243,3 +243,60 @@ describe('cleanupD1Row', () => {
     expect(runner.calls.length).toBe(0);
   });
 });
+
+import { cleanupBlossomVanish } from './e2e-creator-delete.mjs';
+
+function makeFakeFetch(impl) {
+  const calls = [];
+  const fn = async (url, init) => {
+    calls.push({ url, init });
+    return impl({ url, init });
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+describe('cleanupBlossomVanish', () => {
+  const cfg = { ...parseArgs([]), blossomWebhookSecret: 'test-secret' };
+  const PUBKEY = 'f'.repeat(64);
+
+  it('POSTs to /admin/api/vanish with bearer auth and pubkey+reason body', async () => {
+    const fetchImpl = makeFakeFetch(async () => ({
+      ok: true, status: 200,
+      json: async () => ({ vanished: true, pubkey: PUBKEY, reason: 'e2e-test cleanup', fully_deleted: 1, unlinked: 0, errors: 0 })
+    }));
+    const out = await cleanupBlossomVanish(PUBKEY, cfg, fetchImpl);
+    expect(fetchImpl.calls.length).toBe(1);
+    const call = fetchImpl.calls[0];
+    expect(call.url).toBe(`${cfg.blossomBase}/admin/api/vanish`);
+    expect(call.init.method).toBe('POST');
+    expect(call.init.headers.Authorization).toBe('Bearer test-secret');
+    expect(call.init.headers['Content-Type']).toBe('application/json');
+    const body = JSON.parse(call.init.body);
+    expect(body.pubkey).toBe(PUBKEY);
+    expect(body.reason).toBe('e2e-test cleanup');
+    expect(out).toEqual({ fullyDeleted: 1, unlinked: 0, errors: 0 });
+  });
+
+  it('throws on HTTP 4xx/5xx', async () => {
+    const fetchImpl = makeFakeFetch(async () => ({ ok: false, status: 500, text: async () => 'bad gateway' }));
+    await expect(cleanupBlossomVanish(PUBKEY, cfg, fetchImpl)).rejects.toThrow(/500/);
+  });
+
+  it('throws when vanish body reports errors > 0', async () => {
+    const fetchImpl = makeFakeFetch(async () => ({
+      ok: true, status: 200,
+      json: async () => ({ vanished: true, pubkey: PUBKEY, fully_deleted: 0, unlinked: 0, errors: 1 })
+    }));
+    await expect(cleanupBlossomVanish(PUBKEY, cfg, fetchImpl)).rejects.toThrow(/errors/);
+  });
+
+  it('tolerates fully_deleted:0 unlinked:0 (blob already gone from a previous cleanup)', async () => {
+    const fetchImpl = makeFakeFetch(async () => ({
+      ok: true, status: 200,
+      json: async () => ({ vanished: true, pubkey: PUBKEY, fully_deleted: 0, unlinked: 0, errors: 0 })
+    }));
+    const out = await cleanupBlossomVanish(PUBKEY, cfg, fetchImpl);
+    expect(out).toEqual({ fullyDeleted: 0, unlinked: 0, errors: 0 });
+  });
+});

--- a/scripts/e2e-creator-delete.test.mjs
+++ b/scripts/e2e-creator-delete.test.mjs
@@ -1,0 +1,61 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Tests for scripts/e2e-creator-delete.mjs — pure helpers + main() with injected deps.
+// ABOUTME: Vitest runs under @cloudflare/vitest-pool-workers; nodejs_compat is on.
+
+import { describe, it, expect } from 'vitest';
+import { parseArgs } from './e2e-creator-delete.mjs';
+
+describe('parseArgs', () => {
+  it('returns defaults when no flags given', () => {
+    const cfg = parseArgs([]);
+    expect(cfg).toEqual({
+      scenario: 'both',
+      stagingRelay: 'wss://relay.staging.divine.video',
+      funnelcakeApi: 'https://funnelcake.staging.dvines.org',
+      blossomBase: 'https://media.divine.video',
+      modServiceBase: 'https://moderation-api.divine.video',
+      d1Database: 'blossom-webhook-events',
+      cronWaitSeconds: 180,
+      skipCleanup: false
+    });
+  });
+
+  it('parses --scenario=sync', () => {
+    expect(parseArgs(['--scenario=sync']).scenario).toBe('sync');
+  });
+
+  it('parses --scenario=cron', () => {
+    expect(parseArgs(['--scenario=cron']).scenario).toBe('cron');
+  });
+
+  it('rejects unknown scenario', () => {
+    expect(() => parseArgs(['--scenario=foo'])).toThrow(/scenario/i);
+  });
+
+  it('parses --skip-cleanup as boolean', () => {
+    expect(parseArgs(['--skip-cleanup']).skipCleanup).toBe(true);
+  });
+
+  it('parses --cron-wait-seconds as positive integer', () => {
+    expect(parseArgs(['--cron-wait-seconds=240']).cronWaitSeconds).toBe(240);
+  });
+
+  it('rejects --cron-wait-seconds=0', () => {
+    expect(() => parseArgs(['--cron-wait-seconds=0'])).toThrow(/cron-wait/i);
+  });
+
+  it('parses URL overrides', () => {
+    const cfg = parseArgs([
+      '--staging-relay=wss://localhost:7777',
+      '--funnelcake-api=http://localhost:8080',
+      '--blossom-base=http://localhost:7676',
+      '--mod-service-base=http://localhost:8787'
+    ]);
+    expect(cfg.stagingRelay).toBe('wss://localhost:7777');
+    expect(cfg.funnelcakeApi).toBe('http://localhost:8080');
+    expect(cfg.blossomBase).toBe('http://localhost:7676');
+    expect(cfg.modServiceBase).toBe('http://localhost:8787');
+  });
+});

--- a/scripts/e2e-creator-delete.test.mjs
+++ b/scripts/e2e-creator-delete.test.mjs
@@ -513,6 +513,77 @@ describe('assertD1AndBlossomState', () => {
   });
 });
 
+import { computeExitCode, main } from './e2e-creator-delete.mjs';
+
+describe('computeExitCode', () => {
+  it('0 when all scenarios pass and all cleanups ok', () => {
+    expect(computeExitCode([
+      { outcome: 'pass', cleanup: { blossom: { errors: 0 }, d1: { ok: true } } },
+      { outcome: 'pass', cleanup: { blossom: { errors: 0 }, d1: { ok: true } } }
+    ])).toBe(0);
+  });
+
+  it('1 when any scenario fails, regardless of cleanup', () => {
+    expect(computeExitCode([
+      { outcome: 'fail', cleanup: { blossom: { errors: 0 }, d1: { ok: true } } }
+    ])).toBe(1);
+  });
+
+  it('3 when scenarios pass but a cleanup failed', () => {
+    expect(computeExitCode([
+      { outcome: 'pass', cleanup: { blossom: { errors: 0 }, d1: { ok: false, error: 'x' } } }
+    ])).toBe(3);
+  });
+
+  it('1 (takes precedence) when a scenario fails AND cleanup failed', () => {
+    expect(computeExitCode([
+      { outcome: 'fail', cleanup: { blossom: { ok: false, error: 'x' }, d1: { ok: false, error: 'y' } } }
+    ])).toBe(1);
+  });
+
+  it('0 when scenarios pass and cleanup was skipped', () => {
+    expect(computeExitCode([
+      { outcome: 'pass', cleanup: { skipped: true } }
+    ])).toBe(0);
+  });
+});
+
+describe('main (integration)', () => {
+  const baseDeps = {
+    uploadToBlossom: async () => ({ sha256: 'a'.repeat(64), url: 'u' }),
+    publishEvent: async (event) => event.id,
+    waitForIndexing: async () => ({ polls: 1 }),
+    callSyncEndpoint: async () => ({ accepted: true }),
+    pollStatus: async () => ({ status: 'success', blob_sha256: 'a'.repeat(64) }),
+    assertD1AndBlossomState: async () => ({ d1Status: 'success', byteProbe: { kind: 'bytes_gone', flagStateInferred: 'on' } }),
+    cleanupBlossomVanish: async () => ({ fullyDeleted: 1, unlinked: 0, errors: 0 }),
+    cleanupD1Row: async () => {},
+    blossomWebhookSecret: 'test-secret'
+  };
+
+  it('exits 0 on a passing both-scenarios run', async () => {
+    const code = await main(['--scenario=both'], baseDeps);
+    expect(code).toBe(0);
+  });
+
+  it('exits 1 when pollStatus reports failed:*', async () => {
+    const deps = { ...baseDeps, pollStatus: async () => ({ status: 'failed:permanent:target_not_found' }) };
+    const code = await main(['--scenario=sync'], deps);
+    expect(code).toBe(1);
+  });
+
+  it('exits 2 on missing BLOSSOM_WEBHOOK_SECRET', async () => {
+    const deps = { ...baseDeps, blossomWebhookSecret: null, env: {} };
+    const code = await main(['--scenario=sync'], deps);
+    expect(code).toBe(2);
+  });
+
+  it('exits 2 on invalid --scenario', async () => {
+    const code = await main(['--scenario=invalid'], baseDeps);
+    expect(code).toBe(2);
+  });
+});
+
 import { runSyncScenario, runCronScenario } from './e2e-creator-delete.mjs';
 
 describe('runSyncScenario', () => {

--- a/scripts/e2e-creator-delete.test.mjs
+++ b/scripts/e2e-creator-delete.test.mjs
@@ -348,6 +348,132 @@ describe('uploadToBlossom', () => {
     const { sk } = generateTestKey();
     await expect(uploadToBlossom(new Uint8Array(1), SHA, sk, cfg, fetchImpl)).rejects.toThrow(/413/);
   });
+
+  it('returns the server-confirmed sha256 from the response body, not the caller value', async () => {
+    // Regression for Liz's #110 review. Downstream `runScenario()` treats
+    // `upload.sha256` as the canonical server-confirmed hash, so the
+    // previous implementation would have silently propagated the
+    // caller's claim if the two ever diverged.
+    const SERVER_SHA = 'b'.repeat(64);
+    const CALLER_SHA = 'c'.repeat(64);
+    const fetchImpl = makeFakeFetch(async () => ({
+      ok: true, status: 200,
+      json: async () => ({ url: `${cfg.blossomBase}/${SERVER_SHA}`, sha256: SERVER_SHA, size: 42 })
+    }));
+    const { sk } = generateTestKey();
+    const out = await uploadToBlossom(new Uint8Array(42), CALLER_SHA, sk, cfg, fetchImpl);
+    expect(out.sha256).toBe(SERVER_SHA);
+    expect(out.sha256).not.toBe(CALLER_SHA);
+  });
+
+  it('throws when the response body is missing sha256 (contract break)', async () => {
+    const fetchImpl = makeFakeFetch(async () => ({
+      ok: true, status: 200,
+      json: async () => ({ url: 'http://whatever', size: 1 })
+    }));
+    const { sk } = generateTestKey();
+    await expect(
+      uploadToBlossom(new Uint8Array(1), SHA, sk, cfg, fetchImpl)
+    ).rejects.toThrow(/missing sha256/i);
+  });
+});
+
+import { publishEvent } from './e2e-creator-delete.mjs';
+
+/**
+ * Minimal fake WebSocket that lets each test drive the relay-side
+ * behavior (immediate OK true/false, error, or early close) and
+ * records the messages that the client sent. Mimics the shape the
+ * `ws` library exposes: `on()`, `send()`, `close()`.
+ */
+function makeFakeWebSocketCtor(driver) {
+  const instances = [];
+  function Ctor(url) {
+    const handlers = {};
+    const ws = {
+      url,
+      sent: [],
+      closed: false,
+      on(event, cb) { handlers[event] = cb; },
+      send(data) { this.sent.push(data); },
+      close() { this.closed = true; },
+      // Helpers the driver uses to push events at the client:
+      _fire(event, ...args) { if (handlers[event]) handlers[event](...args); },
+    };
+    instances.push(ws);
+    // Defer driver callback until after the caller wires up `on(...)`.
+    setImmediate(() => driver(ws));
+    return ws;
+  }
+  Ctor.instances = instances;
+  return Ctor;
+}
+
+describe('publishEvent', () => {
+  const event = { id: 'e'.repeat(64), pubkey: 'p'.repeat(64), kind: 1, created_at: 0, tags: [], content: '', sig: 's'.repeat(128) };
+  const relayUrl = 'wss://relay.example/test';
+
+  it('resolves with the event id on OK true and closes the socket', async () => {
+    const WebSocket = makeFakeWebSocketCtor((ws) => {
+      ws._fire('open');
+      ws._fire('message', Buffer.from(JSON.stringify(['OK', event.id, true, ''])));
+    });
+    const id = await publishEvent(event, relayUrl, { WebSocket });
+    expect(id).toBe(event.id);
+    expect(WebSocket.instances[0].sent[0]).toContain(event.id);
+    expect(WebSocket.instances[0].closed).toBe(true);
+  });
+
+  it('rejects with the relay reason on OK false and still closes the socket', async () => {
+    const WebSocket = makeFakeWebSocketCtor((ws) => {
+      ws._fire('open');
+      ws._fire('message', Buffer.from(JSON.stringify(['OK', event.id, false, 'blocked: rate limit'])));
+    });
+    await expect(publishEvent(event, relayUrl, { WebSocket })).rejects.toThrow(/blocked: rate limit/);
+    expect(WebSocket.instances[0].closed).toBe(true);
+  });
+
+  it('rejects on early WebSocket close with a concrete publish-failure message', async () => {
+    // Regression for Liz's #110 review. Without a close handler, an
+    // early disconnect from the relay degraded into a generic timeout
+    // ~10s later instead of a concrete failure. The done-once wrapper
+    // now turns a pre-OK close into an immediate rejection.
+    const WebSocket = makeFakeWebSocketCtor((ws) => {
+      ws._fire('open');
+      ws._fire('close', 1006, 'abnormal');
+    });
+    await expect(publishEvent(event, relayUrl, { WebSocket, timeoutMs: 5000 }))
+      .rejects.toThrow(/closed before OK/i);
+  });
+
+  it('rejects on socket error and closes exactly once even if close fires later', async () => {
+    const WebSocket = makeFakeWebSocketCtor((ws) => {
+      ws._fire('open');
+      ws._fire('error', new Error('econnreset'));
+      // Simulate the ws lib firing close after error — must not double-settle.
+      ws._fire('close', 1006, '');
+    });
+    await expect(publishEvent(event, relayUrl, { WebSocket })).rejects.toThrow(/econnreset/);
+  });
+
+  it('rejects on timeout if no OK, error, or close arrives', async () => {
+    const WebSocket = makeFakeWebSocketCtor((ws) => {
+      // Open but never send OK, never close.
+      ws._fire('open');
+    });
+    await expect(publishEvent(event, relayUrl, { WebSocket, timeoutMs: 15 }))
+      .rejects.toThrow(/publish timeout/);
+  });
+
+  it('ignores OK frames for unrelated event ids', async () => {
+    const WebSocket = makeFakeWebSocketCtor((ws) => {
+      ws._fire('open');
+      ws._fire('message', Buffer.from(JSON.stringify(['OK', 'different-event-id', true, ''])));
+      ws._fire('message', Buffer.from(JSON.stringify(['OK', event.id, true, ''])));
+    });
+    const id = await publishEvent(event, relayUrl, { WebSocket });
+    expect(id).toBe(event.id);
+  });
 });
 
 import { waitForIndexing } from './e2e-creator-delete.mjs';
@@ -578,9 +704,78 @@ describe('main (integration)', () => {
     expect(code).toBe(2);
   });
 
+  it('does NOT require BLOSSOM_WEBHOOK_SECRET when --skip-cleanup is set', async () => {
+    // Regression for Liz's #110 review. The inspection mode should run
+    // without requiring a prod admin secret it will never use, since
+    // /admin/api/vanish only runs during cleanup.
+    const deps = {
+      ...baseDeps,
+      blossomWebhookSecret: null,
+      env: {},
+      // Cleanup deps should not be called when skipCleanup is true; if
+      // they are, fail the test loudly.
+      cleanupBlossomVanish: async () => { throw new Error('cleanup should not run with --skip-cleanup'); },
+      cleanupD1Row: async () => { throw new Error('cleanup should not run with --skip-cleanup'); },
+    };
+    const code = await main(['--scenario=sync', '--skip-cleanup'], deps);
+    expect(code).toBe(0);
+  });
+
   it('exits 2 on invalid --scenario', async () => {
     const code = await main(['--scenario=invalid'], baseDeps);
     expect(code).toBe(2);
+  });
+});
+
+import { printSummary } from './e2e-creator-delete.mjs';
+
+describe('printSummary manual-cleanup commands', () => {
+  // Regression for Liz's #110 review. The manual-cleanup block must
+  // render against the effective cfg (blossomBase, d1Database), not
+  // the prod defaults, so operators running the script against an
+  // override target see commands that actually point at their target.
+  const failedResult = {
+    scenario: 'sync',
+    outcome: 'pass',
+    totalDurationMs: 5000,
+    sha256: 'a'.repeat(64),
+    pubkey: 'b'.repeat(64),
+    kind5Id: 'c'.repeat(64),
+    target: 'd'.repeat(64),
+    cleanup: {
+      blossom: { ok: false, error: 'vanish 503' },
+      d1: { ok: false, error: 'd1 unreachable' },
+    },
+  };
+
+  it('renders Blossom vanish curl against cfg.blossomBase', () => {
+    const lines = [];
+    const origError = console.error;
+    console.error = (msg) => lines.push(String(msg));
+    try {
+      printSummary([failedResult], { blossomBase: 'https://staging.blossom.example', d1Database: 'staging-db' });
+    } finally {
+      console.error = origError;
+    }
+    const joined = lines.join('\n');
+    expect(joined).toContain('https://staging.blossom.example/admin/api/vanish');
+    expect(joined).not.toContain('https://media.divine.video/admin/api/vanish');
+    expect(joined).toContain('wrangler d1 execute staging-db');
+    expect(joined).not.toContain('wrangler d1 execute blossom-webhook-events');
+  });
+
+  it('falls back to prod defaults when cfg is absent (older callers)', () => {
+    const lines = [];
+    const origError = console.error;
+    console.error = (msg) => lines.push(String(msg));
+    try {
+      printSummary([failedResult]);
+    } finally {
+      console.error = origError;
+    }
+    const joined = lines.join('\n');
+    expect(joined).toContain('https://media.divine.video/admin/api/vanish');
+    expect(joined).toContain('wrangler d1 execute blossom-webhook-events');
   });
 });
 

--- a/scripts/e2e-creator-delete.test.mjs
+++ b/scripts/e2e-creator-delete.test.mjs
@@ -168,3 +168,34 @@ describe('buildKind34236Event', () => {
     expect(d1).not.toBe(d2);
   });
 });
+
+import { classifyByteProbeResponse } from './e2e-creator-delete.mjs';
+
+describe('classifyByteProbeResponse', () => {
+  it('404 → bytes_gone (flag was on)', () => {
+    expect(classifyByteProbeResponse(404)).toEqual({
+      kind: 'bytes_gone',
+      flagStateInferred: 'on'
+    });
+  });
+
+  it('200 → bytes_present (flag was off)', () => {
+    expect(classifyByteProbeResponse(200)).toEqual({
+      kind: 'bytes_present',
+      flagStateInferred: 'off'
+    });
+  });
+
+  it('410 also counts as bytes_gone (some CDNs serve 410 for deleted)', () => {
+    expect(classifyByteProbeResponse(410)).toEqual({
+      kind: 'bytes_gone',
+      flagStateInferred: 'on'
+    });
+  });
+
+  it('other statuses → unknown (assertion failure)', () => {
+    expect(classifyByteProbeResponse(500).kind).toBe('unknown');
+    expect(classifyByteProbeResponse(403).kind).toBe('unknown');
+    expect(classifyByteProbeResponse(0).kind).toBe('unknown');
+  });
+});

--- a/scripts/e2e-creator-delete.test.mjs
+++ b/scripts/e2e-creator-delete.test.mjs
@@ -79,3 +79,38 @@ describe('parseArgs', () => {
     expect(() => parseArgs(['--staging-relay'])).toThrow(/requires a value/i);
   });
 });
+
+import { generateTestKey, generateSyntheticBlob } from './e2e-creator-delete.mjs';
+import { getPublicKey } from 'nostr-tools/pure';
+import { sha256 as sha256Hash } from '@noble/hashes/sha256';
+import { bytesToHex } from '@noble/hashes/utils';
+
+describe('generateTestKey', () => {
+  it('returns a fresh nsec + hex pubkey each call', () => {
+    const a = generateTestKey();
+    const b = generateTestKey();
+    expect(a.sk).not.toEqual(b.sk);
+    expect(a.pubkey).toMatch(/^[0-9a-f]{64}$/);
+    expect(a.pubkey).toBe(getPublicKey(a.sk));
+  });
+});
+
+describe('generateSyntheticBlob', () => {
+  it('returns exactly 1024 bytes', () => {
+    const { bytes } = generateSyntheticBlob();
+    expect(bytes).toBeInstanceOf(Uint8Array);
+    expect(bytes.length).toBe(1024);
+  });
+
+  it('returns a sha256 that matches the bytes', () => {
+    const { bytes, sha256 } = generateSyntheticBlob();
+    const computed = bytesToHex(sha256Hash(bytes));
+    expect(sha256).toBe(computed);
+  });
+
+  it('produces a different sha256 on each call', () => {
+    const a = generateSyntheticBlob();
+    const b = generateSyntheticBlob();
+    expect(a.sha256).not.toBe(b.sha256);
+  });
+});

--- a/scripts/sign-nip98.mjs
+++ b/scripts/sign-nip98.mjs
@@ -1,49 +1,60 @@
 #!/usr/bin/env node
 // Sign a NIP-98 Authorization header for testing creator-delete endpoints.
-// Usage: node scripts/sign-nip98.mjs --nsec <hex> --url <url> --method <POST|GET>
-// Output: the full "Nostr <base64>" header value, ready to paste into curl -H "Authorization: ..."
+// Usage (CLI): node scripts/sign-nip98.mjs --nsec <hex> --url <url> --method <POST|GET>
+// Usage (import): import { signNip98Header } from './sign-nip98.mjs'
 
 import { generateSecretKey, getPublicKey, finalizeEvent } from 'nostr-tools/pure';
 import { hexToBytes } from '@noble/hashes/utils';
 
-const args = process.argv.slice(2);
-function getArg(name) {
-  const idx = args.indexOf(`--${name}`);
-  return idx >= 0 && args[idx + 1] ? args[idx + 1] : null;
+/**
+ * Sign a NIP-98 Authorization header. Returns the full "Nostr <base64>" header value.
+ * Importable from other scripts; see CLI entry point below for standalone use.
+ */
+export function signNip98Header(sk, url, method) {
+  const event = finalizeEvent({
+    kind: 27235,
+    created_at: Math.floor(Date.now() / 1000),
+    tags: [['u', url], ['method', method.toUpperCase()]],
+    content: ''
+  }, sk);
+  return `Nostr ${Buffer.from(JSON.stringify(event)).toString('base64')}`;
 }
 
-let sk;
-const nsecHex = getArg('nsec');
-if (nsecHex) {
-  sk = hexToBytes(nsecHex);
-} else {
-  sk = generateSecretKey();
-  console.error(`No --nsec provided. Generated ephemeral key. Pubkey: ${getPublicKey(sk)}`);
+// CLI entrypoint — skipped when imported by tests.
+const isMain = typeof process !== 'undefined' && process.argv && import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const args = process.argv.slice(2);
+  const getArg = (name) => {
+    const idx = args.indexOf(`--${name}`);
+    return idx >= 0 && args[idx + 1] ? args[idx + 1] : null;
+  };
+
+  const nsecHex = getArg('nsec');
+  const sk = nsecHex ? hexToBytes(nsecHex) : generateSecretKey();
+  if (!nsecHex) {
+    console.error(`No --nsec provided. Generated ephemeral key. Pubkey: ${getPublicKey(sk)}`);
+  }
+
+  const url = getArg('url');
+  const method = (getArg('method') || 'POST').toUpperCase();
+
+  if (!url) {
+    console.error('Usage: node scripts/sign-nip98.mjs --nsec <hex> --url <url> [--method POST]');
+    process.exit(1);
+  }
+
+  const header = signNip98Header(sk, url, method);
+
+  // Decode the event from the header to get the event ID for logging
+  const eventJson = Buffer.from(header.slice('Nostr '.length), 'base64').toString('utf8');
+  const event = JSON.parse(eventJson);
+
+  // Print just the header value (for use in curl -H "Authorization: <output>")
+  console.log(header);
+
+  // Metadata to stderr so it doesn't pollute the header output
+  console.error(`Pubkey: ${getPublicKey(sk)}`);
+  console.error(`URL: ${url}`);
+  console.error(`Method: ${method}`);
+  console.error(`Event ID: ${event.id}`);
 }
-
-const url = getArg('url');
-const method = (getArg('method') || 'POST').toUpperCase();
-
-if (!url) {
-  console.error('Usage: node scripts/sign-nip98.mjs --nsec <hex> --url <url> [--method POST]');
-  process.exit(1);
-}
-
-const event = finalizeEvent({
-  kind: 27235,
-  created_at: Math.floor(Date.now() / 1000),
-  tags: [['u', url], ['method', method]],
-  content: ''
-}, sk);
-
-const encoded = Buffer.from(JSON.stringify(event)).toString('base64');
-const header = `Nostr ${encoded}`;
-
-// Print just the header value (for use in curl -H "Authorization: <output>")
-console.log(header);
-
-// Metadata to stderr so it doesn't pollute the header output
-console.error(`Pubkey: ${getPublicKey(sk)}`);
-console.error(`URL: ${url}`);
-console.error(`Method: ${method}`);
-console.error(`Event ID: ${event.id}`);

--- a/scripts/sign-nip98.test.mjs
+++ b/scripts/sign-nip98.test.mjs
@@ -1,0 +1,29 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Tests for the exported NIP-98 signing helper consumed by e2e and ad-hoc scripts.
+
+import { describe, it, expect } from 'vitest';
+import { generateSecretKey, getPublicKey, verifyEvent } from 'nostr-tools/pure';
+import { signNip98Header } from './sign-nip98.mjs';
+
+describe('signNip98Header', () => {
+  it('returns a Nostr-scheme Authorization header with a base64-encoded signed kind-27235 event', () => {
+    const sk = generateSecretKey();
+    const header = signNip98Header(sk, 'https://example/api', 'POST');
+    expect(header.startsWith('Nostr ')).toBe(true);
+    const eventJson = Buffer.from(header.slice('Nostr '.length), 'base64').toString('utf8');
+    const event = JSON.parse(eventJson);
+    expect(event.kind).toBe(27235);
+    expect(event.tags).toEqual(expect.arrayContaining([['u', 'https://example/api'], ['method', 'POST']]));
+    expect(event.pubkey).toBe(getPublicKey(sk));
+    expect(verifyEvent(event)).toBe(true);
+  });
+
+  it('normalizes method to uppercase', () => {
+    const sk = generateSecretKey();
+    const header = signNip98Header(sk, 'https://example', 'get');
+    const event = JSON.parse(Buffer.from(header.slice('Nostr '.length), 'base64').toString('utf8'));
+    expect(event.tags).toEqual(expect.arrayContaining([['method', 'GET']]));
+  });
+});


### PR DESCRIPTION
Closes #101. Stacked on top of #106 (sweep) — target branch is the sweep's branch; re-target to main after #106 merges.

Spec: docs/superpowers/specs/2026-04-18-creator-delete-e2e-test-design.md
Plan: docs/superpowers/plans/2026-04-20-creator-delete-e2e-test-plan.md

## Summary

Operator-run script that exercises the full creator-delete pipeline end to end, against real staging relay + prod Blossom + prod mod-service, with active cleanup returning prod systems to pre-run state.

- Fresh ephemeral key + 1KB synthetic pseudo-MP4 per run
- Upload to prod Blossom (BUD-02 PUT with BUD-01 signed auth)
- Publish kind 34236 to staging relay; poll Funnelcake REST until indexed (catches ClickHouse batch-flush + MergeTree dedup lag)
- Two scenarios:
  - **sync**: publish kind 5 + POST to mod-service sync endpoint + poll status (60s)
  - **cron**: publish kind 5 only; wait for cron pickup (180s default, derived from 1-min cron interval)
- Assert D1 row reaches status='success' + Blossom byte probe (infer flag state from 404 vs 200)
- Active cleanup in a finally-style block: POST /admin/api/vanish (surgical full-purge for the test pubkey's one blob) + DELETE D1 row
- JSONL per step on stdout; summary + manual-cleanup instructions on stderr
- Exit codes 0 / 1 / 2 / 3 / 130

Also lands the docs/superpowers/ historical-framing policy in mod-service (ports divinevideo/divine-blossom#91).

## Test plan

- [x] 47 new unit + orchestrator tests for the e2e script (plus 2 for the sign-nip98 refactor). Full suite 975/975 green
- [x] Lint clean
- [x] CLI sanity checks: missing BLOSSOM_WEBHOOK_SECRET exits 2, invalid --scenario exits 2
- [ ] Real-environment smoke run against staging-relay + prod-blossom + prod-mod-service — deferred to rollout validation when #106 lands (spec Task 16)

## Implementation approach

Subagent-driven per-task workflow with two-stage review (spec compliance + code quality) after each of 14 implementation tasks. Two review-driven fixes landed inline:
- Reject value-expecting flags passed without a value (would coerce to \`true\` → silent default or \`validatePositiveInt(true)=1\`)
- Guard cleanupBlossomVanish against missing webhook secret (prevents confusing \`Bearer undefined\` errors)

One intentional deviation from the plan: \`runScenario\` reassigns \`blobSha256 = upload.sha256\` so the server-confirmed sha flows through D1 assertions and the return value, not the locally-computed one. Documented in the orchestrator.

## Notes for reviewers

- WebSocket publish uses \`ws\` (transitive dep via nostr-tools + wrangler). If resolution breaks on a future package bump, add \`ws\` as an explicit dev dependency.
- Contract grounding: \`buildKind34236Event\` pinned against divine-funnelcake/crates/relay/src/relay.rs:1023-1087 and \`validate_imeta_format\`. Vanish response pinned against divine-blossom/src/main.rs:209,3975. Test fixtures match.
- The script does not pre-flight \`CREATOR_DELETE_PIPELINE_ENABLED\` on the prod worker; on pollStatus timeout the error includes a hint pointing at that flag as the likely cause.
- \`publishEvent\` has no direct unit tests (WS fake not injected in tests) — orchestrator-level scenarios exercise it via the \`publishEvent\` dep injection.