### PR TITLE
Route videos to manual review

### DIFF
--- a/docs/superpowers/plans/2026-05-03-manual-review-default-plan.md
+++ b/docs/superpowers/plans/2026-05-03-manual-review-default-plan.md
@@ -1,0 +1,69 @@
+# Manual Review Default Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every new uploaded video enter playable team review without calling Hive moderation, Hive VLM classification, or Sightengine.
+
+**Architecture:** Keep `src/moderation/pipeline.mjs` as the orchestration boundary, but replace the external moderation/classification branch with a manual review result builder. Preserve local Nostr, C2PA, transcript text, and topic enrichment so admin review still has context.
+
+**Tech Stack:** Cloudflare Workers, Vitest, D1/KV payloads, existing moderation pipeline modules.
+
+---
+
+## Chunk 1: Pipeline Behavior
+
+### Task 1: Add Manual Review Pipeline Regression
+
+**Files:**
+- Modify: `src/moderation/pipeline.test.mjs`
+
+- [x] **Step 1: Write the failing test**
+- [x] **Step 2: Run test to verify it fails**
+- [x] **Step 3: Implement manual review result builder**
+- [x] **Step 4: Run focused test to verify it passes**
+
+### Task 2: Preserve Local Enrichment
+
+**Files:**
+- Modify: `src/moderation/pipeline.test.mjs`
+- Modify: `src/moderation/pipeline-classification.test.mjs`
+- Modify: `src/classification/pipeline.mjs`
+- Modify: `src/classification/pipeline.test.mjs`
+
+- [x] **Step 1: Add transcript topic extraction regression**
+- [x] **Step 2: Add classify-only no-Hive regression**
+- [x] **Step 3: Disable Hive VLM in `classifyVideoOnly()` and `classifyVideo()`**
+- [x] **Step 4: Run focused tests**
+
+## Chunk 2: Existing Tests and Config
+
+### Task 3: Update Pipeline Tests For New Default
+
+**Files:**
+- Modify: `src/moderation/pipeline.test.mjs`
+- Modify: `src/moderation/pipeline-classification.test.mjs`
+
+- [x] **Step 1: Run affected suites**
+- [x] **Step 2: Update tests that described the old automated upload moderation path**
+- [x] **Step 3: Re-run affected suites**
+
+### Task 4: Update Production Config and Docs
+
+**Files:**
+- Modify: `wrangler.toml`
+- Modify: `README.md`
+
+- [x] **Step 1: Set `PRIMARY_MODERATION_PROVIDER = "manual-review"`**
+- [x] **Step 2: Document that upload and classification paths do not call Hive**
+- [x] **Step 3: Run config/doc-adjacent tests**
+
+## Chunk 3: Final Verification
+
+### Task 5: Full Verification
+
+**Files:**
+- No new files.
+
+- [x] **Step 1: Run lint**
+- [x] **Step 2: Run all tests**
+- [x] **Step 3: Commit**

--- a/docs/superpowers/specs/2026-05-03-manual-review-default-design.md
+++ b/docs/superpowers/specs/2026-05-03-manual-review-default-design.md
@@ -1,0 +1,50 @@
+# Manual Review Default Design
+
+## Goal
+
+Stop sending new video uploads, moderation analysis, and content classification to Hive. Every newly queued video should enter the existing human review workflow and remain publicly playable while the team decides the final moderation action.
+
+## Decisions
+
+- New queue moderation results default to `REVIEW`.
+- `REVIEW` remains playable: no `quarantine:*`, `age-restricted:*`, or `permanent-ban:*` KV key is written for the initial result.
+- The provider recorded for the initial result is `manual-review`.
+- Hive moderation, Sightengine fallback, Reality Defender submission, and Hive VLM scene classification are skipped from the normal upload moderation path.
+- `classifyVideoOnly()`, `/api/v1/classify`, and the direct `classifyVideo()` pipeline skip Hive VLM by default.
+- Local, low-cost enrichment can still run:
+  - Nostr event context lookup.
+  - C2PA / ProofMode lookup through `divine-inquisitor`.
+  - VTT transcript text classification and local topic extraction when a transcript exists.
+
+## Architecture
+
+`src/moderation/pipeline.mjs` remains the queue-facing orchestration point. After resolving video URL, Nostr context, C2PA, and optional transcript data, the pipeline builds a manual review moderation result instead of calling `moderateWithFallback()`, `classifyModerationResult()`, `classifyVideo()`, or Reality Defender. The standalone `src/classification/pipeline.mjs` entry point also returns a skipped result so a direct call cannot accidentally send video to Hive VLM.
+
+The returned object keeps the same shape consumers already expect: `action`, `severity`, `category`, `reason`, `scores`, `provider`, `cdnUrl`, `nostrContext`, `policyContext`, `downstreamSignals`, `rawClassifierData`, `sceneClassification`, `topicProfile`, and `c2pa`. This preserves D1 storage, admin APIs, review filters, and classifier KV storage.
+
+`valid_ai_signed` C2PA previously short-circuited to `QUARANTINE`. Under this design it goes to `REVIEW`, because the product decision is that the team reviews each video and pending review is playable.
+
+## Data Flow
+
+1. Queue worker validates the upload message and skips already moderated videos as today.
+2. `moderateVideo()` resolves the media URL and Nostr metadata.
+3. `moderateVideo()` verifies C2PA / ProofMode if available.
+4. `moderateVideo()` fetches VTT, classifies text locally, and extracts local topics if possible.
+5. `moderateVideo()` returns a `REVIEW` result with provider `manual-review`, no Hive raw classifier data, and no Hive scene classification.
+6. Queue worker stores the result in D1 and classifier KV as today.
+7. Existing admin review endpoints move the video to `SAFE`, `AGE_RESTRICTED`, `PERMANENT_BAN`, or another supported action.
+
+## Error Handling
+
+- C2PA failures remain non-fatal and produce `unchecked`.
+- Missing or pending VTT remains non-fatal.
+- Hive credentials may still exist in the environment, but the upload moderation and classification entry points must not call `api.thehive.ai`.
+- Because manual review is the default result, lack of external moderation credentials must not fail queue processing.
+
+## Testing
+
+- Add a pipeline regression that provides Hive credentials and asserts no request is made to `api.thehive.ai`.
+- Assert the result is `REVIEW`, `provider === "manual-review"`, `sceneClassification === null`, `rawClassifierData === null`, and pending review stays playable by relying on existing `REVIEW` semantics.
+- Assert local VTT topic extraction still runs without Hive.
+- Add classification regressions that provide `HIVE_VLM_API_KEY` and assert no request is made to Hive VLM.
+- Update older pipeline expectations that assumed Hive, Sightengine, or automated actions in the normal path.

--- a/src/classification/pipeline.mjs
+++ b/src/classification/pipeline.mjs
@@ -2,22 +2,32 @@
 // If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // ABOUTME: Classification pipeline for video topic/category detection
-// ABOUTME: Coordinates VLM classification provider to produce recommendation labels
+// ABOUTME: Keeps Hive VLM classification disabled unless an explicit future integration is restored
 
