### PR TITLE
chore: remove orphaned /api/v1/report endpoint

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -17,7 +17,7 @@ import { hexToBytes, bytesToHex } from '@noble/hashes/utils';
 import dashboardHTML from './admin/dashboard.html';
 import swipeReviewHTML from './admin/swipe-review.html';
 import messagesHTML from './admin/messages.html';
-import { initReportsTable, addReport } from './reports.mjs';
+import { initReportsTable } from './reports.mjs';
 import { initUploaderEnforcementTable, getUploaderEnforcement, setUploaderEnforcement, applyUploaderEnforcementToResult } from './uploader-enforcement.mjs';
 import { formatForStorage, formatForGorse, formatForFunnelcake } from './classification/pipeline.mjs';
 import { topicsToLabels, topicsToWeightedFeatures } from './classification/topic-extractor.mjs';
@@ -3259,39 +3259,6 @@ async function runMigration() {
       }
     }
 
-    if (url.pathname === '/api/v1/report' && request.method === 'POST') {
-      const verification = await authenticateApiRequest(request, env);
-      if (!verification.valid) {
-        console.log(`[API] Authentication failed for /api/v1/report: ${verification.error}`);
-        return apiUnauthorizedResponse(verification);
-      }
-
-      try {
-        const { sha256, reporter_pubkey, report_type, reason } = await request.json();
-
-        if (!sha256 || !reporter_pubkey || !report_type) {
-          return new Response(JSON.stringify({ error: 'sha256, reporter_pubkey, and report_type are required' }), {
-            status: 400,
-            headers: { 'Content-Type': 'application/json' }
-          });
-        }
-
-        const result = await addReport(env.BLOSSOM_DB, { sha256, reporter_pubkey, report_type, reason });
-
-        console.log(`[API] Report added: ${sha256} by ${reporter_pubkey.substring(0, 16)}... escalate=${result.escalate}`);
-
-        return new Response(JSON.stringify({ success: true, ...result }), {
-          headers: { 'Content-Type': 'application/json' }
-        });
-      } catch (error) {
-        console.error('[API] Error adding report:', error);
-        return new Response(JSON.stringify({ error: error.message }), {
-          status: 500,
-          headers: { 'Content-Type': 'application/json' }
-        });
-      }
-    }
-
     // API: Send DM notification only (no Blossom/D1 moderation side effects)
     // Used by relay-manager to notify users after NIP-86 moderation actions
     // Auth: Bearer token or Cloudflare Access JWT
@@ -3902,7 +3869,7 @@ async function runMigration() {
       }
     }
 
