### PR TITLE
feat(#66): classic vine rollback relay batching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,9 @@ jobs:
             exit 0
           fi
 
+          # Retry once for the specific @cloudflare/vitest-pool-workers isolated-storage flake
+          # tracked in cloudflare/workers-sdk#11031. Keep the match narrow so ordinary failures
+          # do not get retried and hidden.
           if grep -Eq "Stack underflow|Failed to pop isolated storage stack frame" /tmp/vitest.log; then
             echo "Detected known @cloudflare/vitest-pool-workers storage stack flake. Retrying once..."
             npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,22 @@ jobs:
         run: npm ci
 
       - name: Run tests
-        run: npm test
+        run: |
+          set -o pipefail
+          npm test 2>&1 | tee /tmp/vitest.log
+          status=${PIPESTATUS[0]}
+
+          if [ "$status" -eq 0 ]; then
+            exit 0
+          fi
+
+          if grep -Eq "Stack underflow|Failed to pop isolated storage stack frame" /tmp/vitest.log; then
+            echo "Detected known @cloudflare/vitest-pool-workers storage stack flake. Retrying once..."
+            npm test
+            exit $?
+          fi
+
+          exit "$status"
 
   deploy:
     name: Deploy

--- a/docs/superpowers/specs/2026-03-31-classic-vine-enforcement-rollback-design.md
+++ b/docs/superpowers/specs/2026-03-31-classic-vine-enforcement-rollback-design.md
@@ -181,6 +181,20 @@ Verification for the rollback is operational, not model-based:
 4. Confirm no paid moderation provider traffic was triggered by the rollback path.
 5. Confirm rerunning the same chunk does not reintroduce blocking state.
 
+## Operator Guidance for Large Batches
+
+The rollback endpoint supports both explicit `videos[]` payloads (with pre-resolved `nostrContext`) and raw `sha256s[]` payloads.
+
+- Prefer `videos[]` for large incident runs whenever possible. This avoids relay metadata lookups entirely and is the fastest path.
+- `sha256s[]` is still supported for emergency runs, but it now uses batched relay lookup with bounded concurrency.
+- Default lookup tuning:
+  - `lookup_chunk_size = 25`
+  - `lookup_concurrency = 3`
+- Safe starting points:
+  - pre-resolved `videos[]`: request `limit` up to `500`
+  - raw `sha256s[]`: request `limit` of `100-250` first, then increase after observing relay stability
+- If relay errors or timeouts appear, reduce `lookup_chunk_size` and/or `lookup_concurrency` before retrying.
+
 ## File-Level Design
 
 - [`src/index.mjs`](../../../src/index.mjs)

--- a/src/moderation/classic-vine-rollback.mjs
+++ b/src/moderation/classic-vine-rollback.mjs
@@ -4,7 +4,7 @@
 // ABOUTME: Helpers for classic Vine enforcement rollback
 // ABOUTME: Confirms rollback candidates and rewrites stale enforcement without re-running moderation
 
-import { fetchNostrEventBySha256, parseVideoEventMetadata } from '../nostr/relay-client.mjs';
+import { fetchNostrEventsBySha256Batch, parseVideoEventMetadata } from '../nostr/relay-client.mjs';
 
 const ARCHIVE_SOURCES = new Set([
   'archive-export',
@@ -15,11 +15,25 @@ const VALID_MODES = new Set(['execute', 'preview', 'resume']);
 const SHA256_PATTERN = /^[0-9a-f]{64}$/i;
 const DEFAULT_LIMIT = 100;
 const MAX_LIMIT = 500;
+const DEFAULT_LOOKUP_CHUNK_SIZE = 25;
+const MAX_LOOKUP_CHUNK_SIZE = 100;
+const DEFAULT_LOOKUP_CONCURRENCY = 3;
+const MAX_LOOKUP_CONCURRENCY = 8;
+const SHA_ONLY_WARNING_THRESHOLD = 100;
 
 function createHttpError(status, message) {
   const error = new Error(message);
   error.status = status;
   return error;
+}
+
+function parseBoundedInteger(value, fallback, min, max) {
+  const parsed = Number.parseInt(String(value), 10);
+  if (!Number.isFinite(parsed)) {
+    return fallback;
+  }
+
+  return Math.min(Math.max(parsed, min), max);
 }
 
 function normalizeRollbackItem(item) {
@@ -72,7 +86,19 @@ function normalizeClassicVineRollbackRequest(body = {}) {
     source: typeof body.source === 'string' && body.source.length > 0 ? body.source : 'sha-list',
     items: rawItems.map(normalizeRollbackItem),
     limit,
-    cursor
+    cursor,
+    lookupChunkSize: parseBoundedInteger(
+      body.lookup_chunk_size ?? body.lookupChunkSize,
+      DEFAULT_LOOKUP_CHUNK_SIZE,
+      1,
+      MAX_LOOKUP_CHUNK_SIZE
+    ),
+    lookupConcurrency: parseBoundedInteger(
+      body.lookup_concurrency ?? body.lookupConcurrency,
+      DEFAULT_LOOKUP_CONCURRENCY,
+      1,
+      MAX_LOOKUP_CONCURRENCY
+    )
   };
 }
 
@@ -93,14 +119,108 @@ function createRollbackCandidateResult(sha256, reason, extras = {}) {
   };
 }
 
-async function resolveRollbackNostrContext(item, env) {
-  if (item.nostrContext) {
-    return item.nostrContext;
+async function resolveRollbackNostrContexts(batch, request, env, deps = {}) {
+  const contextBySha = new Map();
+  const shaToLookup = [];
+  const seenShas = new Set();
+  const lookupFailedShas = new Set();
+  let preResolved = 0;
+  let lookupError = null;
+
+  for (const item of batch) {
+    if (!item.sha256 || !SHA256_PATTERN.test(item.sha256)) {
+      continue;
+    }
+
+    if (item.nostrContext) {
+      if (!contextBySha.has(item.sha256)) {
+        contextBySha.set(item.sha256, item.nostrContext);
+      }
+      preResolved += 1;
+      seenShas.add(item.sha256);
+      continue;
+    }
+
+    if (!seenShas.has(item.sha256)) {
+      seenShas.add(item.sha256);
+      shaToLookup.push(item.sha256);
+    }
   }
 
   const relays = env.NOSTR_RELAY_URL ? [env.NOSTR_RELAY_URL] : ['wss://relay.divine.video'];
-  const event = await fetchNostrEventBySha256(item.sha256, relays, env);
-  return event ? parseVideoEventMetadata(event) : null;
+  const lookupChunkSize = parseBoundedInteger(
+    env.CLASSIC_VINE_ROLLBACK_LOOKUP_CHUNK_SIZE,
+    request.lookupChunkSize,
+    1,
+    MAX_LOOKUP_CHUNK_SIZE
+  );
+  const lookupConcurrency = parseBoundedInteger(
+    env.CLASSIC_VINE_ROLLBACK_LOOKUP_CONCURRENCY,
+    request.lookupConcurrency,
+    1,
+    MAX_LOOKUP_CONCURRENCY
+  );
+  const fetchBatchLookup = deps.fetchNostrEventsBySha256Batch || fetchNostrEventsBySha256Batch;
+  const lookupStartedAt = Date.now();
+
+  if (shaToLookup.length > 0) {
+    try {
+      const eventsBySha = await fetchBatchLookup(shaToLookup, relays, env, {
+        chunkSize: lookupChunkSize,
+        concurrency: lookupConcurrency
+      });
+
+      for (const sha256 of shaToLookup) {
+        const event = eventsBySha.get(sha256) || null;
+        contextBySha.set(sha256, event ? parseVideoEventMetadata(event) : null);
+      }
+    } catch (error) {
+      lookupError = error;
+      for (const sha256 of shaToLookup) {
+        lookupFailedShas.add(sha256);
+      }
+    }
+  }
+
+  const resolved = shaToLookup.filter((sha256) => contextBySha.get(sha256)).length;
+  const missing = shaToLookup.length - resolved;
+
+  return {
+    contextBySha,
+    lookupFailedShas,
+    lookupSummary: {
+      pre_resolved: preResolved,
+      sha_lookup_requested: shaToLookup.length,
+      sha_lookup_resolved: resolved,
+      sha_lookup_missing: missing,
+      chunk_size: lookupChunkSize,
+      concurrency: lookupConcurrency,
+      relay_count: relays.length,
+      duration_ms: Date.now() - lookupStartedAt,
+      error: lookupError?.message || null
+    }
+  };
+}
+
+function buildLookupWarnings(batch, lookupSummary) {
+  const warnings = [];
+  const needsRelayLookupCount = batch.filter((item) => (
+    item.sha256
+      && SHA256_PATTERN.test(item.sha256)
+      && !item.nostrContext
+  )).length;
+  if (needsRelayLookupCount >= SHA_ONLY_WARNING_THRESHOLD) {
+    warnings.push(
+      `Large SHA-only batch (${needsRelayLookupCount} items) will spend time resolving relay metadata. ` +
+      'Prefer videos[] with pre-resolved nostrContext for large rollback runs.'
+    );
+  }
+
+  if (lookupSummary.error) {
+    warnings.push(`Relay lookup encountered an error: ${lookupSummary.error}`);
+  }
+
+  return warnings;
 }
 
 export function isClassicVineRollbackCandidate({ source, nostrContext }) {
@@ -210,6 +330,12 @@ export async function runClassicVineRollback(body, env, deps = {}) {
   const startedAt = typeof deps.now === 'function' ? deps.now() : new Date().toISOString();
   const request = normalizeClassicVineRollbackRequest(body);
   const { batch, nextCursor } = sliceClassicVineRollbackItems(request.items, request.cursor, request.limit);
+  const {
+    contextBySha,
+    lookupFailedShas,
+    lookupSummary
+  } = await resolveRollbackNostrContexts(batch, request, env, deps);
+  const warnings = buildLookupWarnings(batch, lookupSummary);
   const candidates = [];
   let restored = 0;
   let skipped = 0;
@@ -226,7 +352,17 @@ export async function runClassicVineRollback(body, env, deps = {}) {
     }
 
     try {
-      const nostrContext = await resolveRollbackNostrContext(item, env);
+      if (lookupFailedShas.has(item.sha256)) {
+        failed += 1;
+        candidates.push(createRollbackCandidateResult(item.sha256, 'relay-lookup-failed', {
+          would_restore: false,
+          restored: false,
+          error: lookupSummary.error || 'Failed to resolve relay metadata'
+        }));
+        continue;
+      }
+
+      const nostrContext = item.nostrContext || contextBySha.get(item.sha256) || null;
       const matched = isClassicVineRollbackCandidate({
         source: request.source,
         nostrContext
@@ -301,6 +437,8 @@ export async function runClassicVineRollback(body, env, deps = {}) {
     next_cursor: nextCursor,
     started_at: startedAt,
     finished_at: typeof deps.now === 'function' ? deps.now() : new Date().toISOString(),
+    lookup: lookupSummary,
+    warnings,
     candidates
   };
 }

--- a/src/moderation/classic-vine-rollback.test.mjs
+++ b/src/moderation/classic-vine-rollback.test.mjs
@@ -196,4 +196,138 @@ describe('runClassicVineRollback', () => {
       }
     ]);
   });
+
+  it('resolves SHA-only batches through batched relay lookups', async () => {
+    const firstSha = 'a'.repeat(64);
+    const secondSha = 'b'.repeat(64);
+    const calls = [];
+
+    const result = await runClassicVineRollback({
+      mode: 'preview',
+      source: 'sha-list',
+      sha256s: [firstSha, firstSha, secondSha]
+    }, {}, {
+      fetchNostrEventsBySha256Batch: async (sha256s, relays, env, options) => {
+        calls.push({ sha256s, relays, env, options });
+        return new Map([
+          [firstSha, { tags: [['platform', 'vine']] }],
+          [secondSha, null]
+        ]);
+      }
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].sha256s).toEqual([firstSha, secondSha]);
+    expect(result.lookup).toMatchObject({
+      sha_lookup_requested: 2,
+      sha_lookup_resolved: 1,
+      sha_lookup_missing: 1
+    });
+    expect(result.candidates).toEqual([
+      {
+        sha256: firstSha,
+        reason: 'confirmed-classic-vine',
+        would_restore: true
+      },
+      {
+        sha256: firstSha,
+        reason: 'confirmed-classic-vine',
+        would_restore: true
+      },
+      {
+        sha256: secondSha,
+        reason: 'missing-vine-metadata',
+        would_restore: false,
+        restored: false
+      }
+    ]);
+  });
+
+  it('warns operators when large SHA-only batches are used', async () => {
+    const items = Array.from({ length: 100 }, (_, index) => index.toString(16).padStart(64, '0'));
+    const result = await runClassicVineRollback({
+      mode: 'preview',
+      source: 'sha-list',
+      sha256s: items
+    }, {}, {
+      fetchNostrEventsBySha256Batch: async (sha256s) => new Map(sha256s.map((sha256) => [sha256, null]))
+    });
+
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain('Prefer videos[] with pre-resolved nostrContext');
+  });
+
+  it('skips relay lookup when all items already contain nostrContext', async () => {
+    const sha256 = 'c'.repeat(64);
+    let lookupCalled = false;
+
+    const result = await runClassicVineRollback({
+      mode: 'preview',
+      source: 'sha-list',
+      videos: [{
+        sha256,
+        nostrContext: {
+          platform: 'vine',
+          sourceUrl: 'https://vine.co/v/already-resolved'
+        }
+      }]
+    }, {}, {
+      fetchNostrEventsBySha256Batch: async () => {
+        lookupCalled = true;
+        return new Map();
+      }
+    });
+
+    expect(lookupCalled).toBe(false);
+    expect(result.lookup.sha_lookup_requested).toBe(0);
+    expect(result.lookup.pre_resolved).toBe(1);
+    expect(result.candidates).toEqual([
+      {
+        sha256,
+        reason: 'confirmed-classic-vine',
+        would_restore: true
+      }
+    ]);
+  });
+
+  it('reuses pre-resolved context for duplicate SHA items in mixed payloads', async () => {
+    const sha256 = 'd'.repeat(64);
+    const calls = [];
+
+    const result = await runClassicVineRollback({
+      mode: 'preview',
+      source: 'sha-list',
+      videos: [
+        {
+          sha256,
+          nostrContext: {
+            platform: 'vine'
+          }
+        },
+        {
+          sha256
+        }
+      ]
+    }, {}, {
+      fetchNostrEventsBySha256Batch: async (sha256s) => {
+        calls.push(sha256s);
+        return new Map();
+      }
+    });
+
+    expect(calls).toEqual([]);
+    expect(result.lookup.sha_lookup_requested).toBe(0);
+    expect(result.candidates).toEqual([
+      {
+        sha256,
+        reason: 'confirmed-classic-vine',
+        would_restore: true
+      },
+      {
+        sha256,
+        reason: 'confirmed-classic-vine',
+        would_restore: true
+      }
+    ]);
+  });
 });

--- a/src/nostr/relay-client.mjs
+++ b/src/nostr/relay-client.mjs
@@ -6,6 +6,50 @@
 
 import { extractMediaShaFromEvent } from '../validation.mjs';
 
+const DEFAULT_SHA_BATCH_CHUNK_SIZE = 25;
+const MAX_SHA_BATCH_CHUNK_SIZE = 100;
+const DEFAULT_SHA_BATCH_CONCURRENCY = 3;
+const MAX_SHA_BATCH_CONCURRENCY = 8;
+const DEFAULT_SHA_BATCH_QUERY_LIMIT = 100;
+const MAX_SHA_BATCH_QUERY_LIMIT = 500;
+
+function parseBoundedInteger(value, fallback, min, max) {
+  const parsed = Number.parseInt(String(value), 10);
+  if (!Number.isFinite(parsed)) {
+    return fallback;
+  }
+
+  return Math.min(Math.max(parsed, min), max);
+}
+
+function chunkArray(items, chunkSize) {
+  const chunks = [];
+  for (let index = 0; index < items.length; index += chunkSize) {
+    chunks.push(items.slice(index, index + chunkSize));
+  }
+  return chunks;
+}
+
+function hasUnresolvedEvent(eventsBySha) {
+  for (const value of eventsBySha.values()) {
+    if (!value) return true;
+  }
+  return false;
+}
+
+async function runWithConcurrency(items, concurrency, worker) {
+  let currentIndex = 0;
+  const workers = Array.from({ length: Math.min(concurrency, items.length || 1) }, async () => {
+    while (currentIndex < items.length) {
+      const itemIndex = currentIndex;
+      currentIndex += 1;
+      await worker(items[itemIndex], itemIndex);
+    }
+  });
+
+  await Promise.all(workers);
+}
+
 async function queryRelay(relayUrl, filter, env = {}, options = {}) {
   return new Promise((resolve, reject) => {
     let ws;
@@ -103,6 +147,98 @@ async function queryRelay(relayUrl, filter, env = {}, options = {}) {
 }
 
 /**
+ * Fetch Nostr events for many media SHA256 values in relay-friendly batches.
+ *
+ * @param {string[]} sha256s - Video hashes
+ * @param {string[]} relays - Relay URLs to query
+ * @param {Object} env - Environment variables
+ * @param {Object} options - Batch lookup options
+ * @returns {Promise<Map<string, Object|null>>} Map of sha256 -> matching event or null
+ */
+export async function fetchNostrEventsBySha256Batch(sha256s, relays = ['wss://relay.divine.video'], env = {}, options = {}) {
+  const normalizedShas = [...new Set(
+    (Array.isArray(sha256s) ? sha256s : [])
+      .map((sha) => (typeof sha === 'string' ? sha.toLowerCase() : null))
+      .filter(Boolean)
+  )];
+  const eventsBySha = new Map(normalizedShas.map((sha) => [sha, null]));
+
+  if (normalizedShas.length === 0) {
+    return eventsBySha;
+  }
+
+  const chunkSize = parseBoundedInteger(
+    options.chunkSize,
+    DEFAULT_SHA_BATCH_CHUNK_SIZE,
+    1,
+    MAX_SHA_BATCH_CHUNK_SIZE
+  );
+  const concurrency = parseBoundedInteger(
+    options.concurrency,
+    DEFAULT_SHA_BATCH_CONCURRENCY,
+    1,
+    MAX_SHA_BATCH_CONCURRENCY
+  );
+  const queryLimit = parseBoundedInteger(
+    options.limit,
+    Math.min(Math.max(chunkSize * 4, 20), DEFAULT_SHA_BATCH_QUERY_LIMIT),
+    1,
+    MAX_SHA_BATCH_QUERY_LIMIT
+  );
+  const shaChunks = chunkArray(normalizedShas, chunkSize);
+
+  for (const relay of relays) {
+    await runWithConcurrency(shaChunks, concurrency, async (chunk) => {
+      const unresolvedShas = chunk.filter((sha) => !eventsBySha.get(sha));
+      if (unresolvedShas.length === 0) {
+        return;
+      }
+
+      try {
+        const xTagMatches = await queryRelay(relay, {
+          kinds: [34235, 34236],
+          '#x': unresolvedShas,
+          limit: queryLimit
+        }, env, { collectAll: true });
+
+        for (const event of xTagMatches) {
+          const mediaSha = extractMediaShaFromEvent(event);
+          if (mediaSha && eventsBySha.has(mediaSha) && !eventsBySha.get(mediaSha)) {
+            eventsBySha.set(mediaSha, event);
+          }
+        }
+
+        const unresolvedAfterX = unresolvedShas.filter((sha) => !eventsBySha.get(sha));
+        if (unresolvedAfterX.length === 0) {
+          return;
+        }
+
+        const dTagMatches = await queryRelay(relay, {
+          kinds: [34235, 34236],
+          '#d': unresolvedAfterX,
+          limit: queryLimit
+        }, env, { collectAll: true });
+
+        for (const event of dTagMatches) {
+          const mediaSha = extractMediaShaFromEvent(event);
+          if (mediaSha && eventsBySha.has(mediaSha) && !eventsBySha.get(mediaSha)) {
+            eventsBySha.set(mediaSha, event);
+          }
+        }
+      } catch (error) {
+        console.error(`[NOSTR] Failed batch fetch from ${relay}:`, error);
+      }
+    });
+
+    if (!hasUnresolvedEvent(eventsBySha)) {
+      break;
+    }
+  }
+
+  return eventsBySha;
+}
+
+/**
  * Fetch Nostr event for a video SHA256 from relay.
  * Legacy Vine imports use d=vine_id and expose the media hash via x/imeta x,
  * while newer content may still use d=sha256.
@@ -114,36 +250,16 @@ async function queryRelay(relayUrl, filter, env = {}, options = {}) {
  */
 export async function fetchNostrEventBySha256(sha256, relays = ['wss://relay.divine.video'], env = {}) {
   const normalizedSha256 = typeof sha256 === 'string' ? sha256.toLowerCase() : sha256;
-
-  for (const relay of relays) {
-    try {
-      const xTagMatches = await queryRelay(relay, {
-        kinds: [34235, 34236],
-        '#x': [normalizedSha256],
-        limit: 10
-      }, env, { collectAll: true });
-
-      const xTagEvent = xTagMatches.find((event) => extractMediaShaFromEvent(event) === normalizedSha256);
-      if (xTagEvent) {
-        return xTagEvent;
-      }
-
-      const dTagMatches = await queryRelay(relay, {
-        kinds: [34235, 34236],
-        '#d': [normalizedSha256],
-        limit: 10
-      }, env, { collectAll: true });
-
-      const dTagEvent = dTagMatches.find((event) => extractMediaShaFromEvent(event) === normalizedSha256);
-      if (dTagEvent) {
-        return dTagEvent;
-      }
-    } catch (error) {
-      console.error(`[NOSTR] Failed to fetch from ${relay}:`, error);
-    }
+  if (!normalizedSha256) {
+    return null;
   }
 
-  return null;
+  const eventsBySha = await fetchNostrEventsBySha256Batch([normalizedSha256], relays, env, {
+    chunkSize: 1,
+    concurrency: 1,
+    limit: 10
+  });
+  return eventsBySha.get(normalizedSha256) || null;
 }
 
 /**

--- a/src/nostr/relay-client.test.mjs
+++ b/src/nostr/relay-client.test.mjs
@@ -4,6 +4,7 @@
 import { afterEach, describe, it, expect } from 'vitest';
 import {
   fetchNostrEventBySha256,
+  fetchNostrEventsBySha256Batch,
   fetchNostrVideoEventsByDTag,
   parseVideoEventMetadata,
   isOriginalVine,
@@ -387,6 +388,139 @@ describe('fetchNostrEventBySha256', () => {
     globalThis.WebSocket = FakeWebSocket;
 
     await expect(fetchNostrEventBySha256(sha256)).resolves.toEqual(event);
+  });
+});
+
+describe('fetchNostrEventsBySha256Batch', () => {
+  it('resolves mixed SHA batches via x and d fallback filters', async () => {
+    const shaViaX = 'a'.repeat(64);
+    const shaViaD = 'b'.repeat(64);
+    const eventViaX = {
+      id: 'c'.repeat(64),
+      kind: 34236,
+      tags: [
+        ['d', 'legacy-vine-id'],
+        ['x', shaViaX],
+        ['platform', 'vine']
+      ]
+    };
+    const eventViaD = {
+      id: 'd'.repeat(64),
+      kind: 34236,
+      tags: [
+        ['d', shaViaD],
+        ['platform', 'vine']
+      ]
+    };
+    const filters = [];
+
+    class FakeWebSocket {
+      constructor() {
+        this.listeners = {};
+        queueMicrotask(() => this.emit('open'));
+      }
+
+      addEventListener(type, handler) {
+        if (!this.listeners[type]) {
+          this.listeners[type] = [];
+        }
+        this.listeners[type].push(handler);
+      }
+
+      send(message) {
+        const [, subscriptionId, filter] = JSON.parse(message);
+        filters.push(filter);
+        queueMicrotask(() => {
+          if (filter['#x']?.includes(shaViaX)) {
+            this.emit('message', { data: JSON.stringify(['EVENT', subscriptionId, eventViaX]) });
+          }
+          if (filter['#d']?.includes(shaViaD)) {
+            this.emit('message', { data: JSON.stringify(['EVENT', subscriptionId, eventViaD]) });
+          }
+          this.emit('message', { data: JSON.stringify(['EOSE', subscriptionId]) });
+        });
+      }
+
+      close() {
+        queueMicrotask(() => this.emit('close'));
+      }
+
+      emit(type, event = {}) {
+        for (const handler of this.listeners[type] || []) {
+          handler(event);
+        }
+      }
+    }
+
+    globalThis.WebSocket = FakeWebSocket;
+
+    const result = await fetchNostrEventsBySha256Batch([shaViaX, shaViaD], ['wss://relay.divine.video'], {}, {
+      chunkSize: 2,
+      concurrency: 1
+    });
+    expect(result.get(shaViaX)).toEqual(eventViaX);
+    expect(result.get(shaViaD)).toEqual(eventViaD);
+
+    const xFilters = filters.filter((filter) => Array.isArray(filter['#x']));
+    const dFilters = filters.filter((filter) => Array.isArray(filter['#d']));
+    expect(xFilters).toHaveLength(1);
+    expect(xFilters[0]['#x']).toEqual([shaViaX, shaViaD]);
+    expect(dFilters).toHaveLength(1);
+    expect(dFilters[0]['#d']).toEqual([shaViaD]);
+  });
+
+  it('deduplicates input SHAs and keeps unresolved items as null', async () => {
+    const shaResolved = 'e'.repeat(64);
+    const shaMissing = 'f'.repeat(64);
+    const event = {
+      id: '1'.repeat(64),
+      kind: 34236,
+      tags: [
+        ['x', shaResolved],
+        ['platform', 'vine']
+      ]
+    };
+
+    class FakeWebSocket {
+      constructor() {
+        this.listeners = {};
+        queueMicrotask(() => this.emit('open'));
+      }
+
+      addEventListener(type, handler) {
+        if (!this.listeners[type]) {
+          this.listeners[type] = [];
+        }
+        this.listeners[type].push(handler);
+      }
+
+      send(message) {
+        const [, subscriptionId, filter] = JSON.parse(message);
+        queueMicrotask(() => {
+          if (filter['#x']?.includes(shaResolved)) {
+            this.emit('message', { data: JSON.stringify(['EVENT', subscriptionId, event]) });
+          }
+          this.emit('message', { data: JSON.stringify(['EOSE', subscriptionId]) });
+        });
+      }
+
+      close() {
+        queueMicrotask(() => this.emit('close'));
+      }
+
+      emit(type, eventPayload = {}) {
+        for (const handler of this.listeners[type] || []) {
+          handler(eventPayload);
+        }
+      }
+    }
+
+    globalThis.WebSocket = FakeWebSocket;
+
+    const result = await fetchNostrEventsBySha256Batch([shaResolved, shaResolved, shaMissing]);
+    expect(result.size).toBe(2);
+    expect(result.get(shaResolved)).toEqual(event);
+    expect(result.get(shaMissing)).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary
Add batched relay lookup for classic Vine rollback SHA-only runs.

## Problem
Classic Vine rollback handled SHA-only payloads by resolving relay metadata one item at a time. That made large rollback batches slow and relay-heavy, and it provided limited operator visibility when relay lookup degraded.

## Solution
- add batched SHA relay lookup with bounded chunking and concurrency in the Nostr relay client
- switch classic Vine rollback SHA-only discovery to the batched lookup path
- preserve the fast path for pre-resolved `videos[].nostrContext`
- return lookup telemetry and operator warnings in rollback responses
- document safe operator guidance for large rollback batches
- document the scoped CI retry for the known @cloudflare/vitest-pool-workers isolated-storage flake

## Validation
- `npm run lint`
- `npm test`
- GitHub CI: `Lint`, `Test`, `license/cla`

## Risks
- Moderate. This changes the relay lookup strategy for a rollback path that can process large batches.
- Input bounds are clamped and the legacy single-item helper still delegates through the new batch path, which keeps behavior aligned.
- The CI retry remains tightly scoped to the known Cloudflare vitest failure signature.

## Follow-ups
- None in this PR.
- Additional coverage for per-chunk continuation and relay fallback can be added later if needed.
