### PR TITLE
feat: trigger Hive recheck on user reports (incident-driven moderation)

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -6,6 +6,7 @@
 
 import { validateQueueMessage } from './schemas/queue-message.mjs';
 import { moderateVideo, classifyVideoOnly } from './moderation/pipeline.mjs';
+import { applyForceProvider, shouldQueueHiveRecheck } from './moderation/report-trigger.mjs';
 import { publishToFaro, publishToContentRelay, publishLabelEvent } from './nostr/publisher.mjs';
 import { requireAuth, getAuthenticatedUser } from './admin/auth.mjs';
 import { verifyZeroTrustJWT } from './admin/zerotrust.mjs';
@@ -3683,6 +3684,25 @@ async function runMigration() {
           } catch (eventErr) {
             console.error(`[API] Failed to record AI report event for ${sha256}:`, eventErr.message);
           }
+        } else if (env.MODERATION_QUEUE) {
+          const allowed = await shouldQueueHiveRecheck(env.BLOSSOM_DB, sha256);
+          if (allowed) {
+            await env.MODERATION_QUEUE.send({
+              sha256,
+              r2Key: `videos/${sha256}.mp4`,
+              uploadedAt: Date.now(),
+              metadata: {
+                source: 'user-report',
+                forceProvider: 'hiveai',
+                reportType: report_type,
+                reportedBy: reporter_pubkey,
+                ...(reason ? { reportReason: reason } : {})
+              }
+            });
+            console.log(`[API] Queued Hive recheck for reported content ${sha256} (report_type=${report_type})`);
+          } else {
+            console.log(`[API] Skipped Hive recheck for ${sha256} - rate-limited (recent hiveai run)`);
+          }
         }
 
         return new Response(JSON.stringify({ success: true, ...result }), {
@@ -4352,15 +4372,19 @@ async function runMigration() {
         ).bind(sha256).first();
 
         const forceAIDetection = shouldForceAIDetection(metadata);
+        const forcedProviderEnv = applyForceProvider(env, metadata);
+        const providerOverridden = forcedProviderEnv !== env;
 
-        if (existingResult && !forceAIDetection) {
+        if (existingResult && !forceAIDetection && !providerOverridden) {
           console.log(`[MODERATION] ⚠️ SKIPPED ${sha256} - already moderated`);
           console.log(`[MODERATION] Previous result: action=${existingResult.action}, moderated_at=${existingResult.moderated_at}`);
           message.ack();
           continue;
         }
 
-        if (existingResult && forceAIDetection) {
+        if (existingResult && providerOverridden) {
+          console.log(`[MODERATION] Step 4: Provider override requested for already moderated ${sha256}; previous action=${existingResult.action}; new provider=${metadata?.forceProvider}`);
+        } else if (existingResult && forceAIDetection) {
           console.log(`[MODERATION] Step 4: Forced AI detection requested for already moderated ${sha256}; previous action=${existingResult.action}`);
         } else {
           console.log(`[MODERATION] Step 4: No existing result found, starting analysis for ${sha256}`);
@@ -4375,7 +4399,7 @@ async function runMigration() {
           metadata,
           videoSealPayload,
           videoSealBitAccuracy
-        }, env);
+        }, forcedProviderEnv);
 
         if (result.uploadedBy) {
           try {

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -277,6 +277,93 @@ describe('HTTP hostname routing', () => {
     });
   });
 
+  it('queues a Hive moderation recheck when a non-AI report is submitted', async () => {
+    const queued = [];
+    const reporterPubkey = 'b'.repeat(64);
+    const env = createEnv({
+      BLOSSOM_DB: createDbMock(),
+      MODERATION_QUEUE: {
+        async send(message) {
+          queued.push(message);
+        }
+      }
+    });
+
+    const response = await worker.fetch(
+      new Request('https://moderation-api.divine.video/api/v1/report', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer test-service-token'
+        },
+        body: JSON.stringify({
+          sha256: SHA256,
+          reporter_pubkey: reporterPubkey,
+          report_type: 'nudity',
+          reason: 'explicit content'
+        })
+      }),
+      env
+    );
+
+    expect(response.status).toBe(200);
+    expect(queued).toHaveLength(1);
+    expect(queued[0]).toMatchObject({
+      sha256: SHA256,
+      r2Key: `videos/${SHA256}.mp4`,
+      metadata: {
+        source: 'user-report',
+        forceProvider: 'hiveai',
+        reportType: 'nudity',
+        reportedBy: reporterPubkey
+      }
+    });
+  });
+
+  it('skips queuing a Hive recheck when one already ran within the rate-limit window', async () => {
+    const queued = [];
+    const recentIso = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    const env = createEnv({
+      BLOSSOM_DB: createDbMock({
+        moderationResults: new Map([[SHA256, {
+          sha256: SHA256,
+          action: 'REVIEW',
+          provider: 'hiveai',
+          scores: JSON.stringify({}),
+          categories: JSON.stringify([]),
+          moderated_at: recentIso,
+          reviewed_by: null,
+          reviewed_at: null,
+        }]])
+      }),
+      MODERATION_QUEUE: {
+        async send(message) {
+          queued.push(message);
+        }
+      }
+    });
+
+    const response = await worker.fetch(
+      new Request('https://moderation-api.divine.video/api/v1/report', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer test-service-token'
+        },
+        body: JSON.stringify({
+          sha256: SHA256,
+          reporter_pubkey: 'c'.repeat(64),
+          report_type: 'violence',
+          reason: 'graphic'
+        })
+      }),
+      env
+    );
+
+    expect(response.status).toBe(200);
+    expect(queued).toHaveLength(0);
+  });
+
   it('requires admin auth for AI detection stats', async () => {
     const response = await worker.fetch(
       new Request('https://moderation.admin.divine.video/admin/api/ai-detection/stats'),

--- a/src/moderation/report-trigger.mjs
+++ b/src/moderation/report-trigger.mjs
@@ -1,0 +1,39 @@
+// ABOUTME: Helpers for routing user reports to a per-message moderation provider override.
+// Lets POST /api/v1/report (and the queue consumer) trigger Hive on incident only,
+// instead of running Hive on every upload.
+
+const ALLOWED_FORCE_PROVIDERS = new Set(['hiveai', 'sightengine']);
+
+export const HIVE_RECHECK_RATE_LIMIT_MS = 6 * 60 * 60 * 1000;
+
+export function applyForceProvider(env, metadata) {
+  const requested = metadata?.forceProvider;
+  if (!requested || !ALLOWED_FORCE_PROVIDERS.has(requested)) {
+    return env;
+  }
+  return { ...env, PRIMARY_MODERATION_PROVIDER: requested };
+}
+
+export async function shouldQueueHiveRecheck(db, sha256, nowMs = Date.now()) {
+  try {
+    const row = await db
+      .prepare(
+        "SELECT moderated_at FROM moderation_results WHERE sha256 = ? AND provider = 'hiveai' ORDER BY moderated_at DESC LIMIT 1"
+      )
+      .bind(sha256)
+      .first();
+
+    if (!row?.moderated_at) {
+      return true;
+    }
+
+    const lastMs = Date.parse(row.moderated_at);
+    if (!Number.isFinite(lastMs)) {
+      return true;
+    }
+
+    return nowMs - lastMs >= HIVE_RECHECK_RATE_LIMIT_MS;
+  } catch {
+    return true;
+  }
+}

--- a/src/moderation/report-trigger.test.mjs
+++ b/src/moderation/report-trigger.test.mjs
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applyForceProvider,
+  shouldQueueHiveRecheck,
+  HIVE_RECHECK_RATE_LIMIT_MS,
+} from './report-trigger.mjs';
+
+const SHA256 = 'a'.repeat(64);
+
+describe('applyForceProvider', () => {
+  it('returns env unchanged when metadata has no forceProvider', () => {
+    const env = { PRIMARY_MODERATION_PROVIDER: 'manual-review', OTHER: 'x' };
+    const result = applyForceProvider(env, { source: 'user-report' });
+    expect(result).toBe(env);
+  });
+
+  it('returns env unchanged when metadata is null or undefined', () => {
+    const env = { PRIMARY_MODERATION_PROVIDER: 'manual-review' };
+    expect(applyForceProvider(env, null)).toBe(env);
+    expect(applyForceProvider(env, undefined)).toBe(env);
+  });
+
+  it('overrides PRIMARY_MODERATION_PROVIDER when metadata.forceProvider is set', () => {
+    const env = { PRIMARY_MODERATION_PROVIDER: 'manual-review', HIVE_API_KEY: 'k' };
+    const result = applyForceProvider(env, { forceProvider: 'hiveai' });
+    expect(result.PRIMARY_MODERATION_PROVIDER).toBe('hiveai');
+    expect(result.HIVE_API_KEY).toBe('k');
+  });
+
+  it('does not mutate the original env', () => {
+    const env = { PRIMARY_MODERATION_PROVIDER: 'manual-review' };
+    applyForceProvider(env, { forceProvider: 'hiveai' });
+    expect(env.PRIMARY_MODERATION_PROVIDER).toBe('manual-review');
+  });
+
+  it('rejects unknown providers (defends against arbitrary env injection)', () => {
+    const env = { PRIMARY_MODERATION_PROVIDER: 'manual-review' };
+    const result = applyForceProvider(env, { forceProvider: 'evil-provider; rm -rf /' });
+    expect(result).toBe(env);
+  });
+});
+
+describe('shouldQueueHiveRecheck', () => {
+  function dbMockReturning(row) {
+    return {
+      prepare() {
+        return {
+          bind() {
+            return {
+              async first() {
+                return row;
+              },
+            };
+          },
+        };
+      },
+    };
+  }
+
+  it('returns true when no prior hiveai moderation exists', async () => {
+    const result = await shouldQueueHiveRecheck(dbMockReturning(null), SHA256);
+    expect(result).toBe(true);
+  });
+
+  it('returns false when a hiveai moderation ran within the rate-limit window', async () => {
+    const recent = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    const result = await shouldQueueHiveRecheck(
+      dbMockReturning({ moderated_at: recent }),
+      SHA256
+    );
+    expect(result).toBe(false);
+  });
+
+  it('returns true when the prior hiveai moderation is older than the window', async () => {
+    const old = new Date(Date.now() - HIVE_RECHECK_RATE_LIMIT_MS - 1000).toISOString();
+    const result = await shouldQueueHiveRecheck(
+      dbMockReturning({ moderated_at: old }),
+      SHA256
+    );
+    expect(result).toBe(true);
+  });
+
+  it('returns true when D1 is unavailable (fail-open)', async () => {
+    const failingDb = {
+      prepare() {
+        throw new Error('D1 down');
+      },
+    };
+    const result = await shouldQueueHiveRecheck(failingDb, SHA256);
+    expect(result).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Shifts Hive moderation from blanket per-upload (which we just disabled by switching `PRIMARY_MODERATION_PROVIDER=manual-review` on 2026-05-03 to stop \$6k/day billing) to incident-driven per-report. Any user report queues a full Hive moderation pass for that specific sha256, with a 6-hour rate limit per content item so report spam can't re-create the cost bleed.

## Changes

- **`src/moderation/report-trigger.mjs`** (new) — pure helpers:
  - `applyForceProvider(env, metadata)` — returns env with `PRIMARY_MODERATION_PROVIDER` overridden when `metadata.forceProvider` is in the allowlist (`hiveai`, `sightengine`); otherwise returns env unchanged. Defends against arbitrary env injection from queue payloads.
  - `shouldQueueHiveRecheck(db, sha256)` — checks `moderation_results` for the most recent `provider='hiveai'` row; returns false if it ran within `HIVE_RECHECK_RATE_LIMIT_MS` (6 hours). Fail-open if D1 errors.

- **`src/index.mjs`**:
  - `POST /api/v1/report`: when report type is non-AI (existing AI-detection branch is untouched and keeps its current ProofMode-gated behavior), check the rate limit and queue a moderation message with `metadata: { source: 'user-report', forceProvider: 'hiveai', reportType, reportedBy, reportReason }`
  - Queue consumer: `applyForceProvider(env, metadata)` runs before `moderateVideo`; when overridden, the moderation pass uses Hive instead of the env-default `manual-review`. Provider-override messages also bypass the dedupe check on `existingResult` so a re-check actually runs.

## Tests

- `src/moderation/report-trigger.test.mjs` — 9 unit tests (env override, no-mutation, allowlist, rate-limit window, fail-open)
- `src/index.test.mjs` — 2 new integration tests:
  - non-AI report queues `forceProvider: 'hiveai'`
  - rate-limited sha256 (recent hiveai row in D1) does NOT queue another recheck

All 444 tests in `src/index.test.mjs` + `src/moderation/report-trigger.test.mjs` pass when run together. (Note: `npm test` without file args is currently flaky due to a vitest-pool-workers websocket assertion in workerd startup, unrelated to this change — repro by running before/after this branch.)

## Cost shape

| Before today | After 2026-05-03 deploy | After this PR |
|---|---|---|
| Hive on every upload (\$6k/day) | Hive disabled, all uploads → REVIEW queue | Hive only on user-reported items, max once per 6h per sha256 |

At ~tens of reports/day vs thousands of uploads/day, expected Hive billing post-merge is ~100-1000x lower than the pre-2026-05-03 baseline, while restoring automated moderation depth on items humans flagged.

## Deferred (separate PRs)

- kind:1984 listener in relay polling cron (currently only HTTP endpoint receives reports)
- Dashboard "Re-check with Hive" button on REVIEW cards
- Same `forceProvider` plumbing exposed on `POST /admin/api/queue-moderation` for ad-hoc moderator triggering

## Test plan

- [ ] CI green
- [ ] After merge: deploy with `wrangler deploy` (NO auto-deploy on this repo — see project memory `deploy_no_auto_deploy.md`)
- [ ] Verify in production: `POST /api/v1/report` with `report_type: nudity` produces a queued message with `forceProvider: hiveai` and the resulting moderation_results row has `provider='hiveai'`
- [ ] Verify rate limit: second report on same sha256 within 6 hours does NOT trigger another Hive call (check tail logs for "Skipped Hive recheck ... rate-limited")

🤖 Generated with [Claude Code](https://claude.com/claude-code)