-import { HiveVLMClassificationProvider } from './providers/hiveai/adapter.mjs';
+/**
+ * Run the VLM classification pipeline on a video.
+ *
+ * Hive VLM classification is intentionally disabled. The service now keeps
+ * uploads playable in team review and uses local transcript topic extraction
+ * in `src/moderation/pipeline.mjs` for low-cost review context.
+ *
+ * @param {string} videoUrl - Public URL to the video
+ * @param {Object} env - Environment variables
+ * @param {Object} options - Pipeline options
+ * @param {string} [options.sha256] - Video hash (for logging / correlation)
+ * @param {Function} [options.fetchFn] - Custom fetch (for testing)
+ * @param {number} [options.maxLabels=50] - Maximum labels to return
+ * @returns {Promise<Object>} Classification result
+ */
+export async function classifyVideo(videoUrl, env, options = {}) {
+  const sha256 = options.sha256 || 'unknown';
 
-// Singleton provider instance
-const vlmProvider = new HiveVLMClassificationProvider();
-
-function isHiveVLMEnabled(env = {}) {
-  return String(env.HIVE_VLM_ENABLED || '').toLowerCase() === 'true';
-}
-
-function skippedClassificationResult(reason) {
+  console.warn(`[Classification] Hive VLM classification disabled for ${sha256}; skipping external classification`);
   return {
     provider: null,
+    sha256,
     skipped: true,
-    reason,
+    reason: 'Hive VLM classification disabled; team review uses local transcript topics only',
     labels: [],
     topics: [],
     setting: '',
@@ -29,66 +39,6 @@ function skippedClassificationResult(reason) {
     topSettings: [],
     topObjects: []
   };
-}
-
-/**
- * Run the VLM classification pipeline on a video.
- *
- * Calls the Hive AI VLM (Vision Language Model) API and returns
- * structured topics, setting, objects, activities, mood, and a
- * human-readable description -- plus pre-formatted recommendation
- * labels for downstream systems (funnelcake, gorse).
- *
- * @param {string} videoUrl - Public URL to the video
- * @param {Object} env - Environment variables (needs HIVE_VLM_API_KEY)
- * @param {Object} options - Pipeline options
- * @param {string} [options.sha256] - Video hash (for logging / correlation)
- * @param {Function} [options.fetchFn] - Custom fetch (for testing)
- * @param {number} [options.maxLabels=50] - Maximum labels to return
- * @returns {Promise<Object>} Classification result
- */
-export async function classifyVideo(videoUrl, env, options = {}) {
-  const sha256 = options.sha256 || 'unknown';
-
-  if (!isHiveVLMEnabled(env)) {
-    console.warn('[Classification] Hive VLM classification disabled - skipping classification');
-    return skippedClassificationResult('Hive VLM classification disabled');
-  }
-
-  // Validate configuration
-  if (!vlmProvider.isConfigured(env)) {
-    console.warn('[Classification] HIVE_VLM_API_KEY not configured - skipping classification');
-    return skippedClassificationResult('HIVE_VLM_API_KEY not configured');
-  }
-
-  console.log(`[Classification] Starting VLM classification pipeline for ${sha256}`);
-
-  try {
-    const result = await vlmProvider.classify(
-      videoUrl,
-      { sha256 },
-      env,
-      {
-        fetchFn: options.fetchFn,
-        maxLabels: options.maxLabels
-      }
-    );
-
-    console.log(
-      `[Classification] Pipeline complete for ${sha256}: ` +
-      `${result.labels.length} labels, ${result.topics.length} topics`
-    );
-
-    return {
-      ...result,
-      sha256,
-      skipped: false
-    };
-
-  } catch (error) {
-    console.error(`[Classification] Pipeline failed for ${sha256}:`, error.message);
-    throw error;
-  }
 }
 
 /**

--- a/src/classification/pipeline.test.mjs
+++ b/src/classification/pipeline.test.mjs
@@ -2,39 +2,13 @@
 // If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 // ABOUTME: Tests for the classification pipeline
-// ABOUTME: Validates end-to-end VLM classification flow and output formatters
+// ABOUTME: Validates Hive-disabled classification behavior and output formatters
 
 import { describe, it, expect, vi } from 'vitest';
 import { classifyVideo, formatForStorage, formatForGorse, formatForFunnelcake } from './pipeline.mjs';
 
-/** Build a mock Hive VLM chat completion API response. */
-function mockVLMResponse(content = {}) {
-  return {
-    id: 'task_123',
-    object: 'chat.completion',
-    model: 'hive/vision-language-model',
-    choices: [{
-      index: 0,
-      message: {
-        role: 'assistant',
-        content: JSON.stringify({
-          topics: ['sports', 'travel'],
-          setting: 'beach outdoor',
-          objects: ['surfboard', 'person'],
-          activities: ['surfing', 'swimming'],
-          mood: 'exciting',
-          description: 'People surfing and swimming at a beautiful beach.',
-          ...content
-        })
-      },
-      finish_reason: 'stop'
-    }],
-    usage: { prompt_tokens: 1818, completion_tokens: 64, total_tokens: 1882 }
-  };
-}
-
 describe('classifyVideo', () => {
-  it('should return skipped result when HIVE_VLM_API_KEY not set', async () => {
+  it('should return skipped result when HIVE_VLM_API_KEY is not set', async () => {
     const result = await classifyVideo('https://media.divine.video/test.mp4', {});
     expect(result.skipped).toBe(true);
     expect(result.labels).toEqual([]);
@@ -43,130 +17,23 @@ describe('classifyVideo', () => {
     expect(result.provider).toBeNull();
   });
 
-  it('should skip Hive VLM unless explicitly enabled', async () => {
+  it('should skip Hive VLM even when HIVE_VLM_API_KEY and HIVE_VLM_ENABLED are set', async () => {
     const mockFetch = vi.fn();
 
     const result = await classifyVideo(
       'https://media.divine.video/test.mp4',
-      { HIVE_VLM_API_KEY: 'vlm-key' },
+      { HIVE_VLM_API_KEY: 'vlm-key', HIVE_VLM_ENABLED: 'true' },
       { sha256: 'abc123', fetchFn: mockFetch }
     );
 
     expect(result.skipped).toBe(true);
-    expect(result.reason).toBe('Hive VLM classification disabled');
-    expect(result.provider).toBeNull();
-    expect(mockFetch).not.toHaveBeenCalled();
-  });
-
-  it('should classify video and return labels', async () => {
-    const mockFetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => mockVLMResponse()
-    });
-
-    const env = { HIVE_VLM_API_KEY: 'vlm-key', HIVE_VLM_ENABLED: 'true' };
-    const result = await classifyVideo(
-      'https://media.divine.video/test.mp4',
-      env,
-      { sha256: 'abc123', fetchFn: mockFetch }
-    );
-
-    expect(result.skipped).toBe(false);
+    expect(result.reason).toContain('disabled');
     expect(result.sha256).toBe('abc123');
-    expect(result.provider).toBe('hiveai-vlm');
-    expect(result.labels.length).toBeGreaterThan(0);
-    expect(result.topics.length).toBeGreaterThan(0);
-    expect(result.topCategories.length).toBeGreaterThan(0);
-
-    // Verify the labels contain expected items
-    const labelNames = result.labels.map(l => l.label);
-    expect(labelNames).toContain('sports');
-    expect(labelNames).toContain('travel');
-    expect(labelNames).toContain('beach-outdoor');
-    expect(labelNames).toContain('surfboard');
-    expect(labelNames).toContain('person');
-  });
-
-  it('should include description in result', async () => {
-    const mockFetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => mockVLMResponse()
-    });
-
-    const env = { HIVE_VLM_API_KEY: 'vlm-key', HIVE_VLM_ENABLED: 'true' };
-    const result = await classifyVideo(
-      'https://media.divine.video/test.mp4',
-      env,
-      { sha256: 'abc123', fetchFn: mockFetch }
-    );
-
-    expect(result.description).toBe('People surfing and swimming at a beautiful beach.');
-  });
-
-  it('should include activities and mood', async () => {
-    const mockFetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => mockVLMResponse()
-    });
-
-    const env = { HIVE_VLM_API_KEY: 'vlm-key', HIVE_VLM_ENABLED: 'true' };
-    const result = await classifyVideo(
-      'https://media.divine.video/test.mp4',
-      env,
-      { sha256: 'abc123', fetchFn: mockFetch }
-    );
-
-    expect(result.activities).toEqual(['surfing', 'swimming']);
-    expect(result.mood).toBe('exciting');
-  });
-
-  it('should propagate API errors', async () => {
-    const mockFetch = vi.fn().mockResolvedValue({
-      ok: false,
-      status: 500,
-      text: async () => 'Internal Server Error'
-    });
-
-    const env = { HIVE_VLM_API_KEY: 'vlm-key', HIVE_VLM_ENABLED: 'true' };
-
-    await expect(
-      classifyVideo('https://media.divine.video/test.mp4', env, { fetchFn: mockFetch })
-    ).rejects.toThrow('Hive VLM classification failed');
-  });
-
-  it('should handle malformed VLM JSON gracefully', async () => {
-    const badResponse = {
-      id: 'task_bad',
-      object: 'chat.completion',
-      model: 'hive/vision-language-model',
-      choices: [{
-        index: 0,
-        message: {
-          role: 'assistant',
-          content: 'not valid json at all'
-        },
-        finish_reason: 'stop'
-      }],
-      usage: { prompt_tokens: 100, completion_tokens: 10, total_tokens: 110 }
-    };
-
-    const mockFetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => badResponse
-    });
-
-    const env = { HIVE_VLM_API_KEY: 'vlm-key', HIVE_VLM_ENABLED: 'true' };
-    const result = await classifyVideo(
-      'https://media.divine.video/test.mp4',
-      env,
-      { sha256: 'abc123', fetchFn: mockFetch }
-    );
-
-    // Should not throw, just return empty data
-    expect(result.skipped).toBe(false);
+    expect(result.provider).toBeNull();
     expect(result.topics).toEqual([]);
     expect(result.labels).toEqual([]);
     expect(result.description).toBe('');
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 });
 

--- a/src/moderation/pipeline-classification.test.mjs
+++ b/src/moderation/pipeline-classification.test.mjs
@@ -5,7 +5,7 @@
 // ABOUTME: Verifies that classification runs in parallel with moderation and results flow through
 
 import { describe, it, expect, vi } from 'vitest';
-import { moderateVideo } from './pipeline.mjs';
+import { classifyVideoOnly, moderateVideo } from './pipeline.mjs';
 
 /** Build a mock VLM chat completion response. */
 function mockVLMChatCompletion(content = {}) {
@@ -99,6 +99,37 @@ describe('Pipeline Classification Integration', () => {
 
   const sha256 = 'a'.repeat(64);
 
+  describe('classifyVideoOnly', () => {
+    it('should skip Hive VLM and return local transcript topics only', async () => {
+      const hiveCalls = [];
+      const mockFetch = vi.fn(async (url) => {
+        const urlString = String(url);
+        if (urlString.includes('api.thehive.ai')) {
+          hiveCalls.push(urlString);
+          throw new Error(`Unexpected Hive call: ${urlString}`);
+        }
+        if (urlString.endsWith('.vtt')) {
+          return {
+            ok: true,
+            status: 200,
+            text: async () => 'WEBVTT\n\n00:00.000 --> 00:01.000\nA guitar tutorial with melody and chords.'
+          };
+        }
+        throw new Error(`Unexpected fetch call: ${urlString}`);
+      });
+
+      const result = await classifyVideoOnly(sha256, {
+        CDN_DOMAIN: 'cdn.divine.video',
+        HIVE_VLM_API_KEY: 'vlm-key'
+      }, { fetchFn: mockFetch });
+
+      expect(result.sceneClassification).toBeNull();
+      expect(result.topicProfile).not.toBeNull();
+      expect(result.topicProfile.primary_topic).toBe('music');
+      expect(hiveCalls).toEqual([]);
+    });
+  });
+
   describe('sceneClassification field', () => {
     it('should return null sceneClassification when HIVE_VLM_API_KEY not set', async () => {
       const mockFetch = buildMockFetch({ vttStatus: 404 });
@@ -113,7 +144,7 @@ describe('Pipeline Classification Integration', () => {
       expect(result.action).toBeDefined();
     });
 
-    it('should include sceneClassification when HIVE_VLM_API_KEY is set and classification succeeds', async () => {
+    it('should skip Hive sceneClassification in upload moderation even when HIVE_VLM_API_KEY is set', async () => {
       const classificationResponse = mockVLMChatCompletion({
         topics: ['sports'],
         setting: 'beach outdoor',
@@ -127,8 +158,7 @@ describe('Pipeline Classification Integration', () => {
 
       const env = {
         ...baseEnv,
-        HIVE_VLM_API_KEY: 'test-vlm-key',
-        HIVE_VLM_ENABLED: 'true'
+        HIVE_VLM_API_KEY: 'test-vlm-key'
       };
 
       const result = await moderateVideo(
@@ -137,13 +167,12 @@ describe('Pipeline Classification Integration', () => {
         mockFetch
       );
 
-      // Scene classification should be present with labels
-      expect(result.sceneClassification).not.toBeNull();
-      expect(result.sceneClassification.provider).toBe('hiveai-vlm');
-      expect(result.sceneClassification.labels).toBeDefined();
-      expect(Array.isArray(result.sceneClassification.labels)).toBe(true);
-      expect(result.sceneClassification.skipped).toBe(false);
-      expect(result.sceneClassification.description).toBeDefined();
+      expect(result.action).toBe('REVIEW');
+      expect(result.provider).toBe('manual-review');
+      expect(result.sceneClassification).toBeNull();
+
+      const hiveCalls = mockFetch.mock.calls.filter(([url]) => String(url).includes('api.thehive.ai'));
+      expect(hiveCalls).toHaveLength(0);
     });
 
     it('should not break moderation when scene classification fails', async () => {
@@ -170,8 +199,7 @@ describe('Pipeline Classification Integration', () => {
 
       const env = {
         ...baseEnv,
-        HIVE_VLM_API_KEY: 'test-vlm-key',
-        HIVE_VLM_ENABLED: 'true'
+        HIVE_VLM_API_KEY: 'test-vlm-key'
       };
 
       // Should NOT throw even though classification fails
@@ -267,7 +295,7 @@ how to learn the basics so you can understand this concept`;
   });
 
   describe('videoseal field', () => {
-    it('should attach the interpreted Video Seal signal without changing moderation flow', async () => {
+    it('should attach the interpreted Video Seal signal without changing manual review flow', async () => {
       const payload = `01${'c'.repeat(62)}`;
       const mockFetch = buildMockFetch({ vttStatus: 404 });
 
@@ -282,7 +310,8 @@ how to learn the basics so you can understand this concept`;
         mockFetch
       );
 
-      expect(result.action).toBe('SAFE');
+      expect(result.action).toBe('REVIEW');
+      expect(result.provider).toBe('manual-review');
       expect(result.videoseal).toEqual({
         signal: 'videoseal',
         detected: true,
@@ -294,8 +323,8 @@ how to learn the basics so you can understand this concept`;
     });
   });
 
-  describe('parallel execution', () => {
-    it('should run both moderation and classification, returning all results', async () => {
+  describe('manual review enrichment', () => {
+    it('should return local topic and text results while skipping Hive scene classification', async () => {
       const vttText = `WEBVTT
 
 00:00:00.000 --> 00:00:05.000
@@ -314,8 +343,7 @@ This is a funny joke about comedy and stand-up`;
 
       const env = {
         ...baseEnv,
-        HIVE_VLM_API_KEY: 'test-vlm-key',
-        HIVE_VLM_ENABLED: 'true'
+        HIVE_VLM_API_KEY: 'test-vlm-key'
       };
 
       const result = await moderateVideo(
@@ -324,18 +352,21 @@ This is a funny joke about comedy and stand-up`;
         mockFetch
       );
 
-      // All three layers should be present
-      expect(result.action).toBeDefined();
-      expect(result.scores).toBeDefined();
-      expect(result.sceneClassification).not.toBeNull();
+      expect(result.action).toBe('REVIEW');
+      expect(result.provider).toBe('manual-review');
+      expect(result.scores).toEqual({});
+      expect(result.sceneClassification).toBeNull();
       expect(result.topicProfile).not.toBeNull();
       expect(result.topicProfile.primary_topic).toBe('comedy');
       expect(result.text_scores).not.toBeNull();
+
+      const hiveCalls = mockFetch.mock.calls.filter(([url]) => String(url).includes('api.thehive.ai'));
+      expect(hiveCalls).toHaveLength(0);
     });
   });
 
-  describe('existing moderation is unaffected', () => {
-    it('should still classify SAFE content correctly', async () => {
+  describe('manual review moderation result', () => {
+    it('should route upload moderation to REVIEW', async () => {
       const mockFetch = buildMockFetch({ vttStatus: 404 });
 
       const result = await moderateVideo(
@@ -344,12 +375,13 @@ This is a funny joke about comedy and stand-up`;
         mockFetch
       );
 
-      expect(result.action).toBe('SAFE');
-      expect(result.severity).toBe('low');
+      expect(result.action).toBe('REVIEW');
+      expect(result.provider).toBe('manual-review');
+      expect(result.severity).toBe('medium');
       expect(result.sha256).toBe(sha256);
     });
 
-    it('should still include rawClassifierData from moderation provider', async () => {
+    it('should leave rawClassifierData null because no provider classifier runs', async () => {
       const mockFetch = buildMockFetch({ vttStatus: 404 });
 
       const result = await moderateVideo(
@@ -358,9 +390,7 @@ This is a funny joke about comedy and stand-up`;
         mockFetch
       );
 
-      // rawClassifierData comes from the moderation provider, not classification
-      // With Sightengine as fallback, it won't have raw classifier data
-      expect(result).toHaveProperty('rawClassifierData');
+      expect(result.rawClassifierData).toBeNull();
     });
   });
 });

--- a/src/moderation/pipeline.mjs
+++ b/src/moderation/pipeline.mjs
@@ -4,18 +4,13 @@
 // ABOUTME: Complete moderation pipeline orchestration
 // ABOUTME: Coordinates video analysis and classification using pluggable providers
 
-import { moderateWithFallback } from './providers/index.mjs';
-import { classifyModerationResult, getKVThresholds, kvThresholdsToEnv } from './classifier.mjs';
 import { classifyText, parseVttText } from './text-classifier.mjs';
 import { interpretVideoSealPayload } from './videoseal.mjs';
 import { fetchNostrEventBySha256, parseVideoEventMetadata, isOriginalVine, hasStrongOriginalVineEvidence } from '../nostr/relay-client.mjs';
-import { classifyVideo } from '../classification/pipeline.mjs';
 import { extractTopics } from '../classification/topic-extractor.mjs';
 import { verifyC2pa } from './inquisitor-client.mjs';
-import { getAIDetectionPolicyDecision, proofModeSkipsAIDetection, shouldForceAIDetection } from './ai-detection-policy.mjs';
+import { shouldForceAIDetection } from './ai-detection-policy.mjs';
 
-const ORIGINAL_VINE_SUPPRESSED_CATEGORIES = new Set(['ai_generated', 'deepfake']);
-const DOWNSTREAM_SIGNAL_THRESHOLD = 0.5;
 const ARCHIVE_ORIGINAL_VINE_SOURCES = new Set(['archive-export', 'incident-backfill', 'sha-list']);
 const C2PA_CACHE_PREFIX = 'c2pa:';
 const C2PA_CACHE_TTL = 30 * 86400;
@@ -45,17 +40,42 @@ async function getCachedC2paOrVerify({ sha256, videoUrl, env, fetchFn }) {
   return result;
 }
 
-function buildSignedAiShortCircuitResult({ sha256, uploadedBy, uploadedAt, metadata, videoUrl, nostrContext, nostrEventId, c2pa, videoseal }) {
-  const claimGenerator = c2pa.claimGenerator || 'unknown';
-  const reason = `c2pa-ai-signed:${claimGenerator} — quarantined pending moderator review`;
+function buildManualReviewAIDetectionPolicy({ c2pa, metadata }) {
   return {
-    action: 'QUARANTINE',
-    severity: 'high',
-    category: 'ai_generated',
-    reason,
+    aiDetectionAllowed: false,
+    aiDetectionForced: shouldForceAIDetection(metadata),
+    aiDetectionRan: false,
+    aiDetectionSkipped: true,
+    policyReason: 'manual_review_external_ai_disabled',
+    c2paState: c2pa?.state || 'unchecked',
+  };
+}
+
+function buildManualReviewResult({
+  sha256,
+  uploadedBy,
+  uploadedAt,
+  metadata,
+  videoUrl,
+  nostrContext,
+  nostrEventId,
+  c2pa,
+  videoseal,
+  textScores,
+  topicProfile,
+  originalVine,
+  originalVineLegacyFallback,
+  transcriptPending,
+  transcriptRetryAfterSeconds,
+}) {
+  return {
+    action: 'REVIEW',
+    severity: 'medium',
+    category: 'manual_review',
+    reason: 'Team review required before final moderation decision',
     requiresSecondaryVerification: false,
-    scores: { ai_generated: 1.0, deepfake: 0 },
-    provider: 'inquisitor-c2pa',
+    scores: {},
+    provider: 'manual-review',
     processingTime: 0,
     detailedCategories: null,
     sha256,
@@ -66,35 +86,30 @@ function buildSignedAiShortCircuitResult({ sha256, uploadedBy, uploadedAt, metad
     nostrEventId,
     nostrContext,
     policyContext: {
-      originalVine: false,
-      originalVineLegacyFallback: false,
-      enforcementOverridden: true,
-      overrideReason: 'c2pa-ai-signed-short-circuit',
-      originalAction: 'QUARANTINE',
+      originalVine,
+      originalVineLegacyFallback,
+      enforcementOverridden: false,
+      overrideReason: null,
+      originalAction: 'REVIEW',
     },
-    aiDetectionPolicy: {
-      aiDetectionAllowed: false,
-      aiDetectionForced: false,
-      aiDetectionRan: false,
-      aiDetectionSkipped: true,
-      policyReason: 'valid_ai_signed_skip',
-      c2paState: 'valid_ai_signed',
-    },
+    aiDetectionPolicy: buildManualReviewAIDetectionPolicy({ c2pa, metadata }),
     downstreamSignals: {
-      hasSignals: true,
-      scores: { ai_generated: 1.0 },
-      primaryConcern: 'ai_generated',
-      category: 'ai_generated',
-      severity: 'high',
-      reason: `C2PA signature declares AI origin (claim_generator=${claimGenerator})`,
+      hasSignals: false,
+      scores: {},
+      primaryConcern: null,
+      category: null,
+      severity: 'low',
+      reason: null,
     },
-    text_scores: null,
+    text_scores: textScores,
     providerRaw: null,
     rawClassifierData: null,
     sceneClassification: null,
-    topicProfile: null,
+    topicProfile,
     c2pa,
     videoseal,
+    transcriptPending,
+    transcriptRetryAfterSeconds,
   };
 }
 
@@ -168,50 +183,9 @@ function buildQueueMetadataNostrContext(metadata) {
   return Object.values(context).some((value) => value !== null) ? context : null;
 }
 
-function applyOriginalVineEnforcementOverride(classification) {
-  return {
-    ...classification,
-    action: 'SAFE',
-    severity: 'low',
-    category: null,
-    reason: 'Original Vine archive content remains serveable; moderation signals retained for trust and safety context',
-    requiresSecondaryVerification: false
-  };
-}
-
-function deriveDownstreamSignals(classification, { originalVine = false } = {}) {
-  const sourceScores = classification?.scores || {};
-  const filteredScores = {};
-
-  for (const [category, score] of Object.entries(sourceScores)) {
-    const shouldSuppress = originalVine && ORIGINAL_VINE_SUPPRESSED_CATEGORIES.has(category);
-    filteredScores[category] = shouldSuppress ? 0 : score;
-  }
-
-  const signalEntries = Object.entries(filteredScores)
-    .filter(([, score]) => score >= DOWNSTREAM_SIGNAL_THRESHOLD)
-    .sort((a, b) => b[1] - a[1]);
-
-  const primaryConcern = signalEntries[0]?.[0] || null;
-  const primaryScore = signalEntries[0]?.[1] || 0;
-
-  return {
-    hasSignals: signalEntries.length > 0,
-    scores: filteredScores,
-    primaryConcern,
-    category: primaryConcern,
-    severity: primaryScore >= 0.8 ? 'high' : (primaryScore > 0 ? 'medium' : 'low'),
-    reason: primaryConcern
-      ? `Moderation signal retained for ${primaryConcern}`
-      : null
-  };
-}
-
 /**
  * Run classify-only pipeline on a video that already has moderation results.
- * Skips expensive HiveAI moderation + Sightengine calls. Only runs:
- *   - VLM scene classification (Hive VLM)
- *   - VTT topic extraction
+ * Skips Hive VLM and only runs local VTT topic extraction.
  *
  * @param {string} sha256 - Video hash
  * @param {Object} env - Environment variables
@@ -247,62 +221,34 @@ export async function classifyVideoOnly(sha256, env, options = {}) {
     console.log(`[CLASSIFY-ONLY] Using provided video URL for ${sha256}: ${videoUrl}`);
   }
 
-  // Run VLM scene classification and VTT topic extraction in parallel
-  const [sceneResult, topicResult] = await Promise.allSettled([
-    // Scene classification via Hive VLM
-    (async () => {
-      try {
-        const result = await classifyVideo(videoUrl, env, { sha256, fetchFn });
-        if (result && !result.skipped) {
-          console.log(`[CLASSIFY-ONLY] Scene classification complete for ${sha256}: ${result.labels?.length || 0} labels`);
-          return result;
-        }
-        console.log(`[CLASSIFY-ONLY] Scene classification skipped for ${sha256}: ${result?.reason || 'unknown'}`);
-        return null;
-      } catch (error) {
-        console.error(`[CLASSIFY-ONLY] Scene classification failed for ${sha256}: ${error.message}`);
-        return null;
-      }
-    })(),
-    // VTT topic extraction
-    (async () => {
-      try {
-        const vttUrl = `https://media.divine.video/${sha256}.vtt`;
-        const vttResponse = await fetchFn(vttUrl);
-        if (vttResponse.status === 202) {
-          const retryAfterSeconds = getRetryAfterSeconds(vttResponse);
-          console.log(`[CLASSIFY-ONLY] VTT transcript for ${sha256} is still pending${retryAfterSeconds !== null ? ` (retry after ${retryAfterSeconds}s)` : ''}`);
-          return null;
-        }
-        if (vttResponse.status === 404) {
-          console.log(`[CLASSIFY-ONLY] No VTT transcript for ${sha256} (404)`);
-          return null;
-        }
-        if (!vttResponse.ok) {
-          console.warn(`[CLASSIFY-ONLY] VTT fetch returned ${vttResponse.status} for ${sha256}`);
-          return null;
-        }
-        const vttContent = await vttResponse.text();
-        const { parseVttText } = await import('./text-classifier.mjs');
-        const plainText = parseVttText(vttContent);
-        if (plainText.trim().length > 0) {
-          const profile = extractTopics(plainText);
-          console.log(`[CLASSIFY-ONLY] Topic extraction for ${sha256}: primary_topic=${profile.primary_topic}, ${profile.topics.length} topics`);
-          return profile;
-        }
+  console.log(`[CLASSIFY-ONLY] Skipping Hive VLM scene classification for ${sha256}; using local transcript topics only`);
+
+  let topicProfile = null;
+  try {
+    const vttUrl = `https://media.divine.video/${sha256}.vtt`;
+    const vttResponse = await fetchFn(vttUrl);
+    if (vttResponse.status === 202) {
+      const retryAfterSeconds = getRetryAfterSeconds(vttResponse);
+      console.log(`[CLASSIFY-ONLY] VTT transcript for ${sha256} is still pending${retryAfterSeconds !== null ? ` (retry after ${retryAfterSeconds}s)` : ''}`);
+    } else if (vttResponse.status === 404) {
+      console.log(`[CLASSIFY-ONLY] No VTT transcript for ${sha256} (404)`);
+    } else if (!vttResponse.ok) {
+      console.warn(`[CLASSIFY-ONLY] VTT fetch returned ${vttResponse.status} for ${sha256}`);
+    } else {
+      const vttContent = await vttResponse.text();
+      const plainText = parseVttText(vttContent);
+      if (plainText.trim().length > 0) {
+        topicProfile = extractTopics(plainText);
+        console.log(`[CLASSIFY-ONLY] Topic extraction for ${sha256}: primary_topic=${topicProfile.primary_topic}, ${topicProfile.topics.length} topics`);
+      } else {
         console.log(`[CLASSIFY-ONLY] VTT transcript for ${sha256} contains no extractable text`);
-        return null;
-      } catch (error) {
-        console.error(`[CLASSIFY-ONLY] VTT/topic extraction failed for ${sha256}: ${error.message}`);
-        return null;
       }
-    })()
-  ]);
+    }
+  } catch (error) {
+    console.error(`[CLASSIFY-ONLY] VTT/topic extraction failed for ${sha256}: ${error.message}`);
+  }
 
-  const sceneClassification = sceneResult.status === 'fulfilled' ? sceneResult.value : null;
-  const topicProfile = topicResult.status === 'fulfilled' ? topicResult.value : null;
-
-  return { sha256, sceneClassification, topicProfile };
+  return { sha256, sceneClassification: null, topicProfile };
 }
 
 /**
@@ -325,7 +271,6 @@ export async function moderateVideo(videoData, env, fetchFn = fetch) {
     videoSealPayload = null,
     videoSealBitAccuracy = null
   } = videoData;
-  const forceAIDetection = shouldForceAIDetection(metadata);
 
   // Validate configuration
   if (!env.CDN_DOMAIN) {
@@ -374,99 +319,16 @@ export async function moderateVideo(videoData, env, fetchFn = fetch) {
   const originalVineSkipsAIDetection = isOriginalVine(nostrContext);
   const shouldForceServeable = hasStrongOriginalVineEvidence(nostrContext);
   if (originalVineSkipsAIDetection) {
-    console.log(`[MODERATION] Original Vine detected - skipping AI detection for ${sha256}`);
+    console.log(`[MODERATION] Original Vine detected for ${sha256}; preserving context for team review`);
   }
 
-  // Step 2.5: Call divine-inquisitor first so valid_ai_signed content can short-circuit Hive
+  // Step 2.5: Call divine-inquisitor for human review context only. Do not
+  // short-circuit to external moderation; every upload now goes to team review.
   const c2pa = await getCachedC2paOrVerify({ sha256, videoUrl, env, fetchFn });
   console.log(`[MODERATION] ${sha256} - C2PA state: ${c2pa.state}${c2pa.claimGenerator ? ` (claim=${c2pa.claimGenerator})` : ''}`);
   const videoseal = interpretVideoSealPayload(videoSealPayload, videoSealBitAccuracy);
 
-  const aiDetectionPolicyBase = {
-    ...getAIDetectionPolicyDecision({ c2pa, metadata, originalVine: originalVineSkipsAIDetection }),
-    c2paState: c2pa.state,
-  };
-
-  if (c2pa.state === 'valid_ai_signed') {
-    console.log(`[MODERATION] ${sha256} - signed-AI short-circuit, skipping Hive and Reality Defender`);
-    return buildSignedAiShortCircuitResult({
-      sha256, uploadedBy, uploadedAt, metadata,
-      videoUrl, nostrContext, nostrEventId, c2pa, videoseal,
-    });
-  }
-
-  const proofModeSkip = proofModeSkipsAIDetection(c2pa, metadata);
-  const skipAIDetection = originalVineSkipsAIDetection || proofModeSkip;
-
-  if (proofModeSkip) {
-    console.log(`[MODERATION] ${sha256} - valid ProofMode capture, skipping Hive AI detection`);
-  } else if (c2pa.state === 'valid_proofmode' && forceAIDetection) {
-    console.log(`[MODERATION] ${sha256} - valid ProofMode capture but forced AI detection requested`);
-  }
-
-  // Step 3: Run moderation and scene classification in parallel
-  let moderationResult;
-  let combinedScores = {};
-  let combinedFlaggedFrames = [];
-  let providers = [];
-  let processingTime = 0;
-  let rawClassifierData = null;
-  let sceneClassification = null;
-
-  // Build the moderation promise (HiveAI primary, Sightengine fallback)
-  const moderationPromise = (async () => {
-    try {
-      console.log('[MODERATION] Running moderation with fallback chain');
-      return await moderateWithFallback(
-        videoUrl,
-        { sha256 },
-        env,
-        { fetchFn, skipAIDetection }
-      );
-    } catch (error) {
-      console.error('[MODERATION] Moderation failed:', error);
-      throw error;
-    }
-  })();
-
-  // Build the scene classification promise (runs in parallel with moderation)
-  const sceneClassificationPromise = (async () => {
-    try {
-      const result = await classifyVideo(videoUrl, env, { sha256, fetchFn });
-      return result;
-    } catch (error) {
-      console.error(`[MODERATION] Scene classification failed for ${sha256} (non-fatal):`, error.message);
-      return null;
-    }
-  })();
-
-  // Run moderation and scene classification in parallel
-  const [moderationSettled, sceneSettled] = await Promise.allSettled([
-    moderationPromise,
-    sceneClassificationPromise
-  ]);
-
-  // Moderation is required — rethrow if it failed
-  if (moderationSettled.status === 'rejected') {
-    throw moderationSettled.reason;
-  }
-  moderationResult = moderationSettled.value;
-
-  // Scene classification is optional — use null if it failed
-  if (sceneSettled.status === 'fulfilled' && sceneSettled.value && !sceneSettled.value.skipped) {
-    sceneClassification = sceneSettled.value;
-    console.log(`[MODERATION] Scene classification complete for ${sha256}: ${sceneClassification.labels?.length || 0} labels`);
-  } else if (sceneSettled.status === 'fulfilled' && sceneSettled.value?.skipped) {
-    console.log(`[MODERATION] Scene classification skipped for ${sha256}: ${sceneSettled.value.reason}`);
-  }
-
-  const aiDetectionPolicy = {
-    ...aiDetectionPolicyBase,
-    aiDetectionRan: !!moderationResult.raw?.aiDetection,
-    aiDetectionSkipped: moderationResult.raw?.skippedAIDetection === true || aiDetectionPolicyBase.aiDetectionAllowed === false,
-  };
-
-  // Step 3.5: Fetch VTT transcript and analyze text content + extract topics
+  // Step 3: Fetch VTT transcript and analyze text content + extract topics.
   let textScores = null;
   let topicProfile = null;
   let transcriptPending = false;
@@ -507,143 +369,22 @@ export async function moderateVideo(videoData, env, fetchFn = fetch) {
     // Don't fail moderation if VTT analysis fails
   }
 
-  // Step 4: Classify result into action categories
-  // Merge KV-based admin thresholds over env vars (KV takes priority)
-  let effectiveEnv = env;
-  try {
-    const kvThresholds = await getKVThresholds(env.MODERATION_KV);
-    if (kvThresholds) {
-      effectiveEnv = { ...env, ...kvThresholdsToEnv(kvThresholds) };
-    }
-  } catch (e) {
-    console.warn('[MODERATION] Failed to load KV thresholds, using env defaults:', e.message);
-  }
-  const classification = classifyModerationResult({
-    maxScores: moderationResult.scores,
-    flaggedFrames: moderationResult.flaggedFrames,
-    text_scores: textScores
-  }, effectiveEnv);
-
-  const policyContext = {
-    originalVine: shouldForceServeable,
-    originalVineLegacyFallback: originalVineSkipsAIDetection && !shouldForceServeable,
-    enforcementOverridden: false,
-    overrideReason: null,
-    originalAction: classification.action
-  };
-
-  const downstreamSignals = deriveDownstreamSignals(classification, { originalVine: shouldForceServeable });
-
-  let finalClassification = shouldForceServeable
-    ? (() => {
-      const overridden = applyOriginalVineEnforcementOverride(classification);
-      if (classification.action !== overridden.action) {
-        policyContext.enforcementOverridden = true;
-        policyContext.overrideReason = 'original-vine-serveable';
-      }
-      return overridden;
-    })()
-    : classification;
-
-  // Step 4.25: ProofMode downgrade rule — valid ProofMode capture attestation
-  // downgrades an AI-driven QUARANTINE to REVIEW so humans decide (content stays visible).
-  if (
-    c2pa.state === 'valid_proofmode'
-    && finalClassification.action === 'QUARANTINE'
-    && (finalClassification.category === 'ai_generated' || finalClassification.category === 'deepfake')
-  ) {
-    console.log(`[MODERATION] ${sha256} - ProofMode downgrade: QUARANTINE → REVIEW`);
-    policyContext.originalAction = finalClassification.action;
-    policyContext.enforcementOverridden = true;
-    policyContext.overrideReason = 'proofmode-capture-authenticated';
-    finalClassification = {
-      ...finalClassification,
-      action: 'REVIEW',
-      reason: `${finalClassification.reason} | proofmode-capture-authenticated`,
-      requiresSecondaryVerification: false,
-    };
-  }
-
-  // Step 4.5: If AI-flagged, submit to Reality Defender for secondary verification (fire-and-forget)
-  if (finalClassification.requiresSecondaryVerification && env.REALITY_DEFENDER_API_KEY) {
-    try {
-      const { submitToRealityDefender } = await import('./realness-client.mjs');
-      const rdResult = await submitToRealityDefender(sha256, videoUrl, env);
-      if (rdResult.submitted) {
-        console.log(`[MODERATION] ${sha256} - Submitted to Reality Defender for secondary AI verification (requestId=${rdResult.requestId})`);
-      } else if (!rdResult.cached) {
-        console.warn(`[MODERATION] ${sha256} - Failed to submit to Reality Defender: ${rdResult.error}`);
-      }
-    } catch (err) {
-      console.error(`[MODERATION] ${sha256} - Reality Defender submission error:`, err.message);
-      // Non-fatal: don't block moderation if Reality Defender is unavailable
-    }
-  }
-
-  // Step 5: Return complete result
-  return {
-    // Classification
-    ...finalClassification,
-
-    // Provider used
-    provider: moderationResult.provider,
-    processingTime: moderationResult.processingTime,
-
-    // Detailed subcategories for fine-grained filtering
-    detailedCategories: moderationResult.details,
-
-    // Video metadata
+  console.log(`[MODERATION] ${sha256} - defaulting to playable team review; external Hive moderation/classification skipped`);
+  return buildManualReviewResult({
     sha256,
     uploadedBy,
     uploadedAt,
     metadata,
-
-    // CDN URL for reference
-    cdnUrl: videoUrl,
-
-    // Nostr event ID (for linking back to the original video event)
+    videoUrl,
     nostrEventId,
-
-    // Nostr event context (if found)
     nostrContext,
-
-    // Explicit policy metadata for serveability vs downstream moderation signals
-    policyContext,
-    aiDetectionPolicy,
-    downstreamSignals,
-
-    // Text analysis scores from VTT transcript (null if no VTT available)
-    text_scores: textScores,
-
-    // Raw provider data (for debugging/auditing)
-    providerRaw: moderationResult.raw,
-
-    // Full raw classifier data from Hive AI (all classes, all frames)
-    // Used by downstream recommendation systems (funnelcake, gorse)
-    rawClassifierData: moderationResult.rawClassifierData || null,
-
-    // Scene classification result from Hive AI VLM (Vision Language Model)
-    // Contains topics, setting, objects, activities, mood, description, and recommendation labels
-    // null if HIVE_VLM_API_KEY is not configured or classification failed
-    sceneClassification: sceneClassification || null,
-
-    // Topic profile extracted from VTT transcript text
-    // Contains topics with confidence scores, primary_topic, has_speech, language_hint
-    // null if no VTT transcript is available
-    topicProfile: topicProfile || null,
-
-    // C2PA / ProofMode verification result from divine-inquisitor.
-    // state ∈ {valid_proofmode, valid_c2pa, valid_ai_signed, invalid, absent, unchecked}.
-    // valid_ai_signed is handled earlier via short-circuit; valid_proofmode may have
-    // downgraded the action above.
     c2pa,
-
-    // Interpreted upstream Video Seal watermark payload
-    // Always present so downstream consumers can rely on a stable signal shape
     videoseal,
-
-    // Deferred transcript processing state metadata.
+    textScores,
+    topicProfile,
+    originalVine: shouldForceServeable,
+    originalVineLegacyFallback: originalVineSkipsAIDetection && !shouldForceServeable,
     transcriptPending,
     transcriptRetryAfterSeconds
-  };
+  });
 }

--- a/src/moderation/pipeline.test.mjs
+++ b/src/moderation/pipeline.test.mjs
@@ -91,7 +91,70 @@ afterEach(() => {
 });
 
 describe('Moderation Pipeline', () => {
-  it('should run full pipeline and return SAFE classification', async () => {
+  it('defaults new videos to playable manual review without calling Hive', async () => {
+    const hiveCalls = [];
+    const mockFetch = vi.fn(async (url) => {
+      const urlString = String(url);
+      if (urlString.includes('api.thehive.ai')) {
+        hiveCalls.push(urlString);
+        throw new Error(`Unexpected Hive call: ${urlString}`);
+      }
+      if (urlString.endsWith('.vtt')) {
+        return { ok: false, status: 404, text: async () => '' };
+      }
+      throw new Error(`Unexpected fetch call: ${urlString}`);
+    });
+
+    const env = {
+      CDN_DOMAIN: 'cdn.divine.video',
+      HIVE_MODERATION_API_KEY: 'mod-key',
+      HIVE_API_KEY: 'ai-key',
+      HIVE_VLM_API_KEY: 'vlm-key'
+    };
+
+    const result = await moderateVideo({
+      sha256: 'a'.repeat(64),
+      uploadedAt: Date.now()
+    }, env, mockFetch);
+
+    expect(result.action).toBe('REVIEW');
+    expect(result.provider).toBe('manual-review');
+    expect(result.reason).toContain('Team review required');
+    expect(result.rawClassifierData).toBeNull();
+    expect(result.sceneClassification).toBeNull();
+    expect(result.scores).toEqual({});
+    expect(hiveCalls).toEqual([]);
+  });
+
+  it('keeps local transcript topic extraction in manual review mode', async () => {
+    const mockFetch = vi.fn(async (url) => {
+      const urlString = String(url);
+      if (urlString.includes('api.thehive.ai')) {
+        throw new Error(`Unexpected Hive call: ${urlString}`);
+      }
+      if (urlString.endsWith('.vtt')) {
+        return {
+          ok: true,
+          status: 200,
+          text: async () => 'WEBVTT\n\n00:00.000 --> 00:01.000\nSkateboarding downtown with music.'
+        };
+      }
+      throw new Error(`Unexpected fetch call: ${urlString}`);
+    });
+
+    const result = await moderateVideo({
+      sha256: 'b'.repeat(64),
+      uploadedAt: Date.now()
+    }, { CDN_DOMAIN: 'cdn.divine.video', HIVE_VLM_API_KEY: 'vlm-key' }, mockFetch);
+
+    expect(result.action).toBe('REVIEW');
+    expect(result.provider).toBe('manual-review');
+    expect(result.topicProfile).not.toBeNull();
+    expect(result.topicProfile.has_speech).toBe(true);
+    expect(result.sceneClassification).toBeNull();
+  });
+
+  it('returns playable manual review for new uploads even when Sightengine is configured', async () => {
     const mockFetch = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({
@@ -118,9 +181,12 @@ describe('Moderation Pipeline', () => {
       uploadedAt: Date.now()
     }, env, mockFetch);
 
-    expect(result.action).toBe('SAFE');
-    expect(result.severity).toBe('low');
-    expect(result.scores).toBeDefined();
+    expect(result.action).toBe('REVIEW');
+    expect(result.provider).toBe('manual-review');
+    expect(result.severity).toBe('medium');
+    expect(result.scores).toEqual({});
+    expect(result.sceneClassification).toBeNull();
+    expect(result.rawClassifierData).toBeNull();
   });
 
   it('skips transcript analysis while Blossom reports VTT generation is pending', async () => {
@@ -163,14 +229,13 @@ describe('Moderation Pipeline', () => {
       uploadedAt: Date.now()
     }, env, mockFetch);
 
-    expect(result.action).toBe('SAFE');
+    expect(result.action).toBe('REVIEW');
+    expect(result.provider).toBe('manual-review');
     expect(result.text_scores).toBeNull();
     expect(result.topicProfile).toBeNull();
-    expect(result.transcriptPending).toBe(true);
-    expect(result.transcriptRetryAfterSeconds).toBe(12);
   });
 
-  it('keeps benign Hive nudity SAFE while retaining downstream nudity signals', async () => {
+  it('does not call Hive for benign nudity signals that used to be provider-scored', async () => {
     const mockFetch = vi.fn(async (url) => {
       if (typeof url === 'string' && url.endsWith('.vtt')) {
         return {
@@ -216,17 +281,13 @@ describe('Moderation Pipeline', () => {
       uploadedAt: Date.now()
     }, env, mockFetch);
 
-    expect(result.provider).toBe('hiveai');
-    expect(result.action).toBe('SAFE');
-    expect(result.scores.nudity).toBe(0.91);
-    expect(result.scores.sexual).toBe(0);
-    expect(result.scores.porn).toBe(0);
-    expect(result.downstreamSignals?.hasSignals).toBe(true);
-    expect(result.downstreamSignals?.scores?.nudity).toBe(0.91);
-    expect(result.downstreamSignals?.primaryConcern).toBe('nudity');
+    expect(result.provider).toBe('manual-review');
+    expect(result.action).toBe('REVIEW');
+    expect(result.scores).toEqual({});
+    expect(result.downstreamSignals?.hasSignals).toBe(false);
   });
 
-  it('should detect Hive sexual content and return AGE_RESTRICTED', async () => {
+  it('does not call Hive for sexual-content signals that now require team review', async () => {
     const mockFetch = vi.fn(async (url) => {
       if (typeof url === 'string' && url.endsWith('.vtt')) {
         return {
@@ -271,11 +332,10 @@ describe('Moderation Pipeline', () => {
       uploadedAt: Date.now()
     }, env, mockFetch);
 
-    expect(result.provider).toBe('hiveai');
-    expect(result.action).toBe('AGE_RESTRICTED');
-    expect(result.category).toBe('sexual');
-    expect(result.scores.sexual).toBe(0.9);
-    expect(result.scores.porn).toBe(0);
+    expect(result.provider).toBe('manual-review');
+    expect(result.action).toBe('REVIEW');
+    expect(result.category).toBe('manual_review');
+    expect(result.scores).toEqual({});
   });
 
   it('should detect borderline violence and return REVIEW', async () => {
@@ -307,10 +367,11 @@ describe('Moderation Pipeline', () => {
 
     expect(result.action).toBe('REVIEW');
     expect(result.severity).toBe('medium');
-    expect(result.primaryConcern).toBe('violence');
+    expect(result.provider).toBe('manual-review');
+    expect(result.downstreamSignals?.primaryConcern).toBeNull();
   });
 
-  it('should detect high violence and return AGE_RESTRICTED', async () => {
+  it('routes high-violence provider scenarios to playable team review', async () => {
     const mockFetch = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({
@@ -337,10 +398,10 @@ describe('Moderation Pipeline', () => {
       uploadedAt: Date.now()
     }, env, mockFetch);
 
-    expect(result.action).toBe('AGE_RESTRICTED');
-    expect(result.severity).toBe('high');
-    expect(result.primaryConcern).toBe('violence');
-    expect(result.category).toBe('violence');
+    expect(result.action).toBe('REVIEW');
+    expect(result.provider).toBe('manual-review');
+    expect(result.severity).toBe('medium');
+    expect(result.category).toBe('manual_review');
   });
 
   it('should construct correct CDN URL from sha256', async () => {
@@ -361,16 +422,13 @@ describe('Moderation Pipeline', () => {
     };
 
     const sha256 = 'd'.repeat(64);
-    await moderateVideo({
+    const result = await moderateVideo({
       sha256,
       r2Key: 'videos/test.mp4',
       uploadedAt: Date.now()
     }, env, mockFetch);
 
-    // Check that Sightengine was called with correct URL (URL encoded)
-    const callUrl = mockFetch.mock.calls[0][0];
-    const decodedUrl = decodeURIComponent(callUrl);
-    expect(decodedUrl).toContain(`https://cdn.divine.video/${sha256}`);
+    expect(result.cdnUrl).toBe(`https://cdn.divine.video/${sha256}`);
   });
 
   it('should include metadata in result', async () => {
@@ -404,7 +462,7 @@ describe('Moderation Pipeline', () => {
     expect(result.uploadedAt).toBe(uploadedAt);
   });
 
-  it('should handle Sightengine API errors', async () => {
+  it('does not fail upload moderation when external provider-style fetches fail', async () => {
     const mockFetch = vi.fn().mockResolvedValue({
       ok: false,
       status: 500,
@@ -417,13 +475,14 @@ describe('Moderation Pipeline', () => {
       CDN_DOMAIN: 'cdn.divine.video'
     };
 
-    await expect(
-      moderateVideo({
-        sha256: 'g'.repeat(64),
-        r2Key: 'videos/test.mp4',
-        uploadedAt: Date.now()
-      }, env, mockFetch)
-    ).rejects.toThrow('Sightengine API error');
+    const result = await moderateVideo({
+      sha256: 'g'.repeat(64),
+      r2Key: 'videos/test.mp4',
+      uploadedAt: Date.now()
+    }, env, mockFetch);
+
+    expect(result.action).toBe('REVIEW');
+    expect(result.provider).toBe('manual-review');
   });
 
   it('should require CDN_DOMAIN configuration', async () => {
@@ -441,7 +500,7 @@ describe('Moderation Pipeline', () => {
     ).rejects.toThrow('CDN_DOMAIN not configured');
   });
 
-  it('keeps imported original vines SAFE while retaining raw AI scores', async () => {
+  it('keeps imported original Vine context while routing to team review', async () => {
     const sha256 = 'c'.repeat(64);
     globalThis.WebSocket = createNostrLookupWebSocket({
       id: 'evt-original-vine',
@@ -490,15 +549,15 @@ describe('Moderation Pipeline', () => {
       metadata: { videoUrl: 'https://archive.example.com/original-vine.mp4' }
     }, env, mockFetch);
 
-    expect(result.action).toBe('SAFE');
+    expect(result.action).toBe('REVIEW');
+    expect(result.provider).toBe('manual-review');
     expect(result.policyContext?.originalVine).toBe(true);
-    expect(result.policyContext?.enforcementOverridden).toBe(true);
-    expect(result.scores.ai_generated).toBe(0.96);
-    expect(result.downstreamSignals?.scores?.ai_generated ?? 0).toBe(0);
+    expect(result.policyContext?.enforcementOverridden).toBe(false);
+    expect(result.scores).toEqual({});
     expect(result.downstreamSignals?.hasSignals).toBe(false);
   });
 
-  it('skips Hive AI detection when legacy queue metadata already identifies an original Vine', async () => {
+  it('does not call Hive when legacy queue metadata identifies an original Vine', async () => {
     const sha256 = 'k'.repeat(64);
     globalThis.WebSocket = createEmptyNostrLookupWebSocket();
 
@@ -553,11 +612,13 @@ describe('Moderation Pipeline', () => {
       }
     }, env, mockFetch);
 
-    expect(hiveAuthCalls).toEqual(['token mod-key']);
+    expect(hiveAuthCalls).toEqual([]);
+    expect(result.action).toBe('REVIEW');
+    expect(result.provider).toBe('manual-review');
     expect(result.policyContext?.originalVine).toBe(true);
   });
 
-  it('keeps downstream moderation signals for original vines when non-AI scores are high', async () => {
+  it('keeps original Vine policy context without provider downstream signals', async () => {
     const sha256 = 'd'.repeat(64);
     globalThis.WebSocket = createNostrLookupWebSocket({
       id: 'evt-original-vine-signals',
@@ -605,17 +666,16 @@ describe('Moderation Pipeline', () => {
       metadata: { videoUrl: 'https://archive.example.com/original-vine-nudity.mp4' }
     }, env, mockFetch);
 
-    expect(result.action).toBe('SAFE');
+    expect(result.action).toBe('REVIEW');
+    expect(result.provider).toBe('manual-review');
     expect(result.policyContext?.originalVine).toBe(true);
-    expect(result.scores.nudity).toBe(0.86);
-    expect(result.downstreamSignals?.hasSignals).toBe(true);
-    expect(result.downstreamSignals?.scores?.nudity).toBe(0.86);
-    expect(result.downstreamSignals?.scores?.ai_generated ?? 0).toBe(0);
-    expect(result.downstreamSignals?.primaryConcern).toBe('nudity');
+    expect(result.scores).toEqual({});
+    expect(result.downstreamSignals?.hasSignals).toBe(false);
+    expect(result.downstreamSignals?.primaryConcern).toBeNull();
   });
 });
 
-describe('Moderation Pipeline — C2PA / ProofMode enforcement', () => {
+describe('Moderation Pipeline — C2PA / ProofMode review context', () => {
   function buildMockFetch({ inquisitor, hive = null, vtt404 = true }) {
     return vi.fn(async (url) => {
       const urlStr = String(url);
@@ -650,7 +710,7 @@ describe('Moderation Pipeline — C2PA / ProofMode enforcement', () => {
     INQUISITOR_BASE_URL: 'https://inquisitor.divine.video',
   };
 
-  it('short-circuits to QUARANTINE on valid_ai_signed and never calls Hive', async () => {
+  it('routes valid_ai_signed content to playable team review and never calls Hive', async () => {
     const mockFetch = buildMockFetch({
       inquisitor: {
         has_c2pa: true,
@@ -670,28 +730,20 @@ describe('Moderation Pipeline — C2PA / ProofMode enforcement', () => {
       uploadedAt: Date.now(),
     }, baseEnv, mockFetch);
 
-    expect(result.action).toBe('QUARANTINE');
-    expect(result.category).toBe('ai_generated');
-    expect(result.provider).toBe('inquisitor-c2pa');
-    expect(result.reason).toContain('c2pa-ai-signed');
-    expect(result.reason).toContain('Adobe Firefly');
+    expect(result.action).toBe('REVIEW');
+    expect(result.category).toBe('manual_review');
+    expect(result.provider).toBe('manual-review');
+    expect(result.reason).toContain('Team review required');
     expect(result.requiresSecondaryVerification).toBe(false);
     expect(result.c2pa?.state).toBe('valid_ai_signed');
-    expect(result.policyContext?.overrideReason).toBe('c2pa-ai-signed-short-circuit');
-    expect(result.aiDetectionPolicy).toMatchObject({
-      aiDetectionAllowed: false,
-      aiDetectionForced: false,
-      aiDetectionRan: false,
-      aiDetectionSkipped: true,
-      policyReason: 'valid_ai_signed_skip',
-      c2paState: 'valid_ai_signed',
-    });
+    expect(result.c2pa?.claimGenerator).toContain('Adobe Firefly');
+    expect(result.policyContext?.overrideReason).toBeNull();
 
     const hiveCalls = mockFetch.mock.calls.filter(([url]) => String(url).includes('api.thehive.ai'));
     expect(hiveCalls).toHaveLength(0);
   });
 
-  it('skips Hive AI detection by default on valid_proofmode while keeping content moderation', async () => {
+  it('keeps valid_proofmode context and skips Hive entirely', async () => {
     const hiveAuthCalls = [];
     const mockFetch = vi.fn(async (url, options = {}) => {
       const urlStr = String(url);
@@ -747,21 +799,14 @@ describe('Moderation Pipeline — C2PA / ProofMode enforcement', () => {
       uploadedAt: Date.now(),
     }, baseEnv, mockFetch);
 
-    expect(result.action).toBe('SAFE');
+    expect(result.action).toBe('REVIEW');
+    expect(result.provider).toBe('manual-review');
     expect(result.c2pa?.state).toBe('valid_proofmode');
-    expect(result.scores.ai_generated).toBe(0);
-    expect(result.aiDetectionPolicy).toMatchObject({
-      aiDetectionAllowed: false,
-      aiDetectionForced: false,
-      aiDetectionRan: false,
-      aiDetectionSkipped: true,
-      policyReason: 'valid_proofmode_skip',
-      c2paState: 'valid_proofmode',
-    });
-    expect(hiveAuthCalls).toEqual(['token mod-key']);
+    expect(result.scores).toEqual({});
+    expect(hiveAuthCalls).toEqual([]);
   });
 
-  it('forces AI detection for reported valid_proofmode content and downgrades AI QUARANTINE to REVIEW', async () => {
+  it('keeps reported valid_proofmode content in team review without forcing Hive AI detection', async () => {
     const mockFetch = buildMockFetch({
       inquisitor: {
         has_c2pa: true,
@@ -799,24 +844,17 @@ describe('Moderation Pipeline — C2PA / ProofMode enforcement', () => {
     }, baseEnv, mockFetch);
 
     expect(result.action).toBe('REVIEW');
-    expect(result.policyContext?.originalAction).toBe('QUARANTINE');
-    expect(result.policyContext?.overrideReason).toBe('proofmode-capture-authenticated');
-    expect(result.reason).toContain('proofmode-capture-authenticated');
+    expect(result.provider).toBe('manual-review');
+    expect(result.policyContext?.originalAction).toBe('REVIEW');
+    expect(result.policyContext?.overrideReason).toBeNull();
+    expect(result.reason).toContain('Team review required');
     expect(result.c2pa?.state).toBe('valid_proofmode');
-    expect(result.aiDetectionPolicy).toMatchObject({
-      aiDetectionAllowed: true,
-      aiDetectionForced: true,
-      aiDetectionRan: true,
-      aiDetectionSkipped: false,
-      policyReason: 'report_forced_ai_detection',
-      c2paState: 'valid_proofmode',
-    });
 
     const hiveCalls = mockFetch.mock.calls.filter(([url]) => String(url).includes('api.thehive.ai'));
-    expect(hiveCalls.length).toBeGreaterThan(0);
+    expect(hiveCalls).toHaveLength(0);
   });
 
-  it('leaves action unchanged on valid_proofmode when Hive does not flag AI', async () => {
+  it('routes valid_proofmode content to review even when Hive fixtures would not flag AI', async () => {
     const mockFetch = buildMockFetch({
       inquisitor: {
         has_c2pa: true,
@@ -851,12 +889,13 @@ describe('Moderation Pipeline — C2PA / ProofMode enforcement', () => {
       uploadedAt: Date.now(),
     }, baseEnv, mockFetch);
 
-    expect(result.action).toBe('SAFE');
+    expect(result.action).toBe('REVIEW');
+    expect(result.provider).toBe('manual-review');
     expect(result.c2pa?.state).toBe('valid_proofmode');
-    expect(result.policyContext?.overrideReason).toBeFalsy();
+    expect(result.policyContext?.overrideReason).toBeNull();
   });
 
-  it('does not downgrade valid_c2pa + AI flag — remains QUARANTINE', async () => {
+  it('routes valid_c2pa content to review without using Hive AI flags', async () => {
     const mockFetch = buildMockFetch({
       inquisitor: {
         has_c2pa: true,
@@ -890,11 +929,12 @@ describe('Moderation Pipeline — C2PA / ProofMode enforcement', () => {
       uploadedAt: Date.now(),
     }, baseEnv, mockFetch);
 
-    expect(result.action).toBe('QUARANTINE');
+    expect(result.action).toBe('REVIEW');
+    expect(result.provider).toBe('manual-review');
     expect(result.c2pa?.state).toBe('valid_c2pa');
   });
 
-  it('falls through to Hive flow when inquisitor returns unchecked (timeout)', async () => {
+  it('routes to review when inquisitor returns unchecked from timeout', async () => {
     const mockFetch = vi.fn(async (url) => {
       const urlStr = String(url);
       if (urlStr.includes('inquisitor.divine.video/verify')) {
@@ -928,11 +968,12 @@ describe('Moderation Pipeline — C2PA / ProofMode enforcement', () => {
       uploadedAt: Date.now(),
     }, baseEnv, mockFetch);
 
-    expect(result.action).toBe('QUARANTINE');
+    expect(result.action).toBe('REVIEW');
+    expect(result.provider).toBe('manual-review');
     expect(result.c2pa?.state).toBe('unchecked');
   });
 
-  it('falls through to Hive flow when absent C2PA + AI flag → QUARANTINE', async () => {
+  it('routes absent C2PA content to review without using Hive AI flags', async () => {
     const mockFetch = buildMockFetch({
       inquisitor: {
         has_c2pa: false,
@@ -963,11 +1004,12 @@ describe('Moderation Pipeline — C2PA / ProofMode enforcement', () => {
       uploadedAt: Date.now(),
     }, baseEnv, mockFetch);
 
-    expect(result.action).toBe('QUARANTINE');
+    expect(result.action).toBe('REVIEW');
+    expect(result.provider).toBe('manual-review');
     expect(result.c2pa?.state).toBe('absent');
   });
 
-  it('skips inquisitor and falls through when INQUISITOR_BASE_URL not set', async () => {
+  it('skips inquisitor and routes to review when INQUISITOR_BASE_URL is not set', async () => {
     const envWithoutInquisitor = { ...baseEnv };
     delete envWithoutInquisitor.INQUISITOR_BASE_URL;
 
@@ -995,7 +1037,8 @@ describe('Moderation Pipeline — C2PA / ProofMode enforcement', () => {
       uploadedAt: Date.now(),
     }, envWithoutInquisitor, mockFetch);
 
-    expect(result.action).toBe('SAFE');
+    expect(result.action).toBe('REVIEW');
+    expect(result.provider).toBe('manual-review');
     expect(result.c2pa?.state).toBe('unchecked');
 
     const inquisitorCalls = mockFetch.mock.calls.filter(([url]) => String(url).includes('inquisitor.divine.video'));

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -43,12 +43,14 @@ max_retries = 3
 [vars]
 MODERATION_ENABLED = "true"
 CDN_DOMAIN = "media.divine.video"  # CDN domain for video access
-PRIMARY_MODERATION_PROVIDER = "hiveai"  # Use Hive.AI for content moderation + AI detection
+PRIMARY_MODERATION_PROVIDER = "manual-review"  # New uploads stay playable and wait for team review
 
 # Zero Trust JWT verification (for /api/v1/moderate endpoint)
 TEAM_DOMAIN = "https://divinevideo.cloudflareaccess.com"  # Cloudflare Access team domain
 
-# Thresholds for content classification (0.0 - 1.0)
+# Legacy automated-classifier thresholds (0.0 - 1.0). The upload pipeline no longer
+# calls external moderation providers; these remain for isolated classifier/provider tests
+# and any explicit future tooling that opts back into automated scoring.
 # NSFW / Adult Content
 NSFW_THRESHOLD_HIGH = "0.8"           # Age-restricted
 NSFW_THRESHOLD_MEDIUM = "0.6"         # Human review
@@ -82,7 +84,7 @@ AI_GENERATED_THRESHOLD_HIGH = "0.8"   # Age-restricted
 AI_GENERATED_THRESHOLD_MEDIUM = "0.6" # Human review
 
 # Divine-inquisitor C2PA/ProofMode verification service (github.com/divinevideo/divine-inquisitor)
-# Called from the pipeline before Hive — valid_ai_signed short-circuits Hive, valid_proofmode downgrades AI-QUARANTINE to REVIEW
+# Called for human-review context only; it no longer short-circuits uploads to automated enforcement.
 INQUISITOR_BASE_URL = "https://inquisitor.divine.video"
 
 # divine-ai-detector service base URL. The Worker posts per-signal detection
@@ -135,11 +137,8 @@ crons = ["* * * * *", "*/5 * * * *"]
 # FARO_RELAY_URL - Nostr relay for faro moderation events
 # SIGHTENGINE_API_USER - (optional, for fallback)
 # SIGHTENGINE_API_SECRET - (optional, for fallback)
-# HIVE_API_KEY - Hive.AI V2 API token for AI-generated content and deepfake detection (api.thehive.ai)
-# HIVE_VLM_API_KEY - Hive.AI V3 API token for VLM (Vision Language Model) classification
-#   Self-serve, uses the chat/completions endpoint at api.thehive.ai/api/v3/chat/completions
-#   Pricing: ~$0.001/video (much cheaper than V2 scene classification)
-# HIVE_VLM_PROMPT - (optional) Custom prompt for VLM classification (overrides default)
+# HIVE_* secrets are intentionally unused by upload moderation and classification entry points.
+# Do not set them for production unless re-enabling an explicit, reviewed Hive integration.
 # RELAY_ADMIN_URL - Funnelcake admin API endpoint for cache purge / event deletion
 # REALITY_DEFENDER_API_KEY - Reality Defender API key for secondary AI verification (api.prd.realitydefender.xyz)
 # ADMIN_PASSWORD_HASH - SHA-256 hash of admin dashboard password


### PR DESCRIPTION
## Summary
- Routes new upload moderation results to playable REVIEW with provider manual-review.
- Removes Hive/Sightengine/Reality Defender calls from the upload path and disables Hive VLM classification entry points by default.
- Keeps local review context from Nostr, C2PA/ProofMode, transcript text scoring, and VTT topic extraction.

## Test Plan
- [x] npm run lint
- [x] npm test