-    return new Response('Divine Moderation API\n\nPublic endpoints:\nGET  /health\nGET  /check-result/{sha256}\nGET  /api/v1/moderation/vocabulary\n\nAuthenticated endpoints:\nPOST /test-moderate {"sha256":"..."}\nGET  /api/v1/decisions\nGET  /api/v1/decisions/{sha256}\nPOST /api/v1/quarantine/{sha256}\nPOST /api/v1/moderate\nPOST /api/v1/report\nPOST /api/v1/classify\nGET  /api/v1/classifier/{sha256}\nGET  /api/v1/classifier/{sha256}/recommendations\n\nAdmin UI: https://moderation.admin.divine.video/admin', {
+    return new Response('Divine Moderation API\n\nPublic endpoints:\nGET  /health\nGET  /check-result/{sha256}\nGET  /api/v1/moderation/vocabulary\n\nAuthenticated endpoints:\nPOST /test-moderate {"sha256":"..."}\nGET  /api/v1/decisions\nGET  /api/v1/decisions/{sha256}\nPOST /api/v1/quarantine/{sha256}\nPOST /api/v1/moderate\nPOST /api/v1/classify\nGET  /api/v1/classifier/{sha256}\nGET  /api/v1/classifier/{sha256}/recommendations\n\nAdmin UI: https://moderation.admin.divine.video/admin', {
       headers: { 'Content-Type': 'text/plain' }
     });
   },

--- a/src/reports.mjs
+++ b/src/reports.mjs
@@ -1,8 +1,8 @@
 // This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
 // If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 //
-// ABOUTME: User report system for NIP-56 content reporting
-// ABOUTME: Stores reports in D1 and auto-escalates at 3/5 unique reporter thresholds
+// ABOUTME: Reporter lookup for DM moderation notifications
+// ABOUTME: Exposes the user_reports table schema + reporter pubkey lookup used by dm-sender
 
 /**
  * Create user_reports table if it doesn't exist
@@ -20,47 +20,6 @@ export async function initReportsTable(db) {
       UNIQUE(sha256, reporter_pubkey)
     )
   `).run();
-}
-
-/**
- * Insert a report and return escalation level based on unique reporter count
- * @param {D1Database} db
- * @param {{sha256: string, reporter_pubkey: string, report_type: string, reason?: string}} report
- * @returns {Promise<{escalate: 'AGE_RESTRICTED'|'REVIEW'|null}>}
- */
-export async function addReport(db, { sha256, reporter_pubkey, report_type, reason }) {
-  await db.prepare(`
-    INSERT OR IGNORE INTO user_reports (sha256, reporter_pubkey, report_type, reason)
-    VALUES (?, ?, ?, ?)
-  `).bind(sha256, reporter_pubkey, report_type, reason ?? null).run();
-
-  const row = await db.prepare(`
-    SELECT COUNT(DISTINCT reporter_pubkey) AS cnt
-    FROM user_reports
-    WHERE sha256 = ?
-  `).bind(sha256).first();
-
-  const count = row?.cnt ?? 0;
-
-  if (count >= 5) return { escalate: 'AGE_RESTRICTED' };
-  if (count >= 3) return { escalate: 'REVIEW' };
-  return { escalate: null };
-}
-
-/**
- * Return the number of unique reporters for a sha256
- * @param {D1Database} db
- * @param {string} sha256
- * @returns {Promise<number>}
- */
-export async function getReportCount(db, sha256) {
-  const row = await db.prepare(`
-    SELECT COUNT(DISTINCT reporter_pubkey) AS cnt
-    FROM user_reports
-    WHERE sha256 = ?
-  `).bind(sha256).first();
-
-  return row?.cnt ?? 0;
 }
 
 /**

--- a/src/reports.test.mjs
+++ b/src/reports.test.mjs
@@ -1,19 +1,23 @@
 // This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
 // If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 //
-// ABOUTME: Tests for user report system (reports.mjs)
-// ABOUTME: Verifies D1-backed report storage, deduplication, and escalation thresholds
+// ABOUTME: Tests for reporter lookup helpers (reports.mjs)
+// ABOUTME: Verifies D1-backed reporter pubkey lookup used by dm-sender
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import { env } from 'cloudflare:test';
-import { initReportsTable, addReport, getReportCount, getReporterPubkeys } from './reports.mjs';
+import { initReportsTable, getReporterPubkeys } from './reports.mjs';
 
 const SHA256 = ('a'.repeat(63) + '1').slice(0, 64);
 const REPORTER1 = ('b'.repeat(63) + '1').slice(0, 64);
 const REPORTER2 = ('b'.repeat(63) + '2').slice(0, 64);
-const REPORTER3 = ('b'.repeat(63) + '3').slice(0, 64);
-const REPORTER4 = ('b'.repeat(63) + '4').slice(0, 64);
-const REPORTER5 = ('b'.repeat(63) + '5').slice(0, 64);
+
+async function insertReport(db, { sha256, reporter_pubkey, report_type, reason }) {
+  await db.prepare(`
+    INSERT OR IGNORE INTO user_reports (sha256, reporter_pubkey, report_type, reason)
+    VALUES (?, ?, ?, ?)
+  `).bind(sha256, reporter_pubkey, report_type, reason ?? null).run();
+}
 
 describe('reports', () => {
   const db = env.BLOSSOM_DB;
@@ -23,93 +27,6 @@ describe('reports', () => {
     await db.prepare('DELETE FROM user_reports').run();
   });
 
-  describe('addReport', () => {
-    it('should add a new report and not escalate', async () => {
-      const result = await addReport(db, {
-        sha256: SHA256,
-        reporter_pubkey: REPORTER1,
-        report_type: 'nudity',
-        reason: 'inappropriate content',
-      });
-
-      expect(result).toEqual({ escalate: null });
-    });
-
-    it('should deduplicate same reporter for same sha256', async () => {
-      await addReport(db, {
-        sha256: SHA256,
-        reporter_pubkey: REPORTER1,
-        report_type: 'nudity',
-      });
-
-      // Same reporter, same sha256 — should not increase count
-      await addReport(db, {
-        sha256: SHA256,
-        reporter_pubkey: REPORTER1,
-        report_type: 'spam',
-        reason: 'duplicate report',
-      });
-
-      const count = await getReportCount(db, SHA256);
-      expect(count).toBe(1);
-    });
-
-    it('should count different reporters separately', async () => {
-      await addReport(db, {
-        sha256: SHA256,
-        reporter_pubkey: REPORTER1,
-        report_type: 'nudity',
-      });
-
-      await addReport(db, {
-        sha256: SHA256,
-        reporter_pubkey: REPORTER2,
-        report_type: 'nudity',
-      });
-
-      const count = await getReportCount(db, SHA256);
-      expect(count).toBe(2);
-    });
-  });
-
-  describe('escalation thresholds', () => {
-    it('should escalate to REVIEW at 3 unique reporters', async () => {
-      await addReport(db, { sha256: SHA256, reporter_pubkey: REPORTER1, report_type: 'nudity' });
-      await addReport(db, { sha256: SHA256, reporter_pubkey: REPORTER2, report_type: 'nudity' });
-
-      const result = await addReport(db, {
-        sha256: SHA256,
-        reporter_pubkey: REPORTER3,
-        report_type: 'nudity',
-      });
-
-      expect(result).toEqual({ escalate: 'REVIEW' });
-    });
-
-    it('should escalate to AGE_RESTRICTED at 5 unique reporters', async () => {
-      await addReport(db, { sha256: SHA256, reporter_pubkey: REPORTER1, report_type: 'nudity' });
-      await addReport(db, { sha256: SHA256, reporter_pubkey: REPORTER2, report_type: 'nudity' });
-      await addReport(db, { sha256: SHA256, reporter_pubkey: REPORTER3, report_type: 'nudity' });
-      await addReport(db, { sha256: SHA256, reporter_pubkey: REPORTER4, report_type: 'nudity' });
-
-      const result = await addReport(db, {
-        sha256: SHA256,
-        reporter_pubkey: REPORTER5,
-        report_type: 'nudity',
-      });
-
-      expect(result).toEqual({ escalate: 'AGE_RESTRICTED' });
-    });
-  });
-
-  describe('getReportCount', () => {
-    it('should return 0 for unreported sha256', async () => {
-      const unreportedSha256 = ('c'.repeat(63) + '1').slice(0, 64);
-      const count = await getReportCount(db, unreportedSha256);
-      expect(count).toBe(0);
-    });
-  });
-
   describe('getReporterPubkeys', () => {
     it('should return empty array for unreported sha256', async () => {
       const reporters = await getReporterPubkeys(db, ('c'.repeat(63) + '1').slice(0, 64));
@@ -117,10 +34,10 @@ describe('reports', () => {
     });
 
     it('should return unique reporters with report dates', async () => {
-      await addReport(db, { sha256: SHA256, reporter_pubkey: REPORTER1, report_type: 'nudity' });
-      await addReport(db, { sha256: SHA256, reporter_pubkey: REPORTER2, report_type: 'nudity' });
+      await insertReport(db, { sha256: SHA256, reporter_pubkey: REPORTER1, report_type: 'nudity' });
+      await insertReport(db, { sha256: SHA256, reporter_pubkey: REPORTER2, report_type: 'nudity' });
       // Duplicate from REPORTER1 -- should not appear twice
-      await addReport(db, { sha256: SHA256, reporter_pubkey: REPORTER1, report_type: 'spam' });
+      await insertReport(db, { sha256: SHA256, reporter_pubkey: REPORTER1, report_type: 'spam' });
 
       const reporters = await getReporterPubkeys(db, SHA256);
       expect(reporters).toHaveLength(2);
@@ -135,8 +52,8 @@ describe('reports', () => {
 
     it('should not return reporters for different sha256', async () => {
       const otherSha256 = ('d'.repeat(63) + '1').slice(0, 64);
-      await addReport(db, { sha256: SHA256, reporter_pubkey: REPORTER1, report_type: 'nudity' });
-      await addReport(db, { sha256: otherSha256, reporter_pubkey: REPORTER2, report_type: 'nudity' });
+      await insertReport(db, { sha256: SHA256, reporter_pubkey: REPORTER1, report_type: 'nudity' });
+      await insertReport(db, { sha256: otherSha256, reporter_pubkey: REPORTER2, report_type: 'nudity' });
 
       const reporters = await getReporterPubkeys(db, SHA256);
       expect(reporters).toHaveLength(1);


### PR DESCRIPTION
## Summary

Removes the orphaned `POST /api/v1/report` endpoint from `src/index.mjs`. Per your guidance in #19, the endpoint has no identified consumer — user reports flow through relay-manager (Nostr kind 1984) and divine-web (with login, per #93).

## Changes

- Remove `/api/v1/report` handler from `src/index.mjs`
- Remove `/api/v1/report` from the root help text
- Remove unused `addReport()` and `getReportCount()` from `src/reports.mjs` (only the removed handler + their own tests referenced them)
- Remove tests for `addReport` / `getReportCount` / escalation thresholds from `src/reports.test.mjs`
- Rewrite the remaining `getReporterPubkeys` tests to use a direct SQL insert helper (they previously relied on `addReport()` for setup)
- Update ABOUTME comments to reflect `reports.mjs`'s reduced scope (reporter lookup for DM notifications)

## Preserved — still used elsewhere

- `initReportsTable()` — called at worker startup (`src/index.mjs:1061`) so the `user_reports` table exists before dm-reader writes into it
- `getReporterPubkeys()` — dynamically imported by `src/nostr/dm-sender.mjs` to notify reporters
- `user_reports` table — `src/nostr/dm-reader.mjs` writes directly via SQL

## Testing

- `npm test` — **56 test files, 903 tests passed** (down from 909; 6 tests tied to the removed handler were dropped)
- `reports.test.mjs` narrowed to 3 tests around `getReporterPubkeys` (the only remaining exported helper besides `initReportsTable`)

## Notes

- `docs/moderation-dm-plan.md:141` still references `/api/v1/report` as a future wire-in target. Left untouched — that's a planning doc outside this small cleanup scope; happy to update in this PR or a follow-up if you prefer.
- `docs/trust-safety-report.md:214` mentions the `user_reports` table with auto-escalation semantics. The table is preserved; happy to refresh wording in a follow-up.

Fixes #19
