### PR TITLE
fix(transcript): warn on unknown action normalization

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -422,8 +422,16 @@ async function fetchTranscriptAsset(sha256, env) {
   };
 }
 
-function normalizeModerationAction(action) {
-  const normalized = typeof action === 'string' ? action.toUpperCase() : '';
+function normalizeModerationAction(action, { sha256 = null, source = null } = {}) {
+  const rawAction = typeof action === 'string' ? action : '';
+  const normalized = rawAction.toUpperCase();
+  if (!VALID_MODERATION_ACTIONS.has(normalized) && rawAction.trim()) {
+    const contextLabel = source ? ` (${source})` : '';
+    const safeSha = sha256 || 'unknown-sha';
+    console.warn(
+      `[CRON] Transcript reprocess normalized unknown moderation action to SAFE${contextLabel} for ${safeSha}: ${rawAction}`
+    );
+  }
   return VALID_MODERATION_ACTIONS.has(normalized) ? normalized : 'SAFE';
 }
 
@@ -601,8 +609,14 @@ async function processPendingTranscriptReprocess(env) {
       }, effectiveEnv);
       const reprocessedCategories = deriveCategoriesFromClassification(classification);
 
-      const oldAction = normalizeModerationAction(row.action);
-      const newAction = normalizeModerationAction(classification.action);
+      const oldAction = normalizeModerationAction(row.action, {
+        sha256,
+        source: 'stored-action'
+      });
+      const newAction = normalizeModerationAction(classification.action, {
+        sha256,
+        source: 'classification-action'
+      });
 
       const transcriptActionUpdate = await env.BLOSSOM_DB.prepare(`
         UPDATE moderation_results

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -4,7 +4,7 @@
 // ABOUTME: Request routing tests for API/admin hostname separation
 // ABOUTME: Verifies public API exposure, admin isolation, and workers.dev disablement
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import worker from './index.mjs';
 
 const SHA256 = 'a'.repeat(64);
@@ -3345,6 +3345,115 @@ describe('Transcript reprocess cron integration', () => {
       expect(blossomPayloads).toHaveLength(0);
     } finally {
       globalThis.fetch = origFetch;
+    }
+  });
+
+  it('warns when stored action is invalid and normalized to SAFE', async () => {
+    const kvStore = new Map();
+    const blossomPayloads = [];
+    const moderationRow = {
+      sha256: SHA256,
+      action: 'UNKNOWN_ACTION',
+      provider: 'hiveai',
+      scores: JSON.stringify({ nudity: 0.05, violence: 0.01, ai_generated: 0.01 }),
+      categories: JSON.stringify([]),
+      raw_response: JSON.stringify({}),
+      uploaded_by: null,
+      title: null,
+      published_at: null,
+      content_url: `https://media.divine.video/${SHA256}`,
+      transcript_pending: 1,
+      transcript_last_checked_at: null,
+      transcript_resolved_at: null
+    };
+    const env = createTranscriptReprocessEnv({ moderationRow, kvStore, blossomPayloads });
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = async (url, init) => {
+      if (typeof url === 'string' && url.endsWith(`/${SHA256}.vtt`)) {
+        return new Response(
+          'WEBVTT\n\n00:00.000 --> 00:01.000\nhello friends and welcome',
+          { status: 200, headers: { 'Content-Type': 'text/vtt' } }
+        );
+      }
+      if (url === env.BLOSSOM_WEBHOOK_URL) {
+        blossomPayloads.push(JSON.parse(init.body));
+      }
+      return new Response(JSON.stringify({ success: true }), { status: 200 });
+    };
+
+    try {
+      await worker.scheduled(
+        { cron: '*/5 * * * *', scheduledTime: Date.now() },
+        env,
+        { waitUntil: () => {} }
+      );
+
+      expect(moderationRow.transcript_pending).toBe(0);
+      expect(moderationRow.action).toBe('SAFE');
+
+      const normalizedWarnings = warnSpy.mock.calls
+        .map(([message]) => message)
+        .filter((message) => typeof message === 'string' && message.includes('normalized unknown moderation action to SAFE'));
+      expect(normalizedWarnings).toHaveLength(1);
+      expect(normalizedWarnings[0]).toContain(SHA256);
+      expect(normalizedWarnings[0]).toContain('UNKNOWN_ACTION');
+    } finally {
+      globalThis.fetch = origFetch;
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('does not warn for valid stored transcript reprocess actions', async () => {
+    const kvStore = new Map();
+    const blossomPayloads = [];
+    const moderationRow = {
+      sha256: SHA256,
+      action: 'SAFE',
+      provider: 'hiveai',
+      scores: JSON.stringify({ nudity: 0.05, violence: 0.01, ai_generated: 0.01 }),
+      categories: JSON.stringify([]),
+      raw_response: JSON.stringify({}),
+      uploaded_by: null,
+      title: null,
+      published_at: null,
+      content_url: `https://media.divine.video/${SHA256}`,
+      transcript_pending: 1,
+      transcript_last_checked_at: null,
+      transcript_resolved_at: null
+    };
+    const env = createTranscriptReprocessEnv({ moderationRow, kvStore, blossomPayloads });
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = async (url, init) => {
+      if (typeof url === 'string' && url.endsWith(`/${SHA256}.vtt`)) {
+        return new Response(
+          'WEBVTT\n\n00:00.000 --> 00:01.000\nhello friends and welcome',
+          { status: 200, headers: { 'Content-Type': 'text/vtt' } }
+        );
+      }
+      if (url === env.BLOSSOM_WEBHOOK_URL) {
+        blossomPayloads.push(JSON.parse(init.body));
+      }
+      return new Response(JSON.stringify({ success: true }), { status: 200 });
+    };
+
+    try {
+      await worker.scheduled(
+        { cron: '*/5 * * * *', scheduledTime: Date.now() },
+        env,
+        { waitUntil: () => {} }
+      );
+
+      const normalizedWarnings = warnSpy.mock.calls
+        .map(([message]) => message)
+        .filter((message) => typeof message === 'string' && message.includes('normalized unknown moderation action to SAFE'));
+      expect(normalizedWarnings).toHaveLength(0);
+    } finally {
+      globalThis.fetch = origFetch;
+      warnSpy.mockRestore();
     }
   });
 });


### PR DESCRIPTION
## Summary
Warn when transcript reprocessing normalizes an unknown moderation action to `SAFE`.

## Problem
Transcript reprocessing silently coerced unknown moderation actions to `SAFE`. That preserved behavior, but it hid data quality issues and made it harder to spot corrupted stored actions or unexpected classifier outputs.

## Solution
Extend `normalizeModerationAction` with optional context so transcript reprocessing logs a warning when an unknown action is normalized to `SAFE`, including the row SHA and whether the bad value came from stored row state or the classifier result.

## Validation
- `npm run lint`
- `npm test`
- GitHub CI: `Lint`, `Test`, `license/cla`

## Risks
- Low. Behavior is unchanged apart from warning logs on invalid non-empty actions.
- Valid moderation actions do not log.

## Follow-ups
- None.
