### PR TITLE
docs(moderation-dm-plan): drop stale /api/v1/report wire-in reference

### DIFF
--- a/docs/moderation-dm-plan.md
+++ b/docs/moderation-dm-plan.md
@@ -138,7 +138,6 @@ Using `ctx.waitUntil()` ensures DM sending doesn't block the queue consumer or a
 
 **Also wire into:**
 - `/admin/api/moderate/:sha256` — for manual moderator overrides (lookup `uploaded_by` from D1)
-- `/api/v1/report` — when a report leads to escalation, DM the reporter
 
 ---
 


### PR DESCRIPTION
## Summary

Follow-up to #121. Drops the now-stale reference to `/api/v1/report` from `docs/moderation-dm-plan.md` since the endpoint was removed in that PR.

## Context

In her review of #121, @NotThatKindOfDrLiz noted:

> Non-blocking: `docs/moderation-dm-plan.md` still references `/api/v1/report`; worth dropping that stale planning-doc reference in a follow-up or while you are here.

This PR addresses that.

## Changes

`docs/moderation-dm-plan.md` — Phase 2.4 "Wire Into Pipeline" → "Also wire into" list: remove the `/api/v1/report` bullet. The other bullet (`/admin/api/moderate/:sha256`) is still relevant and stays.

```diff
 **Also wire into:**
 - `/admin/api/moderate/:sha256` — for manual moderator overrides (lookup `uploaded_by` from D1)
-- `/api/v1/report` — when a report leads to escalation, DM the reporter
```

## Testing

Docs-only change — no code paths affected. No tests required.
