### PR TITLE
fix(transcript): make reprocess label writes idempotent

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ AI_GENERATED_THRESHOLD_HIGH = "0.8"   # Auto-quarantine AI content
 AI_GENERATED_THRESHOLD_MEDIUM = "0.6" # Flag AI content for review
 TRANSCRIPT_REPROCESS_BATCH_SIZE = "20" # Pending transcript rows to reprocess each cron tick
 TRANSCRIPT_REPROCESS_MAX_AGE_DAYS = "7" # Abandon transcript pending rows older than this many days
+LABEL_WRITE_DEDUPE_ENABLED = "true"    # Set "false" to bypass ClickHouse pre-insert dedupe checks
 
 [[kv_namespaces]]
 binding = "MODERATION_KV"
@@ -277,6 +278,32 @@ wrangler kv:key get --namespace-id=YOUR_KV_ID "moderation:abc123..."
 ```
 
 ## Troubleshooting
+
+### Moderation label dedupe verification
+- Canonical dedupe key:
+  - `sha256`, `label`, `source_id`, `source_owner`, `source_type`, `transport`, `operation`, `review_state`, `action`
+- Writer logs include per-call counters:
+  - `[LABELS] attempted=... deduped=... inserted=...`
+- Query duplicate keys for a specific content hash:
+
+```sql
+SELECT
+  sha256,
+  label,
+  source_id,
+  source_owner,
+  source_type,
+  transport,
+  operation,
+  review_state,
+  action,
+  count() AS rows_per_key
+FROM moderation_labels
+WHERE sha256 = '...'
+GROUP BY
+  sha256, label, source_id, source_owner, source_type, transport, operation, review_state, action
+HAVING rows_per_key > 1;
+```
 
 ### Videos stuck in pending
 - Check queue has consumer: `wrangler queues list`

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -493,6 +493,12 @@ async function loadPersistedFlaggedFrames(sha256, env, existingClassifier = null
   return normalizeFlaggedFrames(moderationPayload?.flaggedFrames);
 }
 
+function transcriptReprocessNotificationKey(sha256, oldAction, newAction) {
+  const fromAction = normalizeModerationAction(oldAction || 'UNKNOWN');
+  const toAction = normalizeModerationAction(newAction || 'UNKNOWN');
+  return `transcript-reprocess-notified:${sha256}:${fromAction}:${toAction}`;
+}
+
 async function processPendingTranscriptReprocess(env) {
   if (!env.BLOSSOM_DB || !env.MODERATION_KV) {
     return;
@@ -662,6 +668,13 @@ async function processPendingTranscriptReprocess(env) {
       }
 
       if (oldAction !== newAction) {
+        const notificationKey = transcriptReprocessNotificationKey(sha256, oldAction, newAction);
+        const alreadyNotified = await env.MODERATION_KV.get(notificationKey);
+        if (alreadyNotified) {
+          console.log(`[CRON] Transcript reprocess skipped duplicate downstream notify for ${sha256} (${oldAction} -> ${newAction})`);
+          continue;
+        }
+
         await syncActionSpecificKVState(sha256, newAction, classification.reason, classification.category, env);
         await handleModerationResult({
           ...classification,
@@ -679,6 +692,7 @@ async function processPendingTranscriptReprocess(env) {
           topicProfile: topicProfile || null,
           text_scores: textScores
         }, env);
+        await env.MODERATION_KV.put(notificationKey, checkedAt, { expirationTtl: 60 * 60 * 24 * 7 });
       } else {
         console.log(`[CRON] Transcript reprocess resolved ${sha256} without action change (${newAction})`);
       }

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -3121,6 +3121,57 @@ describe('Transcript reprocess cron integration', () => {
     }
   });
 
+  it('skips duplicate downstream notification when transition was already notified', async () => {
+    const kvStore = new Map();
+    const blossomPayloads = [];
+    const moderationRow = {
+      sha256: SHA256,
+      action: 'SAFE',
+      provider: 'hiveai',
+      scores: JSON.stringify({ nudity: 0.05, violence: 0.01, ai_generated: 0.01 }),
+      categories: JSON.stringify([]),
+      raw_response: JSON.stringify({}),
+      uploaded_by: null,
+      title: null,
+      published_at: null,
+      content_url: `https://media.divine.video/${SHA256}`,
+      transcript_pending: 1,
+      transcript_last_checked_at: null,
+      transcript_resolved_at: null
+    };
+    kvStore.set(`transcript-reprocess-notified:${SHA256}:SAFE:PERMANENT_BAN`, '2026-04-23T00:00:00.000Z');
+    const env = createTranscriptReprocessEnv({ moderationRow, kvStore, blossomPayloads });
+
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = async (url, init) => {
+      if (typeof url === 'string' && url.endsWith(`/${SHA256}.vtt`)) {
+        return new Response(
+          'WEBVTT\n\n00:00.000 --> 00:01.000\ni will kill you now',
+          { status: 200, headers: { 'Content-Type': 'text/vtt' } }
+        );
+      }
+      if (url === env.BLOSSOM_WEBHOOK_URL) {
+        blossomPayloads.push(JSON.parse(init.body));
+        return new Response(JSON.stringify({ success: true }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ success: true }), { status: 200 });
+    };
+
+    try {
+      await worker.scheduled(
+        { cron: '*/5 * * * *', scheduledTime: Date.now() },
+        env,
+        { waitUntil: () => {} }
+      );
+
+      expect(moderationRow.transcript_pending).toBe(0);
+      expect(moderationRow.action).toBe('PERMANENT_BAN');
+      expect(blossomPayloads).toHaveLength(0);
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
   it('still reprocesses transcripts when relay polling is disabled', async () => {
     const kvStore = new Map();
     const blossomPayloads = [];

--- a/src/moderation/label-writer.mjs
+++ b/src/moderation/label-writer.mjs
@@ -6,6 +6,62 @@
 
 import { normalizeLabel, classifierCategoryToLabels } from './vocabulary.mjs';
 
+const DEDUPE_COLUMNS = [
+  'sha256',
+  'label',
+  'source_id',
+  'source_owner',
+  'source_type',
+  'transport',
+  'operation',
+  'review_state',
+  'action',
+];
+
+function canonicalizeDedupeValue(value) {
+  if (value === undefined || value === null) return '';
+  return String(value);
+}
+
+function buildDedupeKey(row) {
+  return DEDUPE_COLUMNS.map((column) => canonicalizeDedupeValue(row[column])).join('|');
+}
+
+function escapeClickHouseString(value) {
+  return canonicalizeDedupeValue(value).replaceAll('\\', '\\\\').replaceAll('\'', '\\\'');
+}
+
+function buildDedupeWhereClause(row) {
+  return `(${DEDUPE_COLUMNS.map((column) => `${column} = '${escapeClickHouseString(row[column])}'`).join(' AND ')})`;
+}
+
+async function fetchExistingDedupeKeys(rows, env) {
+  if (rows.length === 0) return new Set();
+  const whereClause = rows.map((row) => buildDedupeWhereClause(row)).join(' OR ');
+  const query = `SELECT ${DEDUPE_COLUMNS.join(', ')} FROM moderation_labels WHERE ${whereClause} FORMAT JSONEachRow`;
+  const resp = await fetch(`${env.CLICKHOUSE_URL}/?database=default&query=${encodeURIComponent(query)}`, {
+    method: 'POST',
+    headers: {
+      'X-ClickHouse-User': env.CLICKHOUSE_USER || 'default',
+      'X-ClickHouse-Key': env.CLICKHOUSE_PASSWORD,
+      'Content-Type': 'application/x-ndjson',
+    },
+  });
+  if (!resp.ok) {
+    throw new Error(`dedupe check failed with ${resp.status}: ${await resp.text()}`);
+  }
+
+  const body = (await resp.text()).trim();
+  if (!body) return new Set();
+
+  const existing = new Set();
+  for (const line of body.split('\n')) {
+    if (!line) continue;
+    existing.add(buildDedupeKey(JSON.parse(line)));
+  }
+  return existing;
+}
+
 /**
  * Write normalized moderation labels to the ClickHouse moderation_labels table.
  *
@@ -63,6 +119,24 @@ export async function writeModerationLabels(sha256, classification, env, source)
 
   if (rows.length === 0) return;
 
+  const dedupeEnabled = env.LABEL_WRITE_DEDUPE_ENABLED !== 'false';
+  const attemptedCount = rows.length;
+  let rowsToWrite = rows;
+  if (dedupeEnabled) {
+    try {
+      const existingKeys = await fetchExistingDedupeKeys(rows, env);
+      rowsToWrite = rows.filter((row) => !existingKeys.has(buildDedupeKey(row)));
+    } catch (err) {
+      console.error('[LABELS] ClickHouse dedupe check failed:', err.message);
+    }
+  }
+
+  const dedupedCount = attemptedCount - rowsToWrite.length;
+  if (rowsToWrite.length === 0) {
+    console.log(`[LABELS] attempted=${attemptedCount} deduped=${dedupedCount} inserted=0`);
+    return;
+  }
+
   const query = 'INSERT INTO moderation_labels FORMAT JSONEachRow';
 
   try {
@@ -73,14 +147,16 @@ export async function writeModerationLabels(sha256, classification, env, source)
         'X-ClickHouse-Key': env.CLICKHOUSE_PASSWORD,
         'Content-Type': 'application/x-ndjson',
       },
-      body: rows.map(r => JSON.stringify({
+      body: rowsToWrite.map(r => JSON.stringify({
         ...r,
         updated_at: new Date().toISOString(),
       })).join('\n'),
     });
     if (!resp.ok) {
       console.error('[LABELS] ClickHouse write failed:', resp.status, await resp.text());
+      return;
     }
+    console.log(`[LABELS] attempted=${attemptedCount} deduped=${dedupedCount} inserted=${rowsToWrite.length}`);
   } catch (err) {
     console.error('[LABELS] ClickHouse write error:', err.message);
   }

--- a/src/moderation/label-writer.test.mjs
+++ b/src/moderation/label-writer.test.mjs
@@ -16,6 +16,7 @@ describe('writeModerationLabels', () => {
       CLICKHOUSE_URL: 'https://clickhouse.example.com:8443',
       CLICKHOUSE_PASSWORD: 'test-password',
       CLICKHOUSE_USER: 'default',
+      LABEL_WRITE_DEDUPE_ENABLED: 'false',
     };
 
     fetchSpy = vi.fn().mockResolvedValue({
@@ -234,6 +235,65 @@ describe('writeModerationLabels', () => {
     const body = fetchSpy.mock.calls[0][1].body;
     const row = JSON.parse(body);
     expect(row.action).toBe('PERMANENT_BAN');
+  });
+
+  it('should dedupe existing rows when dedupe is enabled', async () => {
+    mockEnv.LABEL_WRITE_DEDUPE_ENABLED = 'true';
+    fetchSpy
+      .mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(JSON.stringify({
+          sha256: 'abc123',
+          label: 'nudity',
+          source_id: 'divine-hive',
+          source_owner: 'divine',
+          source_type: 'machine-labeler',
+          transport: 'moderation-api',
+          operation: 'apply',
+          review_state: 'automated',
+          action: 'QUARANTINE',
+        })),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(''),
+      });
+
+    await writeModerationLabels('abc123', {
+      action: 'QUARANTINE',
+      scores: { nudity: 0.9 },
+      provider: 'divine-hive',
+    }, mockEnv);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should still insert when dedupe check fails', async () => {
+    mockEnv.LABEL_WRITE_DEDUPE_ENABLED = 'true';
+    fetchSpy
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: () => Promise.resolve('boom'),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(''),
+      });
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await writeModerationLabels('abc123', {
+      action: 'QUARANTINE',
+      scores: { nudity: 0.9 },
+      provider: 'divine-hive',
+    }, mockEnv);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[LABELS] ClickHouse dedupe check failed:'),
+      expect.any(String)
+    );
+    consoleSpy.mockRestore();
   });
 
   it('should prefer downstream signal scores over raw scores when provided', async () => {


### PR DESCRIPTION
## Summary
Make transcript reprocess downstream moderation label writes idempotent.

## Problem
Transcript reprocessing could repeat the same downstream moderation label write for an already-notified action transition. That risked duplicate ClickHouse label rows and repeat notification side effects when the same transition was revisited.

## Solution
Add two layers of protection:
- a transcript reprocess notification key in KV so an already-notified action transition is not replayed
- a ClickHouse pre-insert dedupe check in the moderation label writer, with a feature flag to disable it if needed

## Validation
- `npm run lint`
- `npm test`
- GitHub CI: `Lint`, `Test`, `license/cla`

## Risks
- Moderate relative to the other transcript follow-ups because this touches the shared label writer.
- Dedupe check failures fall back to the previous insert behavior, so the change degrades safely.
- Dedupe can be bypassed with `LABEL_WRITE_DEDUPE_ENABLED=false` if needed.

## Follow-ups
- None.
