### PR TITLE
Gate Hive AI detection and add reporting dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ cost-projections-internal.md
 .claude/worktrees/
 .playwright-mcp/
 tmp/
+.superpowers/

--- a/docs/superpowers/plans/2026-05-03-ai-detection-reporting-plan.md
+++ b/docs/superpowers/plans/2026-05-03-ai-detection-reporting-plan.md
@@ -1,0 +1,761 @@
+# AI Detection Reporting Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build durable AI-detection policy reporting and an admin dashboard panel for ProofMode cost savings and AI-report moderation work.
+
+**Architecture:** Add a small D1 ledger module for AI-detection events, then expose aggregated admin stats from that ledger. Existing report and moderation paths write compact events; the existing dashboard reads a new admin endpoint and renders the reporting band.
+
+**Tech Stack:** Cloudflare Worker, D1, Vitest, plain admin HTML/JS, existing moderation pipeline modules.
+
+---
+
+## File Structure
+
+- Create `migrations/006-ai-detection-events.sql`: production D1 table, uniqueness, and indexes.
+- Create `src/moderation/ai-detection-events.mjs`: table init, event recording, event builders, stats aggregation.
+- Create `src/moderation/ai-detection-events.test.mjs`: focused TDD coverage for idempotent writes and stats.
+- Modify `src/index.mjs`: initialize table, write events from report and queue paths, add `/admin/api/ai-detection/stats`.
+- Modify `src/index.test.mjs`: route and report-trigger coverage.
+- Modify `src/moderation/ai-detection-policy.mjs`: expose a policy reason helper instead of only booleans.
+- Modify `src/moderation/ai-detection-policy.test.mjs`: policy reason coverage.
+- Modify `src/moderation/pipeline.mjs`: include AI-detection policy metadata in results.
+- Modify `src/moderation/pipeline.test.mjs`: verify result metadata for skip, run, and forced cases.
+- Modify `src/admin/dashboard.html`: add the AI detection reporting panel and fetch logic.
+- Modify `src/admin/dashboard-ui.test.mjs`: static dashboard hook coverage.
+
+## Chunk 1: Ledger Module And Migration
+
+### Task 1: Add the D1 schema
+
+**Files:**
+- Create: `migrations/006-ai-detection-events.sql`
+
+- [ ] **Step 1: Write migration**
+
+```sql
+CREATE TABLE IF NOT EXISTS ai_detection_events (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  event_key TEXT NOT NULL UNIQUE,
+  sha256 TEXT NOT NULL,
+  event_type TEXT NOT NULL,
+  policy_reason TEXT,
+  c2pa_state TEXT,
+  ai_detection_ran INTEGER NOT NULL DEFAULT 0,
+  ai_detection_forced INTEGER NOT NULL DEFAULT 0,
+  ai_score REAL,
+  action TEXT,
+  report_type TEXT,
+  metadata_json TEXT,
+  created_at TEXT DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_ai_detection_events_created_at ON ai_detection_events(created_at);
+CREATE INDEX IF NOT EXISTS idx_ai_detection_events_sha256 ON ai_detection_events(sha256);
+CREATE INDEX IF NOT EXISTS idx_ai_detection_events_type ON ai_detection_events(event_type);
+CREATE INDEX IF NOT EXISTS idx_ai_detection_events_reason ON ai_detection_events(policy_reason);
+```
+
+- [ ] **Step 2: Do not apply production migration yet**
+
+Production migration should be applied after code tests pass and before deploy:
+
+```bash
+npx wrangler d1 migrations apply blossom-webhook-events --remote
+```
+
+Expected later: migration `006-ai-detection-events.sql` applies cleanly.
+
+### Task 2: Write failing ledger tests
+
+**Files:**
+- Create: `src/moderation/ai-detection-events.test.mjs`
+- Create: `src/moderation/ai-detection-events.mjs`
+
+- [ ] **Step 1: Write failing tests**
+
+Test cases:
+
+```js
+import { beforeEach, describe, expect, it } from 'vitest';
+import { env } from 'cloudflare:test';
+import {
+  initAIDetectionEventsTable,
+  recordAIDetectionEvent,
+  getAIDetectionStats,
+} from './ai-detection-events.mjs';
+
+describe('AI detection event ledger', () => {
+  beforeEach(async () => {
+    await initAIDetectionEventsTable(env.BLOSSOM_DB);
+    await env.BLOSSOM_DB.prepare('DELETE FROM ai_detection_events').run();
+  });
+
+  it('records events idempotently by event_key', async () => {
+    const event = {
+      eventKey: 'policy:abc:1',
+      sha256: 'a'.repeat(64),
+      eventType: 'policy_decision',
+      policyReason: 'valid_proofmode_skip',
+      c2paState: 'valid_proofmode',
+      aiDetectionRan: false,
+      aiDetectionForced: false,
+      createdAt: '2026-05-03T00:00:00.000Z',
+    };
+
+    await recordAIDetectionEvent(env.BLOSSOM_DB, event);
+    await recordAIDetectionEvent(env.BLOSSOM_DB, event);
+
+    const row = await env.BLOSSOM_DB.prepare(
+      'SELECT COUNT(*) AS cnt FROM ai_detection_events'
+    ).first();
+    expect(row.cnt).toBe(1);
+  });
+
+  it('aggregates runs, skips, forced reports, review outcomes, and estimated savings', async () => {
+    await recordAIDetectionEvent(env.BLOSSOM_DB, {
+      eventKey: 'policy:skip',
+      sha256: 'b'.repeat(64),
+      eventType: 'policy_decision',
+      policyReason: 'valid_proofmode_skip',
+      c2paState: 'valid_proofmode',
+      aiDetectionRan: false,
+      aiDetectionForced: false,
+      createdAt: '2026-05-03T00:10:00.000Z',
+    });
+    await recordAIDetectionEvent(env.BLOSSOM_DB, {
+      eventKey: 'policy:run',
+      sha256: 'c'.repeat(64),
+      eventType: 'policy_decision',
+      policyReason: 'no_proof_ai_detection',
+      c2paState: 'absent',
+      aiDetectionRan: true,
+      aiDetectionForced: false,
+      createdAt: '2026-05-03T00:11:00.000Z',
+    });
+    await recordAIDetectionEvent(env.BLOSSOM_DB, {
+      eventKey: 'report:forced',
+      sha256: 'd'.repeat(64),
+      eventType: 'user_report',
+      policyReason: 'report_forced_ai_detection',
+      aiDetectionRan: false,
+      aiDetectionForced: true,
+      reportType: 'ai_generated',
+      createdAt: '2026-05-03T00:12:00.000Z',
+    });
+    await recordAIDetectionEvent(env.BLOSSOM_DB, {
+      eventKey: 'outcome:review',
+      sha256: 'd'.repeat(64),
+      eventType: 'moderation_outcome',
+      policyReason: 'proofmode_ai_downgrade',
+      c2paState: 'valid_proofmode',
+      aiDetectionRan: true,
+      aiDetectionForced: true,
+      aiScore: 0.97,
+      action: 'REVIEW',
+      createdAt: '2026-05-03T00:13:00.000Z',
+    });
+
+    const stats = await getAIDetectionStats(env.BLOSSOM_DB, {
+      window: '24h',
+      now: new Date('2026-05-03T01:00:00.000Z'),
+      estimatedCostCents: 65,
+    });
+
+    expect(stats.totals.aiDetectionRuns).toBe(1);
+    expect(stats.totals.aiDetectionSkips).toBe(1);
+    expect(stats.totals.proofModeSkips).toBe(1);
+    expect(stats.totals.reportForcedChecks).toBe(1);
+    expect(stats.totals.openReviewItems).toBe(1);
+    expect(stats.estimatedSpendAvoidedCents).toBe(65);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+```bash
+npx vitest run --dir src moderation/ai-detection-events.test.mjs
+```
+
+Expected: FAIL because `ai-detection-events.mjs` exports do not exist or are not implemented.
+
+### Task 3: Implement the ledger module
+
+**Files:**
+- Modify: `src/moderation/ai-detection-events.mjs`
+
+- [ ] **Step 1: Implement minimal module**
+
+Core exports:
+
+```js
+export async function initAIDetectionEventsTable(db) { /* CREATE TABLE + indexes */ }
+export async function recordAIDetectionEvent(db, event) { /* INSERT OR IGNORE */ }
+export function parseAIDetectionStatsWindow(value) { /* 24h, 7d, 30d, all */ }
+export async function getAIDetectionStats(db, options = {}) { /* aggregates */ }
+```
+
+Implementation notes:
+
+- Store booleans as `0` or `1`.
+- Serialize only compact metadata into `metadata_json`.
+- Use `INSERT OR IGNORE` on `event_key`.
+- Use `SUM(CASE WHEN ... THEN 1 ELSE 0 END)` for D1 compatibility.
+- For `window !== 'all'`, bind a cutoff ISO timestamp.
+
+- [ ] **Step 2: Run tests to verify GREEN**
+
+```bash
+npx vitest run --dir src moderation/ai-detection-events.test.mjs
+```
+
+Expected: PASS.
+
+## Chunk 2: Policy Metadata In Pipeline Results
+
+### Task 4: Extend AI-detection policy helper
+
+**Files:**
+- Modify: `src/moderation/ai-detection-policy.mjs`
+- Modify: `src/moderation/ai-detection-policy.test.mjs`
+
+- [ ] **Step 1: Write failing policy tests**
+
+Add expectations for a new helper:
+
+```js
+import { getAIDetectionPolicyDecision } from './ai-detection-policy.mjs';
+
+expect(getAIDetectionPolicyDecision({
+  c2pa: { state: 'valid_proofmode' },
+  metadata: {},
+  originalVine: false,
+})).toMatchObject({
+  aiDetectionAllowed: false,
+  policyReason: 'valid_proofmode_skip',
+});
+
+expect(getAIDetectionPolicyDecision({
+  c2pa: { state: 'valid_proofmode' },
+  metadata: { forceAIDetection: true },
+  originalVine: false,
+})).toMatchObject({
+  aiDetectionAllowed: true,
+  aiDetectionForced: true,
+  policyReason: 'report_forced_ai_detection',
+});
+```
+
+- [ ] **Step 2: Run RED**
+
+```bash
+npx vitest run --dir src moderation/ai-detection-policy.test.mjs
+```
+
+Expected: FAIL because the new helper is absent.
+
+- [ ] **Step 3: Implement helper**
+
+Return a small object:
+
+```js
+{
+  aiDetectionAllowed: boolean,
+  aiDetectionForced: boolean,
+  policyReason: 'valid_proofmode_skip' | 'report_forced_ai_detection' | 'original_vine_skip' | 'no_proof_ai_detection' | 'provenance_present_ai_detection',
+}
+```
+
+Keep existing `shouldForceAIDetection` and `proofModeSkipsAIDetection` exports for compatibility.
+
+- [ ] **Step 4: Run GREEN**
+
+```bash
+npx vitest run --dir src moderation/ai-detection-policy.test.mjs
+```
+
+Expected: PASS.
+
+### Task 5: Attach policy metadata to moderation results
+
+**Files:**
+- Modify: `src/moderation/pipeline.mjs`
+- Modify: `src/moderation/pipeline.test.mjs`
+
+- [ ] **Step 1: Write failing pipeline tests**
+
+Extend existing ProofMode/no-proof tests to assert:
+
+```js
+expect(result.aiDetectionPolicy).toMatchObject({
+  aiDetectionAllowed: false,
+  aiDetectionForced: false,
+  policyReason: 'valid_proofmode_skip',
+});
+```
+
+For forced report case:
+
+```js
+expect(result.aiDetectionPolicy).toMatchObject({
+  aiDetectionAllowed: true,
+  aiDetectionForced: true,
+  policyReason: 'report_forced_ai_detection',
+});
+```
+
+- [ ] **Step 2: Run RED**
+
+```bash
+npx vitest run --dir src moderation/pipeline.test.mjs -t "C2PA / ProofMode enforcement"
+```
+
+Expected: FAIL because `result.aiDetectionPolicy` is absent.
+
+- [ ] **Step 3: Implement result metadata**
+
+In `moderateVideo`, compute the policy decision after C2PA verification and include it in the returned result:
+
+```js
+const aiDetectionPolicy = {
+  ...getAIDetectionPolicyDecision({ c2pa, metadata, originalVine: originalVineSkipsAIDetection }),
+  c2paState: c2pa.state,
+};
+```
+
+After provider response, include actual result booleans:
+
+```js
+aiDetectionPolicy.aiDetectionRan = !!moderationResult.raw?.aiDetection;
+aiDetectionPolicy.aiDetectionSkipped = moderationResult.raw?.skippedAIDetection === true;
+```
+
+For `valid_ai_signed` short circuit, include:
+
+```js
+aiDetectionPolicy: {
+  aiDetectionAllowed: false,
+  aiDetectionForced: false,
+  aiDetectionRan: false,
+  aiDetectionSkipped: true,
+  policyReason: 'valid_ai_signed_skip',
+  c2paState: 'valid_ai_signed',
+}
+```
+
+- [ ] **Step 4: Run GREEN**
+
+```bash
+npx vitest run --dir src moderation/pipeline.test.mjs -t "C2PA / ProofMode enforcement"
+```
+
+Expected: PASS.
+
+## Chunk 3: Event Writes From Reports And Moderation
+
+### Task 6: Build event objects
+
+**Files:**
+- Modify: `src/moderation/ai-detection-events.mjs`
+- Modify: `src/moderation/ai-detection-events.test.mjs`
+
+- [ ] **Step 1: Write failing builder tests**
+
+Add tests for:
+
+```js
+buildAIReportEvent({ sha256, reportType, createdAt })
+buildAIPolicyDecisionEvent({ sha256, uploadedAt, result })
+buildAIOutcomeEvent({ sha256, uploadedAt, result })
+```
+
+Expected outputs should include stable `eventKey` and compact fields.
+
+- [ ] **Step 2: Run RED**
+
+```bash
+npx vitest run --dir src moderation/ai-detection-events.test.mjs
+```
+
+Expected: FAIL because builders are absent.
+
+- [ ] **Step 3: Implement builders**
+
+Rules:
+
+- Report event key: `report:${sha256}:${reportType}:${createdAt}`
+- Policy event key: `policy:${sha256}:${uploadedAt}:${forceFlag}`
+- Outcome event key: `outcome:${sha256}:${uploadedAt}:${action}:${policyReason}`
+- Outcome `policyReason` becomes `proofmode_ai_downgrade` when `result.policyContext?.overrideReason === 'proofmode-capture-authenticated'`.
+
+- [ ] **Step 4: Run GREEN**
+
+```bash
+npx vitest run --dir src moderation/ai-detection-events.test.mjs
+```
+
+Expected: PASS.
+
+### Task 7: Write events from `/api/v1/report`
+
+**Files:**
+- Modify: `src/index.mjs`
+- Modify: `src/index.test.mjs`
+
+- [ ] **Step 1: Write failing route test**
+
+Extend the existing "queues a forced AI recheck" test to use a DB mock that captures SQL inserts into `ai_detection_events`, then assert one event is written when `report_type` is `ai_generated`.
+
+Expected event:
+
+```js
+expect(insertedEvent).toMatchObject({
+  event_type: 'user_report',
+  policy_reason: 'report_forced_ai_detection',
+  ai_detection_forced: 1,
+  report_type: 'ai_generated',
+});
+```
+
+- [ ] **Step 2: Run RED**
+
+```bash
+npx vitest run --dir src index.test.mjs -t "queues a forced AI recheck"
+```
+
+Expected: FAIL because no ledger event is written.
+
+- [ ] **Step 3: Implement route write**
+
+Import:
+
+```js
+import { initAIDetectionEventsTable, recordAIDetectionEvent, buildAIReportEvent } from './moderation/ai-detection-events.mjs';
+```
+
+Initialize the table next to `initReportsTable`.
+
+After successful AI report enqueue, call:
+
+```js
+await recordAIDetectionEvent(env.BLOSSOM_DB, buildAIReportEvent({
+  sha256,
+  reportType: report_type,
+  createdAt: new Date().toISOString(),
+}));
+```
+
+If the ledger write fails, log the error but do not fail the user report.
+
+- [ ] **Step 4: Run GREEN**
+
+```bash
+npx vitest run --dir src index.test.mjs -t "queues a forced AI recheck"
+```
+
+Expected: PASS.
+
+### Task 8: Write events from queue moderation results
+
+**Files:**
+- Modify: `src/index.mjs`
+- Modify: `src/moderation/ai-detection-events.test.mjs`
+
+- [ ] **Step 1: Write failing helper test**
+
+Add a test that builds policy and outcome events from a forced ProofMode `REVIEW` result and verifies:
+
+```js
+expect(policy.eventType).toBe('policy_decision');
+expect(policy.aiDetectionForced).toBe(true);
+expect(outcome.eventType).toBe('moderation_outcome');
+expect(outcome.policyReason).toBe('proofmode_ai_downgrade');
+expect(outcome.action).toBe('REVIEW');
+```
+
+- [ ] **Step 2: Run RED**
+
+```bash
+npx vitest run --dir src moderation/ai-detection-events.test.mjs
+```
+
+Expected: FAIL until builders support outcome downgrade logic.
+
+- [ ] **Step 3: Implement queue writes**
+
+After the moderation result has been stored in `moderation_results`, record:
+
+```js
+await recordAIDetectionEvent(env.BLOSSOM_DB, buildAIPolicyDecisionEvent({
+  sha256,
+  uploadedAt,
+  result,
+}));
+
+await recordAIDetectionEvent(env.BLOSSOM_DB, buildAIOutcomeEvent({
+  sha256,
+  uploadedAt,
+  result,
+}));
+```
+
+Wrap each in a non-fatal try/catch. Moderation must continue even if reporting fails.
+
+- [ ] **Step 4: Run targeted tests**
+
+```bash
+npx vitest run --dir src moderation/ai-detection-events.test.mjs moderation/pipeline.test.mjs index.test.mjs -t "AI detection|ProofMode|queues a forced AI recheck"
+```
+
+Expected: PASS.
+
+## Chunk 4: Admin Stats Endpoint
+
+### Task 9: Add endpoint tests
+
+**Files:**
+- Modify: `src/index.test.mjs`
+
+- [ ] **Step 1: Write failing auth test**
+
+```js
+const response = await worker.fetch(
+  new Request('https://moderation.admin.divine.video/admin/api/ai-detection/stats'),
+  createEnv()
+);
+expect(response.status).toBe(401);
+```
+
+- [ ] **Step 2: Write failing success test**
+
+Use a DB mock that returns aggregate rows and assert:
+
+```js
+expect(response.status).toBe(200);
+await expect(response.json()).resolves.toMatchObject({
+  window: '24h',
+  totals: {
+    aiDetectionRuns: 1,
+    proofModeSkips: 1,
+    reportForcedChecks: 1,
+  },
+});
+```
+
+- [ ] **Step 3: Run RED**
+
+```bash
+npx vitest run --dir src index.test.mjs -t "ai-detection/stats"
+```
+
+Expected: FAIL because the route does not exist.
+
+### Task 10: Implement endpoint
+
+**Files:**
+- Modify: `src/index.mjs`
+
+- [ ] **Step 1: Add route**
+
+Place near `/admin/api/stats`:
+
+```js
+if (url.pathname === '/admin/api/ai-detection/stats') {
+  const authError = await requireAuth(request, env);
+  if (authError) return authError;
+
+  const stats = await getAIDetectionStats(env.BLOSSOM_DB, {
+    window: url.searchParams.get('window') || '24h',
+    estimatedCostCents: Number(env.HIVE_AI_DETECTION_ESTIMATED_COST_CENTS || 0) || null,
+  });
+
+  return new Response(JSON.stringify(stats), { headers: JSON_HEADERS });
+}
+```
+
+- [ ] **Step 2: Run GREEN**
+
+```bash
+npx vitest run --dir src index.test.mjs -t "ai-detection/stats"
+```
+
+Expected: PASS.
+
+## Chunk 5: Dashboard Panel
+
+### Task 11: Add dashboard hook tests
+
+**Files:**
+- Modify: `src/admin/dashboard-ui.test.mjs`
+
+- [ ] **Step 1: Write failing static tests**
+
+Assert dashboard contains:
+
+```js
+expect(dashboardHTML).toContain('ai-detection-panel');
+expect(dashboardHTML).toContain('/admin/api/ai-detection/stats');
+expect(dashboardHTML).toContain('loadAIDetectionStats');
+expect(dashboardHTML).toContain('AI Detection');
+expect(dashboardHTML).toContain('Estimated spend avoided');
+```
+
+- [ ] **Step 2: Run RED**
+
+```bash
+npx vitest run --dir src admin/dashboard-ui.test.mjs
+```
+
+Expected: FAIL because panel hooks are absent.
+
+### Task 12: Implement dashboard panel
+
+**Files:**
+- Modify: `src/admin/dashboard.html`
+
+- [ ] **Step 1: Add HTML band**
+
+Add near existing stat cards:
+
+```html
+<section id="ai-detection-panel" class="ai-detection-panel">
+  <div class="section-header">
+    <h2>AI Detection</h2>
+    <select id="ai-detection-window" onchange="loadAIDetectionStats()">
+      <option value="24h">24h</option>
+      <option value="7d">7d</option>
+      <option value="30d">30d</option>
+      <option value="all">All</option>
+    </select>
+  </div>
+  <div class="ai-detection-cards">
+    <div class="stat-card"><div class="stat-label">AI runs</div><div id="ai-detection-runs" class="stat-value">-</div></div>
+    <div class="stat-card"><div class="stat-label">AI skipped</div><div id="ai-detection-skips" class="stat-value">-</div></div>
+    <div class="stat-card"><div class="stat-label">ProofMode skips</div><div id="ai-proofmode-skips" class="stat-value">-</div></div>
+    <div class="stat-card"><div class="stat-label">Report-forced</div><div id="ai-report-forced" class="stat-value">-</div></div>
+    <div class="stat-card"><div class="stat-label">Estimated spend avoided</div><div id="ai-spend-avoided" class="stat-value">-</div></div>
+  </div>
+  <div id="ai-detection-breakdown"></div>
+  <div id="ai-detection-review-slice"></div>
+</section>
+```
+
+- [ ] **Step 2: Add JS fetch/render function**
+
+```js
+async function loadAIDetectionStats() {
+  const windowValue = document.getElementById('ai-detection-window')?.value || '24h';
+  const response = await fetch('/admin/api/ai-detection/stats?window=' + encodeURIComponent(windowValue));
+  if (!response.ok) throw new Error('AI detection stats failed');
+  const stats = await response.json();
+  document.getElementById('ai-detection-runs').textContent = (stats.totals?.aiDetectionRuns || 0).toLocaleString();
+  document.getElementById('ai-detection-skips').textContent = (stats.totals?.aiDetectionSkips || 0).toLocaleString();
+  document.getElementById('ai-proofmode-skips').textContent = (stats.totals?.proofModeSkips || 0).toLocaleString();
+  document.getElementById('ai-report-forced').textContent = (stats.totals?.reportForcedChecks || 0).toLocaleString();
+  document.getElementById('ai-spend-avoided').textContent = formatEstimatedSpend(stats.estimatedSpendAvoidedCents);
+}
+```
+
+Call `loadAIDetectionStats()` from the same startup path as `loadRealStats()`.
+
+- [ ] **Step 3: Run GREEN**
+
+```bash
+npx vitest run --dir src admin/dashboard-ui.test.mjs
+```
+
+Expected: PASS.
+
+## Chunk 6: Verification, Migration, Deploy
+
+### Task 13: Run focused verification
+
+- [ ] **Step 1: Run focused tests**
+
+```bash
+npx vitest run --dir src moderation/ai-detection-events.test.mjs moderation/ai-detection-policy.test.mjs moderation/pipeline.test.mjs index.test.mjs admin/dashboard-ui.test.mjs
+```
+
+Expected: all selected files pass.
+
+- [ ] **Step 2: Run lint**
+
+```bash
+npm run lint
+```
+
+Expected: lint passes.
+
+- [ ] **Step 3: Run full source suite**
+
+```bash
+npx vitest run --dir src
+```
+
+Expected: all source tests pass.
+
+### Task 14: Apply D1 migration
+
+- [ ] **Step 1: Apply remote migration**
+
+```bash
+npx wrangler d1 migrations apply blossom-webhook-events --remote
+```
+
+Expected: migration `006-ai-detection-events.sql` applies successfully.
+
+- [ ] **Step 2: Verify table exists**
+
+```bash
+npx wrangler d1 execute blossom-webhook-events --remote --command "SELECT COUNT(*) AS cnt FROM ai_detection_events"
+```
+
+Expected: returns one row with `cnt`.
+
+### Task 15: Deploy and smoke test
+
+- [ ] **Step 1: Deploy**
+
+```bash
+npm run deploy
+```
+
+Expected: Wrangler reports a new version ID and routes for both production hostnames.
+
+- [ ] **Step 2: Smoke test public API**
+
+```bash
+curl -sS -i --max-time 10 https://moderation-api.divine.video/ | sed -n '1,20p'
+```
+
+Expected: HTTP 200.
+
+- [ ] **Step 3: Smoke test admin endpoint with Zero Trust context if available**
+
+Use browser or authenticated request to:
+
+```text
+https://moderation.admin.divine.video/admin/api/ai-detection/stats?window=24h
+```
+
+Expected: JSON response for authenticated admin, 401/Access challenge for unauthenticated request.
+
+### Task 16: Commit implementation
+
+- [ ] **Step 1: Check status**
+
+```bash
+git status --short
+```
+
+Expected: only intended files changed, plus pre-existing unrelated untracked files remain untouched.
+
+- [ ] **Step 2: Commit intended implementation files only**
+
+```bash
+git add migrations/006-ai-detection-events.sql src/moderation/ai-detection-events.mjs src/moderation/ai-detection-events.test.mjs src/moderation/ai-detection-policy.mjs src/moderation/ai-detection-policy.test.mjs src/moderation/pipeline.mjs src/moderation/pipeline.test.mjs src/index.mjs src/index.test.mjs src/admin/dashboard.html src/admin/dashboard-ui.test.mjs docs/superpowers/plans/2026-05-03-ai-detection-reporting-plan.md
+git commit -m "feat: add ai detection reporting dashboard"
+```
+
+Expected: commit succeeds without staging unrelated files.

--- a/docs/superpowers/specs/2026-05-03-ai-detection-reporting-design.md
+++ b/docs/superpowers/specs/2026-05-03-ai-detection-reporting-design.md
@@ -1,0 +1,174 @@
+# AI Detection Reporting And Audit Ledger
+
+**Date:** 2026-05-03
+**Status:** Approved
+**Scope:** admin reporting for ProofMode AI-detection cost control and moderation review visibility in `divine-moderation-service`
+
+## Problem
+
+The service now avoids paid Hive AI detection when a video has valid ProofMode provenance, unless a user reports it as AI-generated. That change protects spend, but the moderation team cannot yet answer the obvious operational questions:
+
+- How many paid AI checks are still running?
+- How many checks did ProofMode or signed AI provenance avoid?
+- How many user AI reports forced rechecks?
+- Which forced rechecks need human review?
+- What is the estimated spend avoided after the policy change?
+
+The current admin dashboard has global moderation stats, but it does not expose the AI-detection policy path or record enough durable audit data to trend the new behavior.
+
+## User Intent
+
+Build both:
+
+- a dedicated admin dashboard panel that shows cost and moderation operations at a glance
+- a durable D1 ledger that records policy decisions and outcomes going forward
+
+The first version should be useful quickly and not block content visibility. Valid ProofMode content that is AI-flagged after a report should remain visible and go to human `REVIEW`.
+
+## Design
+
+Add a small AI-detection reporting subsystem alongside the existing admin stats.
+
+### Source Of Truth
+
+Use D1 as the reporting source of truth for policy events recorded after this feature ships.
+
+Existing tables stay in place:
+
+- `moderation_results` remains the source of final moderation action and scores.
+- `user_reports` remains the source of user reports and unique reporter counts.
+
+Add one append-only ledger table:
+
+- `ai_detection_events` records policy decisions, user-report triggers, and moderation outcomes.
+
+The dashboard should label exact ledger metrics as "since enabled". Any derived historical number from older `moderation_results` or `user_reports` must be clearly labeled as derived, because older rows do not prove whether Hive AI detection was skipped by ProofMode at the time.
+
+### Ledger Events
+
+Record three event types:
+
+- `policy_decision`: paid AI detection ran or skipped, and why.
+- `user_report`: an AI/deepfake/synthetic report triggered a forced AI recheck.
+- `moderation_outcome`: final moderation action, AI score, C2PA state, and whether ProofMode downgraded an AI hide decision to `REVIEW`.
+
+Important fields:
+
+- `sha256`
+- `event_type`
+- `policy_reason`
+- `c2pa_state`
+- `ai_detection_ran`
+- `ai_detection_forced`
+- `ai_score`
+- `action`
+- `report_type`
+- `metadata_json`
+- `created_at`
+
+Do not duplicate reporter private details into the ledger. The existing `user_reports` table already stores reporter pubkeys when needed for report workflow.
+
+### Deduplication
+
+Queue retries can run the same unit of work more than once. Ledger writes should include an idempotency key where possible:
+
+- report-trigger events: `report:<sha256>:<report_type>:<created_at-or-existing-report-id-if-available>`
+- policy/outcome events: `moderation:<sha256>:<uploadedAt>:<forceFlag>:<event_type>`
+
+If an exact key already exists, ignore the duplicate. Counts should use the ledger rows, not logs.
+
+### Dashboard API
+
+Add an admin-only endpoint:
+
+`GET /admin/api/ai-detection/stats?window=24h`
+
+Return:
+
+- top-level counts: AI runs, AI skips, ProofMode skips, signed-AI skips, forced report checks, open review items
+- estimated spend avoided if an estimated per-check cost is configured
+- policy breakdown by reason
+- review breakdown for report-forced and ProofMode-downgraded items
+- recent open review rows with `sha256`, action, C2PA state, AI score, report count, and age
+
+Window support should start simple:
+
+- `24h`
+- `7d`
+- `30d`
+- `all`
+
+### Cost Estimate
+
+The dashboard should always show raw counts. Dollar estimates should be optional and clearly marked as estimated.
+
+Use a config value such as `HIVE_AI_DETECTION_ESTIMATED_COST_CENTS` or leave the cost field null when not configured. This avoids hard-coding vendor pricing into application behavior.
+
+### Dashboard UI
+
+Add a dedicated band to `src/admin/dashboard.html`, near the existing stat cards.
+
+Cards:
+
+- AI detection runs
+- AI detection skipped
+- ProofMode skips
+- report-forced rechecks
+- open AI review items
+- estimated spend avoided
+
+Below the cards:
+
+- a policy breakdown table
+- a review queue slice linking into existing video review actions
+
+The panel should reuse the existing admin dashboard style and fetch data from the new endpoint. If the endpoint fails, show a small error state and leave the rest of the dashboard usable.
+
+### Moderation Flow Writes
+
+Write ledger events in these paths:
+
+- `/api/v1/report`: when an AI/deepfake/synthetic report queues a forced AI recheck.
+- queue consumer / `moderateVideo`: when the policy decides whether Hive AI detection should run.
+- `handleModerationResult` or the queue consumer after the D1 result write: when final action and score are known.
+
+The policy helper should expose enough information for reporting without re-deriving the reason in multiple places.
+
+### Review Semantics
+
+Keep the current product behavior:
+
+- Valid ProofMode skips paid AI detection by default.
+- AI reports force AI detection.
+- If forced AI detection flags valid ProofMode content as AI-generated or deepfake, the action stays `REVIEW`, not hidden.
+- `REVIEW` is internal and does not restrict Blossom serving.
+
+The dashboard should make those cases visible to moderators.
+
+## Non-Goals
+
+- No exact backfill of skipped AI detections before the ledger exists.
+- No vendor billing reconciliation in this feature.
+- No new moderation action type.
+- No separate standalone dashboard app.
+- No exposure of reporter private details in the reporting panel.
+
+## Testing
+
+Add coverage for:
+
+- initializing the `ai_detection_events` table and indexes
+- inserting idempotent ledger events
+- reporting AI policy counts for `24h`, `7d`, `30d`, and `all`
+- `/api/v1/report` writing a user-report ledger event for AI reports
+- queue/pipeline writing policy and outcome events for ProofMode skip, no-proof run, and forced report recheck
+- `/admin/api/ai-detection/stats` requiring admin auth
+- dashboard HTML containing the new panel hooks and using the new endpoint
+
+## Rollout
+
+1. Add and apply D1 migration.
+2. Deploy ledger writes and dashboard endpoint.
+3. Deploy dashboard UI.
+4. Verify counts start populating from new queue traffic.
+5. Tune the optional estimated cost config after real Hive pricing is confirmed.

--- a/migrations/006-ai-detection-events.sql
+++ b/migrations/006-ai-detection-events.sql
@@ -1,0 +1,21 @@
+-- Track AI-detection policy decisions and outcomes for cost and moderation reporting.
+CREATE TABLE IF NOT EXISTS ai_detection_events (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  event_key TEXT NOT NULL UNIQUE,
+  sha256 TEXT NOT NULL,
+  event_type TEXT NOT NULL,
+  policy_reason TEXT,
+  c2pa_state TEXT,
+  ai_detection_ran INTEGER NOT NULL DEFAULT 0,
+  ai_detection_forced INTEGER NOT NULL DEFAULT 0,
+  ai_score REAL,
+  action TEXT,
+  report_type TEXT,
+  metadata_json TEXT,
+  created_at TEXT DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_ai_detection_events_created_at ON ai_detection_events(created_at);
+CREATE INDEX IF NOT EXISTS idx_ai_detection_events_sha256 ON ai_detection_events(sha256);
+CREATE INDEX IF NOT EXISTS idx_ai_detection_events_type ON ai_detection_events(event_type);
+CREATE INDEX IF NOT EXISTS idx_ai_detection_events_reason ON ai_detection_events(policy_reason);

--- a/src/admin/dashboard-ui.test.mjs
+++ b/src/admin/dashboard-ui.test.mjs
@@ -21,4 +21,12 @@ describe('dashboard provenance UI hooks', () => {
     expect(dashboardHTML).toContain('Invalid Proof');
     expect(dashboardHTML).toContain('c2pa-badge');
   });
+
+  it('contains AI detection reporting panel hooks', () => {
+    expect(dashboardHTML).toContain('ai-detection-panel');
+    expect(dashboardHTML).toContain('/admin/api/ai-detection/stats');
+    expect(dashboardHTML).toContain('loadAIDetectionStats');
+    expect(dashboardHTML).toContain('AI Detection');
+    expect(dashboardHTML).toContain('Estimated spend avoided');
+  });
 });

--- a/src/admin/dashboard.html
+++ b/src/admin/dashboard.html
@@ -73,6 +73,85 @@
       margin-top: 5px;
     }
 
+    .ai-detection-panel {
+      background: #10141d;
+      border: 1px solid #24324a;
+      border-radius: 8px;
+      padding: 16px;
+      margin: 18px 0 20px;
+    }
+
+    .ai-detection-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 12px;
+      margin-bottom: 14px;
+      flex-wrap: wrap;
+    }
+
+    .ai-detection-header h2 {
+      font-size: 18px;
+      color: #f8fafc;
+      margin: 0;
+    }
+
+    .ai-detection-summary {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(145px, 1fr));
+      gap: 10px;
+      margin-bottom: 14px;
+    }
+
+    .ai-detection-card {
+      background: #151b27;
+      border: 1px solid #263247;
+      border-radius: 8px;
+      padding: 12px;
+    }
+
+    .ai-detection-card .stat-value {
+      font-size: 22px;
+    }
+
+    .ai-detection-details {
+      display: grid;
+      grid-template-columns: minmax(260px, 1fr) minmax(260px, 1fr);
+      gap: 12px;
+    }
+
+    @media (max-width: 900px) {
+      .ai-detection-details {
+        grid-template-columns: 1fr;
+      }
+    }
+
+    .ai-detection-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 12px;
+    }
+
+    .ai-detection-table th,
+    .ai-detection-table td {
+      border-bottom: 1px solid #263247;
+      padding: 7px 4px;
+      text-align: left;
+    }
+
+    .ai-detection-table th {
+      color: #94a3b8;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      font-size: 10px;
+    }
+
+    .ai-detection-muted {
+      color: #94a3b8;
+      font-size: 12px;
+    }
+
     .controls {
       display: flex;
       gap: 15px;
@@ -1847,6 +1926,62 @@
     </div>
   </div>
 
+  <section class="ai-detection-panel" id="ai-detection-panel">
+    <div class="ai-detection-header">
+      <div>
+        <h2>AI Detection</h2>
+        <div class="ai-detection-muted">Ledger-backed reporting for paid AI checks, ProofMode skips, and report-forced review work.</div>
+      </div>
+      <div class="control-group" style="margin: 0;">
+        <label for="ai-detection-window">Window</label>
+        <select id="ai-detection-window" onchange="loadAIDetectionStats()">
+          <option value="24h">24h</option>
+          <option value="7d">7d</option>
+          <option value="30d">30d</option>
+          <option value="all">All</option>
+        </select>
+      </div>
+    </div>
+
+    <div class="ai-detection-summary">
+      <div class="ai-detection-card">
+        <div class="stat-label">AI runs</div>
+        <div class="stat-value" id="ai-detection-runs">-</div>
+      </div>
+      <div class="ai-detection-card">
+        <div class="stat-label">AI skipped</div>
+        <div class="stat-value" id="ai-detection-skips">-</div>
+      </div>
+      <div class="ai-detection-card">
+        <div class="stat-label">ProofMode skips</div>
+        <div class="stat-value" id="ai-proofmode-skips">-</div>
+      </div>
+      <div class="ai-detection-card">
+        <div class="stat-label">Report-forced</div>
+        <div class="stat-value" id="ai-report-forced">-</div>
+      </div>
+      <div class="ai-detection-card">
+        <div class="stat-label">Open review</div>
+        <div class="stat-value" id="ai-open-review">-</div>
+      </div>
+      <div class="ai-detection-card">
+        <div class="stat-label">Estimated spend avoided</div>
+        <div class="stat-value" id="ai-spend-avoided">-</div>
+      </div>
+    </div>
+
+    <div class="ai-detection-details">
+      <div>
+        <div class="stat-label" style="margin-bottom: 6px;">Policy breakdown</div>
+        <div id="ai-detection-breakdown" class="ai-detection-muted">Loading...</div>
+      </div>
+      <div>
+        <div class="stat-label" style="margin-bottom: 6px;">Needs review</div>
+        <div id="ai-detection-review-slice" class="ai-detection-muted">Loading...</div>
+      </div>
+    </div>
+  </section>
+
   <div class="lookup-panel">
     <div class="lookup-form">
       <div class="lookup-input-group">
@@ -2519,6 +2654,70 @@
         }
       } catch (error) {
         console.error('Failed to load real stats:', error);
+      }
+    }
+
+    function formatEstimatedSpend(cents) {
+      if (typeof cents !== 'number' || !Number.isFinite(cents)) return 'n/a';
+      return '$' + (cents / 100).toLocaleString(undefined, { maximumFractionDigits: 0 });
+    }
+
+    function formatPolicyReason(reason) {
+      const labels = {
+        valid_proofmode_skip: 'Valid ProofMode, AI skipped',
+        valid_ai_signed_skip: 'Valid AI-signed, Hive skipped',
+        original_vine_skip: 'Original Vine, AI skipped',
+        no_proof_ai_detection: 'No proof, AI ran',
+        provenance_present_ai_detection: 'Other provenance, AI ran',
+        report_forced_ai_detection: 'User report forced AI check',
+        proofmode_ai_downgrade: 'ProofMode AI hit sent to review'
+      };
+      return labels[reason] || String(reason || 'unknown').replaceAll('_', ' ');
+    }
+
+    function renderAIDetectionBreakdown(rows) {
+      if (!rows || rows.length === 0) {
+        return '<div class="ai-detection-muted">No ledger events in this window yet.</div>';
+      }
+      return '<table class="ai-detection-table"><thead><tr><th>Reason</th><th>Count</th></tr></thead><tbody>'
+        + rows.map(row => '<tr><td>' + escapeHtml(formatPolicyReason(row.policyReason)) + '</td><td>' + (row.count || 0).toLocaleString() + '</td></tr>').join('')
+        + '</tbody></table>';
+    }
+
+    function renderAIDetectionReviewSlice(stats) {
+      const rows = stats.recentReviewItems || [];
+      if (rows.length === 0) {
+        return '<div class="ai-detection-muted">No AI-report review items in this window.</div>';
+      }
+      return '<table class="ai-detection-table"><thead><tr><th>Video</th><th>Reason</th><th>Score</th></tr></thead><tbody>'
+        + rows.map(row => {
+          const score = typeof row.aiScore === 'number' ? Math.round(row.aiScore * 100) + '%' : '-';
+          const sha = escapeHtml(row.sha256 || '');
+          return '<tr><td><button class="action-btn secondary" style="padding:3px 7px;font-size:11px;" data-sha256="' + sha + '" onclick="lookupVideo(this.dataset.sha256)">' + escapeHtml((row.sha256 || '').substring(0, 10)) + '...</button></td><td>' + escapeHtml(formatPolicyReason(row.policyReason)) + '</td><td>' + score + '</td></tr>';
+        }).join('')
+        + '</tbody></table>';
+    }
+
+    async function loadAIDetectionStats() {
+      try {
+        const windowValue = document.getElementById('ai-detection-window')?.value || '24h';
+        const response = await fetch('/admin/api/ai-detection/stats?window=' + encodeURIComponent(windowValue));
+        if (!response.ok) throw new Error('HTTP ' + response.status);
+        const stats = await response.json();
+        const totals = stats.totals || {};
+
+        document.getElementById('ai-detection-runs').textContent = (totals.aiDetectionRuns || 0).toLocaleString();
+        document.getElementById('ai-detection-skips').textContent = (totals.aiDetectionSkips || 0).toLocaleString();
+        document.getElementById('ai-proofmode-skips').textContent = (totals.proofModeSkips || 0).toLocaleString();
+        document.getElementById('ai-report-forced').textContent = (totals.reportForcedChecks || 0).toLocaleString();
+        document.getElementById('ai-open-review').textContent = (totals.openReviewItems || 0).toLocaleString();
+        document.getElementById('ai-spend-avoided').textContent = formatEstimatedSpend(stats.estimatedSpendAvoidedCents);
+        document.getElementById('ai-detection-breakdown').innerHTML = renderAIDetectionBreakdown(stats.policyBreakdown);
+        document.getElementById('ai-detection-review-slice').innerHTML = renderAIDetectionReviewSlice(stats);
+      } catch (error) {
+        console.error('Failed to load AI detection stats:', error);
+        document.getElementById('ai-detection-breakdown').textContent = 'AI detection reporting unavailable.';
+        document.getElementById('ai-detection-review-slice').textContent = 'AI detection reporting unavailable.';
       }
     }
 
@@ -5047,6 +5246,7 @@
     });
 
     loadRealStats();
+    loadAIDetectionStats();
     updateMuteToggleButton();
 
     // Refresh stats when returning from another page (e.g., Quick Review).
@@ -5058,6 +5258,7 @@
       if (document.visibilityState === 'visible' && Date.now() - lastStatsFetch > 30000) {
         lastStatsFetch = Date.now();
         loadRealStats();
+        loadAIDetectionStats();
       }
     });
 

--- a/src/classification/pipeline.mjs
+++ b/src/classification/pipeline.mjs
@@ -9,6 +9,28 @@ import { HiveVLMClassificationProvider } from './providers/hiveai/adapter.mjs';
 // Singleton provider instance
 const vlmProvider = new HiveVLMClassificationProvider();
 
+function isHiveVLMEnabled(env = {}) {
+  return String(env.HIVE_VLM_ENABLED || '').toLowerCase() === 'true';
+}
+
+function skippedClassificationResult(reason) {
+  return {
+    provider: null,
+    skipped: true,
+    reason,
+    labels: [],
+    topics: [],
+    setting: '',
+    objects: [],
+    activities: [],
+    mood: '',
+    description: '',
+    topCategories: [],
+    topSettings: [],
+    topObjects: []
+  };
+}
+
 /**
  * Run the VLM classification pipeline on a video.
  *
@@ -28,24 +50,15 @@ const vlmProvider = new HiveVLMClassificationProvider();
 export async function classifyVideo(videoUrl, env, options = {}) {
   const sha256 = options.sha256 || 'unknown';
 
+  if (!isHiveVLMEnabled(env)) {
+    console.warn('[Classification] Hive VLM classification disabled - skipping classification');
+    return skippedClassificationResult('Hive VLM classification disabled');
+  }
+
   // Validate configuration
   if (!vlmProvider.isConfigured(env)) {
     console.warn('[Classification] HIVE_VLM_API_KEY not configured - skipping classification');
-    return {
-      provider: null,
-      skipped: true,
-      reason: 'HIVE_VLM_API_KEY not configured',
-      labels: [],
-      topics: [],
-      setting: '',
-      objects: [],
-      activities: [],
-      mood: '',
-      description: '',
-      topCategories: [],
-      topSettings: [],
-      topObjects: []
-    };
+    return skippedClassificationResult('HIVE_VLM_API_KEY not configured');
   }
 
   console.log(`[Classification] Starting VLM classification pipeline for ${sha256}`);

--- a/src/classification/pipeline.test.mjs
+++ b/src/classification/pipeline.test.mjs
@@ -43,13 +43,28 @@ describe('classifyVideo', () => {
     expect(result.provider).toBeNull();
   });
 
+  it('should skip Hive VLM unless explicitly enabled', async () => {
+    const mockFetch = vi.fn();
+
+    const result = await classifyVideo(
+      'https://media.divine.video/test.mp4',
+      { HIVE_VLM_API_KEY: 'vlm-key' },
+      { sha256: 'abc123', fetchFn: mockFetch }
+    );
+
+    expect(result.skipped).toBe(true);
+    expect(result.reason).toBe('Hive VLM classification disabled');
+    expect(result.provider).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
   it('should classify video and return labels', async () => {
     const mockFetch = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => mockVLMResponse()
     });
 
-    const env = { HIVE_VLM_API_KEY: 'vlm-key' };
+    const env = { HIVE_VLM_API_KEY: 'vlm-key', HIVE_VLM_ENABLED: 'true' };
     const result = await classifyVideo(
       'https://media.divine.video/test.mp4',
       env,
@@ -78,7 +93,7 @@ describe('classifyVideo', () => {
       json: async () => mockVLMResponse()
     });
 
-    const env = { HIVE_VLM_API_KEY: 'vlm-key' };
+    const env = { HIVE_VLM_API_KEY: 'vlm-key', HIVE_VLM_ENABLED: 'true' };
     const result = await classifyVideo(
       'https://media.divine.video/test.mp4',
       env,
@@ -94,7 +109,7 @@ describe('classifyVideo', () => {
       json: async () => mockVLMResponse()
     });
 
-    const env = { HIVE_VLM_API_KEY: 'vlm-key' };
+    const env = { HIVE_VLM_API_KEY: 'vlm-key', HIVE_VLM_ENABLED: 'true' };
     const result = await classifyVideo(
       'https://media.divine.video/test.mp4',
       env,
@@ -112,7 +127,7 @@ describe('classifyVideo', () => {
       text: async () => 'Internal Server Error'
     });
 
-    const env = { HIVE_VLM_API_KEY: 'vlm-key' };
+    const env = { HIVE_VLM_API_KEY: 'vlm-key', HIVE_VLM_ENABLED: 'true' };
 
     await expect(
       classifyVideo('https://media.divine.video/test.mp4', env, { fetchFn: mockFetch })
@@ -140,7 +155,7 @@ describe('classifyVideo', () => {
       json: async () => badResponse
     });
 
-    const env = { HIVE_VLM_API_KEY: 'vlm-key' };
+    const env = { HIVE_VLM_API_KEY: 'vlm-key', HIVE_VLM_ENABLED: 'true' };
     const result = await classifyVideo(
       'https://media.divine.video/test.mp4',
       env,

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -17,11 +17,12 @@ import { hexToBytes, bytesToHex } from '@noble/hashes/utils';
 import dashboardHTML from './admin/dashboard.html';
 import swipeReviewHTML from './admin/swipe-review.html';
 import messagesHTML from './admin/messages.html';
-import { initReportsTable } from './reports.mjs';
+import { initReportsTable, addReport, isAiReportType } from './reports.mjs';
 import { initUploaderEnforcementTable, getUploaderEnforcement, setUploaderEnforcement, applyUploaderEnforcementToResult } from './uploader-enforcement.mjs';
 import { formatForStorage, formatForGorse, formatForFunnelcake } from './classification/pipeline.mjs';
 import { extractTopics, topicsToLabels, topicsToWeightedFeatures } from './classification/topic-extractor.mjs';
 import { classifyModerationResult, getKVThresholds, kvThresholdsToEnv, setKVThresholds, DEFAULT_THRESHOLDS } from './moderation/classifier.mjs';
+import { shouldForceAIDetection } from './moderation/ai-detection-policy.mjs';
 import { isValidSha256, isValidLookupIdentifier, isValidPubkey, parseMaybeJson, getEventTagValue, parseImetaParams, extractShaFromUrl, extractMediaShaFromEvent } from './validation.mjs';
 import { parseRetryAfterSeconds } from './http-utils.mjs';
 import { classifyText, parseVttText } from './moderation/text-classifier.mjs';
@@ -3606,6 +3607,55 @@ async function runMigration() {
       }
     }
 
+    if (url.pathname === '/api/v1/report' && request.method === 'POST') {
+      const verification = await authenticateApiRequest(request, env);
+      if (!verification.valid) {
+        console.log(`[API] Authentication failed for /api/v1/report: ${verification.error}`);
+        return apiUnauthorizedResponse(verification);
+      }
+
+      try {
+        const { sha256, reporter_pubkey, report_type, reason } = await request.json();
+
+        if (!sha256 || !reporter_pubkey || !report_type) {
+          return new Response(JSON.stringify({ error: 'sha256, reporter_pubkey, and report_type are required' }), {
+            status: 400,
+            headers: { 'Content-Type': 'application/json' }
+          });
+        }
+
+        const result = await addReport(env.BLOSSOM_DB, { sha256, reporter_pubkey, report_type, reason });
+
+        console.log(`[API] Report added: ${sha256} by ${reporter_pubkey.substring(0, 16)}... escalate=${result.escalate}`);
+
+        if (isAiReportType(report_type) && env.MODERATION_QUEUE) {
+          await env.MODERATION_QUEUE.send({
+            sha256,
+            r2Key: `videos/${sha256}.mp4`,
+            uploadedAt: Date.now(),
+            metadata: {
+              source: 'user-report',
+              forceAIDetection: true,
+              reportType: report_type,
+              reportedBy: reporter_pubkey,
+              ...(reason ? { reportReason: reason } : {})
+            }
+          });
+          console.log(`[API] Queued forced AI detection for reported content ${sha256}`);
+        }
+
+        return new Response(JSON.stringify({ success: true, ...result }), {
+          headers: { 'Content-Type': 'application/json' }
+        });
+      } catch (error) {
+        console.error('[API] Error adding report:', error);
+        return new Response(JSON.stringify({ error: error.message }), {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }
+    }
+
     // API: Send DM notification only (no Blossom/D1 moderation side effects)
     // Used by relay-manager to notify users after NIP-86 moderation actions
     // Auth: Bearer token or Cloudflare Access JWT
@@ -4259,14 +4309,20 @@ async function runMigration() {
           'SELECT sha256, action, moderated_at FROM moderation_results WHERE sha256 = ?'
         ).bind(sha256).first();
 
-        if (existingResult) {
+        const forceAIDetection = shouldForceAIDetection(metadata);
+
+        if (existingResult && !forceAIDetection) {
           console.log(`[MODERATION] ⚠️ SKIPPED ${sha256} - already moderated`);
           console.log(`[MODERATION] Previous result: action=${existingResult.action}, moderated_at=${existingResult.moderated_at}`);
           message.ack();
           continue;
         }
 
-        console.log(`[MODERATION] Step 4: No existing result found, starting analysis for ${sha256}`);
+        if (existingResult && forceAIDetection) {
+          console.log(`[MODERATION] Step 4: Forced AI detection requested for already moderated ${sha256}; previous action=${existingResult.action}`);
+        } else {
+          console.log(`[MODERATION] Step 4: No existing result found, starting analysis for ${sha256}`);
+        }
         console.log(`[MODERATION] Blossom blob URL: https://${env.CDN_DOMAIN}/blobs/${sha256}`);
 
         // Run moderation pipeline
