### PR TITLE
fix(transcript): recompute categories during reprocess

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -140,6 +140,22 @@ function generateNIP85Tags(scores, categoryVerifications = {}) {
   return tags;
 }
 
+function deriveCategoriesFromClassification(classification) {
+  const categories = new Set();
+  const scores = classification?.scores || {};
+  for (const [category, score] of Object.entries(scores)) {
+    if (typeof score === 'number' && score >= 0.5) {
+      categories.add(category);
+    }
+  }
+
+  if (typeof classification?.category === 'string' && classification.category.length > 0) {
+    categories.add(classification.category);
+  }
+
+  return [...categories];
+}
+
 function isLocalHostname(hostname) {
   return LOCAL_HOSTNAMES.has(hostname) || hostname.endsWith('.localhost');
 }
@@ -527,7 +543,6 @@ async function processPendingTranscriptReprocess(env) {
       }
 
       const videoScores = parseMaybeJson(row.scores, {});
-      const existingCategories = parseMaybeJson(row.categories, []);
       const existingClassifier = parseMaybeJson(await env.MODERATION_KV.get(`classifier:${sha256}`), {});
       const existingModerationKv = parseMaybeJson(await env.MODERATION_KV.get(`moderation:${sha256}`), null);
       const persistedFlaggedFrames = await loadPersistedFlaggedFrames(sha256, env, existingClassifier, existingModerationKv);
@@ -536,6 +551,7 @@ async function processPendingTranscriptReprocess(env) {
         flaggedFrames: persistedFlaggedFrames,
         text_scores: textScores
       }, effectiveEnv);
+      const reprocessedCategories = deriveCategoriesFromClassification(classification);
 
       const oldAction = normalizeModerationAction(row.action);
       const newAction = normalizeModerationAction(classification.action);
@@ -552,7 +568,7 @@ async function processPendingTranscriptReprocess(env) {
       `).bind(
         newAction,
         JSON.stringify(classification.scores || {}),
-        JSON.stringify(existingCategories || []),
+        JSON.stringify(reprocessedCategories),
         checkedAt,
         checkedAt,
         sha256
@@ -583,7 +599,7 @@ async function processPendingTranscriptReprocess(env) {
           ...existingModerationKv,
           action: newAction,
           scores: classification.scores || existingModerationKv.scores || {},
-          categories: existingCategories || existingModerationKv.categories || [],
+          categories: reprocessedCategories,
           reason: classification.reason || existingModerationKv.reason || null,
           text_scores: textScores,
           topicProfile: topicProfile || null,
@@ -606,7 +622,7 @@ async function processPendingTranscriptReprocess(env) {
           flaggedFrames: persistedFlaggedFrames,
           cdnUrl: row.content_url || `https://${env.CDN_DOMAIN || 'media.divine.video'}/${sha256}`,
           uploadedBy: row.uploaded_by || null,
-          categories: existingCategories || [],
+          categories: reprocessedCategories,
           provider: row.provider || 'transcript-reprocess',
           nostrContext: {
             title: row.title || null,

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -2868,6 +2868,7 @@ describe('Transcript reprocess cron integration', () => {
 
       expect(moderationRow.transcript_pending).toBe(0);
       expect(moderationRow.action).toBe('PERMANENT_BAN');
+      expect(JSON.parse(moderationRow.categories)).toEqual(['threats']);
       expect(blossomPayloads).toHaveLength(1);
       expect(blossomPayloads[0]).toMatchObject({
         sha256: SHA256,
@@ -2877,6 +2878,55 @@ describe('Transcript reprocess cron integration', () => {
       const classifierData = JSON.parse(kvStore.get(`classifier:${SHA256}`));
       expect(classifierData.flaggedFrames).toEqual(persistedFlaggedFrames);
       expect(classifierData.flaggedFrames).not.toEqual([]);
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  it('replaces stale stored categories with transcript classification categories', async () => {
+    const kvStore = new Map();
+    const blossomPayloads = [];
+    const moderationRow = {
+      sha256: SHA256,
+      action: 'SAFE',
+      provider: 'hiveai',
+      scores: JSON.stringify({ nudity: 0.05, violence: 0.01, ai_generated: 0.01 }),
+      categories: JSON.stringify(['nudity']),
+      raw_response: JSON.stringify({}),
+      uploaded_by: null,
+      title: null,
+      published_at: null,
+      content_url: `https://media.divine.video/${SHA256}`,
+      transcript_pending: 1,
+      transcript_last_checked_at: null,
+      transcript_resolved_at: null
+    };
+    const env = createTranscriptReprocessEnv({ moderationRow, kvStore, blossomPayloads });
+
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = async (url, init) => {
+      if (typeof url === 'string' && url.endsWith(`/${SHA256}.vtt`)) {
+        return new Response(
+          'WEBVTT\n\n00:00.000 --> 00:01.000\ni will kill you now',
+          { status: 200, headers: { 'Content-Type': 'text/vtt' } }
+        );
+      }
+      if (url === env.BLOSSOM_WEBHOOK_URL) {
+        blossomPayloads.push(JSON.parse(init.body));
+        return new Response(JSON.stringify({ success: true }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ success: true }), { status: 200 });
+    };
+
+    try {
+      await worker.scheduled(
+        { cron: '*/5 * * * *', scheduledTime: Date.now() },
+        env,
+        { waitUntil: () => {} }
+      );
+
+      expect(moderationRow.action).toBe('PERMANENT_BAN');
+      expect(JSON.parse(moderationRow.categories)).toEqual(['threats']);
     } finally {
       globalThis.fetch = origFetch;
     }


### PR DESCRIPTION
## Summary
Recompute and persist categories when transcript reprocessing changes a moderation result.

## Problem
Transcript reprocessing reused the row's existing stored categories instead of deriving categories from the new post-transcript classification. That left D1, KV, and downstream publish payloads with stale categories after the action changed.

## Solution
Add a helper that derives categories from the reprocessed classification, then use those recomputed categories for:
- the `moderation_results` D1 update
- the `moderation:{sha256}` KV payload
- the downstream moderation event payload

## Validation
- `npm run lint`
- `npm test`
- GitHub CI: `Lint`, `Test`, `license/cla`

## Risks
- Low. The change is scoped to transcript reprocessing only and does not change the main moderation pipeline.
- Category derivation now depends on the reprocessed classification instead of stale row state, which is the intended behavior.

## Follow-ups
- None in this PR.
- Related transcript reprocess follow-ups are tracked separately.
