### PR TITLE
fix(transcript): abandon stale pending rows after max age

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ VIOLENCE_THRESHOLD_MEDIUM = "0.6"
 AI_GENERATED_THRESHOLD_HIGH = "0.8"   # Auto-quarantine AI content
 AI_GENERATED_THRESHOLD_MEDIUM = "0.6" # Flag AI content for review
 TRANSCRIPT_REPROCESS_BATCH_SIZE = "20" # Pending transcript rows to reprocess each cron tick
+TRANSCRIPT_REPROCESS_MAX_AGE_DAYS = "7" # Abandon transcript pending rows older than this many days
 
 [[kv_namespaces]]
 binding = "MODERATION_KV"

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -411,6 +411,14 @@ function normalizeModerationAction(action) {
   return VALID_MODERATION_ACTIONS.has(normalized) ? normalized : 'SAFE';
 }
 
+function parseIsoTimestampMs(value) {
+  if (typeof value !== 'string' || value.length === 0) {
+    return null;
+  }
+  const parsedMs = Date.parse(value);
+  return Number.isFinite(parsedMs) ? parsedMs : null;
+}
+
 async function getEffectiveModerationEnv(env) {
   let effectiveEnv = env;
   try {
@@ -474,9 +482,14 @@ async function processPendingTranscriptReprocess(env) {
     return;
   }
 
+  const maxAgeDaysRaw = Number.parseInt(env.TRANSCRIPT_REPROCESS_MAX_AGE_DAYS || '7', 10);
+  const maxAgeDays = Math.min(Math.max(Number.isFinite(maxAgeDaysRaw) ? maxAgeDaysRaw : 7, 1), 365);
+  const maxAgeMs = maxAgeDays * 24 * 60 * 60 * 1000;
+  const nowMs = Date.now();
   const batchSize = Math.min(Math.max(Number.parseInt(env.TRANSCRIPT_REPROCESS_BATCH_SIZE || '20', 10) || 20, 1), 100);
   const pendingResult = await env.BLOSSOM_DB.prepare(`
-    SELECT sha256, action, provider, scores, categories, raw_response, uploaded_by, title, published_at, content_url
+    SELECT sha256, action, provider, scores, categories, raw_response, uploaded_by, title, published_at, content_url,
+           transcript_pending_since, moderated_at
     FROM moderation_results
     WHERE transcript_pending = 1
     ORDER BY COALESCE(transcript_pending_since, moderated_at) ASC
@@ -494,8 +507,43 @@ async function processPendingTranscriptReprocess(env) {
   for (const row of rows) {
     const { sha256 } = row;
     const checkedAt = new Date().toISOString();
+    const pendingSinceMs = parseIsoTimestampMs(row.transcript_pending_since) ?? parseIsoTimestampMs(row.moderated_at);
 
     try {
+      if (pendingSinceMs !== null && (nowMs - pendingSinceMs) >= maxAgeMs) {
+        const staleUpdate = await env.BLOSSOM_DB.prepare(`
+          UPDATE moderation_results
+          SET transcript_pending = 0,
+              transcript_last_checked_at = ?,
+              transcript_resolved_at = ?
+          WHERE sha256 = ? AND transcript_pending = 1 AND reviewed_by IS NULL
+        `).bind(checkedAt, checkedAt, sha256).run();
+
+        if (staleUpdate?.meta?.changes === 0) {
+          console.log(`[CRON] Transcript reprocess skipped ${sha256} because row was manually reviewed`);
+          continue;
+        }
+
+        const existingModerationKv = parseMaybeJson(await env.MODERATION_KV.get(`moderation:${sha256}`), null);
+        const staleAction = normalizeModerationAction(row.action);
+        const moderationPayload = {
+          ...(existingModerationKv || {}),
+          sha256,
+          action: existingModerationKv?.action || staleAction,
+          transcriptPending: false,
+          transcriptResolvedAt: checkedAt,
+          transcriptResolutionReason: 'max_age_abandoned'
+        };
+        await env.MODERATION_KV.put(
+          `moderation:${sha256}`,
+          JSON.stringify(moderationPayload),
+          { expirationTtl: 60 * 60 * 24 * 90 }
+        );
+
+        console.log(`[CRON] Transcript reprocess abandoned ${sha256} after ${maxAgeDays} day max age`);
+        continue;
+      }
+
       const transcript = await fetchTranscriptAsset(sha256, env);
 
       if (transcript.pending) {

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -2624,10 +2624,11 @@ describe('RD auto-escalation cron integration', () => {
 });
 
 describe('Transcript reprocess cron integration', () => {
-  function createTranscriptReprocessEnv({ moderationRow, kvStore, blossomPayloads }) {
+  function createTranscriptReprocessEnv({ moderationRow, kvStore, blossomPayloads, envOverrides = {} }) {
     return {
       CDN_DOMAIN: 'media.divine.video',
       BLOSSOM_WEBHOOK_URL: 'https://mock-blossom.test/admin/moderate',
+      TRANSCRIPT_REPROCESS_MAX_AGE_DAYS: '7',
       BLOSSOM_DB: {
         prepare(sql) {
           let bindings = [];
@@ -2694,9 +2695,79 @@ describe('Transcript reprocess cron integration', () => {
         }
       },
       MODERATION_QUEUE: { async send() {} },
-      __blossomPayloads: blossomPayloads
+      __blossomPayloads: blossomPayloads,
+      ...envOverrides
     };
   }
+
+  function isoDaysAgo(days) {
+    return new Date(Date.now() - (days * 24 * 60 * 60 * 1000)).toISOString();
+  }
+
+  it('abandons stale transcript pending rows after configured max age', async () => {
+    const kvStore = new Map();
+    const blossomPayloads = [];
+    const moderationRow = {
+      sha256: SHA256,
+      action: 'SAFE',
+      provider: 'hiveai',
+      scores: JSON.stringify({ nudity: 0.05, violence: 0.01, ai_generated: 0.01 }),
+      categories: JSON.stringify([]),
+      raw_response: JSON.stringify({}),
+      moderated_at: isoDaysAgo(10),
+      transcript_pending_since: isoDaysAgo(10),
+      uploaded_by: null,
+      title: null,
+      published_at: null,
+      content_url: `https://media.divine.video/${SHA256}`,
+      transcript_pending: 1,
+      transcript_last_checked_at: null,
+      transcript_resolved_at: null
+    };
+    kvStore.set(`moderation:${SHA256}`, JSON.stringify({ sha256: SHA256, action: 'SAFE', reason: null }));
+    const env = createTranscriptReprocessEnv({
+      moderationRow,
+      kvStore,
+      blossomPayloads,
+      envOverrides: { TRANSCRIPT_REPROCESS_MAX_AGE_DAYS: '5' }
+    });
+
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = async (url, init) => {
+      if (typeof url === 'string' && url.endsWith(`/${SHA256}.vtt`)) {
+        return {
+          ok: true,
+          status: 202,
+          headers: { get(name) { return name === 'Retry-After' ? '30' : null; } },
+          json: async () => ({ status: 'processing' })
+        };
+      }
+      if (url === env.BLOSSOM_WEBHOOK_URL) {
+        blossomPayloads.push(JSON.parse(init.body));
+      }
+      return new Response(JSON.stringify({ success: true }), { status: 200 });
+    };
+
+    try {
+      await worker.scheduled(
+        { cron: '*/5 * * * *', scheduledTime: Date.now() },
+        env,
+        { waitUntil: () => {} }
+      );
+
+      expect(moderationRow.transcript_pending).toBe(0);
+      expect(moderationRow.action).toBe('SAFE');
+      expect(moderationRow.transcript_resolved_at).toBeTruthy();
+      expect(blossomPayloads).toHaveLength(0);
+
+      const moderationPayload = JSON.parse(kvStore.get(`moderation:${SHA256}`));
+      expect(moderationPayload.transcriptPending).toBe(false);
+      expect(moderationPayload.transcriptResolvedAt).toBeTruthy();
+      expect(moderationPayload.transcriptResolutionReason).toBe('max_age_abandoned');
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
 
   it('keeps transcript pending rows pending while VTT is still 202', async () => {
     const kvStore = new Map();
@@ -2708,6 +2779,8 @@ describe('Transcript reprocess cron integration', () => {
       scores: JSON.stringify({ nudity: 0.05, violence: 0.01, ai_generated: 0.01 }),
       categories: JSON.stringify([]),
       raw_response: JSON.stringify({}),
+      moderated_at: isoDaysAgo(2),
+      transcript_pending_since: isoDaysAgo(2),
       uploaded_by: null,
       title: null,
       published_at: null,
@@ -2745,6 +2818,122 @@ describe('Transcript reprocess cron integration', () => {
       expect(moderationRow.transcript_last_checked_at).toBeTruthy();
       expect(moderationRow.transcript_resolved_at).toBeNull();
       expect(blossomPayloads).toHaveLength(0);
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  it('uses default 7-day max age when env var is not set', async () => {
+    const kvStore = new Map();
+    const blossomPayloads = [];
+    const moderationRow = {
+      sha256: SHA256,
+      action: 'SAFE',
+      provider: 'hiveai',
+      scores: JSON.stringify({ nudity: 0.05, violence: 0.01, ai_generated: 0.01 }),
+      categories: JSON.stringify([]),
+      raw_response: JSON.stringify({}),
+      moderated_at: isoDaysAgo(8),
+      transcript_pending_since: isoDaysAgo(8),
+      uploaded_by: null,
+      title: null,
+      published_at: null,
+      content_url: `https://media.divine.video/${SHA256}`,
+      transcript_pending: 1,
+      transcript_last_checked_at: null,
+      transcript_resolved_at: null
+    };
+    kvStore.set(`moderation:${SHA256}`, JSON.stringify({ sha256: SHA256, action: 'SAFE' }));
+    const env = createTranscriptReprocessEnv({
+      moderationRow,
+      kvStore,
+      blossomPayloads,
+      envOverrides: { TRANSCRIPT_REPROCESS_MAX_AGE_DAYS: undefined }
+    });
+
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = async (url, init) => {
+      if (typeof url === 'string' && url.endsWith(`/${SHA256}.vtt`)) {
+        return {
+          ok: true,
+          status: 202,
+          headers: { get(name) { return name === 'Retry-After' ? '30' : null; } },
+          json: async () => ({ status: 'processing' })
+        };
+      }
+      if (url === env.BLOSSOM_WEBHOOK_URL) {
+        blossomPayloads.push(JSON.parse(init.body));
+      }
+      return new Response(JSON.stringify({ success: true }), { status: 200 });
+    };
+
+    try {
+      await worker.scheduled(
+        { cron: '*/5 * * * *', scheduledTime: Date.now() },
+        env,
+        { waitUntil: () => {} }
+      );
+
+      expect(moderationRow.transcript_pending).toBe(0);
+      expect(moderationRow.transcript_resolved_at).toBeTruthy();
+      expect(blossomPayloads).toHaveLength(0);
+      const moderationPayload = JSON.parse(kvStore.get(`moderation:${SHA256}`));
+      expect(moderationPayload.transcriptResolutionReason).toBe('max_age_abandoned');
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  it('falls back to moderated_at when transcript_pending_since is missing', async () => {
+    const kvStore = new Map();
+    const blossomPayloads = [];
+    const moderationRow = {
+      sha256: SHA256,
+      action: 'SAFE',
+      provider: 'hiveai',
+      scores: JSON.stringify({ nudity: 0.05, violence: 0.01, ai_generated: 0.01 }),
+      categories: JSON.stringify([]),
+      raw_response: JSON.stringify({}),
+      moderated_at: isoDaysAgo(9),
+      transcript_pending_since: null,
+      uploaded_by: null,
+      title: null,
+      published_at: null,
+      content_url: `https://media.divine.video/${SHA256}`,
+      transcript_pending: 1,
+      transcript_last_checked_at: null,
+      transcript_resolved_at: null
+    };
+    kvStore.set(`moderation:${SHA256}`, JSON.stringify({ sha256: SHA256, action: 'SAFE' }));
+    const env = createTranscriptReprocessEnv({ moderationRow, kvStore, blossomPayloads });
+
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = async (url, init) => {
+      if (typeof url === 'string' && url.endsWith(`/${SHA256}.vtt`)) {
+        return {
+          ok: true,
+          status: 202,
+          headers: { get(name) { return name === 'Retry-After' ? '30' : null; } },
+          json: async () => ({ status: 'processing' })
+        };
+      }
+      if (url === env.BLOSSOM_WEBHOOK_URL) {
+        blossomPayloads.push(JSON.parse(init.body));
+      }
+      return new Response(JSON.stringify({ success: true }), { status: 200 });
+    };
+
+    try {
+      await worker.scheduled(
+        { cron: '*/5 * * * *', scheduledTime: Date.now() },
+        env,
+        { waitUntil: () => {} }
+      );
+
+      expect(moderationRow.transcript_pending).toBe(0);
+      expect(moderationRow.transcript_resolved_at).toBeTruthy();
+      const moderationPayload = JSON.parse(kvStore.get(`moderation:${SHA256}`));
+      expect(moderationPayload.transcriptResolutionReason).toBe('max_age_abandoned');
     } finally {
       globalThis.fetch = origFetch;
     }
@@ -3039,6 +3228,70 @@ describe('Transcript reprocess cron integration', () => {
       expect(moderationRow.action).toBe('QUARANTINE');
       expect(moderationRow.transcript_pending).toBe(1);
       expect(moderationRow.transcript_resolved_at).toBeNull();
+      expect(blossomPayloads).toHaveLength(0);
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  it('keeps stale pending row untouched when manually reviewed', async () => {
+    const kvStore = new Map();
+    const blossomPayloads = [];
+    const moderationRow = {
+      sha256: SHA256,
+      action: 'QUARANTINE',
+      provider: 'hiveai',
+      scores: JSON.stringify({ nudity: 0.05, violence: 0.01, ai_generated: 0.01 }),
+      categories: JSON.stringify([]),
+      raw_response: JSON.stringify({}),
+      moderated_at: isoDaysAgo(10),
+      transcript_pending_since: isoDaysAgo(10),
+      uploaded_by: null,
+      title: null,
+      published_at: null,
+      content_url: `https://media.divine.video/${SHA256}`,
+      reviewed_by: 'admin',
+      reviewed_at: '2026-04-22T10:00:00.000Z',
+      transcript_pending: 1,
+      transcript_last_checked_at: null,
+      transcript_resolved_at: null
+    };
+    kvStore.set(`moderation:${SHA256}`, JSON.stringify({ sha256: SHA256, action: 'QUARANTINE' }));
+    const env = createTranscriptReprocessEnv({
+      moderationRow,
+      kvStore,
+      blossomPayloads,
+      envOverrides: { TRANSCRIPT_REPROCESS_MAX_AGE_DAYS: '5' }
+    });
+
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = async (url, init) => {
+      if (typeof url === 'string' && url.endsWith(`/${SHA256}.vtt`)) {
+        return {
+          ok: true,
+          status: 202,
+          headers: { get(name) { return name === 'Retry-After' ? '30' : null; } },
+          json: async () => ({ status: 'processing' })
+        };
+      }
+      if (url === env.BLOSSOM_WEBHOOK_URL) {
+        blossomPayloads.push(JSON.parse(init.body));
+      }
+      return new Response(JSON.stringify({ success: true }), { status: 200 });
+    };
+
+    try {
+      await worker.scheduled(
+        { cron: '*/5 * * * *', scheduledTime: Date.now() },
+        env,
+        { waitUntil: () => {} }
+      );
+
+      expect(moderationRow.action).toBe('QUARANTINE');
+      expect(moderationRow.transcript_pending).toBe(1);
+      expect(moderationRow.transcript_resolved_at).toBeNull();
+      const moderationPayload = JSON.parse(kvStore.get(`moderation:${SHA256}`));
+      expect(moderationPayload.transcriptResolutionReason).toBeUndefined();
       expect(blossomPayloads).toHaveLength(0);
     } finally {
       globalThis.fetch = origFetch;


### PR DESCRIPTION
## Summary
Abandon transcript-pending moderation rows once they exceed a configurable maximum age.

## Problem
Transcript reprocessing retried rows indefinitely when Blossom kept returning transcript generation pending. That left stale `transcript_pending` rows in the queue forever with no terminal resolution state.

## Solution
Add a max-age guard to transcript reprocessing that:
- computes row age from `transcript_pending_since`, falling back to `moderated_at`
- clears transcript pending state when the row exceeds the configured age
- records `transcriptResolutionReason: 'max_age_abandoned'` in moderation KV
- skips abandonment for manually reviewed rows
- exposes `TRANSCRIPT_REPROCESS_MAX_AGE_DAYS` in the README

## Validation
- `npm run lint`
- `npm test`
- GitHub CI: `Lint`, `Test`, `license/cla`

## Risks
- Low. The change is scoped to transcript reprocessing only.
- Rows with invalid or missing timestamps are not abandoned automatically; they continue through the normal retry path.
- Manual review protection remains intact via the existing `reviewed_by IS NULL` guard.

## Follow-ups
- None in this PR.
- Related transcript reprocess follow-ups are tracked separately.