@@ -4721,8 +4777,10 @@ async function handleModerationResult(result, env) {
   }
 
   // Notify reporters who filed reports on this content (non-blocking)
-  const { notifyReporters: notifyReportersOfOutcome } = await import('./nostr/dm-sender.mjs');
-  notifyReportersOfOutcome(sha256, action, env, '[MODERATION]').catch(() => {});
+  if (env.NOSTR_PRIVATE_KEY) {
+    const { notifyReporters: notifyReportersOfOutcome } = await import('./nostr/dm-sender.mjs');
+    notifyReportersOfOutcome(sha256, action, env, '[MODERATION]').catch(() => {});
+  }
 
   // Write normalized moderation labels to ClickHouse
   try {

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -23,6 +23,7 @@ import { formatForStorage, formatForGorse, formatForFunnelcake } from './classif
 import { extractTopics, topicsToLabels, topicsToWeightedFeatures } from './classification/topic-extractor.mjs';
 import { classifyModerationResult, getKVThresholds, kvThresholdsToEnv, setKVThresholds, DEFAULT_THRESHOLDS } from './moderation/classifier.mjs';
 import { shouldForceAIDetection } from './moderation/ai-detection-policy.mjs';
+import { buildAIOutcomeEvent, buildAIPolicyDecisionEvent, buildAIReportEvent, getAIDetectionStats, initAIDetectionEventsTable, recordAIDetectionEvent } from './moderation/ai-detection-events.mjs';
 import { isValidSha256, isValidLookupIdentifier, isValidPubkey, parseMaybeJson, getEventTagValue, parseImetaParams, extractShaFromUrl, extractMediaShaFromEvent } from './validation.mjs';
 import { parseRetryAfterSeconds } from './http-utils.mjs';
 import { classifyText, parseVttText } from './moderation/text-classifier.mjs';
@@ -1397,6 +1398,7 @@ export default {
 
     // Ensure reports table exists
     await initReportsTable(env.BLOSSOM_DB);
+    await initAIDetectionEventsTable(env.BLOSSOM_DB);
 
     if (url.pathname === '/health') {
       return corsResponse(jsonResponse(200, {
@@ -1669,6 +1671,34 @@ export default {
         return new Response(JSON.stringify({ error: error.message }), {
           status: 500,
           headers: { 'Content-Type': 'application/json' }
+        });
+      }
+    }
+
+    // Get AI-detection policy reporting stats for dashboard
+    if (url.pathname === '/admin/api/ai-detection/stats') {
+      const authError = await requireAuth(request, env);
+      if (authError) {
+        console.log(`[${requestId}] Unauthorized access to /admin/api/ai-detection/stats`);
+        return authError;
+      }
+
+      try {
+        const estimatedCostCents = Number(env.HIVE_AI_DETECTION_ESTIMATED_COST_CENTS);
+        const stats = await getAIDetectionStats(env.BLOSSOM_DB, {
+          window: url.searchParams.get('window') || '24h',
+          estimatedCostCents: Number.isFinite(estimatedCostCents) && estimatedCostCents > 0
+            ? estimatedCostCents
+            : null,
+        });
+        return new Response(JSON.stringify(stats), {
+          headers: JSON_HEADERS
+        });
+      } catch (error) {
+        console.error(`[${requestId}] Failed to get AI detection stats:`, error);
+        return new Response(JSON.stringify({ error: error.message }), {
+          status: 500,
+          headers: JSON_HEADERS
         });
       }
     }
@@ -3629,6 +3659,7 @@ async function runMigration() {
         console.log(`[API] Report added: ${sha256} by ${reporter_pubkey.substring(0, 16)}... escalate=${result.escalate}`);
 
         if (isAiReportType(report_type) && env.MODERATION_QUEUE) {
+          const reportedAt = new Date().toISOString();
           await env.MODERATION_QUEUE.send({
             sha256,
             r2Key: `videos/${sha256}.mp4`,
@@ -3642,6 +3673,16 @@ async function runMigration() {
             }
           });
           console.log(`[API] Queued forced AI detection for reported content ${sha256}`);
+
+          try {
+            await recordAIDetectionEvent(env.BLOSSOM_DB, buildAIReportEvent({
+              sha256,
+              reportType: report_type,
+              createdAt: reportedAt,
+            }));
+          } catch (eventErr) {
+            console.error(`[API] Failed to record AI report event for ${sha256}:`, eventErr.message);
+          }
         }
 
         return new Response(JSON.stringify({ success: true, ...result }), {
@@ -4278,6 +4319,7 @@ async function runMigration() {
    */
   async queue(batch, env) {
     console.log(`[MODERATION] Processing batch of ${batch.messages.length} videos`);
+    await initAIDetectionEventsTable(env.BLOSSOM_DB);
 
     for (const message of batch.messages) {
       const startTime = Date.now();
@@ -4388,6 +4430,22 @@ async function runMigration() {
           null
         ).run();
         console.log(`[MODERATION] Step 7: D1 write successful`);
+
+        try {
+          await recordAIDetectionEvent(env.BLOSSOM_DB, buildAIPolicyDecisionEvent({
+            sha256,
+            uploadedAt,
+            result,
+          }));
+          await recordAIDetectionEvent(env.BLOSSOM_DB, buildAIOutcomeEvent({
+            sha256,
+            uploadedAt,
+            result,
+          }));
+          console.log(`[MODERATION] Step 7.1: AI detection reporting events recorded for ${sha256}`);
+        } catch (eventErr) {
+          console.error(`[MODERATION] Failed to record AI detection events for ${sha256}:`, eventErr.message);
+        }
 
         // Step 7.5: Store classifier + classification data in KV for recommendation systems
         {

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -9,7 +9,16 @@ import worker from './index.mjs';
 
 const SHA256 = 'a'.repeat(64);
 
-function createDbMock({ moderationResults = new Map(), moderationListRows = [], webhookEvents = new Map() } = {}) {
+function createDbMock({
+  moderationResults = new Map(),
+  moderationListRows = [],
+  webhookEvents = new Map(),
+  aiDetectionEvents = [],
+  aiDetectionStatsRow = null,
+  aiDetectionPolicyRows = [],
+  aiDetectionReviewRows = [],
+  aiDetectionRecentRows = [],
+} = {}) {
   return {
     prepare(sql) {
       let bindings = [];
@@ -20,6 +29,22 @@ function createDbMock({ moderationResults = new Map(), moderationListRows = [], 
           return this;
         },
         async run() {
+          if (/INSERT OR IGNORE INTO ai_detection_events/i.test(sql)) {
+            aiDetectionEvents.push({
+              event_key: bindings[0],
+              sha256: bindings[1],
+              event_type: bindings[2],
+              policy_reason: bindings[3],
+              c2pa_state: bindings[4],
+              ai_detection_ran: bindings[5],
+              ai_detection_forced: bindings[6],
+              ai_score: bindings[7],
+              action: bindings[8],
+              report_type: bindings[9],
+              metadata_json: bindings[10],
+              created_at: bindings[11],
+            });
+          }
           return { success: true };
         },
         async first() {
@@ -29,11 +54,23 @@ function createDbMock({ moderationResults = new Map(), moderationListRows = [], 
           if (sql.includes('FROM bunny_webhook_events')) {
             return webhookEvents.get(bindings[0]) ?? null;
           }
+          if (sql.includes('FROM ai_detection_events')) {
+            return aiDetectionStatsRow;
+          }
           return null;
         },
         async all() {
           if (sql.includes('FROM moderation_results') && sql.includes('ORDER BY moderated_at')) {
             return { results: moderationListRows };
+          }
+          if (sql.includes('FROM ai_detection_events') && sql.includes("event_type = 'policy_decision'")) {
+            return { results: aiDetectionPolicyRows };
+          }
+          if (sql.includes('FROM ai_detection_events') && sql.includes('GROUP BY policy_reason')) {
+            return { results: aiDetectionReviewRows };
+          }
+          if (sql.includes('FROM ai_detection_events') && sql.includes('ORDER BY created_at DESC')) {
+            return { results: aiDetectionRecentRows };
           }
           return { results: [] };
         }
@@ -190,8 +227,10 @@ describe('HTTP hostname routing', () => {
 
   it('queues a forced AI recheck when users report content as AI-generated', async () => {
     const queued = [];
+    const aiDetectionEvents = [];
     const reporterPubkey = 'b'.repeat(64);
     const env = createEnv({
+      BLOSSOM_DB: createDbMock({ aiDetectionEvents }),
       MODERATION_QUEUE: {
         async send(message) {
           queued.push(message);
@@ -227,6 +266,78 @@ describe('HTTP hostname routing', () => {
         reportType: 'ai_generated',
         reportedBy: reporterPubkey
       }
+    });
+    expect(aiDetectionEvents).toHaveLength(1);
+    expect(aiDetectionEvents[0]).toMatchObject({
+      sha256: SHA256,
+      event_type: 'user_report',
+      policy_reason: 'report_forced_ai_detection',
+      ai_detection_forced: 1,
+      report_type: 'ai_generated',
+    });
+  });
+
+  it('requires admin auth for AI detection stats', async () => {
+    const response = await worker.fetch(
+      new Request('https://moderation.admin.divine.video/admin/api/ai-detection/stats'),
+      createEnv({ ALLOW_DEV_ACCESS: 'false' })
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it('returns AI detection stats for authenticated admins', async () => {
+    const env = createEnv({
+      BLOSSOM_DB: createDbMock({
+        aiDetectionStatsRow: {
+          ai_detection_runs: 1,
+          ai_detection_skips: 2,
+          proofmode_skips: 2,
+          signed_ai_skips: 0,
+          original_vine_skips: 0,
+          report_forced_checks: 1,
+          open_review_items: 1,
+        },
+        aiDetectionPolicyRows: [
+          { policy_reason: 'valid_proofmode_skip', count: 2 },
+          { policy_reason: 'no_proof_ai_detection', count: 1 },
+        ],
+        aiDetectionReviewRows: [
+          { policy_reason: 'proofmode_ai_downgrade', count: 1 },
+        ],
+        aiDetectionRecentRows: [
+          {
+            sha256: SHA256,
+            action: 'REVIEW',
+            c2pa_state: 'valid_proofmode',
+            ai_score: 0.97,
+            policy_reason: 'proofmode_ai_downgrade',
+            created_at: '2026-05-03T00:00:00.000Z',
+          },
+        ],
+      }),
+      HIVE_AI_DETECTION_ESTIMATED_COST_CENTS: '65',
+    });
+
+    const response = await worker.fetch(
+      new Request('https://moderation.admin.divine.video/admin/api/ai-detection/stats?window=24h', {
+        headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' },
+      }),
+      env
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      window: '24h',
+      totals: {
+        aiDetectionRuns: 1,
+        aiDetectionSkips: 2,
+        proofModeSkips: 2,
+        reportForcedChecks: 1,
+        openReviewItems: 1,
+      },
+      estimatedSpendAvoidedCents: 130,
+      recentReviewItems: [{ sha256: SHA256, action: 'REVIEW' }],
     });
   });
 

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -188,6 +188,48 @@ describe('HTTP hostname routing', () => {
     });
   });
 
+  it('queues a forced AI recheck when users report content as AI-generated', async () => {
+    const queued = [];
+    const reporterPubkey = 'b'.repeat(64);
+    const env = createEnv({
+      MODERATION_QUEUE: {
+        async send(message) {
+          queued.push(message);
+        }
+      }
+    });
+
+    const response = await worker.fetch(
+      new Request('https://moderation-api.divine.video/api/v1/report', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer test-service-token'
+        },
+        body: JSON.stringify({
+          sha256: SHA256,
+          reporter_pubkey: reporterPubkey,
+          report_type: 'ai_generated',
+          reason: 'looks synthetic'
+        })
+      }),
+      env
+    );
+
+    expect(response.status).toBe(200);
+    expect(queued).toHaveLength(1);
+    expect(queued[0]).toMatchObject({
+      sha256: SHA256,
+      r2Key: `videos/${SHA256}.mp4`,
+      metadata: {
+        source: 'user-report',
+        forceAIDetection: true,
+        reportType: 'ai_generated',
+        reportedBy: reporterPubkey
+      }
+    });
+  });
+
   it('returns legacy 401 shape for unauthenticated /api/v1/scan', async () => {
     const response = await worker.fetch(
       new Request('https://moderation-api.divine.video/api/v1/scan', {

--- a/src/moderation/ai-detection-events.mjs
+++ b/src/moderation/ai-detection-events.mjs
@@ -1,0 +1,215 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Durable ledger and reporting helpers for paid AI-detection policy decisions
+// ABOUTME: Powers admin cost and review reporting for ProofMode/report-triggered AI checks
+
+const VALID_WINDOWS = new Map([
+  ['24h', 24 * 60 * 60 * 1000],
+  ['7d', 7 * 24 * 60 * 60 * 1000],
+  ['30d', 30 * 24 * 60 * 60 * 1000],
+  ['all', null],
+]);
+
+export async function initAIDetectionEventsTable(db) {
+  await db.prepare(`
+    CREATE TABLE IF NOT EXISTS ai_detection_events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      event_key TEXT NOT NULL UNIQUE,
+      sha256 TEXT NOT NULL,
+      event_type TEXT NOT NULL,
+      policy_reason TEXT,
+      c2pa_state TEXT,
+      ai_detection_ran INTEGER NOT NULL DEFAULT 0,
+      ai_detection_forced INTEGER NOT NULL DEFAULT 0,
+      ai_score REAL,
+      action TEXT,
+      report_type TEXT,
+      metadata_json TEXT,
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP
+    )
+  `).run();
+
+  await db.prepare('CREATE INDEX IF NOT EXISTS idx_ai_detection_events_created_at ON ai_detection_events(created_at)').run();
+  await db.prepare('CREATE INDEX IF NOT EXISTS idx_ai_detection_events_sha256 ON ai_detection_events(sha256)').run();
+  await db.prepare('CREATE INDEX IF NOT EXISTS idx_ai_detection_events_type ON ai_detection_events(event_type)').run();
+  await db.prepare('CREATE INDEX IF NOT EXISTS idx_ai_detection_events_reason ON ai_detection_events(policy_reason)').run();
+}
+
+export async function recordAIDetectionEvent(db, event) {
+  if (!db || !event?.eventKey || !event?.sha256 || !event?.eventType) {
+    return { recorded: false, reason: 'invalid_event' };
+  }
+
+  const metadataJson = event.metadata === undefined
+    ? null
+    : JSON.stringify(event.metadata);
+
+  await db.prepare(`
+    INSERT OR IGNORE INTO ai_detection_events (
+      event_key, sha256, event_type, policy_reason, c2pa_state,
+      ai_detection_ran, ai_detection_forced, ai_score, action, report_type,
+      metadata_json, created_at
+    )
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).bind(
+    event.eventKey,
+    event.sha256,
+    event.eventType,
+    event.policyReason ?? null,
+    event.c2paState ?? null,
+    event.aiDetectionRan ? 1 : 0,
+    event.aiDetectionForced ? 1 : 0,
+    typeof event.aiScore === 'number' ? event.aiScore : null,
+    event.action ?? null,
+    event.reportType ?? null,
+    metadataJson,
+    event.createdAt ?? new Date().toISOString(),
+  ).run();
+
+  return { recorded: true };
+}
+
+export function parseAIDetectionStatsWindow(value) {
+  return VALID_WINDOWS.has(value) ? value : '24h';
+}
+
+export async function getAIDetectionStats(db, options = {}) {
+  const window = parseAIDetectionStatsWindow(options.window);
+  const now = options.now instanceof Date ? options.now : new Date();
+  const cutoffMs = VALID_WINDOWS.get(window);
+  const cutoff = cutoffMs === null ? null : new Date(now.getTime() - cutoffMs).toISOString();
+  const estimatedCostCents = Number.isFinite(options.estimatedCostCents)
+    ? options.estimatedCostCents
+    : null;
+  const whereClause = cutoff ? 'WHERE created_at >= ?' : '';
+  const bindWindow = stmt => cutoff ? stmt.bind(cutoff) : stmt;
+
+  const totalsRow = await bindWindow(db.prepare(`
+    SELECT
+      SUM(CASE WHEN event_type = 'policy_decision' AND ai_detection_ran = 1 THEN 1 ELSE 0 END) AS ai_detection_runs,
+      SUM(CASE WHEN event_type = 'policy_decision' AND ai_detection_ran = 0 THEN 1 ELSE 0 END) AS ai_detection_skips,
+      SUM(CASE WHEN event_type = 'policy_decision' AND policy_reason = 'valid_proofmode_skip' THEN 1 ELSE 0 END) AS proofmode_skips,
+      SUM(CASE WHEN event_type = 'policy_decision' AND policy_reason = 'valid_ai_signed_skip' THEN 1 ELSE 0 END) AS signed_ai_skips,
+      SUM(CASE WHEN event_type = 'policy_decision' AND policy_reason = 'original_vine_skip' THEN 1 ELSE 0 END) AS original_vine_skips,
+      SUM(CASE WHEN event_type = 'user_report' AND ai_detection_forced = 1 THEN 1 ELSE 0 END) AS report_forced_checks,
+      SUM(CASE WHEN event_type = 'moderation_outcome' AND action = 'REVIEW' THEN 1 ELSE 0 END) AS open_review_items
+    FROM ai_detection_events
+    ${whereClause}
+  `)).first();
+
+  const policyRows = await bindWindow(db.prepare(`
+    SELECT policy_reason, COUNT(*) AS count
+    FROM ai_detection_events
+    ${whereClause ? `${whereClause} AND` : 'WHERE'} event_type = 'policy_decision'
+    GROUP BY policy_reason
+    ORDER BY count DESC
+  `)).all();
+
+  const reviewRows = await bindWindow(db.prepare(`
+    SELECT policy_reason, COUNT(*) AS count
+    FROM ai_detection_events
+    ${whereClause ? `${whereClause} AND` : 'WHERE'} event_type = 'moderation_outcome' AND action = 'REVIEW'
+    GROUP BY policy_reason
+    ORDER BY count DESC
+  `)).all();
+
+  const recentReviewRows = await bindWindow(db.prepare(`
+    SELECT sha256, action, c2pa_state, ai_score, policy_reason, created_at
+    FROM ai_detection_events
+    ${whereClause ? `${whereClause} AND` : 'WHERE'} event_type = 'moderation_outcome' AND action = 'REVIEW'
+    ORDER BY created_at DESC
+    LIMIT 10
+  `)).all();
+
+  const totals = {
+    aiDetectionRuns: totalsRow?.ai_detection_runs ?? 0,
+    aiDetectionSkips: totalsRow?.ai_detection_skips ?? 0,
+    proofModeSkips: totalsRow?.proofmode_skips ?? 0,
+    signedAISkips: totalsRow?.signed_ai_skips ?? 0,
+    originalVineSkips: totalsRow?.original_vine_skips ?? 0,
+    reportForcedChecks: totalsRow?.report_forced_checks ?? 0,
+    openReviewItems: totalsRow?.open_review_items ?? 0,
+  };
+
+  return {
+    window,
+    since: cutoff,
+    totals,
+    estimatedSpendAvoidedCents: estimatedCostCents === null
+      ? null
+      : totals.aiDetectionSkips * estimatedCostCents,
+    policyBreakdown: (policyRows.results || []).map(row => ({
+      policyReason: row.policy_reason || 'unknown',
+      count: row.count || 0,
+    })),
+    reviewBreakdown: (reviewRows.results || []).map(row => ({
+      policyReason: row.policy_reason || 'unknown',
+      count: row.count || 0,
+    })),
+    recentReviewItems: (recentReviewRows.results || []).map(row => ({
+      sha256: row.sha256,
+      action: row.action,
+      c2paState: row.c2pa_state,
+      aiScore: row.ai_score,
+      policyReason: row.policy_reason,
+      createdAt: row.created_at,
+    })),
+  };
+}
+
+export function buildAIReportEvent({ sha256, reportType, createdAt }) {
+  return {
+    eventKey: `report:${sha256}:${reportType}:${createdAt}`,
+    sha256,
+    eventType: 'user_report',
+    policyReason: 'report_forced_ai_detection',
+    aiDetectionRan: false,
+    aiDetectionForced: true,
+    reportType,
+    createdAt,
+  };
+}
+
+export function buildAIPolicyDecisionEvent({ sha256, uploadedAt, result }) {
+  const policy = result?.aiDetectionPolicy || {};
+  const forceFlag = policy.aiDetectionForced ? 'forced' : 'default';
+  return {
+    eventKey: `policy:${sha256}:${uploadedAt ?? 'unknown'}:${forceFlag}`,
+    sha256,
+    eventType: 'policy_decision',
+    policyReason: policy.policyReason || 'unknown',
+    c2paState: result?.c2pa?.state || policy.c2paState || null,
+    aiDetectionRan: policy.aiDetectionRan === true,
+    aiDetectionForced: policy.aiDetectionForced === true,
+    createdAt: new Date().toISOString(),
+  };
+}
+
+export function buildAIOutcomeEvent({ sha256, uploadedAt, result }) {
+  const policy = result?.aiDetectionPolicy || {};
+  const policyReason = result?.policyContext?.overrideReason === 'proofmode-capture-authenticated'
+    ? 'proofmode_ai_downgrade'
+    : (policy.policyReason || 'unknown');
+  const aiScore = Math.max(
+    numericScore(result?.scores?.ai_generated),
+    numericScore(result?.scores?.deepfake),
+  );
+
+  return {
+    eventKey: `outcome:${sha256}:${uploadedAt ?? 'unknown'}:${result?.action || 'unknown'}:${policyReason}`,
+    sha256,
+    eventType: 'moderation_outcome',
+    policyReason,
+    c2paState: result?.c2pa?.state || policy.c2paState || null,
+    aiDetectionRan: policy.aiDetectionRan === true,
+    aiDetectionForced: policy.aiDetectionForced === true,
+    aiScore: Number.isFinite(aiScore) ? aiScore : null,
+    action: result?.action || null,
+    createdAt: new Date().toISOString(),
+  };
+}
+
+function numericScore(value) {
+  return typeof value === 'number' ? value : Number.NEGATIVE_INFINITY;
+}

--- a/src/moderation/ai-detection-events.test.mjs
+++ b/src/moderation/ai-detection-events.test.mjs
@@ -1,0 +1,144 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Tests for durable AI-detection policy and cost reporting events
+// ABOUTME: Covers idempotent ledger writes and admin reporting aggregates
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { env } from 'cloudflare:test';
+import {
+  buildAIOutcomeEvent,
+  buildAIPolicyDecisionEvent,
+  buildAIReportEvent,
+  getAIDetectionStats,
+  initAIDetectionEventsTable,
+  recordAIDetectionEvent,
+} from './ai-detection-events.mjs';
+
+const SHA = 'a'.repeat(64);
+
+describe('AI detection event ledger', () => {
+  beforeEach(async () => {
+    await initAIDetectionEventsTable(env.BLOSSOM_DB);
+    await env.BLOSSOM_DB.prepare('DELETE FROM ai_detection_events').run();
+  });
+
+  it('records events idempotently by event_key', async () => {
+    const event = {
+      eventKey: 'policy:abc:1',
+      sha256: SHA,
+      eventType: 'policy_decision',
+      policyReason: 'valid_proofmode_skip',
+      c2paState: 'valid_proofmode',
+      aiDetectionRan: false,
+      aiDetectionForced: false,
+      createdAt: '2026-05-03T00:00:00.000Z',
+    };
+
+    await recordAIDetectionEvent(env.BLOSSOM_DB, event);
+    await recordAIDetectionEvent(env.BLOSSOM_DB, event);
+
+    const row = await env.BLOSSOM_DB.prepare('SELECT COUNT(*) AS cnt FROM ai_detection_events').first();
+    expect(row.cnt).toBe(1);
+  });
+
+  it('aggregates runs, skips, forced reports, review outcomes, and estimated savings', async () => {
+    await recordAIDetectionEvent(env.BLOSSOM_DB, {
+      eventKey: 'policy:skip',
+      sha256: 'b'.repeat(64),
+      eventType: 'policy_decision',
+      policyReason: 'valid_proofmode_skip',
+      c2paState: 'valid_proofmode',
+      aiDetectionRan: false,
+      aiDetectionForced: false,
+      createdAt: '2026-05-03T00:10:00.000Z',
+    });
+    await recordAIDetectionEvent(env.BLOSSOM_DB, {
+      eventKey: 'policy:run',
+      sha256: 'c'.repeat(64),
+      eventType: 'policy_decision',
+      policyReason: 'no_proof_ai_detection',
+      c2paState: 'absent',
+      aiDetectionRan: true,
+      aiDetectionForced: false,
+      createdAt: '2026-05-03T00:11:00.000Z',
+    });
+    await recordAIDetectionEvent(env.BLOSSOM_DB, {
+      eventKey: 'report:forced',
+      sha256: 'd'.repeat(64),
+      eventType: 'user_report',
+      policyReason: 'report_forced_ai_detection',
+      aiDetectionRan: false,
+      aiDetectionForced: true,
+      reportType: 'ai_generated',
+      createdAt: '2026-05-03T00:12:00.000Z',
+    });
+    await recordAIDetectionEvent(env.BLOSSOM_DB, {
+      eventKey: 'outcome:review',
+      sha256: 'd'.repeat(64),
+      eventType: 'moderation_outcome',
+      policyReason: 'proofmode_ai_downgrade',
+      c2paState: 'valid_proofmode',
+      aiDetectionRan: true,
+      aiDetectionForced: true,
+      aiScore: 0.97,
+      action: 'REVIEW',
+      createdAt: '2026-05-03T00:13:00.000Z',
+    });
+
+    const stats = await getAIDetectionStats(env.BLOSSOM_DB, {
+      window: '24h',
+      now: new Date('2026-05-03T01:00:00.000Z'),
+      estimatedCostCents: 65,
+    });
+
+    expect(stats.totals.aiDetectionRuns).toBe(1);
+    expect(stats.totals.aiDetectionSkips).toBe(1);
+    expect(stats.totals.proofModeSkips).toBe(1);
+    expect(stats.totals.reportForcedChecks).toBe(1);
+    expect(stats.totals.openReviewItems).toBe(1);
+    expect(stats.estimatedSpendAvoidedCents).toBe(65);
+  });
+
+  it('builds compact report, policy, and outcome events', () => {
+    const report = buildAIReportEvent({
+      sha256: SHA,
+      reportType: 'ai_generated',
+      createdAt: '2026-05-03T00:00:00.000Z',
+    });
+    expect(report).toMatchObject({
+      eventKey: `report:${SHA}:ai_generated:2026-05-03T00:00:00.000Z`,
+      eventType: 'user_report',
+      policyReason: 'report_forced_ai_detection',
+      aiDetectionForced: true,
+      reportType: 'ai_generated',
+    });
+
+    const result = {
+      action: 'REVIEW',
+      scores: { ai_generated: 0.97 },
+      c2pa: { state: 'valid_proofmode' },
+      aiDetectionPolicy: {
+        policyReason: 'report_forced_ai_detection',
+        aiDetectionRan: true,
+        aiDetectionForced: true,
+      },
+      policyContext: { overrideReason: 'proofmode-capture-authenticated' },
+    };
+
+    const policy = buildAIPolicyDecisionEvent({ sha256: SHA, uploadedAt: 1777770000000, result });
+    const outcome = buildAIOutcomeEvent({ sha256: SHA, uploadedAt: 1777770000000, result });
+
+    expect(policy).toMatchObject({
+      eventType: 'policy_decision',
+      policyReason: 'report_forced_ai_detection',
+      aiDetectionForced: true,
+    });
+    expect(outcome).toMatchObject({
+      eventType: 'moderation_outcome',
+      policyReason: 'proofmode_ai_downgrade',
+      action: 'REVIEW',
+      aiScore: 0.97,
+    });
+  });
+});

--- a/src/moderation/ai-detection-policy.mjs
+++ b/src/moderation/ai-detection-policy.mjs
@@ -11,3 +11,48 @@ export function shouldForceAIDetection(metadata) {
 export function proofModeSkipsAIDetection(c2pa, metadata) {
   return c2pa?.state === 'valid_proofmode' && !shouldForceAIDetection(metadata);
 }
+
+export function getAIDetectionPolicyDecision({ c2pa, metadata, originalVine = false } = {}) {
+  const aiDetectionForced = shouldForceAIDetection(metadata);
+
+  if (aiDetectionForced) {
+    return {
+      aiDetectionAllowed: true,
+      aiDetectionForced: true,
+      policyReason: 'report_forced_ai_detection',
+    };
+  }
+
+  if (c2pa?.state === 'valid_ai_signed') {
+    return {
+      aiDetectionAllowed: false,
+      aiDetectionForced: false,
+      policyReason: 'valid_ai_signed_skip',
+    };
+  }
+
+  if (c2pa?.state === 'valid_proofmode') {
+    return {
+      aiDetectionAllowed: false,
+      aiDetectionForced: false,
+      policyReason: 'valid_proofmode_skip',
+    };
+  }
+
+  if (originalVine) {
+    return {
+      aiDetectionAllowed: false,
+      aiDetectionForced: false,
+      policyReason: 'original_vine_skip',
+    };
+  }
+
+  const c2paState = c2pa?.state || 'unchecked';
+  return {
+    aiDetectionAllowed: true,
+    aiDetectionForced: false,
+    policyReason: c2paState === 'absent' || c2paState === 'unchecked'
+      ? 'no_proof_ai_detection'
+      : 'provenance_present_ai_detection',
+  };
+}

--- a/src/moderation/ai-detection-policy.mjs
+++ b/src/moderation/ai-detection-policy.mjs
@@ -1,0 +1,13 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Policy helpers for deciding when paid AI-generated detection should run
+// ABOUTME: Keeps ProofMode cost gating consistent across queue and pipeline paths
+
+export function shouldForceAIDetection(metadata) {
+  return metadata?.forceAIDetection === true || metadata?.force_ai_detection === true;
+}
+
+export function proofModeSkipsAIDetection(c2pa, metadata) {
+  return c2pa?.state === 'valid_proofmode' && !shouldForceAIDetection(metadata);
+}

--- a/src/moderation/ai-detection-policy.test.mjs
+++ b/src/moderation/ai-detection-policy.test.mjs
@@ -1,0 +1,27 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Tests for paid AI-detection policy gates
+// ABOUTME: Verifies ProofMode skips AI detection unless an AI report forces it
+
+import { describe, expect, it } from 'vitest';
+import { proofModeSkipsAIDetection, shouldForceAIDetection } from './ai-detection-policy.mjs';
+
+describe('AI detection policy', () => {
+  it('forces AI detection for camelCase and snake_case queue metadata flags', () => {
+    expect(shouldForceAIDetection({ forceAIDetection: true })).toBe(true);
+    expect(shouldForceAIDetection({ force_ai_detection: true })).toBe(true);
+  });
+
+  it('does not force AI detection for absent or false metadata flags', () => {
+    expect(shouldForceAIDetection(null)).toBe(false);
+    expect(shouldForceAIDetection({})).toBe(false);
+    expect(shouldForceAIDetection({ forceAIDetection: false })).toBe(false);
+  });
+
+  it('skips AI detection for valid ProofMode unless forced by a report', () => {
+    expect(proofModeSkipsAIDetection({ state: 'valid_proofmode' }, {})).toBe(true);
+    expect(proofModeSkipsAIDetection({ state: 'valid_proofmode' }, { forceAIDetection: true })).toBe(false);
+    expect(proofModeSkipsAIDetection({ state: 'absent' }, {})).toBe(false);
+  });
+});

--- a/src/moderation/ai-detection-policy.test.mjs
+++ b/src/moderation/ai-detection-policy.test.mjs
@@ -5,7 +5,7 @@
 // ABOUTME: Verifies ProofMode skips AI detection unless an AI report forces it
 
 import { describe, expect, it } from 'vitest';
-import { proofModeSkipsAIDetection, shouldForceAIDetection } from './ai-detection-policy.mjs';
+import { getAIDetectionPolicyDecision, proofModeSkipsAIDetection, shouldForceAIDetection } from './ai-detection-policy.mjs';
 
 describe('AI detection policy', () => {
   it('forces AI detection for camelCase and snake_case queue metadata flags', () => {
@@ -23,5 +23,37 @@ describe('AI detection policy', () => {
     expect(proofModeSkipsAIDetection({ state: 'valid_proofmode' }, {})).toBe(true);
     expect(proofModeSkipsAIDetection({ state: 'valid_proofmode' }, { forceAIDetection: true })).toBe(false);
     expect(proofModeSkipsAIDetection({ state: 'absent' }, {})).toBe(false);
+  });
+
+  it('describes why AI detection is skipped or allowed', () => {
+    expect(getAIDetectionPolicyDecision({
+      c2pa: { state: 'valid_proofmode' },
+      metadata: {},
+      originalVine: false,
+    })).toMatchObject({
+      aiDetectionAllowed: false,
+      aiDetectionForced: false,
+      policyReason: 'valid_proofmode_skip',
+    });
+
+    expect(getAIDetectionPolicyDecision({
+      c2pa: { state: 'valid_proofmode' },
+      metadata: { forceAIDetection: true },
+      originalVine: false,
+    })).toMatchObject({
+      aiDetectionAllowed: true,
+      aiDetectionForced: true,
+      policyReason: 'report_forced_ai_detection',
+    });
+
+    expect(getAIDetectionPolicyDecision({
+      c2pa: { state: 'absent' },
+      metadata: {},
+      originalVine: false,
+    })).toMatchObject({
+      aiDetectionAllowed: true,
+      aiDetectionForced: false,
+      policyReason: 'no_proof_ai_detection',
+    });
   });
 });

--- a/src/moderation/pipeline-classification.test.mjs
+++ b/src/moderation/pipeline-classification.test.mjs
@@ -127,7 +127,8 @@ describe('Pipeline Classification Integration', () => {
 
       const env = {
         ...baseEnv,
-        HIVE_VLM_API_KEY: 'test-vlm-key'
+        HIVE_VLM_API_KEY: 'test-vlm-key',
+        HIVE_VLM_ENABLED: 'true'
       };
 
       const result = await moderateVideo(
@@ -169,7 +170,8 @@ describe('Pipeline Classification Integration', () => {
 
       const env = {
         ...baseEnv,
-        HIVE_VLM_API_KEY: 'test-vlm-key'
+        HIVE_VLM_API_KEY: 'test-vlm-key',
+        HIVE_VLM_ENABLED: 'true'
       };
 
       // Should NOT throw even though classification fails
@@ -312,7 +314,8 @@ This is a funny joke about comedy and stand-up`;
 
       const env = {
         ...baseEnv,
-        HIVE_VLM_API_KEY: 'test-vlm-key'
+        HIVE_VLM_API_KEY: 'test-vlm-key',
+        HIVE_VLM_ENABLED: 'true'
       };
 
       const result = await moderateVideo(

--- a/src/moderation/pipeline.mjs
+++ b/src/moderation/pipeline.mjs
@@ -12,6 +12,7 @@ import { fetchNostrEventBySha256, parseVideoEventMetadata, isOriginalVine, hasSt
 import { classifyVideo } from '../classification/pipeline.mjs';
 import { extractTopics } from '../classification/topic-extractor.mjs';
 import { verifyC2pa } from './inquisitor-client.mjs';
+import { proofModeSkipsAIDetection, shouldForceAIDetection } from './ai-detection-policy.mjs';
 
 const ORIGINAL_VINE_SUPPRESSED_CATEGORIES = new Set(['ai_generated', 'deepfake']);
 const DOWNSTREAM_SIGNAL_THRESHOLD = 0.5;
@@ -316,6 +317,7 @@ export async function moderateVideo(videoData, env, fetchFn = fetch) {
     videoSealPayload = null,
     videoSealBitAccuracy = null
   } = videoData;
+  const forceAIDetection = shouldForceAIDetection(metadata);
 
   // Validate configuration
   if (!env.CDN_DOMAIN) {
@@ -361,9 +363,9 @@ export async function moderateVideo(videoData, env, fetchFn = fetch) {
   }
 
   // Step 2: Check if this is an original Vine (skip AI detection for pre-2018 content)
-  const skipAIDetection = isOriginalVine(nostrContext);
+  const originalVineSkipsAIDetection = isOriginalVine(nostrContext);
   const shouldForceServeable = hasStrongOriginalVineEvidence(nostrContext);
-  if (skipAIDetection) {
+  if (originalVineSkipsAIDetection) {
     console.log(`[MODERATION] Original Vine detected - skipping AI detection for ${sha256}`);
   }
 
@@ -378,6 +380,15 @@ export async function moderateVideo(videoData, env, fetchFn = fetch) {
       sha256, uploadedBy, uploadedAt, metadata,
       videoUrl, nostrContext, nostrEventId, c2pa, videoseal,
     });
+  }
+
+  const proofModeSkip = proofModeSkipsAIDetection(c2pa, metadata);
+  const skipAIDetection = originalVineSkipsAIDetection || proofModeSkip;
+
+  if (proofModeSkip) {
+    console.log(`[MODERATION] ${sha256} - valid ProofMode capture, skipping Hive AI detection`);
+  } else if (c2pa.state === 'valid_proofmode' && forceAIDetection) {
+    console.log(`[MODERATION] ${sha256} - valid ProofMode capture but forced AI detection requested`);
   }
 
   // Step 3: Run moderation and scene classification in parallel
@@ -496,7 +507,7 @@ export async function moderateVideo(videoData, env, fetchFn = fetch) {
 
   const policyContext = {
     originalVine: shouldForceServeable,
-    originalVineLegacyFallback: skipAIDetection && !shouldForceServeable,
+    originalVineLegacyFallback: originalVineSkipsAIDetection && !shouldForceServeable,
     enforcementOverridden: false,
     overrideReason: null,
     originalAction: classification.action

--- a/src/moderation/pipeline.mjs
+++ b/src/moderation/pipeline.mjs
@@ -12,7 +12,7 @@ import { fetchNostrEventBySha256, parseVideoEventMetadata, isOriginalVine, hasSt
 import { classifyVideo } from '../classification/pipeline.mjs';
 import { extractTopics } from '../classification/topic-extractor.mjs';
 import { verifyC2pa } from './inquisitor-client.mjs';
-import { proofModeSkipsAIDetection, shouldForceAIDetection } from './ai-detection-policy.mjs';
+import { getAIDetectionPolicyDecision, proofModeSkipsAIDetection, shouldForceAIDetection } from './ai-detection-policy.mjs';
 
 const ORIGINAL_VINE_SUPPRESSED_CATEGORIES = new Set(['ai_generated', 'deepfake']);
 const DOWNSTREAM_SIGNAL_THRESHOLD = 0.5;
@@ -71,6 +71,14 @@ function buildSignedAiShortCircuitResult({ sha256, uploadedBy, uploadedAt, metad
       enforcementOverridden: true,
       overrideReason: 'c2pa-ai-signed-short-circuit',
       originalAction: 'QUARANTINE',
+    },
+    aiDetectionPolicy: {
+      aiDetectionAllowed: false,
+      aiDetectionForced: false,
+      aiDetectionRan: false,
+      aiDetectionSkipped: true,
+      policyReason: 'valid_ai_signed_skip',
+      c2paState: 'valid_ai_signed',
     },
     downstreamSignals: {
       hasSignals: true,
@@ -374,6 +382,11 @@ export async function moderateVideo(videoData, env, fetchFn = fetch) {
   console.log(`[MODERATION] ${sha256} - C2PA state: ${c2pa.state}${c2pa.claimGenerator ? ` (claim=${c2pa.claimGenerator})` : ''}`);
   const videoseal = interpretVideoSealPayload(videoSealPayload, videoSealBitAccuracy);
 
+  const aiDetectionPolicyBase = {
+    ...getAIDetectionPolicyDecision({ c2pa, metadata, originalVine: originalVineSkipsAIDetection }),
+    c2paState: c2pa.state,
+  };
+
   if (c2pa.state === 'valid_ai_signed') {
     console.log(`[MODERATION] ${sha256} - signed-AI short-circuit, skipping Hive and Reality Defender`);
     return buildSignedAiShortCircuitResult({
@@ -446,6 +459,12 @@ export async function moderateVideo(videoData, env, fetchFn = fetch) {
   } else if (sceneSettled.status === 'fulfilled' && sceneSettled.value?.skipped) {
     console.log(`[MODERATION] Scene classification skipped for ${sha256}: ${sceneSettled.value.reason}`);
   }
+
+  const aiDetectionPolicy = {
+    ...aiDetectionPolicyBase,
+    aiDetectionRan: !!moderationResult.raw?.aiDetection,
+    aiDetectionSkipped: moderationResult.raw?.skippedAIDetection === true || aiDetectionPolicyBase.aiDetectionAllowed === false,
+  };
 
   // Step 3.5: Fetch VTT transcript and analyze text content + extract topics
   let textScores = null;
@@ -590,6 +609,7 @@ export async function moderateVideo(videoData, env, fetchFn = fetch) {
 
     // Explicit policy metadata for serveability vs downstream moderation signals
     policyContext,
+    aiDetectionPolicy,
     downstreamSignals,
 
     // Text analysis scores from VTT transcript (null if no VTT available)

--- a/src/moderation/pipeline.test.mjs
+++ b/src/moderation/pipeline.test.mjs
@@ -683,7 +683,69 @@ describe('Moderation Pipeline — C2PA / ProofMode enforcement', () => {
     expect(hiveCalls).toHaveLength(0);
   });
 
-  it('downgrades AI-driven QUARANTINE to REVIEW on valid_proofmode', async () => {
+  it('skips Hive AI detection by default on valid_proofmode while keeping content moderation', async () => {
+    const hiveAuthCalls = [];
+    const mockFetch = vi.fn(async (url, options = {}) => {
+      const urlStr = String(url);
+
+      if (urlStr.includes('inquisitor.divine.video/verify')) {
+        return {
+          ok: true,
+          json: async () => ({
+            has_c2pa: true,
+            valid: true,
+            validation_state: 'valid',
+            is_proofmode: true,
+            claim_generator: 'ProofMode/1.1.9 Android/14',
+            assertions: [],
+            actions: [],
+            ingredients: [],
+            verified_at: '2026-04-17T10:00:00Z',
+          }),
+        };
+      }
+
+      if (urlStr.endsWith('.vtt')) {
+        return { ok: false, status: 404, text: async () => '' };
+      }
+
+      if (urlStr.includes('api.thehive.ai')) {
+        hiveAuthCalls.push(options.headers?.authorization || null);
+        return {
+          ok: true,
+          json: async () => ({
+            status: [{
+              response: {
+                output: [
+                  {
+                    time: 0,
+                    classes: [
+                      { class: 'general_nsfw', score: 0.05 },
+                      { class: 'ai_generated', score: 0.98 },
+                    ],
+                  },
+                ],
+              },
+            }],
+          }),
+        };
+      }
+
+      throw new Error(`Unexpected fetch call: ${urlStr}`);
+    });
+
+    const result = await moderateVideo({
+      sha256: '9'.repeat(64),
+      uploadedAt: Date.now(),
+    }, baseEnv, mockFetch);
+
+    expect(result.action).toBe('SAFE');
+    expect(result.c2pa?.state).toBe('valid_proofmode');
+    expect(result.scores.ai_generated).toBe(0);
+    expect(hiveAuthCalls).toEqual(['token mod-key']);
+  });
+
+  it('forces AI detection for reported valid_proofmode content and downgrades AI QUARANTINE to REVIEW', async () => {
     const mockFetch = buildMockFetch({
       inquisitor: {
         has_c2pa: true,
@@ -717,6 +779,7 @@ describe('Moderation Pipeline — C2PA / ProofMode enforcement', () => {
     const result = await moderateVideo({
       sha256: 'b'.repeat(64),
       uploadedAt: Date.now(),
+      metadata: { forceAIDetection: true, source: 'ai-report' },
     }, baseEnv, mockFetch);
 
     expect(result.action).toBe('REVIEW');

--- a/src/moderation/pipeline.test.mjs
+++ b/src/moderation/pipeline.test.mjs
@@ -678,6 +678,14 @@ describe('Moderation Pipeline — C2PA / ProofMode enforcement', () => {
     expect(result.requiresSecondaryVerification).toBe(false);
     expect(result.c2pa?.state).toBe('valid_ai_signed');
     expect(result.policyContext?.overrideReason).toBe('c2pa-ai-signed-short-circuit');
+    expect(result.aiDetectionPolicy).toMatchObject({
+      aiDetectionAllowed: false,
+      aiDetectionForced: false,
+      aiDetectionRan: false,
+      aiDetectionSkipped: true,
+      policyReason: 'valid_ai_signed_skip',
+      c2paState: 'valid_ai_signed',
+    });
 
     const hiveCalls = mockFetch.mock.calls.filter(([url]) => String(url).includes('api.thehive.ai'));
     expect(hiveCalls).toHaveLength(0);
@@ -742,6 +750,14 @@ describe('Moderation Pipeline — C2PA / ProofMode enforcement', () => {
     expect(result.action).toBe('SAFE');
     expect(result.c2pa?.state).toBe('valid_proofmode');
     expect(result.scores.ai_generated).toBe(0);
+    expect(result.aiDetectionPolicy).toMatchObject({
+      aiDetectionAllowed: false,
+      aiDetectionForced: false,
+      aiDetectionRan: false,
+      aiDetectionSkipped: true,
+      policyReason: 'valid_proofmode_skip',
+      c2paState: 'valid_proofmode',
+    });
     expect(hiveAuthCalls).toEqual(['token mod-key']);
   });
 
@@ -787,6 +803,14 @@ describe('Moderation Pipeline — C2PA / ProofMode enforcement', () => {
     expect(result.policyContext?.overrideReason).toBe('proofmode-capture-authenticated');
     expect(result.reason).toContain('proofmode-capture-authenticated');
     expect(result.c2pa?.state).toBe('valid_proofmode');
+    expect(result.aiDetectionPolicy).toMatchObject({
+      aiDetectionAllowed: true,
+      aiDetectionForced: true,
+      aiDetectionRan: true,
+      aiDetectionSkipped: false,
+      policyReason: 'report_forced_ai_detection',
+      c2paState: 'valid_proofmode',
+    });
 
     const hiveCalls = mockFetch.mock.calls.filter(([url]) => String(url).includes('api.thehive.ai'));
     expect(hiveCalls.length).toBeGreaterThan(0);

--- a/src/moderation/providers/hiveai/adapter.mjs
+++ b/src/moderation/providers/hiveai/adapter.mjs
@@ -95,11 +95,11 @@ export class HiveAIProvider extends BaseModerationProvider {
 
     try {
       const hasModeration = !!env.HIVE_MODERATION_API_KEY;
-      // Skip AI detection for original Vines (pre-2018 content predates AI generation)
+      // Skip AI detection when the policy layer already has stronger provenance.
       const hasAIDetection = !!env.HIVE_AI_DETECTION_API_KEY && !options.skipAIDetection;
 
       console.log(`[HiveAI] Starting moderation for ${metadata.sha256}`);
-      console.log(`[HiveAI] Models: content=${hasModeration}, ai_detection=${hasAIDetection}${options.skipAIDetection ? ' (skipped - original Vine)' : ''}`);
+      console.log(`[HiveAI] Models: content=${hasModeration}, ai_detection=${hasAIDetection}${options.skipAIDetection ? ' (skipped by policy)' : ''}`);
 
       // Call Hive.AI APIs (runs both in parallel if both keys present)
       const rawResult = await moderateVideoWithHiveAI(

--- a/src/moderation/providers/hiveai/client.mjs
+++ b/src/moderation/providers/hiveai/client.mjs
@@ -92,7 +92,7 @@ export async function moderateVideoWithHiveAI(videoUrl, metadata, env, options =
     skippedAIDetection: false
   };
 
-  // Run both APIs in parallel (unless AI detection is skipped)
+  // Run both APIs in parallel unless the policy layer skips AI detection.
   const promises = [];
 
   if (env.HIVE_MODERATION_API_KEY) {
@@ -103,7 +103,6 @@ export async function moderateVideoWithHiveAI(videoUrl, metadata, env, options =
     );
   }
 
-  // Skip AI detection for original Vines (pre-2018 content predates AI generation)
   if (env.HIVE_AI_DETECTION_API_KEY && !options.skipAIDetection) {
     promises.push(
       moderateWithHiveAIDetection(videoUrl, env, options)
@@ -112,7 +111,7 @@ export async function moderateVideoWithHiveAI(videoUrl, metadata, env, options =
     );
   } else if (options.skipAIDetection) {
     results.skippedAIDetection = true;
-    console.log('[HiveAI] Skipping AI detection (original Vine content)');
+    console.log('[HiveAI] Skipping AI detection (policy gate)');
   }
 
   if (promises.length === 0) {

--- a/src/reports.mjs
+++ b/src/reports.mjs
@@ -23,6 +23,64 @@ export async function initReportsTable(db) {
 }
 
 /**
+ * Insert a report and return escalation level based on unique reporter count
+ * @param {D1Database} db
+ * @param {{sha256: string, reporter_pubkey: string, report_type: string, reason?: string}} report
+ * @returns {Promise<{escalate: 'AGE_RESTRICTED'|'REVIEW'|null}>}
+ */
+export async function addReport(db, { sha256, reporter_pubkey, report_type, reason }) {
+  await db.prepare(`
+    INSERT OR IGNORE INTO user_reports (sha256, reporter_pubkey, report_type, reason)
+    VALUES (?, ?, ?, ?)
+  `).bind(sha256, reporter_pubkey, report_type, reason ?? null).run();
+
+  const row = await db.prepare(`
+    SELECT COUNT(DISTINCT reporter_pubkey) AS cnt
+    FROM user_reports
+    WHERE sha256 = ?
+  `).bind(sha256).first();
+
+  const count = row?.cnt ?? 0;
+
+  if (count >= 5) return { escalate: 'AGE_RESTRICTED' };
+  if (count >= 3) return { escalate: 'REVIEW' };
+  return { escalate: null };
+}
+
+const AI_REPORT_TYPES = new Set([
+  'ai',
+  'ai-generated',
+  'ai_generated',
+  'aigenerated',
+  'synthetic',
+  'synthetic-media',
+  'synthetic_media',
+  'deepfake',
+]);
+
+export function isAiReportType(reportType) {
+  if (typeof reportType !== 'string') return false;
+  const normalized = reportType.trim().toLowerCase().replace(/\s+/g, '_');
+  return AI_REPORT_TYPES.has(normalized);
+}
+
+/**
+ * Return the number of unique reporters for a sha256
+ * @param {D1Database} db
+ * @param {string} sha256
+ * @returns {Promise<number>}
+ */
+export async function getReportCount(db, sha256) {
+  const row = await db.prepare(`
+    SELECT COUNT(DISTINCT reporter_pubkey) AS cnt
+    FROM user_reports
+    WHERE sha256 = ?
+  `).bind(sha256).first();
+
+  return row?.cnt ?? 0;
+}
+
+/**
  * Return all unique reporters for a sha256 with their earliest report date
  * @param {D1Database} db
  * @param {string} sha256

--- a/src/reports.test.mjs
+++ b/src/reports.test.mjs
@@ -6,11 +6,14 @@
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import { env } from 'cloudflare:test';
-import { initReportsTable, getReporterPubkeys } from './reports.mjs';
+import { initReportsTable, addReport, getReportCount, getReporterPubkeys, isAiReportType } from './reports.mjs';
 
 const SHA256 = ('a'.repeat(63) + '1').slice(0, 64);
 const REPORTER1 = ('b'.repeat(63) + '1').slice(0, 64);
 const REPORTER2 = ('b'.repeat(63) + '2').slice(0, 64);
+const REPORTER3 = ('b'.repeat(63) + '3').slice(0, 64);
+const REPORTER4 = ('b'.repeat(63) + '4').slice(0, 64);
+const REPORTER5 = ('b'.repeat(63) + '5').slice(0, 64);
 
 async function insertReport(db, { sha256, reporter_pubkey, report_type, reason }) {
   await db.prepare(`
@@ -25,6 +28,109 @@ describe('reports', () => {
   beforeEach(async () => {
     await initReportsTable(db);
     await db.prepare('DELETE FROM user_reports').run();
+  });
+
+  describe('isAiReportType', () => {
+    it('matches AI and deepfake report labels case-insensitively', () => {
+      expect(isAiReportType('ai')).toBe(true);
+      expect(isAiReportType('AI_GENERATED')).toBe(true);
+      expect(isAiReportType('synthetic-media')).toBe(true);
+      expect(isAiReportType('deepfake')).toBe(true);
+    });
+
+    it('does not match ordinary safety report labels', () => {
+      expect(isAiReportType('nudity')).toBe(false);
+      expect(isAiReportType('violence')).toBe(false);
+      expect(isAiReportType('spam')).toBe(false);
+      expect(isAiReportType(null)).toBe(false);
+    });
+  });
+
+  describe('addReport', () => {
+    it('should add a new report and not escalate', async () => {
+      const result = await addReport(db, {
+        sha256: SHA256,
+        reporter_pubkey: REPORTER1,
+        report_type: 'nudity',
+        reason: 'inappropriate content',
+      });
+
+      expect(result).toEqual({ escalate: null });
+    });
+
+    it('should deduplicate same reporter for same sha256', async () => {
+      await addReport(db, {
+        sha256: SHA256,
+        reporter_pubkey: REPORTER1,
+        report_type: 'nudity',
+      });
+
+      // Same reporter, same sha256 — should not increase count
+      await addReport(db, {
+        sha256: SHA256,
+        reporter_pubkey: REPORTER1,
+        report_type: 'spam',
+        reason: 'duplicate report',
+      });
+
+      const count = await getReportCount(db, SHA256);
+      expect(count).toBe(1);
+    });
+
+    it('should count different reporters separately', async () => {
+      await addReport(db, {
+        sha256: SHA256,
+        reporter_pubkey: REPORTER1,
+        report_type: 'nudity',
+      });
+
+      await addReport(db, {
+        sha256: SHA256,
+        reporter_pubkey: REPORTER2,
+        report_type: 'nudity',
+      });
+
+      const count = await getReportCount(db, SHA256);
+      expect(count).toBe(2);
+    });
+  });
+
+  describe('escalation thresholds', () => {
+    it('should escalate to REVIEW at 3 unique reporters', async () => {
+      await addReport(db, { sha256: SHA256, reporter_pubkey: REPORTER1, report_type: 'nudity' });
+      await addReport(db, { sha256: SHA256, reporter_pubkey: REPORTER2, report_type: 'nudity' });
+
+      const result = await addReport(db, {
+        sha256: SHA256,
+        reporter_pubkey: REPORTER3,
+        report_type: 'nudity',
+      });
+
+      expect(result).toEqual({ escalate: 'REVIEW' });
+    });
+
+    it('should escalate to AGE_RESTRICTED at 5 unique reporters', async () => {
+      await addReport(db, { sha256: SHA256, reporter_pubkey: REPORTER1, report_type: 'nudity' });
+      await addReport(db, { sha256: SHA256, reporter_pubkey: REPORTER2, report_type: 'nudity' });
+      await addReport(db, { sha256: SHA256, reporter_pubkey: REPORTER3, report_type: 'nudity' });
+      await addReport(db, { sha256: SHA256, reporter_pubkey: REPORTER4, report_type: 'nudity' });
+
+      const result = await addReport(db, {
+        sha256: SHA256,
+        reporter_pubkey: REPORTER5,
+        report_type: 'nudity',
+      });
+
+      expect(result).toEqual({ escalate: 'AGE_RESTRICTED' });
+    });
+  });
+
+  describe('getReportCount', () => {
+    it('should return 0 for unreported sha256', async () => {
+      const unreportedSha256 = ('c'.repeat(63) + '1').slice(0, 64);
+      const count = await getReportCount(db, unreportedSha256);
+      expect(count).toBe(0);
+    });
   });
 
   describe('getReporterPubkeys', () => {


### PR DESCRIPTION
## Summary
- Gate paid Hive AI detection to no-proof uploads or user AI reports, while valid ProofMode AI hits go to review instead of being hidden.
- Add a D1-backed `ai_detection_events` ledger and admin stats API for runs, skips, report-forced checks, open review items, and spend avoided.
- Add an AI Detection panel to the moderation admin dashboard with time-window summaries and recent review items.

## Test Plan
- [x] npm run lint
- [x] npx vitest run --dir src
- [x] git diff --check
- [x] npx wrangler d1 migrations apply blossom-webhook-events --remote
- [x] npm run deploy
- [x] curl -i https://moderation-api.divine.video/health