### PR TITLE
feat: notify relay on QUARANTINE for reversible enforcement

### DIFF
--- a/scripts/backfill-quarantine-relay.mjs
+++ b/scripts/backfill-quarantine-relay.mjs
@@ -1,0 +1,199 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: One-shot backfill — pushes existing QUARANTINE moderation_results rows
+// ABOUTME: into funnelcake's quarantined_events_set so the relay matches Blossom.
+//
+// Usage:
+//   FUNNELCAKE_ADMIN_URL=https://relay.divine.video \
+//   NOSTR_PRIVATE_KEY=<hex> \
+//   node scripts/backfill-quarantine-relay.mjs [--dry-run] [--limit N] [--concurrency 5]
+//
+// Reads QUARANTINE rows from prod D1 via `wrangler d1 execute --remote`, then
+// uses the same notifyRelay() helper as the worker to POST a NIP-98-signed
+// add to /api/moderation/quarantine for each row that has an event_id.
+//
+// Resumable: writes scripts/.backfill-quarantine-relay.checkpoint with the
+// list of sha256s already processed; rerun skips them.
+
+import { notifyRelay } from '../src/relay-notifier.mjs';
+
+const D1_DATABASE = 'blossom-webhook-events';
+
+export function parseArgs(argv) {
+  const out = { dryRun: false, limit: null, concurrency: 5 };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--dry-run') out.dryRun = true;
+    else if (argv[i] === '--limit') out.limit = parseInt(argv[++i], 10);
+    else if (argv[i] === '--concurrency') out.concurrency = parseInt(argv[++i], 10);
+  }
+  return out;
+}
+
+async function loadCheckpoint(checkpointPath) {
+  const { readFileSync, existsSync } = await import('node:fs');
+  if (!existsSync(checkpointPath)) return new Set();
+  return new Set(
+    readFileSync(checkpointPath, 'utf8')
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean),
+  );
+}
+
+async function appendCheckpoint(checkpointPath, sha256) {
+  const { writeFileSync, existsSync, mkdirSync } = await import('node:fs');
+  const { dirname } = await import('node:path');
+  if (!existsSync(dirname(checkpointPath))) {
+    mkdirSync(dirname(checkpointPath), { recursive: true });
+  }
+  writeFileSync(checkpointPath, `${sha256}\n`, { flag: 'a' });
+}
+
+async function fetchQuarantineRows() {
+  const { execFileSync } = await import('node:child_process');
+  const sql =
+    "SELECT sha256, event_id FROM moderation_results " +
+    "WHERE action = 'QUARANTINE' AND event_id IS NOT NULL AND event_id != ''";
+  const stdout = execFileSync(
+    'npx',
+    ['--yes', 'wrangler', 'd1', 'execute', D1_DATABASE, '--remote', '--json', `--command=${sql}`],
+    { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024, stdio: ['ignore', 'pipe', 'inherit'] },
+  );
+  const parsed = JSON.parse(stdout);
+  const results = Array.isArray(parsed) ? parsed[0]?.results : parsed?.results;
+  if (!Array.isArray(results)) {
+    throw new Error('Unexpected wrangler d1 output shape');
+  }
+  return results;
+}
+
+export async function processChunk(rows, env, dryRun, notify = notifyRelay) {
+  return Promise.all(
+    rows.map(async (row) => {
+      if (dryRun) {
+        return { row, result: { success: true, skipped: true, reason: 'dry-run' } };
+      }
+      const result = await notify(row.sha256, row.event_id, 'QUARANTINE', env);
+      return { row, result };
+    }),
+  );
+}
+
+async function main() {
+  const { fileURLToPath } = await import('node:url');
+  const { dirname, join } = await import('node:path');
+  const __filename = fileURLToPath(import.meta.url);
+  const checkpointPath = join(dirname(__filename), '.backfill-quarantine-relay.checkpoint');
+
+  const args = parseArgs(process.argv.slice(2));
+  const env = {
+    FUNNELCAKE_ADMIN_URL: process.env.FUNNELCAKE_ADMIN_URL,
+    NOSTR_PRIVATE_KEY: process.env.NOSTR_PRIVATE_KEY,
+  };
+
+  if (!env.FUNNELCAKE_ADMIN_URL) {
+    console.error('Missing FUNNELCAKE_ADMIN_URL env var.');
+    process.exit(1);
+  }
+  if (!env.NOSTR_PRIVATE_KEY && !args.dryRun) {
+    console.error('Missing NOSTR_PRIVATE_KEY env var (required unless --dry-run).');
+    process.exit(1);
+  }
+
+  console.log('[BACKFILL] Quarantine relay sync');
+  console.log(`[BACKFILL] Admin URL: ${env.FUNNELCAKE_ADMIN_URL}`);
+  console.log(`[BACKFILL] Dry-run: ${args.dryRun}`);
+  console.log(`[BACKFILL] Concurrency: ${args.concurrency}`);
+  console.log('');
+
+  console.log('[BACKFILL] Fetching QUARANTINE rows from D1...');
+  const all = await fetchQuarantineRows();
+  console.log(`[BACKFILL] Total candidates: ${all.length}`);
+
+  const done = await loadCheckpoint(checkpointPath);
+  const todo = all.filter((row) => !done.has(row.sha256));
+  console.log(`[BACKFILL] Already processed (checkpoint): ${done.size}`);
+  console.log(`[BACKFILL] Remaining: ${todo.length}`);
+  if (args.limit) {
+    console.log(`[BACKFILL] Capping run at --limit ${args.limit}`);
+  }
+  const work = args.limit ? todo.slice(0, args.limit) : todo;
+  console.log('');
+
+  if (work.length === 0) {
+    console.log('[BACKFILL] Nothing to do.');
+    return;
+  }
+
+  let ok = 0;
+  let skipped = 0;
+  let failed = 0;
+  const failures = [];
+
+  for (let i = 0; i < work.length; i += args.concurrency) {
+    const chunk = work.slice(i, i + args.concurrency);
+    const results = await processChunk(chunk, env, args.dryRun);
+
+    for (const { row, result } of results) {
+      const short = row.sha256.substring(0, 16);
+      if (result.success && !result.skipped) {
+        ok++;
+        if (!args.dryRun) await appendCheckpoint(checkpointPath, row.sha256);
+        console.log(`  [OK]   ${short}... event=${row.event_id.substring(0, 16)}...`);
+      } else if (result.success && result.skipped) {
+        skipped++;
+        if (!args.dryRun) await appendCheckpoint(checkpointPath, row.sha256);
+        console.log(`  [SKIP] ${short}... ${result.reason || ''}`);
+      } else {
+        failed++;
+        failures.push({ sha256: row.sha256, error: result.error });
+        console.error(`  [FAIL] ${short}... ${result.error}`);
+      }
+    }
+
+    // Light rate-limiting between chunks (funnelcake has its own limits).
+    if (!args.dryRun && i + args.concurrency < work.length) {
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+  }
+
+  console.log('');
+  console.log('='.repeat(60));
+  console.log('[BACKFILL] Summary:');
+  console.log(`  Processed:  ${work.length}`);
+  console.log(`  Quarantined: ${ok}`);
+  console.log(`  Skipped:    ${skipped}`);
+  console.log(`  Failed:     ${failed}`);
+  console.log('='.repeat(60));
+
+  if (failed > 0) {
+    console.log('');
+    console.log('[BACKFILL] Failures (re-run to retry — successes are checkpointed):');
+    for (const f of failures.slice(0, 25)) {
+      console.log(`  ${f.sha256} - ${f.error}`);
+    }
+    if (failures.length > 25) {
+      console.log(`  ... and ${failures.length - 25} more.`);
+    }
+    process.exit(1);
+  }
+}
+
+// Only run main() when invoked directly, not when imported by tests.
+async function isDirectInvocation() {
+  if (typeof process === 'undefined' || !process.argv?.[1]) return false;
+  try {
+    const { fileURLToPath } = await import('node:url');
+    return fileURLToPath(import.meta.url) === process.argv[1];
+  } catch {
+    return false;
+  }
+}
+
+if (await isDirectInvocation()) {
+  main().catch((err) => {
+    console.error('[BACKFILL] Fatal:', err);
+    process.exit(1);
+  });
+}

--- a/scripts/backfill-quarantine-relay.test.mjs
+++ b/scripts/backfill-quarantine-relay.test.mjs
@@ -1,0 +1,65 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Unit tests for the helpers exported by backfill-quarantine-relay.mjs.
+// ABOUTME: notifyRelay() itself is covered by relay-notifier.test.mjs; here we
+// ABOUTME: just check argv parsing and chunk dispatch shape.
+
+import { describe, it, expect, vi } from 'vitest';
+import { parseArgs, processChunk } from './backfill-quarantine-relay.mjs';
+
+describe('parseArgs', () => {
+  it('defaults to live run with concurrency 5 and no limit', () => {
+    expect(parseArgs([])).toEqual({ dryRun: false, limit: null, concurrency: 5 });
+  });
+
+  it('reads --dry-run, --limit, --concurrency', () => {
+    expect(parseArgs(['--dry-run', '--limit', '50', '--concurrency', '8'])).toEqual({
+      dryRun: true,
+      limit: 50,
+      concurrency: 8,
+    });
+  });
+
+  it('ignores unknown args', () => {
+    expect(parseArgs(['--frobnicate', '--limit', '10'])).toEqual({
+      dryRun: false,
+      limit: 10,
+      concurrency: 5,
+    });
+  });
+});
+
+describe('processChunk', () => {
+  it('does not call notify when dryRun is true', async () => {
+    const notify = vi.fn();
+    const rows = [
+      { sha256: 'a'.repeat(64), event_id: 'b'.repeat(64) },
+      { sha256: 'c'.repeat(64), event_id: 'd'.repeat(64) },
+    ];
+    const out = await processChunk(rows, {}, true, notify);
+    expect(notify).not.toHaveBeenCalled();
+    expect(out).toHaveLength(2);
+    for (const r of out) {
+      expect(r.result).toEqual({ success: true, skipped: true, reason: 'dry-run' });
+    }
+  });
+
+  it('calls notify with QUARANTINE for each row in live mode', async () => {
+    const notify = vi
+      .fn()
+      .mockResolvedValueOnce({ success: true })
+      .mockResolvedValueOnce({ success: false, error: 'boom' });
+    const rows = [
+      { sha256: 'a'.repeat(64), event_id: 'b'.repeat(64) },
+      { sha256: 'c'.repeat(64), event_id: 'd'.repeat(64) },
+    ];
+    const out = await processChunk(rows, { FUNNELCAKE_ADMIN_URL: 'x' }, false, notify);
+    expect(notify).toHaveBeenCalledTimes(2);
+    for (const call of notify.mock.calls) {
+      expect(call[2]).toBe('QUARANTINE');
+    }
+    expect(out[0].result.success).toBe(true);
+    expect(out[1].result.success).toBe(false);
+  });
+});

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -29,6 +29,7 @@ import { parseRetryAfterSeconds } from './http-utils.mjs';
 import { classifyText, parseVttText } from './moderation/text-classifier.mjs';
 import { notifyAtprotoLabeler } from './atproto/label-webhook.mjs';
 import { buildDownstreamPublishContext } from './moderation/downstream-publishing.mjs';
+import { notifyRelay } from './relay-notifier.mjs';
 import { runClassicVineRollback } from './moderation/classic-vine-rollback.mjs';
 import { notifyBlossom } from './blossom-client.mjs';
 import { handleSyncDelete } from './creator-delete/sync-endpoint.mjs';
@@ -2004,7 +2005,7 @@ export default {
       // Get existing moderation result — check D1 first, fall back to KV
       let existing = null;
       const d1Row = await env.BLOSSOM_DB.prepare(
-        'SELECT sha256, action, provider, scores, categories, moderated_at, reviewed_by, reviewed_at, uploaded_by FROM moderation_results WHERE sha256 = ?'
+        'SELECT sha256, action, provider, scores, categories, moderated_at, reviewed_by, reviewed_at, uploaded_by, event_id FROM moderation_results WHERE sha256 = ?'
       ).bind(sha256).first();
 
       if (d1Row) {
@@ -2142,6 +2143,14 @@ export default {
         return blossomFailureResponse(sha256, action, blossomResult.error);
       }
 
+      // Symmetric add/remove on funnelcake's quarantine Set so manual
+      // overrides also flip the relay-side hide.
+      const adminRelayEventId = d1Row?.event_id || null;
+      const adminRelayResult = await notifyRelay(sha256, adminRelayEventId, action, env);
+      if (!adminRelayResult.success && !adminRelayResult.skipped) {
+        console.warn(`[ADMIN] Relay notification failed: ${adminRelayResult.error}`);
+      }
+
       // For PERMANENT_BAN: also delete the event from the relay (funnelcake),
       // but only after Blossom confirms enforcement to avoid partial moderation.
       let relayDeleteResult = null;
@@ -2270,7 +2279,7 @@ export default {
       } else {
         // Fall back to D1
         const d1Row = await env.BLOSSOM_DB.prepare(
-          'SELECT sha256, action, provider, scores, categories, moderated_at, reviewed_by, reviewed_at FROM moderation_results WHERE sha256 = ?'
+          'SELECT sha256, action, provider, scores, categories, moderated_at, reviewed_by, reviewed_at, event_id FROM moderation_results WHERE sha256 = ?'
         ).bind(sha256).first();
         if (d1Row) {
           existing = {
@@ -3837,12 +3846,29 @@ async function runMigration() {
           return blossomFailureResponse(sha256, action.toUpperCase(), blossomResult.error);
         }
 
+        // Symmetric add/remove on funnelcake's quarantine Set. Look up the
+        // event id from D1 (we don't have it on the request body for this
+        // external-API endpoint).
+        const apiEventIdRow = await env.BLOSSOM_DB.prepare(
+          'SELECT event_id FROM moderation_results WHERE sha256 = ?'
+        ).bind(sha256).first();
+        const apiRelayResult = await notifyRelay(
+          sha256,
+          apiEventIdRow?.event_id || null,
+          action.toUpperCase(),
+          env,
+        );
+        if (!apiRelayResult.success && !apiRelayResult.skipped) {
+          console.warn(`[API] Relay notification failed: ${apiRelayResult.error}`);
+        }
+
         return new Response(JSON.stringify({
           success: true,
           sha256,
           action: action.toUpperCase(),
           updated_at: new Date().toISOString(),
-          blossom_notified: blossomResult.success || false
+          blossom_notified: blossomResult.success || false,
+          relay_notified: apiRelayResult.success && !apiRelayResult.skipped,
         }), {
           headers: { 'Content-Type': 'application/json' }
         });
@@ -4810,6 +4836,18 @@ async function handleModerationResult(result, env) {
 
   if (!blossomResult.success && !blossomResult.skipped) {
     console.warn(`[MODERATION] Blossom notification failed: ${blossomResult.error}`);
+  }
+
+  // Tell funnelcake to add/remove the relay event from its quarantined Set.
+  // Symmetric with notifyBlossom — same fire-and-forget failure handling.
+  // PERMANENT_BAN is handled by deleteEventFromRelayBySha256 below; notifyRelay
+  // skips it internally so we don't double-act.
+  const relayEventId = result.nostrContext?.eventId || null;
+  const relayResult = await notifyRelay(sha256, relayEventId, action, env);
+  if (!relayResult.success && !relayResult.skipped) {
+    console.warn(`[MODERATION] Relay notification failed: ${relayResult.error}`);
+  } else if (relayResult.success && !relayResult.skipped) {
+    console.log(`[MODERATION] ${sha256} - Relay quarantine state updated for ${action}`);
   }
 
   // For PERMANENT_BAN: delete the event from the relay so externally-hosted content

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -4859,10 +4859,11 @@ async function handleModerationResult(result, env) {
     }
   }
 
-  // Send DM to creator for non-SAFE actions (non-blocking)
-  // DMs sent for permanent actions only. QUARANTINE is temporary (pending secondary
-  // verification) — DM fires when it resolves to PERMANENT_BAN via auto-escalation.
-  if (['PERMANENT_BAN', 'AGE_RESTRICTED'].includes(action) && uploadedBy && env.NOSTR_PRIVATE_KEY) {
+  // Send DM to creator for non-SAFE actions (non-blocking).
+  // QUARANTINE now also DMs because the relay-side hide makes the video
+  // disappear from public feeds; without a heads-up the creator would just
+  // see their upload vanish. The under-review template explains the 24h SLA.
+  if (['PERMANENT_BAN', 'AGE_RESTRICTED', 'QUARANTINE'].includes(action) && uploadedBy && env.NOSTR_PRIVATE_KEY) {
     try {
       const { sendModerationDM } = await import('./nostr/dm-sender.mjs');
       await sendModerationDM(uploadedBy, sha256, action, reason, env, null, { categories: result.categories, title: result.nostrContext?.title, publishedAt: result.nostrContext?.publishedAt });

--- a/src/nostr/dm-sender.mjs
+++ b/src/nostr/dm-sender.mjs
@@ -51,9 +51,12 @@ const TEMPLATES = {
   AGE_RESTRICTED: (reason, sha256, title, publishedAt) =>
     `${contentSubject(title)}${postedDate(publishedAt)} has been age-restricted because it was found to ${reason}. It's still available, but only visible to viewers who have confirmed their age.\n${contentLink(sha256)}\n${FOOTER}`,
 
-  // QUARANTINE intentionally ignores reason — the message is generic per spec
+  // QUARANTINE intentionally ignores reason — the message is generic per spec.
+  // Mentions the 24-hour SLA and reassures the creator that the video is
+  // still visible to them via direct link / their profile when signed in,
+  // since the relay-side hide otherwise looks like a silent shadow-ban.
   QUARANTINE: (_reason, sha256, title, publishedAt) =>
-    `${contentSubject(title)}${postedDate(publishedAt)} has been temporarily hidden while we review it. A moderator will take a look shortly. If you'd like to provide context, you can reply to this message.\n${contentLink(sha256)}\n${FOOTER}`,
+    `${contentSubject(title)}${postedDate(publishedAt)} is currently under review by our moderation team. A human moderator will take a look within 24 hours and either restore it or contact you with next steps.\n\nUntil then, the video is hidden from public feeds but still visible to you via the direct link below or from your profile when you're signed in. If you'd like to provide context, you can reply to this message.\n${contentLink(sha256)}\n${FOOTER}`,
 
   // Account-level suspension — no content link, not content-specific.
   // Used by relay-manager when banning a user's pubkey.

--- a/src/nostr/dm-sender.test.mjs
+++ b/src/nostr/dm-sender.test.mjs
@@ -68,8 +68,13 @@ describe('DM Sender - Message Templates', () => {
   it('should produce correct message for QUARANTINE', () => {
     const message = getMessageForAction('QUARANTINE', 'potential violation', 'ghi789');
 
-    expect(message).toContain('temporarily hidden');
-    expect(message).toContain('moderator will take a look');
+    expect(message).toContain('under review');
+    // Creators need to know roughly when to expect a decision; the 24h SLA
+    // is what we promise in policy and what the plan calls for explicitly.
+    expect(message).toMatch(/24 hours|24h|within a day/i);
+    // Author can still see their own under-review content via direct link;
+    // surfacing that prevents "did I get shadow-banned?" confusion.
+    expect(message).toMatch(/your profile|signed in|direct link/i);
     expect(message).toContain('divine.video/video/ghi789');
   });
 
@@ -379,7 +384,7 @@ describe('DM Sender - selectTemplate (Category-Specific)', () => {
     const msg = selectTemplate('QUARANTINE', 'custom reason', null, 'abc123');
 
     // QUARANTINE template is generic per spec — reason param is unused
-    expect(msg).toContain('temporarily hidden');
+    expect(msg).toContain('under review');
     expect(msg).not.toContain('custom reason');
   });
 
@@ -442,7 +447,7 @@ describe('DM Sender - selectTemplate (Category-Specific)', () => {
   it('should produce QUARANTINE template with reply invitation', () => {
     const msg = selectTemplate('QUARANTINE', null, '{"deepfake": 0.85}', 'ghi789');
 
-    expect(msg).toContain('temporarily hidden');
+    expect(msg).toContain('under review');
     expect(msg).toContain('reply to this message');
     expect(msg).toContain('divine.video/video/ghi789');
   });

--- a/src/nostr/publisher.mjs
+++ b/src/nostr/publisher.mjs
@@ -11,7 +11,7 @@ import { hexToBytes } from '@noble/hashes/utils';
 /**
  * NIP-32 label mapping for content categories
  */
-const CATEGORY_LABELS = {
+export const CATEGORY_LABELS = {
   'nudity': 'nudity',
   'violence': 'violence',
   'gore': 'gore',
@@ -192,10 +192,12 @@ function createReportEvent(report, privateKeyHex) {
  * @param {number} labelData.score - AI confidence score (0-1)
  * @param {string} [labelData.cdnUrl] - URL to video
  * @param {string} [labelData.nostrEventId] - Original Nostr event ID if known
+ * @param {string} [labelData.source] - 'human-moderator' (default) or 'automated' (Hive/RD/etc.)
  * @param {Object} env - Environment with Nostr credentials
+ * @param {Object} [mockRelay] - Mock relay for testing
  * @returns {Promise<Object>} Published event details
  */
-export async function publishLabelEvent(labelData, env) {
+export async function publishLabelEvent(labelData, env, mockRelay = null) {
   const { sha256, category, status, score, cdnUrl, nostrEventId } = labelData;
 
   // Validate configuration
@@ -218,6 +220,16 @@ export async function publishLabelEvent(labelData, env) {
   console.log(`[LABEL] Publishing kind 1985 label: ${category}=${status} for ${sha256.substring(0, 16)}...`);
 
   try {
+    if (mockRelay) {
+      await mockRelay.publish(event);
+      return {
+        published: true,
+        eventId: event.id,
+        pubkey: event.pubkey,
+        relay: relayUrl
+      };
+    }
+
     // Connect and publish
     const relayOptions = {};
     if (env.CF_ACCESS_CLIENT_ID && env.CF_ACCESS_CLIENT_SECRET) {
@@ -254,6 +266,8 @@ export async function publishLabelEvent(labelData, env) {
  */
 function createLabelEvent(labelData, privateKeyHex) {
   const { sha256, category, status, score, cdnUrl, nostrEventId } = labelData;
+  const source = labelData.source === 'automated' ? 'automated' : 'human-moderator';
+  const verified = source === 'human-moderator';
 
   // Get the standard label name
   const labelName = CATEGORY_LABELS[category] || category;
@@ -267,22 +281,22 @@ function createLabelEvent(labelData, privateKeyHex) {
   ];
 
   // For confirmed labels, add the positive label
-  // For rejected labels, add a "not-X" label to indicate human verified it's NOT this
+  // For rejected labels, add a "not-X" label to indicate the labeler says it is NOT this
   if (status === 'confirmed') {
     // Positive label with metadata
     const metadata = JSON.stringify({
       confidence: score,
-      verified: true,
-      source: 'human-moderator',
+      verified,
+      source,
       sha256: sha256
     });
     tags.push(['l', labelName, namespace, metadata]);
   } else if (status === 'rejected') {
-    // Negative label - human verified this is NOT the category
+    // Negative label - labeler says this is NOT the category
     const metadata = JSON.stringify({
       confidence: score,
-      verified: true,
-      source: 'human-moderator',
+      verified,
+      source,
       rejected: true,
       sha256: sha256
     });
@@ -303,9 +317,10 @@ function createLabelEvent(labelData, privateKeyHex) {
   tags.push(['x', sha256]);  // Content hash reference
 
   // Build content (human-readable summary)
+  const subject = source === 'automated' ? 'Automated moderator flagged' : 'Human moderator verified';
   const content = status === 'confirmed'
-    ? `Human moderator verified: This content contains ${labelName} (AI confidence: ${(score * 100).toFixed(0)}%)`
-    : `Human moderator verified: This content does NOT contain ${labelName} (AI false positive, was ${(score * 100).toFixed(0)}%)`;
+    ? `${subject}: This content contains ${labelName} (confidence: ${(score * 100).toFixed(0)}%)`
+    : `${subject}: This content does NOT contain ${labelName} (was ${(score * 100).toFixed(0)}%)`;
 
   // Create unsigned event
   const unsignedEvent = {

--- a/src/nostr/publisher.test.mjs
+++ b/src/nostr/publisher.test.mjs
@@ -5,7 +5,7 @@
 // ABOUTME: Verifies NIP-56 (kind 1984) reporting events are created correctly
 
 import { describe, it, expect, vi } from 'vitest';
-import { publishToFaro } from './publisher.mjs';
+import { publishToFaro, publishLabelEvent } from './publisher.mjs';
 
 describe('Nostr Event Publisher', () => {
   it('should create a kind 1984 report event for QUARANTINE', async () => {
@@ -230,5 +230,110 @@ describe('Nostr Event Publisher', () => {
     }, env, mockRelay);
 
     expect(mockRelay.publish).not.toHaveBeenCalled();
+  });
+});
+
+describe('publishLabelEvent (automated source)', () => {
+  // The relay's content_labels_mv only ingests kind 1985 events from pubkeys in
+  // nostr.trusted_labelers. The nsfw_labeled_events_set MV then picks up anything
+  // in the 'content-warning' namespace. So an automated kind 1985 with the right
+  // namespace is the canonical signal we want to emit at QUARANTINE time.
+  const baseEnv = () => ({
+    NOSTR_PRIVATE_KEY: 'a'.repeat(64),
+    NOSTR_RELAY_URL: 'wss://relay.divine.video',
+  });
+
+  function withMockRelay(env) {
+    const mockRelay = { publish: vi.fn().mockResolvedValue(undefined) };
+    return { mockRelay, env };
+  }
+
+  it('publishes a kind-1985 content-warning label when source=automated', async () => {
+    const { mockRelay, env } = withMockRelay(baseEnv());
+
+    const result = await publishLabelEvent({
+      sha256: 'a'.repeat(64),
+      category: 'ai_generated',
+      status: 'confirmed',
+      score: 0.97,
+      source: 'automated',
+      nostrEventId: 'd'.repeat(64),
+    }, env, mockRelay);
+
+    expect(result.published).toBe(true);
+    const event = mockRelay.publish.mock.calls[0][0];
+    expect(event.kind).toBe(1985);
+    // Namespace declaration for content-warning
+    expect(event.tags).toEqual(expect.arrayContaining([
+      ['L', 'content-warning'],
+    ]));
+    // Label tag in the content-warning namespace
+    const labelTag = event.tags.find((t) => t[0] === 'l' && t[2] === 'content-warning');
+    expect(labelTag).toBeDefined();
+    expect(labelTag[1]).toBe('ai-generated');
+    // References the relay event id
+    expect(event.tags).toEqual(expect.arrayContaining([
+      ['e', 'd'.repeat(64)],
+    ]));
+  });
+
+  it('marks automated labels as unverified in tag metadata', async () => {
+    const { mockRelay, env } = withMockRelay(baseEnv());
+
+    await publishLabelEvent({
+      sha256: 'a'.repeat(64),
+      category: 'deepfake',
+      status: 'confirmed',
+      score: 0.91,
+      source: 'automated',
+      nostrEventId: 'b'.repeat(64),
+    }, env, mockRelay);
+
+    const event = mockRelay.publish.mock.calls[0][0];
+    const labelTag = event.tags.find((t) => t[0] === 'l' && t[2] === 'content-warning');
+    expect(labelTag).toBeDefined();
+    const metadata = JSON.parse(labelTag[3]);
+    expect(metadata.source).toBe('automated');
+    expect(metadata.verified).toBe(false);
+    expect(metadata.confidence).toBe(0.91);
+  });
+
+  it('defaults to human-moderator when source is omitted (no regression)', async () => {
+    const { mockRelay, env } = withMockRelay(baseEnv());
+
+    await publishLabelEvent({
+      sha256: 'a'.repeat(64),
+      category: 'nudity',
+      status: 'confirmed',
+      score: 0.8,
+    }, env, mockRelay);
+
+    const event = mockRelay.publish.mock.calls[0][0];
+    const labelTag = event.tags.find((t) => t[0] === 'l' && t[2] === 'content-warning');
+    const metadata = JSON.parse(labelTag[3]);
+    expect(metadata.source).toBe('human-moderator');
+    expect(metadata.verified).toBe(true);
+  });
+
+  it('automated rejected labels are still emitted as not-{label}', async () => {
+    // Mirrors the human-moderator rejection shape — keeps the existing relay path
+    // for "this is NOT category X" intact when an automated source disagrees.
+    const { mockRelay, env } = withMockRelay(baseEnv());
+
+    await publishLabelEvent({
+      sha256: 'a'.repeat(64),
+      category: 'ai_generated',
+      status: 'rejected',
+      score: 0.04,
+      source: 'automated',
+      nostrEventId: 'c'.repeat(64),
+    }, env, mockRelay);
+
+    const event = mockRelay.publish.mock.calls[0][0];
+    const labelTag = event.tags.find((t) => t[0] === 'l' && t[2] === 'content-warning');
+    expect(labelTag[1]).toBe('not-ai-generated');
+    const metadata = JSON.parse(labelTag[3]);
+    expect(metadata.source).toBe('automated');
+    expect(metadata.rejected).toBe(true);
   });
 });

--- a/src/relay-notifier.mjs
+++ b/src/relay-notifier.mjs
@@ -1,0 +1,116 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: NIP-98 outbound client paired with notifyBlossom — adds/removes
+// ABOUTME: events from funnelcake's quarantined_events_set on action transitions.
+
+import { finalizeEvent } from 'nostr-tools/pure';
+import { hexToBytes, bytesToHex } from '@noble/hashes/utils';
+import { sha256 } from '@noble/hashes/sha256';
+
+const QUARANTINE_PATH = '/api/moderation/quarantine';
+const HEX64 = /^[0-9a-f]{64}$/;
+
+function sha256Hex(bytes) {
+  return bytesToHex(sha256(bytes));
+}
+
+function buildNip98Token(privateKeyHex, method, url, bodyBytes) {
+  const tags = [
+    ['u', url],
+    ['method', method],
+  ];
+  if (bodyBytes && bodyBytes.length > 0) {
+    tags.push(['payload', sha256Hex(bodyBytes)]);
+  }
+  const event = finalizeEvent(
+    {
+      kind: 27235,
+      created_at: Math.floor(Date.now() / 1000),
+      tags,
+      content: '',
+    },
+    hexToBytes(privateKeyHex),
+  );
+  // Cloudflare Workers don't have Buffer; use btoa with the JSON-stringified event.
+  // btoa requires Latin-1; the JSON of a NIP-98 event is ASCII so it's safe.
+  const json = JSON.stringify(event);
+  return typeof Buffer !== 'undefined'
+    ? Buffer.from(json).toString('base64')
+    : btoa(json);
+}
+
+/**
+ * Tell funnelcake to add/remove the relay event from its quarantine Set so
+ * public/discovery feeds stop serving it (or resume serving it on un-quarantine).
+ *
+ * Symmetric with notifyBlossom: same call site in handleModerationResult,
+ * same {success, skipped, error} shape, same fire-and-forget failure mode.
+ *
+ * @param {string} sha256Hex Video sha256 (carried for logging only)
+ * @param {string|null} eventId Relay event id (kind 34236). Required.
+ * @param {string} action SAFE | REVIEW | QUARANTINE | AGE_RESTRICTED | PERMANENT_BAN
+ * @param {Object} env Worker env. Reads FUNNELCAKE_ADMIN_URL, NOSTR_PRIVATE_KEY.
+ * @param {typeof fetch} [fetcher] Injected fetch for testing.
+ * @returns {Promise<{success: boolean, skipped?: boolean, reason?: string, error?: string}>}
+ */
+export async function notifyRelay(sha256Hex, eventId, action, env, fetcher = fetch) {
+  if (!env?.FUNNELCAKE_ADMIN_URL) {
+    return { success: true, skipped: true, reason: 'FUNNELCAKE_ADMIN_URL not configured' };
+  }
+  if (action === 'PERMANENT_BAN') {
+    // PERMANENT_BAN already deletes the event via NIP-09; quarantine entry
+    // (if any) becomes moot once the event is deleted.
+    return { success: true, skipped: true, reason: 'PERMANENT_BAN handled by NIP-09 path' };
+  }
+  if (action === 'REVIEW') {
+    // REVIEW is internal — content stays publicly accessible until a moderator decides.
+    return { success: true, skipped: true, reason: 'REVIEW is internal-only' };
+  }
+  if (!eventId) {
+    return { success: true, skipped: true, reason: 'no event_id on moderation result' };
+  }
+  if (!HEX64.test(eventId)) {
+    return { success: false, skipped: true, error: 'event_id must be 64-char lowercase hex' };
+  }
+  if (!env.NOSTR_PRIVATE_KEY) {
+    return { success: false, error: 'NOSTR_PRIVATE_KEY not configured' };
+  }
+
+  const isQuarantine = action === 'QUARANTINE';
+  const isClear = action === 'SAFE' || action === 'AGE_RESTRICTED';
+
+  if (!isQuarantine && !isClear) {
+    return { success: true, skipped: true, reason: `no relay action for ${action}` };
+  }
+
+  const url = isQuarantine
+    ? `${env.FUNNELCAKE_ADMIN_URL}${QUARANTINE_PATH}`
+    : `${env.FUNNELCAKE_ADMIN_URL}${QUARANTINE_PATH}/${eventId}`;
+  const method = isQuarantine ? 'POST' : 'DELETE';
+  const bodyObj = isQuarantine
+    ? { event_id: eventId, reason: `auto-${action.toLowerCase()}` }
+    : null;
+  const bodyBytes = bodyObj ? new TextEncoder().encode(JSON.stringify(bodyObj)) : null;
+
+  const token = buildNip98Token(env.NOSTR_PRIVATE_KEY, method, url, bodyBytes);
+
+  try {
+    const headers = {
+      Authorization: `Nostr ${token}`,
+      'Content-Type': 'application/json',
+    };
+    const init = { method, headers };
+    if (bodyBytes) {
+      init.body = JSON.stringify(bodyObj);
+    }
+    const res = await fetcher(url, init);
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      return { success: false, error: `HTTP ${res.status}: ${text}` };
+    }
+    return { success: true };
+  } catch (err) {
+    return { success: false, error: err.message };
+  }
+}

--- a/src/relay-notifier.test.mjs
+++ b/src/relay-notifier.test.mjs
@@ -1,0 +1,155 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Tests for the funnelcake relay quarantine notifier
+// ABOUTME: Verifies symmetric add/remove on action transitions and NIP-98 outbound auth
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { notifyRelay } from './relay-notifier.mjs';
+
+const PRIVATE_KEY = 'a'.repeat(64);
+const EVENT_ID = 'd'.repeat(64);
+const SHA256 = 'b'.repeat(64);
+
+function makeEnv(overrides = {}) {
+  return {
+    FUNNELCAKE_ADMIN_URL: 'https://relay.divine.video',
+    NOSTR_PRIVATE_KEY: PRIVATE_KEY,
+    ...overrides,
+  };
+}
+
+function okFetch() {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    text: () => Promise.resolve(''),
+  });
+}
+
+describe('notifyRelay', () => {
+  let fetcher;
+  beforeEach(() => {
+    fetcher = okFetch();
+  });
+
+  it('skips when FUNNELCAKE_ADMIN_URL is not configured', async () => {
+    const env = makeEnv({ FUNNELCAKE_ADMIN_URL: undefined });
+    const result = await notifyRelay(SHA256, EVENT_ID, 'QUARANTINE', env, fetcher);
+    expect(result).toEqual(expect.objectContaining({ success: true, skipped: true }));
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it('skips when event_id is missing (no relay event to hide)', async () => {
+    const env = makeEnv();
+    const result = await notifyRelay(SHA256, null, 'QUARANTINE', env, fetcher);
+    expect(result.success).toBe(true);
+    expect(result.skipped).toBe(true);
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it('skips PERMANENT_BAN (handled by the existing NIP-09 delete path)', async () => {
+    const env = makeEnv();
+    const result = await notifyRelay(SHA256, EVENT_ID, 'PERMANENT_BAN', env, fetcher);
+    expect(result.success).toBe(true);
+    expect(result.skipped).toBe(true);
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it('skips REVIEW (no enforcement; review is internal)', async () => {
+    const env = makeEnv();
+    const result = await notifyRelay(SHA256, EVENT_ID, 'REVIEW', env, fetcher);
+    expect(result.success).toBe(true);
+    expect(result.skipped).toBe(true);
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it('POSTs to /api/moderation/quarantine on QUARANTINE with NIP-98 auth', async () => {
+    const env = makeEnv();
+    const result = await notifyRelay(SHA256, EVENT_ID, 'QUARANTINE', env, fetcher);
+
+    expect(result.success).toBe(true);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    const [url, opts] = fetcher.mock.calls[0];
+    expect(url).toBe('https://relay.divine.video/api/moderation/quarantine');
+    expect(opts.method).toBe('POST');
+    expect(opts.headers['Authorization']).toMatch(/^Nostr [A-Za-z0-9+/=]+$/);
+    expect(opts.headers['Content-Type']).toBe('application/json');
+    const body = JSON.parse(opts.body);
+    expect(body.event_id).toBe(EVENT_ID);
+    expect(body.reason).toMatch(/auto-quarantine/);
+  });
+
+  it('DELETEs /api/moderation/quarantine/{event_id} on SAFE (un-quarantine)', async () => {
+    const env = makeEnv();
+    const result = await notifyRelay(SHA256, EVENT_ID, 'SAFE', env, fetcher);
+
+    expect(result.success).toBe(true);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    const [url, opts] = fetcher.mock.calls[0];
+    expect(url).toBe(`https://relay.divine.video/api/moderation/quarantine/${EVENT_ID}`);
+    expect(opts.method).toBe('DELETE');
+    expect(opts.headers['Authorization']).toMatch(/^Nostr /);
+    expect(opts.body).toBeFalsy();
+  });
+
+  it('DELETEs on AGE_RESTRICTED (clears any prior under-review hide)', async () => {
+    // AGE_RESTRICTED differs from QUARANTINE: the file is gated client-side, but
+    // the relay event is still discoverable by age-gated viewers, so any prior
+    // QUARANTINE entry must be removed.
+    const env = makeEnv();
+    const result = await notifyRelay(SHA256, EVENT_ID, 'AGE_RESTRICTED', env, fetcher);
+
+    expect(result.success).toBe(true);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(fetcher.mock.calls[0][1].method).toBe('DELETE');
+  });
+
+  it('does not throw on non-2xx responses; returns {success: false, error}', async () => {
+    fetcher = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve('boom'),
+    });
+    const env = makeEnv();
+    const result = await notifyRelay(SHA256, EVENT_ID, 'QUARANTINE', env, fetcher);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/500/);
+  });
+
+  it('does not throw on fetch network errors', async () => {
+    fetcher = vi.fn().mockRejectedValue(new Error('Network error'));
+    const env = makeEnv();
+    const result = await notifyRelay(SHA256, EVENT_ID, 'QUARANTINE', env, fetcher);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/Network error/);
+  });
+
+  it('rejects an event_id that is not 64-char lowercase hex', async () => {
+    const env = makeEnv();
+    const bad = "a'); DROP TABLE events; --";
+    const result = await notifyRelay(SHA256, bad, 'QUARANTINE', env, fetcher);
+    expect(result.success).toBe(false);
+    expect(result.skipped).toBe(true);
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it('signs a NIP-98 event whose payload tag matches the body sha256', async () => {
+    // Without this property, funnelcake's NIP-98 verifier rejects the request
+    // when there's a body. We can decode the base64 token and inspect the tags.
+    const env = makeEnv();
+    await notifyRelay(SHA256, EVENT_ID, 'QUARANTINE', env, fetcher);
+    const opts = fetcher.mock.calls[0][1];
+    const token = opts.headers['Authorization'].replace(/^Nostr /, '');
+    const event = JSON.parse(Buffer.from(token, 'base64').toString('utf8'));
+    expect(event.kind).toBe(27235);
+    const uTag = event.tags.find((t) => t[0] === 'u');
+    const methodTag = event.tags.find((t) => t[0] === 'method');
+    const payloadTag = event.tags.find((t) => t[0] === 'payload');
+    expect(uTag[1]).toBe('https://relay.divine.video/api/moderation/quarantine');
+    expect(methodTag[1]).toBe('POST');
+    expect(payloadTag).toBeDefined();
+    // payload tag should be 64-char hex
+    expect(payloadTag[1]).toMatch(/^[0-9a-f]{64}$/);
+  });
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -117,6 +117,12 @@ RELAY_POLLING_RELAY_URL = "wss://relay.divine.video"  # Relay to poll for new vi
 RELAY_POLLING_LOOKBACK_HOURS = "1"                # How far back to look for events (in hours)
 RELAY_POLLING_LIMIT = "100"                       # Max events to fetch per poll
 
+# Funnelcake admin URL — destination for notifyRelay() NIP-98 add/remove
+# webhooks against /api/moderation/quarantine. Empty string = relay-side
+# enforcement disabled (notifyRelay returns skipped). Signed with NOSTR_PRIVATE_KEY,
+# so the corresponding pubkey must be in funnelcake's ADMIN_PUBKEYS.
+FUNNELCAKE_ADMIN_URL = "https://relay.divine.video"
+
 # Creator-delete pipeline feature flag (default off; flip to "true" via `wrangler secret put` or [vars] once ready)
 CREATOR_DELETE_PIPELINE_ENABLED = "false"
 # Relay used to fetch creator kind 5 delete events and target video events.


### PR DESCRIPTION
## Summary

Pairs with [divine-funnelcake#341](https://github.com/divinevideo/divine-funnelcake/pull/341). Stops divine.video from rendering "Failed to load video" cards on QUARANTINEd content by hiding the kind 34236 from public surfaces at the relay layer, in addition to Blossom's existing 404. Reversible — flips back when un-quarantined.

Pre-existing damage: 216 QUARANTINEd rows in production D1 (`SELECT … WHERE action='QUARANTINE'`), 156 with event_id, ~98 within the last 7 days. All currently render the broken player on divine.video.

## What this changes

- **`src/relay-notifier.mjs`**: new `notifyRelay(sha256, eventId, action, env)` helper, NIP-98-signed POST/DELETE to `${FUNNELCAKE_ADMIN_URL}/api/moderation/quarantine`. Same `{success, skipped, error}` shape as `notifyBlossom`.
  - `QUARANTINE` → POST add
  - `SAFE` / `AGE_RESTRICTED` → DELETE remove
  - `PERMANENT_BAN` → skipped (existing NIP-09 path handles it)
  - `REVIEW` → skipped (REVIEW stays publicly visible by design)
- **`src/index.mjs`**: parallel `notifyRelay` call alongside `notifyBlossom` in:
  - `handleModerationResult` (queue/cron path) — uses `result.nostrContext.eventId`
  - `/admin/api/moderate` — looks up `event_id` from D1
  - `/api/v1/moderate` — same D1 lookup; surfaces `relay_notified` in the response
- **DM trigger**: `'QUARANTINE'` added to the action list at `src/index.mjs:4866` and the template at `src/nostr/dm-sender.mjs` mentions the 24-hour human review SLA and notes the video is still visible to the author via direct link / their own profile.
- **`wrangler.toml`**: new `FUNNELCAKE_ADMIN_URL = "https://relay.divine.video"`. Empty string disables relay-side enforcement (notifyRelay returns skipped). Signing uses the existing `NOSTR_PRIVATE_KEY`; matching pubkey `81549b…cd2898` is already in funnelcake's `ADMIN_PUBKEYS` (no infra change).
- **`scripts/backfill-quarantine-relay.mjs`**: one-shot script that reads existing QUARANTINE rows from D1 and POSTs each to the new admin endpoint. `--dry-run`, `--limit`, `--concurrency`, plus a checkpoint file for resumability.

## Test plan

- [x] `npm test` — 1149 passed, 65 files
- [x] `relay-notifier.test.mjs` — 11 cases (auth headers, action mapping, fetch failure, missing config, hex validation)
- [x] `backfill-quarantine-relay.test.mjs` — 5 cases (parseArgs, processChunk dry-run + live)
- [x] `dm-sender.test.mjs` — QUARANTINE template asserts 24h SLA + author-still-sees language
- [ ] After funnelcake#341 deploys: `node scripts/backfill-quarantine-relay.mjs --dry-run` → expect ~156 candidates, 0 calls
- [ ] After this deploys: `--limit 5` live run → confirm 5 events appear in `nostr.quarantined_events_set` and disappear from public feeds
- [ ] Full backfill of remaining ~151

## Plan & rollout

Plan: `docs/superpowers/plans/2026-05-04-relay-quarantine-enforcement-plan.md`

Rollout order (deploys are user-initiated):
1. Land funnelcake#341 → run migration 000116 → deploy → smoke test admin endpoints
2. Land this PR → `wrangler deploy` → confirm a fresh QUARANTINE call hits the relay set
3. `node scripts/backfill-quarantine-relay.mjs --limit 5` → eyeball
4. `node scripts/backfill-quarantine-relay.mjs` → full backfill
5. Browser-verify Dessy's video URL no longer renders the broken player

## Author visibility

This PR hides quarantined videos from public feeds. The direct event/profile URL still loads them today (same shape as how NSFW filters work). Truly per-viewer hiding ("only the author sees their own quarantined video, anywhere") is a follow-up that needs viewer-aware profile auth — the schema for that already exists in `private_accounts.approved_viewers`, which I noted in the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)