### PR TITLE
chore: add repo contribution guardrails

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,41 @@
+name: Bug Report
+description: Report a bug or regression
+title: "fix: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use generic descriptors for external partners, customers, brands, campaign names, and other sensitive identities unless a maintainer has approved naming them publicly.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Briefly describe the problem.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: List the queue flow, API call, admin action, or event sequence needed to reproduce the issue.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Result
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Result
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Include relevant environment details, logs, or payloads. Redact secrets and sensitive external names.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+name: Feature Request
+description: Propose a new feature or improvement
+title: "feat: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use generic descriptors for external partners, customers, brands, campaign names, and other sensitive identities unless a maintainer has approved naming them publicly.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Describe the feature or improvement.
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / Motivation
+      description: Explain why this work is needed.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed Approach
+      description: Describe the intended behavior or implementation direction.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Include queue behavior, API examples, or rollout notes as needed. Redact secrets and sensitive external names.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+## Summary
+
+-
+
+## Motivation
+
+-
+
+## Related Issue
+
+- Closes #
+
+## Validation
+
+- [ ] `npm run lint`
+- [ ] `npm test`
+- [ ] relevant Wrangler or queue-flow validation if applicable
+- [ ] I could not run some validation locally, and I explained why below
+
+## Manual Test Plan / Notes
+
+-
+
+## Visuals / API Examples
+
+- [ ] No visual change
+- [ ] Screenshots, sample payloads, or logs attached if needed
+
+## Public Artifact Review
+
+- [ ] Titles, descriptions, branch names, and screenshots avoid partner, customer, brand, campaign, or other sensitive external names unless explicitly approved

--- a/.github/workflows/semantic_pr.yml
+++ b/.github/workflows/semantic_pr.yml
@@ -1,0 +1,12 @@
+name: Semantic PR
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  semantic-pull-request:
+    uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/semantic_pull_request.yml@v1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- Worker code lives under `src/`.
+- Data and runtime configuration lives in `wrangler.toml`, `migrations/`, and supporting scripts under `scripts/`.
+- Operational and product docs live in `README.md`, `CONTENT_MODERATION.md`, `CDN_INTEGRATION.md`, `CLOUDFLARE_ACCESS_SETUP.md`, `ADMIN_SETUP.md`, and `docs/`.
+- Keep queue processing, moderation policy, admin endpoints, and relay integration changes scoped so they are easy to review.
+
+## Build, Test, and Validation Commands
+- `npm run lint`: custom repo lint pass.
+- `npm test`: Vitest suite.
+- `npm run dev`: local Worker development with Wrangler.
+- `npm run deploy`: deploy the Worker. Use only when intentionally shipping changes.
+
+## Coding Style & Naming Conventions
+- Follow the existing TypeScript, Cloudflare Worker, and queue-processing patterns already established in the repo.
+- Keep moderation policy changes, queue behavior changes, and admin/auth changes focused. Do not mix unrelated cleanup or refactors into the same PR.
+- Verify URLs, relay endpoints, secrets, and bindings against `wrangler.toml` and the relevant docs before changing them. Do not hardcode environment-specific domains or secrets in application code.
+
+## Security & Operational Notes
+- Never commit secrets, API tokens, private keys, Cloudflare Access credentials, or screenshots/logs containing sensitive values.
+- Public issues, PRs, branch names, screenshots, and descriptions must not mention corporate partners, customers, brands, campaign names, or other sensitive external identities unless a maintainer explicitly approves it. Use generic descriptors instead.
+- Be explicit about any changes that affect moderation outcomes, quarantine decisions, admin auth, or relay publishing behavior.
+
+## Pull Request Guardrails
+- PR titles must use Conventional Commit format: `type(scope): summary` or `type: summary`.
+- Set the correct PR title when opening the PR. Do not rely on fixing it later.
+- If a PR title is edited after opening, verify that the semantic PR title check reruns successfully.
+- Keep PRs tightly scoped. Do not include unrelated formatting churn, dependency noise, or drive-by refactors.
+- Temporary or transitional code must include `TODO(#issue):` with a tracking issue.
+- UI, admin, or externally visible API behavior changes should include screenshots, sample payloads, or an explicit note that there is no visual change.
+- PR descriptions must include a summary, motivation, linked issue, and manual validation plan.
+- Before requesting review, run the relevant checks for the files you changed, or note what you could not run.


### PR DESCRIPTION
## Summary
- add repo-local contributor and agent guardrails in AGENTS.md
- add semantic PR title enforcement plus PR and issue templates
- reinforce redaction of sensitive external names in public repo artifacts

## Motivation
- make repo-local contribution expectations explicit for humans and AI agents
- align this repo with the org standard without duplicating existing moderation docs

## Validation
- not run; docs and GitHub metadata changes only