### PR TITLE
perf: moderation dashboard speedup (kill fan-out, KV-cache stats, untriaged window function, legacy backfill)

### DIFF
--- a/docs/superpowers/plans/2026-05-05-moderation-dashboard-speedup-plan.md
+++ b/docs/superpowers/plans/2026-05-05-moderation-dashboard-speedup-plan.md
@@ -1,0 +1,1222 @@
+# Moderation Dashboard Speedup Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `moderation.admin.divine.video` p95 page load < 1.5s (today: 5–15s) without changing what the dashboard displays.
+
+**Architecture:** Five PRs. (1) D1 indexes + new column. (2) Widen SELECTs and remove the 50× funnelcake fan-out. (3) KV-cached stats. (4) Untriaged endpoint cleanup. (5) Backfill cron for legacy rows. Spec: `docs/superpowers/specs/2026-05-05-moderation-dashboard-speedup-design.md`.
+
+**Tech Stack:** Cloudflare Workers, D1 (SQLite), KV, vitest with `@cloudflare/vitest-pool-workers`.
+
+**Conventions used everywhere:**
+- TDD: write failing test → confirm it fails → implement → confirm it passes → commit.
+- Tests live next to source: `src/foo.mjs` ↔ `src/foo.test.mjs`.
+- Run a single test file: `npm test -- src/path/to/file.test.mjs`.
+- Run the full suite: `npm test`.
+- All commits are conventional: `feat:`, `fix:`, `perf:`, `test:`, `refactor:`, `chore:`.
+- Don't merge to main without `npm test` passing locally.
+
+---
+
+## Chunk 1: PR1 — D1 migration (indexes + lookup_attempted_at column)
+
+This is the only PR that ships pure schema. Code changes that depend on the new index land in PR2.
+
+### Task 1.1: Write the migration file
+
+**Files:**
+- Create: `migrations/009-dashboard-speedup-indexes.sql`
+
+- [ ] **Step 1: Create the SQL file**
+
+```sql
+-- Composite index that satisfies the dashboard's primary list query:
+-- WHERE action = ? ORDER BY moderated_at DESC LIMIT N
+-- Replaces the temp B-tree sort on every page nav.
+CREATE INDEX IF NOT EXISTS idx_moderation_action_date
+  ON moderation_results(action, moderated_at DESC);
+
+-- Supports the uploader-history query in buildUploaderHistory().
+CREATE INDEX IF NOT EXISTS idx_moderation_uploaded_by_date
+  ON moderation_results(uploaded_by, moderated_at DESC);
+
+-- Supports the latest-event-per-sha lookup that PR4 will rewrite.
+CREATE INDEX IF NOT EXISTS idx_bunny_events_sha256_received
+  ON bunny_webhook_events(sha256, received_at DESC);
+
+-- Partial index for the FLAGGED filter
+-- (action IN (...) AND reviewed_by IS NULL).
+CREATE INDEX IF NOT EXISTS idx_moderation_unreviewed
+  ON moderation_results(action, moderated_at DESC)
+  WHERE reviewed_by IS NULL;
+
+-- Tracks last attempt time so the backfill cron in PR5 can skip rows
+-- it already tried. Nullable; populated by the backfill.
+ALTER TABLE moderation_results ADD COLUMN lookup_attempted_at TEXT;
+```
+
+### Task 1.2: Wire migrations into miniflare (test runner)
+
+The current `wrangler.toml` does not set `migrations_dir`, so
+`@cloudflare/vitest-pool-workers` initialises an empty schema in
+miniflare. Once PR2's tests start asserting on the new column /
+indexes, the test schema must match production.
+
+**Files:**
+- Modify: `wrangler.toml` (the `[[d1_databases]]` block)
+
+- [ ] **Step 1:** Add `migrations_dir = "migrations"` under the existing D1 binding:
+
+```toml
+[[d1_databases]]
+binding = "BLOSSOM_DB"
+database_name = "blossom-webhook-events"
+database_id = "829f06cf-294b-4491-8611-30fc53df2589"
+migrations_dir = "migrations"
+```
+
+- [ ] **Step 2:** Verify locally that `npm test` still passes — miniflare
+will replay migrations on every test boot.
+
+- [ ] **Step 3:** Commit alongside the migration file.
+
+### Task 1.3: Apply migration to remote D1
+
+- [ ] **Step 1: Dry-run / inspect**
+
+Run: `wrangler d1 migrations list blossom-webhook-events --remote`
+Expected: `009-dashboard-speedup-indexes.sql` listed as not yet applied.
+
+- [ ] **Step 2: Apply**
+
+Run: `wrangler d1 migrations apply blossom-webhook-events --remote`
+Expected: "✓ 009-dashboard-speedup-indexes.sql".
+
+- [ ] **Step 3: Verify schema**
+
+Run:
+```
+wrangler d1 execute blossom-webhook-events --remote --command \
+  "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='moderation_results' ORDER BY name"
+```
+Expected output includes `idx_moderation_action_date`, `idx_moderation_unreviewed`, `idx_moderation_uploaded_by_date`.
+
+Run:
+```
+wrangler d1 execute blossom-webhook-events --remote --command \
+  "PRAGMA table_info(moderation_results)" | grep lookup_attempted_at
+```
+Expected: column present.
+
+### Task 1.4: Add a verify-query-plans script
+
+**Files:**
+- Create: `scripts/verify-query-plans.mjs`
+
+- [ ] **Step 1: Write the script**
+
+```js
+#!/usr/bin/env node
+// ABOUTME: Run EXPLAIN QUERY PLAN on the dashboard's hot queries and
+// fail loudly if any of them regress to a temp B-tree sort or correlated scan.
+
+import { execSync } from 'node:child_process';
+
+const DB = 'blossom-webhook-events';
+const QUERIES = [
+  {
+    name: 'list-by-action',
+    sql: `EXPLAIN QUERY PLAN SELECT sha256 FROM moderation_results WHERE action='REVIEW' ORDER BY moderated_at DESC LIMIT 50`,
+    forbid: ['TEMP B-TREE'],
+    require: ['idx_moderation_action_date']
+  },
+  {
+    name: 'flagged-count',
+    sql: `EXPLAIN QUERY PLAN SELECT COUNT(*) FROM moderation_results WHERE action='REVIEW' AND reviewed_by IS NULL`,
+    forbid: ['TEMP B-TREE'],
+    require: ['idx_moderation_unreviewed']
+  },
+  {
+    name: 'uploader-history',
+    sql: `EXPLAIN QUERY PLAN SELECT sha256 FROM moderation_results WHERE uploaded_by='abc' ORDER BY moderated_at DESC LIMIT 10`,
+    forbid: ['TEMP B-TREE'],
+    require: ['idx_moderation_uploaded_by_date']
+  }
+];
+
+let failed = 0;
+for (const q of QUERIES) {
+  const out = execSync(
+    `wrangler d1 execute ${DB} --remote --command ${JSON.stringify(q.sql)}`,
+    { encoding: 'utf8' }
+  );
+  const ok =
+    q.forbid.every((bad) => !out.includes(bad)) &&
+    q.require.every((needle) => out.includes(needle));
+  console.log(`${ok ? '✓' : '✗'} ${q.name}`);
+  if (!ok) {
+    console.log(out);
+    failed++;
+  }
+}
+process.exit(failed ? 1 : 0);
+```
+
+- [ ] **Step 2: Run it post-migration**
+
+Run: `node scripts/verify-query-plans.mjs`
+Expected: three checkmarks, exit 0.
+
+### Task 1.5: Commit and open PR1
+
+- [ ] **Step 1: Commit**
+
+```
+git add migrations/009-dashboard-speedup-indexes.sql scripts/verify-query-plans.mjs
+git commit -m "perf: add composite indexes + lookup_attempted_at for dashboard speedup
+
+Adds idx_moderation_action_date, idx_moderation_uploaded_by_date,
+idx_moderation_unreviewed, idx_bunny_events_sha256_received, and a
+nullable lookup_attempted_at column for the backfill cron in PR5.
+
+EXPLAIN QUERY PLAN verified: list, flagged-count, and uploader-history
+queries no longer require a temp B-tree sort.
+
+Spec: docs/superpowers/specs/2026-05-05-moderation-dashboard-speedup-design.md"
+```
+
+- [ ] **Step 2: Open PR**
+
+Run `gh pr create` with body summarizing: layer L1 of the speedup spec, no code change, EXPLAIN output attached. Wait for the auto-deploy + verify in production before starting Chunk 2.
+
+---
+
+## Chunk 2: PR2 — Widen SELECTs, remove fan-out, batch uploader_enforcement
+
+This is the big perceived speedup. Target: `/admin/api/videos?limit=50` from 3-10s to <200ms.
+
+### Task 2.1: Extract `buildAdminVideoFromRow` into its own module
+
+Why: makes it pure, testable, and prevents a regression where `buildStoredLookupMetadata` reads columns that aren't selected.
+
+**Files:**
+- Create: `src/admin/lookup-helpers.mjs`
+- Create: `src/admin/lookup-helpers.test.mjs`
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+// src/admin/lookup-helpers.test.mjs
+import { describe, it, expect } from 'vitest';
+import { buildAdminVideoFromRow, ADMIN_VIDEO_COLUMNS } from './lookup-helpers.mjs';
+
+describe('buildAdminVideoFromRow', () => {
+  it('produces a complete video shape from a fully-populated row', () => {
+    const row = {
+      sha256: 'a'.repeat(64),
+      action: 'REVIEW',
+      provider: 'manual-review',
+      scores: '{"nsfw":0.2}',
+      categories: '["nsfw"]',
+      moderated_at: '2026-05-05T00:00:00Z',
+      reviewed_by: null,
+      reviewed_at: null,
+      uploaded_by: 'b'.repeat(64),
+      event_id: 'c'.repeat(64),
+      title: 'Test Video',
+      author: 'Alice',
+      content_url: 'https://example.com/v.mp4',
+      published_at: '1717200000'
+    };
+    const out = buildAdminVideoFromRow(row, { cdnDomain: 'media.divine.video' });
+    expect(out).toMatchObject({
+      sha256: row.sha256,
+      action: 'REVIEW',
+      eventId: row.event_id,
+      divineUrl: `https://divine.video/video/${row.event_id}`,
+      uploaded_by: row.uploaded_by,
+      nostrContext: {
+        title: 'Test Video',
+        author: 'Alice',
+        url: row.content_url,
+        eventId: row.event_id
+      }
+    });
+    expect(out.scores).toEqual({ nsfw: 0.2 });
+  });
+
+  it('returns null eventId/divineUrl/nostrContext when row has no metadata', () => {
+    const row = {
+      sha256: 'a'.repeat(64),
+      action: 'SAFE',
+      moderated_at: '2026-05-05T00:00:00Z'
+    };
+    const out = buildAdminVideoFromRow(row, { cdnDomain: 'media.divine.video' });
+    expect(out.eventId).toBeNull();
+    expect(out.divineUrl).toBeNull();
+    expect(out.nostrContext).toBeNull();
+  });
+
+  it('exports the column list expected to be in SELECTs', () => {
+    expect(ADMIN_VIDEO_COLUMNS).toContain('event_id');
+    expect(ADMIN_VIDEO_COLUMNS).toContain('title');
+    expect(ADMIN_VIDEO_COLUMNS).toContain('author');
+    expect(ADMIN_VIDEO_COLUMNS).toContain('content_url');
+    expect(ADMIN_VIDEO_COLUMNS).toContain('published_at');
+  });
+});
+```
+
+- [ ] **Step 2: Run, confirm fail**
+
+Run: `npm test -- src/admin/lookup-helpers.test.mjs`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```js
+// src/admin/lookup-helpers.mjs
+// ABOUTME: Pure helpers that turn a moderation_results row into the shape
+// the admin dashboard expects. No side effects, no DB, no fetch.
+
+export const ADMIN_VIDEO_COLUMNS = [
+  'sha256',
+  'action',
+  'provider',
+  'scores',
+  'categories',
+  'moderated_at',
+  'reviewed_by',
+  'reviewed_at',
+  'uploaded_by',
+  'event_id',
+  'title',
+  'author',
+  'content_url',
+  'published_at'
+];
+
+function safeParseJSON(value, fallback) {
+  if (value == null) return fallback;
+  if (typeof value !== 'string') return value;
+  try { return JSON.parse(value); } catch { return fallback; }
+}
+
+export function buildAdminVideoFromRow(row, { cdnDomain }) {
+  const eventId = row.event_id || null;
+  const publishedAt = row.published_at ? Number.parseInt(row.published_at, 10) : null;
+  const hasContext = Boolean(
+    row.title || row.author || row.content_url || eventId || row.uploaded_by || publishedAt
+  );
+
+  return {
+    sha256: row.sha256,
+    action: row.action,
+    provider: row.provider || null,
+    scores: safeParseJSON(row.scores, {}),
+    categories: safeParseJSON(row.categories, []),
+    processedAt: row.moderated_at ? new Date(row.moderated_at).getTime() : null,
+    moderated_at: row.moderated_at,
+    reviewed_by: row.reviewed_by || null,
+    reviewed_at: row.reviewed_at || null,
+    uploaded_by: row.uploaded_by || null,
+    eventId,
+    divineUrl: eventId ? `https://divine.video/video/${encodeURIComponent(eventId)}` : null,
+    cdnUrl: `https://${cdnDomain}/${row.sha256}`,
+    nostrContext: hasContext ? {
+      title: row.title || null,
+      author: row.author || null,
+      // client/content are not stored. List view leaves them null;
+      // detail view (/admin/api/video/:id) still fills them via funnelcake.
+      client: null,
+      content: null,
+      url: row.content_url || null,
+      publishedAt: Number.isFinite(publishedAt) ? publishedAt : null,
+      pubkey: row.uploaded_by ? `${row.uploaded_by.substring(0, 16)}...` : null,
+      eventId,
+      platform: null
+    } : null
+  };
+}
+```
+
+- [ ] **Step 4: Run, confirm pass**
+
+Run: `npm test -- src/admin/lookup-helpers.test.mjs`
+Expected: 3 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/admin/lookup-helpers.mjs src/admin/lookup-helpers.test.mjs
+git commit -m "refactor: extract buildAdminVideoFromRow into pure helper
+
+Pure row→admin-video mapper that the new /admin/api/videos handler
+will use directly, replacing the per-row getAdminLookupVideo +
+funnelcake fetch fan-out."
+```
+
+### Task 2.2: Add a fan-out test that pins current behavior on a fully-populated row
+
+Why: prove there are zero funnelcake calls when the row already has `event_id`, and snapshot the JSON shape so any field regression fails loudly.
+
+**Files:**
+- Create: `src/admin/dashboard-fanout.test.mjs`
+
+- [ ] **Step 1: Write the failing test**
+
+**Note on the testing approach.** Spying on `globalThis.fetch` under
+`@cloudflare/vitest-pool-workers` is unreliable — the worker module
+captures its `fetch` reference at module-eval time inside the isolate.
+Instead, we prove "no fan-out" **structurally** by counting calls to
+`env.BLOSSOM_DB.prepare`. The new code calls it exactly twice (list +
+uploader_enforcement IN); the old code called it ~50+ times. We also
+intercept funnelcake by having the test set the legacy fallthrough
+trigger off — i.e., every seeded row has `event_id` populated. If the
+production code accidentally still calls funnelcake we observe it via
+a wrapper around `fetchFunnelcakeLookupVideo` (Task 2.3 step 0 below
+exports a hook for this).
+
+```js
+// src/admin/dashboard-fanout.test.mjs
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import worker from '../index.mjs';
+import { env } from 'cloudflare:test';
+
+// IMPORTANT: do NOT include lookup_attempted_at — that column ships in
+// PR1's migration; PR2's test environment may not have it.
+const ROW = {
+  sha256: 'a'.repeat(64),
+  action: 'REVIEW',
+  provider: 'manual-review',
+  scores: '{"nsfw":0.2}',
+  categories: '["nsfw"]',
+  raw_response: null,
+  moderated_at: '2026-05-05T00:00:00Z',
+  reviewed_by: null,
+  reviewed_at: null,
+  review_notes: null,
+  published_label_id: null,
+  uploaded_by: 'b'.repeat(64),
+  title: 'Test',
+  author: 'Alice',
+  event_id: 'c'.repeat(64),
+  content_url: 'https://example.com/v.mp4',
+  published_at: '1717200000',
+  videoseal: null,
+  transcript_pending: 0,
+  transcript_pending_since: null,
+  transcript_last_checked_at: null,
+  transcript_resolved_at: null
+};
+
+describe('/admin/api/videos fan-out', () => {
+  let prepareSpy;
+  beforeEach(async () => {
+    prepareSpy = vi.spyOn(env.BLOSSOM_DB, 'prepare');
+    await env.BLOSSOM_DB.prepare(
+      `INSERT OR REPLACE INTO moderation_results (${Object.keys(ROW).join(',')}) VALUES (${Object.keys(ROW).map(() => '?').join(',')})`
+    ).bind(...Object.values(ROW)).run();
+    prepareSpy.mockClear(); // ignore the seeding call
+  });
+  afterEach(async () => {
+    prepareSpy.mockRestore();
+    await env.BLOSSOM_DB.prepare('DELETE FROM moderation_results WHERE sha256=?').bind(ROW.sha256).run();
+  });
+
+  it('issues at most 2 D1 prepare calls (list + uploader_enforcement)', async () => {
+    const req = new Request('https://moderation.admin.divine.video/admin/api/videos?limit=50', {
+      headers: { 'CF-Access-Authenticated-User-Email': 'test@divine.video' }
+    });
+    const res = await worker.fetch(req, env, { waitUntil: () => {}, passThroughOnException: () => {} });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.videos.length).toBeGreaterThan(0);
+    // Exactly: 1 list query + 1 uploader_enforcement IN query.
+    // Anything more = fan-out has been reintroduced.
+    expect(prepareSpy.mock.calls.length).toBeLessThanOrEqual(2);
+  });
+
+  it('preserves the response shape (golden snapshot)', async () => {
+    const req = new Request('https://moderation.admin.divine.video/admin/api/videos?limit=50', {
+      headers: { 'CF-Access-Authenticated-User-Email': 'test@divine.video' }
+    });
+    const res = await worker.fetch(req, env, { waitUntil: () => {}, passThroughOnException: () => {} });
+    const body = await res.json();
+    const v = body.videos.find((row) => row.sha256 === ROW.sha256);
+    // All keys expected on the response, including uploaderEnforcement
+    // attached by the batch query.
+    expect(Object.keys(v).sort()).toEqual([
+      'action', 'categories', 'cdnUrl', 'divineUrl', 'eventId',
+      'moderated_at', 'nostrContext', 'processedAt', 'provider',
+      'reviewed_at', 'reviewed_by', 'scores', 'sha256', 'uploaded_by',
+      'uploaderEnforcement'
+    ]);
+    expect(v.eventId).toBe(ROW.event_id);
+    expect(v.divineUrl).toBe(`https://divine.video/video/${ROW.event_id}`);
+    expect(v.nostrContext).toMatchObject({
+      title: 'Test',
+      author: 'Alice',
+      client: null,
+      content: null,
+      url: ROW.content_url,
+      eventId: ROW.event_id,
+      platform: null
+    });
+    expect(typeof v.nostrContext.publishedAt).toBe('number');
+    expect(v.uploaderEnforcement).toMatchObject({
+      pubkey: ROW.uploaded_by
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run, confirm fail**
+
+Run: `npm test -- src/admin/dashboard-fanout.test.mjs`
+Expected: FAIL — funnelcake fetch happens (`funnelcakeCalls.length` > 0) and snapshot keys are wrong.
+
+(Auth is bypassed by the test harness when `CF-Access-Authenticated-User-Email` is set; if the codebase uses different test auth, mirror an existing test in `src/admin/auth.test.mjs`.)
+
+### Task 2.3: Wire the helper into `/admin/api/videos`
+
+**Files:**
+- Modify: `src/index.mjs` lines 1469-1570
+
+- [ ] **Step 1: Replace the SELECT and the per-row fan-out**
+
+Find the block at `src/index.mjs:1469-1570`. Replace the SELECT column list at line 1511 and the `Promise.all(videoRows.map(...))` block at lines 1539-1558 with:
+
+```js
+// at top of file, near existing imports
+import { ADMIN_VIDEO_COLUMNS, buildAdminVideoFromRow } from './admin/lookup-helpers.mjs';
+```
+
+```js
+// inside the /admin/api/videos handler, replacing the existing query:
+const query = `
+  SELECT ${ADMIN_VIDEO_COLUMNS.join(', ')}
+  FROM moderation_results
+  ${whereClause}
+  ORDER BY moderated_at ${orderDirection}
+  LIMIT ? OFFSET ?
+`;
+params.push(limit + 1, offset);
+
+const result = await env.BLOSSOM_DB.prepare(query).bind(...params).all();
+const rows = result.results || [];
+const hasMore = rows.length > limit;
+const pageRows = rows.slice(0, limit);
+
+// Build videos directly from rows. No second D1 read, no funnelcake fetch.
+const videos = pageRows.map((row) => buildAdminVideoFromRow(row, {
+  cdnDomain: env.CDN_DOMAIN || 'media.divine.video'
+}));
+
+// Batch uploader_enforcement: one query for all unique uploaded_by values.
+const uploaderPubkeys = [...new Set(videos.map((v) => v.uploaded_by).filter(Boolean))];
+if (uploaderPubkeys.length > 0) {
+  const placeholders = uploaderPubkeys.map(() => '?').join(',');
+  const enf = await env.BLOSSOM_DB.prepare(
+    `SELECT pubkey, approval_required, relay_banned FROM uploader_enforcement WHERE pubkey IN (${placeholders})`
+  ).bind(...uploaderPubkeys).all();
+  const map = new Map((enf.results || []).map((r) => [r.pubkey, r]));
+  for (const v of videos) {
+    if (v.uploaded_by) {
+      v.uploaderEnforcement = map.get(v.uploaded_by) || {
+        pubkey: v.uploaded_by,
+        approval_required: 0,
+        relay_banned: 0
+      };
+    }
+  }
+}
+
+console.log(`[${requestId}] Returning ${videos.length} videos in ${Date.now() - startTime}ms`);
+return new Response(JSON.stringify({
+  videos,
+  offset,
+  limit,
+  hasMore,
+  nextOffset: hasMore ? offset + limit : null
+}), { headers: JSON_HEADERS });
+```
+
+(Drop the `await Promise.all(videoRows.map(...))` block entirely. The legacy fallthrough — fetching funnelcake when `event_id IS NULL` — does NOT happen on the list endpoint anymore. After PR5's backfill, ~0% of rows lack event_id; until then, those rows render with `eventId: null` on cards but the detail-view link still works because the dashboard falls back to `sha256`-based lookups.)
+
+- [ ] **Step 2: Run the fan-out test**
+
+Run: `npm test -- src/admin/dashboard-fanout.test.mjs`
+Expected: both tests pass.
+
+- [ ] **Step 3: Run the full suite**
+
+Run: `npm test`
+Expected: 305+ tests pass (303 existing + 3 new from Task 2.1 + 2 new from Task 2.2). No regressions.
+
+### Task 2.4: Widen the SELECTs in `getAdminLookupVideo` and `/api/v1/decisions`
+
+These power the manual-lookup ("Open Video") field and the public API.
+
+**Files:**
+- Modify: `src/index.mjs:992-996` (getAdminLookupVideo)
+- Modify: `src/index.mjs:3939-3989` (/api/v1/decisions)
+
+- [ ] **Step 1: getAdminLookupVideo — widen the SELECT**
+
+Replace the SELECT at `src/index.mjs:992-996`:
+```js
+const moderatedRow = await env.BLOSSOM_DB.prepare(`
+  SELECT ${ADMIN_VIDEO_COLUMNS.join(', ')}, raw_response, review_notes, videoseal
+  FROM moderation_results
+  WHERE sha256 = ?
+`).bind(hash).first();
+```
+
+This keeps the manual-lookup detail-view path consistent with the list path. `enrichAdminLookupVideo` still runs here (one row, one funnelcake call max) — by design, the detail view fills `nostrContext.client/content`.
+
+- [ ] **Step 2: /api/v1/decisions — widen the SELECT**
+
+Replace the SELECT at line 3951:
+```js
+let query = `SELECT ${ADMIN_VIDEO_COLUMNS.join(', ')} FROM moderation_results`;
+```
+
+Public response shape only gains fields; downstream consumers tolerating additive change keep working.
+
+- [ ] **Step 3: Run full suite**
+
+Run: `npm test`
+Expected: all pass.
+
+- [ ] **Step 4: Commit**
+
+```
+git add src/index.mjs src/admin/dashboard-fanout.test.mjs
+git commit -m "perf: kill per-row funnelcake fan-out in /admin/api/videos
+
+- Widen SELECT to include event_id/title/author/content_url/published_at
+  (columns added by migration 004 but never selected here).
+- Replace 50× getAdminLookupVideo + funnelcake fetch with a synchronous
+  buildAdminVideoFromRow mapper.
+- Batch uploader_enforcement into one IN(?,?,...) query.
+- Detail view (/admin/api/video/:id) still calls funnelcake on demand,
+  so client/content fields keep rendering for opened videos.
+
+Per-page round-trips drop from ~150-250 to ~3."
+```
+
+- [ ] **Step 5: Open PR2**
+
+`gh pr create` with the spec link and a curl-timing before/after.
+
+---
+
+## Chunk 3: PR3 — KV cache for stats
+
+Target: `/admin/api/stats` from 200-500ms to <50ms (cached).
+
+### Task 3.1: Build the `cachedStat` helper
+
+**Files:**
+- Create: `src/admin/cache.mjs`
+- Create: `src/admin/cache.test.mjs`
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+// src/admin/cache.test.mjs
+import { describe, it, expect, vi } from 'vitest';
+import { cachedStat } from './cache.mjs';
+import { env } from 'cloudflare:test';
+
+const KEY = 'stats:v1:test';
+
+describe('cachedStat', () => {
+  it('computes on miss and writes to KV via waitUntil', async () => {
+    await env.MODERATION_KV.delete(KEY);
+    const compute = vi.fn().mockResolvedValue({ ok: 1 });
+    const waitUntil = vi.fn();
+    const result = await cachedStat(env, { waitUntil }, 'test', 60, compute);
+    expect(result).toEqual({ ok: 1 });
+    expect(compute).toHaveBeenCalledTimes(1);
+    expect(waitUntil).toHaveBeenCalledTimes(1);
+    // The waitUntil callback writes to KV.
+    await waitUntil.mock.calls[0][0];
+    const cached = JSON.parse(await env.MODERATION_KV.get(KEY));
+    expect(cached).toEqual({ ok: 1 });
+  });
+
+  it('returns cached value on hit without calling compute', async () => {
+    await env.MODERATION_KV.put(KEY, JSON.stringify({ ok: 99 }));
+    const compute = vi.fn();
+    const result = await cachedStat(env, { waitUntil: () => {} }, 'test', 60, compute);
+    expect(result).toEqual({ ok: 99 });
+    expect(compute).not.toHaveBeenCalled();
+  });
+
+  it('bypasses cache read when fresh=true but still writes back', async () => {
+    await env.MODERATION_KV.put(KEY, JSON.stringify({ ok: 'stale' }));
+    const compute = vi.fn().mockResolvedValue({ ok: 'fresh' });
+    const waitUntil = vi.fn();
+    const result = await cachedStat(env, { waitUntil }, 'test', 60, compute, { fresh: true });
+    expect(result).toEqual({ ok: 'fresh' });
+    expect(compute).toHaveBeenCalled();
+    await waitUntil.mock.calls[0][0];
+    const cached = JSON.parse(await env.MODERATION_KV.get(KEY));
+    expect(cached).toEqual({ ok: 'fresh' });
+  });
+});
+```
+
+- [ ] **Step 2: Run, confirm fail**
+
+Run: `npm test -- src/admin/cache.test.mjs`
+Expected: FAIL, module not found.
+
+- [ ] **Step 3: Implement**
+
+```js
+// src/admin/cache.mjs
+// ABOUTME: Tiny KV wrapper for caching stat aggregates with non-blocking writes.
+
+export async function cachedStat(env, ctx, key, ttlSeconds, compute, options = {}) {
+  const fullKey = `stats:v1:${key}`;
+  if (!options.fresh) {
+    const cached = await env.MODERATION_KV.get(fullKey);
+    if (cached !== null) {
+      try { return JSON.parse(cached); } catch { /* fall through to compute */ }
+    }
+  }
+  const fresh = await compute();
+  // Don't block the response on the KV write.
+  ctx.waitUntil(env.MODERATION_KV.put(
+    fullKey,
+    JSON.stringify(fresh),
+    { expirationTtl: ttlSeconds }
+  ));
+  return fresh;
+}
+```
+
+- [ ] **Step 4: Run, confirm pass**
+
+Run: `npm test -- src/admin/cache.test.mjs`
+Expected: 3 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/admin/cache.mjs src/admin/cache.test.mjs
+git commit -m "feat: add cachedStat helper for KV-cached aggregates"
+```
+
+### Task 3.2: Wrap `/admin/api/stats` and `/admin/api/ai-detection/stats`
+
+**Files:**
+- Modify: `src/index.mjs:1573-1677` (stats handler)
+- Modify: `src/index.mjs:1680-1707` (ai-detection-stats handler)
+
+- [ ] **Step 1: Add import**
+
+```js
+import { cachedStat } from './admin/cache.mjs';
+```
+
+- [ ] **Step 2: Wrap stats endpoint**
+
+Inside the `/admin/api/stats` handler at `src/index.mjs:1573-1677`, after
+the auth check and `console.log` line, replace the entire `try { … }
+catch { … }` body with the version below. The closure must reproduce
+the **exact** response shape the dashboard expects (verified at
+`dashboard.html:2643-2649`): `totalInD1`, `totalModerated`, `untriaged`,
+`pendingFlagged`, plus `breakdown.{safe,review,ageRestricted,permanentBan}`
+and `pending.{review,quarantine,ageRestricted,permanentBan}`.
+
+```js
+try {
+  const fresh = url.searchParams.get('fresh') === '1';
+  const stats = await cachedStat(env, ctx, 'admin-stats', 60, async () => {
+    const [totalResult, moderationStats, pendingStats] = await Promise.all([
+      env.BLOSSOM_DB.prepare(`
+        SELECT COUNT(DISTINCT sha256) as total
+        FROM bunny_webhook_events
+        WHERE sha256 IS NOT NULL AND status_name NOT IN ('error', 'deleted')
+      `).first(),
+      env.BLOSSOM_DB.prepare(`
+        SELECT action, COUNT(*) as count FROM moderation_results GROUP BY action
+      `).all(),
+      env.BLOSSOM_DB.prepare(`
+        SELECT action, COUNT(*) as count FROM moderation_results
+        WHERE reviewed_by IS NULL GROUP BY action
+      `).all()
+    ]);
+
+    const totalInD1 = totalResult?.total || 0;
+    const breakdown = { safe: 0, review: 0, ageRestricted: 0, permanentBan: 0 };
+    let totalModerated = 0;
+    for (const row of (moderationStats?.results || [])) {
+      const count = row.count || 0;
+      totalModerated += count;
+      if (row.action === 'SAFE') breakdown.safe = count;
+      else if (row.action === 'REVIEW') breakdown.review = count;
+      else if (row.action === 'AGE_RESTRICTED') breakdown.ageRestricted = count;
+      else if (row.action === 'PERMANENT_BAN') breakdown.permanentBan = count;
+    }
+
+    const pending = { review: 0, quarantine: 0, ageRestricted: 0, permanentBan: 0 };
+    for (const row of (pendingStats?.results || [])) {
+      const count = row.count || 0;
+      if (row.action === 'REVIEW') pending.review = count;
+      else if (row.action === 'QUARANTINE') pending.quarantine = count;
+      else if (row.action === 'AGE_RESTRICTED') pending.ageRestricted = count;
+      else if (row.action === 'PERMANENT_BAN') pending.permanentBan = count;
+    }
+
+    const pendingFlagged = pending.review + pending.quarantine + pending.ageRestricted + pending.permanentBan;
+    const untriaged = Math.max(0, totalInD1 - totalModerated);
+
+    return { totalInD1, totalModerated, untriaged, pendingFlagged, breakdown, pending };
+  }, { fresh });
+
+  return new Response(JSON.stringify(stats), { headers: JSON_HEADERS });
+} catch (error) {
+  console.error(`[${requestId}] Failed to get stats:`, error);
+  return new Response(JSON.stringify({ error: error.message }), {
+    status: 500, headers: { 'Content-Type': 'application/json' }
+  });
+}
+```
+
+The handler signature is `async fetch(request, env, ctx)` so `ctx` is in scope.
+
+- [ ] **Step 3: Wrap ai-detection-stats endpoint**
+
+Same shape, key `ai-detection-stats:${windowValue}`.
+
+- [ ] **Step 4: Add Refresh button → ?fresh=1**
+
+In `src/admin/dashboard.html`:
+- Find `loadRealStats` (line 2633).
+- Change `fetch('/admin/api/stats')` to `fetch('/admin/api/stats' + (forceFresh ? '?fresh=1' : ''))`, where `forceFresh` is a parameter.
+- Find the existing Refresh button (`onclick="loadVideos()"` at line 2075). Add a sibling that calls `loadRealStats(true)`.
+
+(If a single Refresh button is preferred, have `loadVideos()` also call `loadRealStats(true)`.)
+
+- [ ] **Step 5: Add a stats integration test**
+
+Create `src/admin/stats-cache.test.mjs` with two cases: cold call hits D1 once, warm call within 60s reads only KV (assert no `BLOSSOM_DB.prepare` call via spy).
+
+- [ ] **Step 6: Run full suite + commit**
+
+Run: `npm test`
+Commit:
+```
+perf: cache /admin/api/stats and /admin/api/ai-detection/stats in KV (60s)
+
+Aggregations on the 322k-row moderation_results table no longer fire
+on every dashboard mount. Refresh button passes ?fresh=1 to bypass.
+```
+
+### Task 3.3: Cache `/admin/api/untriaged` COUNT and `/api/v1/decisions` COUNT
+
+Same wrapper, smaller keys.
+
+- [ ] **Step 1**: In `/admin/api/untriaged` (line 1793-1803), wrap the COUNT in `cachedStat(env, ctx, 'untriaged-total', 60, compute)`.
+- [ ] **Step 2**: In `/api/v1/decisions` (line 3974-3979), wrap the COUNT in `cachedStat(env, ctx, 'decisions-count:' + filterKey, 60, compute)`.
+- [ ] **Step 3**: Run `npm test`. Commit.
+
+### Task 3.4: Open PR3
+
+`gh pr create`. Wait for deploy and verify.
+
+---
+
+## Chunk 4: PR4 — Untriaged endpoint cleanup
+
+Target: `/admin/api/untriaged?limit=50` from 1-3s to <300ms.
+
+### Task 4.1: Extract `latestBunnyEventBySha` helper
+
+**Files:**
+- Create: `src/admin/bunny-events.mjs`
+- Create: `src/admin/bunny-events.test.mjs`
+
+- [ ] **Step 1: Write the failing test**
+
+Test cases:
+- Single sha with multiple events → returns only the latest by `received_at`.
+- Limit/offset pagination over the latest-per-sha view.
+- COUNT helper returns same total.
+- `EXPLAIN QUERY PLAN` (run once via `wrangler d1 execute` in a release-checklist script, NOT vitest) does not show `CORRELATED` and does show `idx_bunny_events_sha256_received`.
+
+- [ ] **Step 2: Implement**
+
+Use `ROW_NUMBER() OVER (PARTITION BY sha256 ORDER BY received_at DESC)`.
+**Do NOT use `GROUP BY sha256 HAVING received_at = MAX(received_at)`** —
+SQLite's "bare column" rule only picks the MAX row's columns when the
+MAX aggregate appears in the SELECT list. With MAX only in HAVING,
+the non-aggregated columns (`hls_url`, `mp4_url`, etc.) come from an
+arbitrary row in the group. Window-function form is deterministic and
+uses `idx_bunny_events_sha256_received` for the partition order.
+
+```js
+// src/admin/bunny-events.mjs
+export async function latestBunnyEventBySha(env, { limit = 50, offset = 0, excludeStatusNames = ['error', 'deleted'] } = {}) {
+  const placeholders = excludeStatusNames.map(() => '?').join(',');
+  const sql = `
+    WITH ranked AS (
+      SELECT
+        sha256, video_guid, hls_url, mp4_url, thumbnail_url, received_at, status_name,
+        ROW_NUMBER() OVER (PARTITION BY sha256 ORDER BY received_at DESC) AS rn
+      FROM bunny_webhook_events
+      WHERE sha256 IS NOT NULL
+        AND status_name NOT IN (${placeholders})
+    )
+    SELECT sha256, video_guid, hls_url, mp4_url, thumbnail_url, received_at, status_name
+    FROM ranked
+    WHERE rn = 1
+    ORDER BY received_at DESC
+    LIMIT ? OFFSET ?
+  `;
+  const result = await env.BLOSSOM_DB.prepare(sql)
+    .bind(...excludeStatusNames, limit, offset)
+    .all();
+  return result.results || [];
+}
+
+export async function countLatestBunnyEvents(env, { excludeStatusNames = ['error', 'deleted'] } = {}) {
+  const placeholders = excludeStatusNames.map(() => '?').join(',');
+  const sql = `
+    SELECT COUNT(DISTINCT sha256) AS total
+    FROM bunny_webhook_events
+    WHERE sha256 IS NOT NULL
+      AND status_name NOT IN (${placeholders})
+  `;
+  const row = await env.BLOSSOM_DB.prepare(sql).bind(...excludeStatusNames).first();
+  return row?.total || 0;
+}
+
+export async function latestBunnyEventForSha(env, sha256) {
+  const row = await env.BLOSSOM_DB.prepare(`
+    SELECT sha256, video_guid, hls_url, mp4_url, thumbnail_url, received_at, status_name
+    FROM bunny_webhook_events
+    WHERE sha256 = ?
+    ORDER BY received_at DESC
+    LIMIT 1
+  `).bind(sha256).first();
+  return row || null;
+}
+```
+
+After implementing, add a test that seeds two events for the same sha
+with different `hls_url` values, then asserts the helper returns the
+URL from the row with the larger `received_at`. This is the test that
+fails on the GROUP BY HAVING variant.
+
+- [ ] **Step 3: Run tests, confirm pass.**
+
+- [ ] **Step 4: Commit**
+
+```
+refactor: extract latestBunnyEventBySha helper, drop correlated subquery
+
+Replaces four hand-rolled copies of the latest-event-per-sha lookup
+(src/index.mjs:1036, 1149, 1707, 1779) with a single helper that uses
+ROW_NUMBER() OVER (PARTITION BY sha256 ORDER BY received_at DESC),
+backed by idx_bunny_events_sha256_received added in PR1.
+```
+
+### Task 4.2: Replace the four call sites
+
+- [ ] **Step 1**: `src/index.mjs:685-693` (transcript reprocess area, only if it uses the same pattern — re-verify; if not, leave it).
+- [ ] **Step 2**: `src/index.mjs:1031-1039` (getAdminLookupVideo) → `latestBunnyEventForSha(env, hash)`.
+- [ ] **Step 3**: `src/index.mjs:1138-` (getStoredAdminPlaybackCandidates) → `latestBunnyEventForSha(env, sha256)` for the second branch.
+- [ ] **Step 4**: `src/index.mjs:1707-1732` (untriaged list) → `latestBunnyEventBySha(env, { limit, offset })`.
+- [ ] **Step 5**: `src/index.mjs:1779-1803` (untriaged count) → wrap `countLatestBunnyEvents(env)` in `cachedStat`.
+
+After each, run `npm test`. Commit each in its own atomic patch (small diffs).
+
+### Task 4.3: Parallelize the KV reads in untriaged
+
+- [ ] **Step 1**: At `src/index.mjs:1736-1741`, replace:
+```js
+for (const row of result.results) {
+  const existingResult = await env.MODERATION_KV.get(`moderation:${row.sha256}`);
+  if (!existingResult) unmoderatedRows.push(row);
+}
+```
+with:
+```js
+const moderationFlags = await Promise.all(
+  result.results.map((row) => env.MODERATION_KV.get(`moderation:${row.sha256}`))
+);
+const unmoderatedRows = result.results.filter((_, i) => !moderationFlags[i]);
+```
+
+### Task 4.4: Cache the per-row Nostr fetch
+
+- [ ] **Step 1**: Wrap `fetchNostrEventBySha256` in untriaged with KV cache:
+
+```js
+async function cachedNostrEvent(env, sha256, relays) {
+  const key = `nostr:event:${sha256}`;
+  const cached = await env.MODERATION_KV.get(key);
+  if (cached) return JSON.parse(cached);
+  const event = await fetchNostrEventBySha256(sha256, relays, env);
+  if (event) {
+    // 1-hour TTL; events for unmoderated content rarely change.
+    await env.MODERATION_KV.put(key, JSON.stringify(event), { expirationTtl: 3600 });
+  }
+  return event;
+}
+```
+
+Use it in the `nostrPromises.map` at `src/index.mjs:1745-1763`.
+
+### Task 4.5: Tests + commit + PR
+
+- [ ] Run `npm test`. Add `src/admin/untriaged-query.test.mjs` with a golden fixture: seed 3 sha256 with 5 events each, assert latest-per-sha returns 3 rows in correct order.
+- [ ] Run `node scripts/verify-query-plans.mjs` adapted to include the new `latestBunnyEventBySha` query.
+- [ ] Commit and open PR4.
+
+---
+
+## Chunk 5: PR5 — Backfill cron for legacy rows
+
+Behind feature flag `BACKFILL_ENABLED`. Defaults to off.
+
+### Task 5.1: Build `backfillLookupColumns`
+
+**Files:**
+- Create: `src/admin/backfill-lookup-columns.mjs`
+- Create: `src/admin/backfill-lookup-columns.test.mjs`
+
+- [ ] **Step 1: Write failing tests**
+
+Test cases:
+1. Picks rows with `event_id IS NULL`, ordered by `moderated_at DESC`, limit honored.
+2. On hit, UPDATE sets event_id/title/author/content_url/published_at + lookup_attempted_at; row with non-null event_id is not touched.
+3. On 404, sets `lookup_attempted_at` only.
+4. On HTTP error, no DB write.
+5. Concurrency cap respected (mock `fetch` to track in-flight count).
+6. Mutex: two concurrent `runBackfill` calls — one runs, one returns `{ skipped: 'locked' }`. Each row processed at most once.
+7. Mutex auto-releases after TTL (use a fake clock or `expirationTtl` mock).
+
+- [ ] **Step 2: Implement**
+
+The backfill takes `fetchLookup` as a dependency-injected function. In
+production it's `fetchFunnelcakeLookupVideo` (which already wraps the
+HTTP call + `buildFunnelcakeVideoLookup` parse). In tests it's a stub.
+This avoids re-implementing the funnelcake response parser and keeps
+the test mock unambiguous (no `vi.spyOn(globalThis, 'fetch')` games).
+
+`fetchFunnelcakeLookupVideo` returns either:
+- `null` on 404 (treat as "missing")
+- A parsed object: `{ eventId, videoUrl, uploadedBy, createdAt, nostrContext: { title, author, publishedAt, url, ... }, ... }` (see `src/index.mjs:212-249`)
+- Or throws on non-2xx HTTP
+
+```js
+// src/admin/backfill-lookup-columns.mjs
+// ABOUTME: Cron worker that fills event_id/title/author/content_url/published_at
+// on legacy moderation_results rows by calling the funnelcake video API.
+
+const LOCK_KEY = 'backfill:lock';
+const LOCK_TTL_S = 300;
+
+export async function runBackfill(env, options = {}) {
+  const {
+    limit,
+    concurrency = 10,
+    fetchLookup,                              // REQUIRED: (sha256) => Promise<lookup|null>
+    now = () => new Date().toISOString()
+  } = options;
+
+  if (typeof fetchLookup !== 'function') {
+    throw new Error('runBackfill: fetchLookup is required');
+  }
+  if (env.BACKFILL_ENABLED !== 'true') return { skipped: 'disabled' };
+
+  const lock = await env.MODERATION_KV.get(LOCK_KEY);
+  if (lock) return { skipped: 'locked' };
+  await env.MODERATION_KV.put(LOCK_KEY, String(Date.now()), { expirationTtl: LOCK_TTL_S });
+
+  try {
+    const rowsLimit = Math.max(1, Math.min(limit ?? Number(env.BACKFILL_ROWS_PER_TICK ?? '200'), 500));
+    const retryAfter = new Date(Date.now() - 7 * 24 * 3600 * 1000).toISOString();
+    const rows = (await env.BLOSSOM_DB.prepare(`
+      SELECT sha256
+      FROM moderation_results
+      WHERE event_id IS NULL
+        AND (lookup_attempted_at IS NULL OR lookup_attempted_at < ?)
+      ORDER BY moderated_at DESC
+      LIMIT ?
+    `).bind(retryAfter, rowsLimit).all()).results || [];
+
+    let updated = 0, missing = 0, errored = 0;
+
+    const queue = [...rows];
+    async function worker() {
+      while (queue.length > 0) {
+        const row = queue.shift();
+        if (!row) continue;
+        const attemptedAt = now();
+        let lookup;
+        try {
+          lookup = await fetchLookup(row.sha256);
+        } catch {
+          errored++;
+          continue;
+        }
+        if (!lookup) {
+          // 404 — record the attempt so we don't re-poll for 7 days.
+          await env.BLOSSOM_DB.prepare(
+            `UPDATE moderation_results SET lookup_attempted_at = ? WHERE sha256 = ? AND event_id IS NULL`
+          ).bind(attemptedAt, row.sha256).run();
+          missing++;
+          continue;
+        }
+        const ctx = lookup.nostrContext || {};
+        await env.BLOSSOM_DB.prepare(
+          `UPDATE moderation_results SET
+             event_id = COALESCE(?, event_id),
+             title = COALESCE(?, title),
+             author = COALESCE(?, author),
+             content_url = COALESCE(?, content_url),
+             published_at = COALESCE(?, published_at),
+             lookup_attempted_at = ?
+           WHERE sha256 = ? AND event_id IS NULL`
+        ).bind(
+          lookup.eventId || null,
+          ctx.title || null,
+          ctx.author || null,
+          lookup.videoUrl || ctx.url || null,
+          ctx.publishedAt != null ? String(ctx.publishedAt) : null,
+          attemptedAt,
+          row.sha256
+        ).run();
+        updated++;
+      }
+    }
+    await Promise.all(Array.from({ length: concurrency }, worker));
+
+    return { picked: rows.length, updated, missing, errored };
+  } finally {
+    await env.MODERATION_KV.delete(LOCK_KEY);
+  }
+}
+```
+
+- [ ] **Step 3: Run tests, confirm pass.**
+
+### Task 5.2: Wire into the every-minute cron
+
+**Files:**
+- Modify: `src/index.mjs:4601-4622` (scheduled handler)
+
+- [ ] **Step 1**: After the `creator-delete` block at 4604-4621, add:
+
+```js
+// Backfill legacy moderation_results lookup columns. Gated by BACKFILL_ENABLED.
+try {
+  const result = await runBackfill(env, {
+    fetchLookup: (sha256) => fetchFunnelcakeLookupVideo(sha256)
+  });
+  if (!result.skipped) {
+    console.log(`[BACKFILL] picked=${result.picked} updated=${result.updated} missing=${result.missing} errored=${result.errored}`);
+  }
+} catch (e) {
+  console.error('[BACKFILL] failed:', e);
+}
+```
+
+Add the import at the top of the file:
+```js
+import { runBackfill } from './admin/backfill-lookup-columns.mjs';
+```
+
+`fetchFunnelcakeLookupVideo` is already in scope at module level (defined at `src/index.mjs:305`).
+
+### Task 5.3: Manual trigger endpoint
+
+- [ ] **Step 1**: Add to `src/index.mjs` near other admin endpoints:
+
+```js
+if (url.pathname === '/admin/api/backfill/run' && request.method === 'POST') {
+  const authError = await requireAuth(request, env);
+  if (authError) return authError;
+  const count = Math.min(Number(url.searchParams.get('count') || '200'), 500);
+  const result = await runBackfill(env, {
+    limit: count,
+    fetchLookup: (sha256) => fetchFunnelcakeLookupVideo(sha256)
+  });
+  return new Response(JSON.stringify(result), { headers: JSON_HEADERS });
+}
+```
+
+### Task 5.4: Update `wrangler.toml`
+
+- [ ] **Step 1**: Add to `[vars]`:
+```
+BACKFILL_ENABLED = "false"  # flip to "true" via secret/var to start the backfill
+BACKFILL_ROWS_PER_TICK = "200"
+```
+
+(Cron is already wired at `* * * * *`, no change needed.)
+
+### Task 5.5: Tests + commit + PR
+
+- [ ] **Step 1**: Run `npm test`.
+- [ ] **Step 2**: Commit:
+
+```
+feat: backfill cron for legacy moderation_results lookup columns
+
+Populates event_id/title/author/content_url/published_at on rows
+predating migration 004's storage of those columns. Idempotent,
+rate-limited (200/min default), KV-mutex protected against
+overlapping cron + manual-trigger runs. Off by default behind
+BACKFILL_ENABLED=true.
+
+After full backfill (~26h at default rate), the funnelcake fallback
+in /admin/api/video/:id and getAdminLookupVideo becomes near-zero
+on legacy data.
+```
+
+- [ ] **Step 3**: Open PR5.
+
+### Task 5.6: Production verification
+
+- [ ] **Step 1**: After PR5 merges, manually trigger a 100-row batch:
+
+`curl -X POST -H "Cookie: ..." 'https://moderation.admin.divine.video/admin/api/backfill/run?count=100'`
+
+Expected: `{ picked: 100, updated: <up_to_100>, missing: ..., errored: 0 }`.
+
+- [ ] **Step 2**: Inspect the rows updated:
+
+```
+wrangler d1 execute blossom-webhook-events --remote --command \
+  "SELECT COUNT(*) FROM moderation_results WHERE event_id IS NULL"
+```
+
+Should drop by `updated` from the previous count.
+
+- [ ] **Step 3**: Flip `BACKFILL_ENABLED=true`:
+
+`wrangler secret put BACKFILL_ENABLED` (set to `true`) — or update `[vars]` and redeploy.
+
+- [ ] **Step 4**: Monitor over 24h with the same `COUNT(*)` query. Expect ~12k/hr decrease.
+
+---
+
+## Final acceptance
+
+- [ ] All five PRs merged and deployed.
+- [ ] `curl -w '%{time_total}'` against `/admin/api/videos?limit=50` returns < 0.3s (warm).
+- [ ] `curl -w '%{time_total}'` against `/admin/api/stats` returns < 0.1s (cached).
+- [ ] `curl -w '%{time_total}'` against `/admin/api/untriaged?limit=50` returns < 0.4s (warm).
+- [ ] Manual dashboard load (cleared cache, fresh tab): first paint < 1.5s, full grid < 2s.
+- [ ] `SELECT COUNT(*) FROM moderation_results WHERE event_id IS NULL` trends to near 0 over 24-48h after backfill is enabled.
+- [ ] No regression in the 303-test baseline; new tests added (~12-15 additional).
+- [ ] Moderators stop complaining.

--- a/docs/superpowers/specs/2026-05-05-moderation-dashboard-speedup-design.md
+++ b/docs/superpowers/specs/2026-05-05-moderation-dashboard-speedup-design.md
@@ -1,0 +1,458 @@
+# Moderation Dashboard Speedup — Design
+
+Status: Draft
+Author: rabble (with Claude)
+Date: 2026-05-05
+
+## Problem
+
+The moderation dashboard at `moderation.admin.divine.video` is slow enough
+that paid moderators wait on page loads. Concrete causes, all confirmed by
+reading the code and running queries against production D1:
+
+1. **Per-row external fan-out.** `/admin/api/videos` calls
+   `getAdminLookupVideo(sha256)` for every row already returned by its main
+   list query (`src/index.mjs:1539-1558`). Inside that helper,
+   `enrichAdminLookupVideo` (`src/index.mjs:852-898`) fires
+   `fetchFunnelcakeLookupVideo`, an HTTP call to `relay.divine.video`,
+   whenever `eventId || divineUrl || nostrContext` is null. The list-query
+   `SELECT` and `getAdminLookupVideo`'s own `SELECT` (`src/index.mjs:992-996`,
+   `1511`) **omit** the columns (`event_id`, `title`, `author`,
+   `content_url`, `published_at`) that would populate those fields, even
+   though the columns exist on `moderation_results` (added by
+   `migrations/004-content-metadata.sql`). `buildStoredLookupMetadata`
+   reads those keys off the row, but they are `undefined` because they
+   were never selected, so `eventId`/`nostrContext` are always falsy and
+   the funnelcake branch always wins. Result: the funnelcake fetch fires
+   for every card, every page, even for rows whose data is already in
+   D1. A single funnelcake request was timed at ~1.6s today.
+2. **Wrong-shape indexes.** `moderation_results` (322,917 rows) has
+   single-column indexes on `action` and `moderated_at`. The dashboard's
+   primary list query (`WHERE action=? ORDER BY moderated_at DESC LIMIT
+   50`) cannot use them together; SQLite picks `idx_moderation_action` and
+   builds a `TEMP B-TREE FOR ORDER BY` on every page nav (verified with
+   `EXPLAIN QUERY PLAN`).
+3. **Correlated-subquery scan in `/admin/api/untriaged`.** The "latest
+   event per sha" lookup is hand-rolled as
+   `WHERE received_at = (SELECT MAX(received_at) FROM bunny_webhook_events
+   e2 WHERE e2.sha256 = e1.sha256)` and is copy-pasted four times in
+   `src/index.mjs` (subquery line numbers: 1036, 1149, 1707, 1779 — in
+   `getAdminLookupVideo`, `getStoredAdminPlaybackCandidates`,
+   `/admin/api/untriaged` list, and `/admin/api/untriaged` count).
+   `EXPLAIN QUERY PLAN` shows a full-table scan of `e1` with a correlated
+   scalar subquery per row.
+4. **Sequential KV reads** inside `for...of await` loops
+   (`src/index.mjs:1736-1741`).
+5. **Uncached full-table aggregations.** `/admin/api/stats` runs
+   `COUNT(DISTINCT sha256)` plus two `GROUP BY action` aggregations on
+   every dashboard mount and every `visibilitychange`. None of it cached.
+6. **(Note: not actually a problem.)** `dashboard.html` is already served
+   with `Cache-Control: no-cache` and a deterministic content-hash ETag
+   (`src/index.mjs:69-95`). Browsers revalidate but get a 304 when the
+   file hasn't changed. **L6 in earlier drafts of this spec proposed
+   re-doing this; that work is unnecessary and is dropped from scope.**
+
+Population data confirms the SELECT-widening fix is high-leverage:
+- Rows since 2026-04-01: **5,994/6,044 (99%) already have `event_id`**.
+- Rows total: 6,905/322,917 (~2%) — but the dashboard sorts
+  `moderated_at DESC LIMIT 50`, so the moderator's working window is
+  already mostly populated. Backfill addresses the rest.
+
+## Goals
+
+- Sub-second `/admin/api/videos`, `/admin/api/untriaged`, and
+  `/admin/api/stats` (p95).
+- Dashboard mount < 1.5s end-to-end on a warm cache.
+- All current functionality preserved. Every field rendered today must
+  keep rendering. Every action must keep working. Response shapes
+  unchanged.
+- Backfill all 316k legacy rows so legacy navigation is fast too.
+
+## Non-Goals
+
+- Redesigning the dashboard UI.
+- Changing the moderation pipeline, scoring, or category logic.
+- Changing what data we store in `moderation_results`.
+- Changing public API response shapes consumed by other services.
+- Switching off Cloudflare Workers / D1.
+
+## Constraints
+
+- Cloudflare Workers: 50 concurrent subrequests, 30s CPU, KV eventual
+  consistency.
+- D1 / SQLite: limited window-function support compared to PG; verify
+  with `EXPLAIN QUERY PLAN` before relying on `ROW_NUMBER()`.
+- Production: 322,917 rows in `moderation_results`. Auto-deploys on
+  merge to `main` via `cloudflare/wrangler-action`.
+
+## Architecture — five layers, ordered by impact
+
+(L6 in an earlier draft was a no-op; dropped.)
+
+### L1. Composite indexes (D1 migration)
+
+New file `migrations/009-dashboard-speedup-indexes.sql` (numeric
+sequence follows the existing convention; latest is `008-`):
+
+```sql
+CREATE INDEX IF NOT EXISTS idx_moderation_action_date
+  ON moderation_results(action, moderated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_moderation_uploaded_by_date
+  ON moderation_results(uploaded_by, moderated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_bunny_events_sha256_received
+  ON bunny_webhook_events(sha256, received_at DESC);
+
+-- Partial index for the FLAGGED filter (action IN (...) AND
+-- reviewed_by IS NULL). The dashboard's "Flagged" stat-card uses this
+-- predicate; without the partial index the count requires fetching
+-- every row to check reviewed_by.
+CREATE INDEX IF NOT EXISTS idx_moderation_unreviewed
+  ON moderation_results(action, moderated_at DESC)
+  WHERE reviewed_by IS NULL;
+
+-- Tracks when we last asked funnelcake about a sha that has no
+-- event_id, so the backfill cron doesn't loop forever on permanent
+-- 404s. Migration also adds the column.
+ALTER TABLE moderation_results ADD COLUMN lookup_attempted_at TEXT;
+```
+
+`IF NOT EXISTS` makes it safe to re-run. D1 builds these inline; on
+322k rows the build takes seconds. No down time.
+
+**Verification:** after applying, run
+`EXPLAIN QUERY PLAN SELECT … WHERE action='REVIEW' ORDER BY
+moderated_at DESC LIMIT 50` and confirm the plan no longer contains
+`USE TEMP B-TREE FOR ORDER BY`.
+
+### L2. Widen SELECTs and remove the per-row fan-out
+
+**Code touch points (single file, `src/index.mjs`):**
+
+- `getAdminLookupVideo` (line 992): add `event_id, title, author,
+  content_url, published_at` to the SELECT.
+- `/admin/api/videos` (line 1511): same widening.
+- `/api/v1/decisions` (line 3951): same widening — preserves response
+  shape, just fills more fields.
+
+**Then in `/admin/api/videos` (lines 1539-1558)** replace:
+
+```js
+const videos = await Promise.all(videoRows.map(async (video) => {
+  const enriched = await getAdminLookupVideo(video.sha256, env);
+  // ...
+}));
+```
+
+with a synchronous mapper that builds the response from the row using
+`buildStoredLookupMetadata(row)`. No second D1 read, no funnelcake fetch.
+
+**Funnelcake fallback path** is preserved: when `event_id IS NULL`
+(legacy rows pre-backfill), fall through to the slow path. After
+backfill completes, this becomes ≈ 0% of rows.
+
+**Field-level shape change to acknowledge.**
+`buildStoredLookupMetadata` hard-codes `nostrContext.client = null`
+and `nostrContext.content = null` (`src/index.mjs:272-273`); these
+two fields are not stored in `moderation_results` today. The
+funnelcake fetch currently fills them. After this change, on the
+**list endpoint** those two fields will be `null` for every row.
+The dashboard's list cards do not display `client` or `content`
+prominently (verified by reading `createCard`/`createTriageCard` in
+`dashboard.html`), so this is acceptable. The **single-video lookup
+endpoint** `/admin/api/video/:id` keeps the on-demand funnelcake
+fetch so the detail view continues to show those fields. We are
+explicitly trading one network call per **page** of cards for one
+network call per **opened detail view** — net win because moderators
+look at far fewer detail views than they scroll past cards.
+
+**Batch uploader_enforcement.** Collect the unique non-null
+`uploaded_by` values from the page, do one
+`SELECT … FROM uploader_enforcement WHERE pubkey IN (?,?,…)` query,
+attach by pubkey lookup. Replaces N parallel D1 round-trips with 1.
+
+**Result per page render**: 1 list query + 1 IN query + KV cached
+stats. ~3 round-trips, down from ~150-250.
+
+### L3. KV cache for stats
+
+Wrap `/admin/api/stats`, `/admin/api/ai-detection/stats`, the COUNT
+in `/api/v1/decisions`, and the COUNT in `/admin/api/untriaged` with
+a small helper. The handler signature in `src/index.mjs` is
+`async fetch(request, env, ctx)` (`src/index.mjs:1341`), so `ctx`
+must be threaded through:
+
+```js
+async function cachedStat(env, ctx, key, ttlSeconds, compute) {
+  const cached = await env.MODERATION_KV.get(`stats:v1:${key}`);
+  if (cached) return JSON.parse(cached);
+  const fresh = await compute();
+  // best-effort write, do not block response
+  ctx.waitUntil(env.MODERATION_KV.put(
+    `stats:v1:${key}`,
+    JSON.stringify(fresh),
+    { expirationTtl: ttlSeconds }
+  ));
+  return fresh;
+}
+```
+
+- TTL: 60s.
+- `?fresh=1` bypasses the cache **read but still writes** the fresh
+  value back. (Otherwise 50 moderators each hitting Refresh would
+  cause a cache stampede; with bypass-read-only-then-write, the
+  first one populates the cache for the rest.)
+- Cron prewarms every 60s so the first request after a TTL window is
+  still served from cache.
+- Cache key encodes filter params: `stats:v1:videos:action=REVIEW`.
+
+Stats endpoint goes from ~200-500ms to ~5-10ms.
+
+### L4. Untriaged cleanup
+
+Replace the correlated subquery with one of:
+
+1. `ROW_NUMBER() OVER (PARTITION BY sha256 ORDER BY received_at DESC) = 1`
+2. `GROUP BY sha256 HAVING received_at = MAX(received_at)`
+
+We will write both, run `EXPLAIN QUERY PLAN`, pick the one that uses
+`idx_bunny_events_sha256_received` cleanly with no temp B-tree.
+
+The four hand-rolled copies of this logic (subquery line numbers:
+`src/index.mjs:1036, 1149, 1707, 1779`) get extracted into a single
+helper `latestBunnyEventBySha(env, { sha256?, limit?, offset? })`.
+
+Parallelize the KV reads at line 1737 with `Promise.all`. Cache the
+COUNT in KV with 60s TTL.
+
+**Cache the per-row Nostr fetch.** Even after L1+L2, the untriaged
+endpoint still fires one `fetchNostrEventBySha256` WebSocket call per
+sha (`src/index.mjs:1745-1763`). Add a KV cache:
+`nostr:event:${sha256}` with 1-hour TTL. The Triage list rarely
+changes its top entries within an hour, and a cache miss falls
+through to the existing live fetch. This brings untriaged from ~50
+parallel WS calls to typically 0-3.
+
+### L5. Legacy backfill cron
+
+New file `src/admin/backfill-lookup-columns.mjs`. Wired into
+`scheduled` in `src/index.mjs` and into `wrangler.toml` cron.
+
+Behavior, every 60s:
+1. `SELECT sha256 FROM moderation_results WHERE event_id IS NULL AND
+   (lookup_attempted_at IS NULL OR lookup_attempted_at < ?)
+   ORDER BY moderated_at DESC LIMIT 200`
+   — newest legacy first, since those are more likely to be reviewed.
+2. For each, call `fetchFunnelcakeLookupVideo(sha256)`, capped at 10
+   concurrent.
+3. On hit: `UPDATE moderation_results SET event_id = ?, title = ?,
+   author = ?, content_url = ?, published_at = ?,
+   lookup_attempted_at = ? WHERE sha256 = ? AND event_id IS NULL`
+   (the trailing condition keeps it idempotent).
+4. On 404: `UPDATE … SET lookup_attempted_at = ? WHERE sha256 = ?`
+   so we don't loop forever on permanent misses. Retry after 7 days.
+5. On HTTP error: log, no DB write, retry next tick.
+
+**New column.** `ALTER TABLE moderation_results ADD COLUMN
+lookup_attempted_at TEXT` — included in the L1 migration.
+
+**Rate.** 200 rows/min × 60 min = 12k/hr → 316k rows ≈ **26 hours**.
+Configurable via env var `BACKFILL_ROWS_PER_TICK`.
+
+**Manual trigger.** `POST /admin/api/backfill/run?count=N` (auth
+required) lets ops kick a one-off batch.
+
+**Feature flag.** `BACKFILL_ENABLED=true` env var. Off by default in
+the first deploy; flipped on after L1-L4 verify clean in production.
+
+**Idempotency.** The `WHERE event_id IS NULL` predicate on the UPDATE
+guarantees no overwrite of already-populated rows.
+
+**Mutex / overlap protection.** The cron tick + the manual trigger
+could race and both call funnelcake for the same 200 shas, doubling
+load on `relay.divine.video`. Before each batch, take a KV lock:
+```
+const lock = await env.MODERATION_KV.get('backfill:lock');
+if (lock) return { skipped: 'locked' };
+await env.MODERATION_KV.put('backfill:lock', String(Date.now()),
+  { expirationTtl: 300 });
+try { … run batch … }
+finally { await env.MODERATION_KV.delete('backfill:lock'); }
+```
+TTL of 300s means a crashed worker auto-releases. The
+`expirationTtl` doubles as a deadlock fuse.
+
+### L6. Static-asset caching — DROPPED
+
+Earlier draft proposed switching `dashboard.html` from `no-store` to
+`max-age=300`. Reading the actual code (`src/index.mjs:69-95`)
+showed the page is already served with `Cache-Control: no-cache`
+and a deterministic content-hash ETag, so browsers already
+revalidate-and-304 on every nav. No change needed.
+
+## Components / file map
+
+| Layer | File | Change |
+|-------|------|--------|
+| L1 | `migrations/009-dashboard-speedup-indexes.sql` | new |
+| L2 | `src/index.mjs` | widen SELECTs, kill fan-out, batch enforcement |
+| L2 | `src/admin/lookup-helpers.mjs` (new) | extract row→admin-shape mapper for testing |
+| L3 | `src/index.mjs` | wrap three stat endpoints in `cachedStat` |
+| L3 | `src/admin/cache.mjs` (new) | `cachedStat` helper |
+| L4 | `src/index.mjs` | replace correlated subquery, parallelize KV |
+| L4 | `src/admin/bunny-events.mjs` (new) | `latestBunnyEventBySha` helper |
+| L5 | `src/admin/backfill-lookup-columns.mjs` (new) | cron worker |
+| L5 | `src/index.mjs` | scheduled handler dispatch + manual trigger |
+| L5 | `wrangler.toml` | cron trigger entry |
+| L6 | — | dropped, already implemented |
+
+## Testing
+
+**Discipline**: TDD per layer. For each behavior change:
+1. Write a test that fails on `main`.
+2. Write the fix.
+3. Confirm the test passes and the existing 303-test suite still does.
+
+**New test files:**
+
+- `src/admin/dashboard-fanout.test.mjs` —
+  - Stubs `fetch` and `enrichAdminLookupVideo` with counters.
+  - Seeds D1 fixture with rows that have `event_id` populated.
+  - Calls `/admin/api/videos`.
+  - Asserts `fetch.callCount === 0` (no funnelcake).
+  - Asserts `enrichAdminLookupVideo.callCount === 0` (no per-row helper).
+  - **Golden snapshot test**: pin the exact JSON shape of
+    `videos[0]` for a fully-populated row. Compare byte-for-byte
+    before/after the change to catch any field reordering, missing
+    key, or unexpected `undefined`. Separate snapshot for a
+    partially-populated row (post-backfill 404 sentinel).
+  - **Legacy fallthrough test**: row with `event_id IS NULL` —
+    asserts funnelcake IS called exactly once and the response
+    includes the funnelcake-derived fields.
+
+- `src/admin/stats-cache.test.mjs` —
+  - First call: D1 hit, KV write.
+  - Second call within TTL: KV hit, no D1 read.
+  - `?fresh=1`: D1 hit, KV write.
+
+- `src/admin/untriaged-query.test.mjs` —
+  - Seeds `bunny_webhook_events` with multiple events per sha256.
+  - Asserts new helper returns the same rows as the old correlated
+    subquery (golden test).
+  - `EXPLAIN QUERY PLAN` does not contain `TEMP B-TREE` or
+    `CORRELATED`.
+
+- `src/admin/backfill-lookup-columns.test.mjs` —
+  - Idempotent: second run on same row is a no-op.
+  - 404 path sets `lookup_attempted_at`.
+  - HTTP error path leaves row unchanged.
+  - Honors `BACKFILL_ROWS_PER_TICK`.
+  - Concurrency cap respected.
+  - **Mutex test:** start two concurrent runs — assert one returns
+    `{ skipped: 'locked' }` and the other does the work. Each row
+    is processed at most once across both calls.
+
+- `src/admin/lookup-helpers.test.mjs` —
+  - `buildStoredLookupMetadata` returns expected shape for all column
+    populations (none, partial, full).
+
+**Existing tests** must still pass without modification — that is the
+guarantee that response shapes are unchanged.
+
+**EXPLAIN QUERY PLAN tests** are not run in vitest (D1 binding does
+not expose `EXPLAIN`). They live in
+`scripts/verify-query-plans.mjs`, run via `wrangler d1 execute`,
+included in the release checklist. Each PR touching SQL must show
+the plan output in its description.
+
+## Rollout
+
+Split into five small PRs so each can bake independently and any
+regression is easy to bisect.
+
+1. **PR 1 — L1 only (migration).** Adds composite indexes,
+   partial index, and `lookup_attempted_at` column. No code change.
+   Apply via `wrangler d1 migrations apply` then verify
+   `EXPLAIN QUERY PLAN` for the three target queries. Trivial
+   revert: `DROP INDEX`.
+2. **PR 2 — L2 (widen SELECTs + kill fan-out).** This is the
+   biggest perceived speedup for moderators. Includes the field-level
+   shape change call-out from the L2 section. Lands after L1 is in
+   prod for at least a few hours.
+3. **PR 3 — L3 (KV cache for stats).**
+4. **PR 4 — L4 (untriaged: helper extraction, window query, KV
+   parallelization, Nostr cache).**
+5. **PR 5 — L5 (backfill cron + manual trigger).** Ships with
+   `BACKFILL_ENABLED=false`. After verifying the manual trigger on
+   a 100-row batch, flip to `true`. Monitor progress via
+   `SELECT COUNT(*) FROM moderation_results WHERE event_id IS NULL`.
+
+Each PR is independently revertable. Dropping the indexes is a
+single statement; reverting the cache wrapper is a code revert; the
+backfill is gated behind a flag.
+
+## Performance targets
+
+| Endpoint | Today (observed) | Target (p95) |
+|----------|------------------|--------------|
+| `/admin/api/videos?limit=50` | 3-10s | < 200ms |
+| `/admin/api/stats` | 200-500ms | < 50ms (cached) |
+| `/admin/api/untriaged?limit=50` | 1-3s | < 300ms |
+| Dashboard mount | 5-15s | < 1.5s |
+
+Measured via `time_starttransfer` from a curl harness before and
+after each PR.
+
+## Risks and mitigations
+
+- **D1 query planner picks wrong index after we add composites.**
+  Mitigation: run `EXPLAIN QUERY PLAN` post-migration; add
+  `INDEXED BY` hint if needed; one of the new indexes is a strict
+  superset of an existing one and the planner generally picks the
+  more specific one.
+- **KV-cached stats become stale during a moderator's session.**
+  Mitigation: 60s TTL is short. Refresh button passes `?fresh=1`.
+  Visibilitychange already debounces to 30s.
+- **Funnelcake API rate-limits the backfill.** Mitigation: 10 concurrent
+  cap, 200/min default rate; can dial down via env var without redeploy.
+- **A row's writer changes the schema again.** Mitigation: backfill is
+  idempotent and only touches rows where `event_id IS NULL`.
+
+## Initial-mount fetch audit
+
+The dashboard fires the following endpoints on initial mount
+(grepped from `src/admin/dashboard.html`). Spec coverage noted:
+
+| Endpoint | Hit on mount? | Covered by spec? |
+|----------|--------------|------------------|
+| `/admin/api/stats` | yes (`loadRealStats`) | L3 |
+| `/admin/api/ai-detection/stats` | yes (`loadAIDetectionStats`) | L3 |
+| `/admin/api/untriaged` or `/admin/api/videos` | yes (one or the other depending on filter) | L2/L4 |
+| `/admin/api/messages` | yes (unread badge) | not addressed; small payload, low priority |
+| `/admin/api/thresholds` | only when modal opens | not addressed |
+| `/admin/api/nostr-context/:sha256` | only on detail-view click | not addressed |
+| `/admin/api/transcript/:sha256` | only on detail-view click | not addressed |
+| `/admin/api/uploader/:pubkey` | only on detail-view click | not addressed |
+| `/admin/api/realness/:sha256` | only on detail-view click | not addressed |
+| `/admin/api/classifier/:sha256` | only on detail-view click | not addressed |
+
+The on-mount fetches are all addressed. Detail-view fetches are
+out of scope for this spec; they fire only when a moderator opens
+a single video.
+
+## Open questions
+
+- Should the backfill cron also populate `uploaded_by` if missing?
+  Currently `uploaded_by` is well-populated on legacy rows; defer.
+- Should `getUploaderEnforcement` move off the list endpoint
+  entirely, fetched only on detail-view? Defer; the batched
+  `WHERE pubkey IN (…)` should be fast enough.
+
+## Out of scope (follow-ups, separate spec if needed)
+
+- Server-side rendering of the dashboard.
+- Replacing the inline 5,490-line `dashboard.html` with a bundled
+  asset.
+- Migrating off D1 to a different store.
+- Pagination via cursors instead of offsets.

--- a/migrations/009-dashboard-speedup-indexes.sql
+++ b/migrations/009-dashboard-speedup-indexes.sql
@@ -1,0 +1,27 @@
+-- Composite index satisfying the dashboard's primary list query:
+-- WHERE action = ? ORDER BY moderated_at DESC LIMIT N.
+-- Without this, SQLite picks idx_moderation_action and adds a
+-- TEMP B-TREE FOR ORDER BY on every page nav (verified via EXPLAIN).
+CREATE INDEX IF NOT EXISTS idx_moderation_action_date
+  ON moderation_results(action, moderated_at DESC);
+
+-- Supports buildUploaderHistory's per-uploader recent-flagged scan.
+CREATE INDEX IF NOT EXISTS idx_moderation_uploaded_by_date
+  ON moderation_results(uploaded_by, moderated_at DESC);
+
+-- Supports the latest-event-per-sha lookup that
+-- src/admin/bunny-events.mjs (window-function CTE) consumes.
+CREATE INDEX IF NOT EXISTS idx_bunny_events_sha256_received
+  ON bunny_webhook_events(sha256, received_at DESC);
+
+-- Partial index for the dashboard's FLAGGED filter
+-- (action IN (...) AND reviewed_by IS NULL). Small (only unreviewed
+-- rows), tight, lets the count avoid a full scan.
+CREATE INDEX IF NOT EXISTS idx_moderation_unreviewed
+  ON moderation_results(action, moderated_at DESC)
+  WHERE reviewed_by IS NULL;
+
+-- Tracks the last time the backfill cron tried to populate this
+-- row's lookup metadata. Lets us skip rows we already tried for 7
+-- days (avoids hammering funnelcake on permanent 404s).
+ALTER TABLE moderation_results ADD COLUMN lookup_attempted_at TEXT;

--- a/scripts/verify-query-plans.mjs
+++ b/scripts/verify-query-plans.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+// ABOUTME: Run EXPLAIN QUERY PLAN on the dashboard's hot queries and
+// fail if any of them regress (temp B-tree sort, correlated subquery,
+// missing index). Run after applying migration 009.
+//
+// Usage: node scripts/verify-query-plans.mjs [--remote|--local]
+// Default: --remote.
+
+import { execSync } from 'node:child_process';
+
+const DB = 'blossom-webhook-events';
+const flag = process.argv.includes('--local') ? '--local' : '--remote';
+
+const QUERIES = [
+  {
+    name: 'list-by-action',
+    sql: `EXPLAIN QUERY PLAN SELECT sha256 FROM moderation_results WHERE action='REVIEW' ORDER BY moderated_at DESC LIMIT 50`,
+    forbid: ['TEMP B-TREE'],
+    require: ['idx_moderation_action_date'],
+  },
+  {
+    name: 'flagged-count',
+    sql: `EXPLAIN QUERY PLAN SELECT COUNT(*) FROM moderation_results WHERE action='REVIEW' AND reviewed_by IS NULL`,
+    forbid: ['TEMP B-TREE'],
+    require: ['idx_moderation_unreviewed'],
+  },
+  {
+    name: 'uploader-history',
+    sql: `EXPLAIN QUERY PLAN SELECT sha256 FROM moderation_results WHERE uploaded_by='abc' ORDER BY moderated_at DESC LIMIT 10`,
+    forbid: ['TEMP B-TREE'],
+    require: ['idx_moderation_uploaded_by_date'],
+  },
+  {
+    name: 'latest-bunny-event-per-sha',
+    sql: `EXPLAIN QUERY PLAN WITH ranked AS (
+      SELECT sha256, received_at, ROW_NUMBER() OVER (PARTITION BY sha256 ORDER BY received_at DESC) AS rn
+      FROM bunny_webhook_events
+      WHERE sha256 IS NOT NULL AND status_name NOT IN ('error','deleted')
+    ) SELECT sha256 FROM ranked WHERE rn = 1 ORDER BY received_at DESC LIMIT 50`,
+    forbid: ['CORRELATED'],
+    require: ['idx_bunny_events_sha256_received'],
+  },
+];
+
+let failed = 0;
+for (const q of QUERIES) {
+  const out = execSync(
+    `wrangler d1 execute ${DB} ${flag} --command ${JSON.stringify(q.sql)}`,
+    { encoding: 'utf8' },
+  );
+  const missingForbid = q.forbid.filter((bad) => out.includes(bad));
+  const missingRequire = q.require.filter((needle) => !out.includes(needle));
+  const ok = missingForbid.length === 0 && missingRequire.length === 0;
+  console.log(`${ok ? '✓' : '✗'} ${q.name}`);
+  if (!ok) {
+    if (missingForbid.length) console.log(`    forbidden phrases present: ${missingForbid.join(', ')}`);
+    if (missingRequire.length) console.log(`    required phrases absent:   ${missingRequire.join(', ')}`);
+    console.log(out.split('\n').filter((l) => l.includes('detail')).map((l) => `    ${l.trim()}`).join('\n'));
+    failed++;
+  }
+}
+process.exit(failed ? 1 : 0);

--- a/src/admin/backfill-lookup-columns.mjs
+++ b/src/admin/backfill-lookup-columns.mjs
@@ -1,0 +1,122 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Cron worker that fills event_id/title/author/content_url/published_at
+// ABOUTME: on legacy moderation_results rows by calling fetchFunnelcakeLookupVideo.
+// ABOUTME: Idempotent (UPDATE WHERE event_id IS NULL); rate-limited; KV-mutex
+// ABOUTME: protected against overlap with manual triggers.
+
+const LOCK_KEY = 'backfill:lock';
+const LOCK_TTL_S = 300; // 5 minutes — also a deadlock fuse if the worker dies mid-batch.
+const RETRY_AFTER_DAYS = 7;
+
+/**
+ * Run a single backfill batch.
+ *
+ * Required: `fetchLookup` (DI) — typically `fetchFunnelcakeLookupVideo`
+ * from src/index.mjs. Returns either null (404) or a parsed lookup
+ * object with shape `{ eventId, videoUrl, uploadedBy, createdAt,
+ * nostrContext: { title, author, publishedAt, url, ... }, ... }`
+ * (see buildFunnelcakeVideoLookup in src/index.mjs:212).
+ *
+ * Returns `{ skipped }` when disabled or another run holds the lock,
+ * otherwise `{ picked, updated, missing, errored }`.
+ */
+export async function runBackfill(env, options = {}) {
+  const {
+    limit,
+    concurrency = 10,
+    fetchLookup,
+    now = () => new Date().toISOString(),
+  } = options;
+
+  if (typeof fetchLookup !== 'function') {
+    throw new Error('runBackfill: fetchLookup is required');
+  }
+  if (env.BACKFILL_ENABLED !== 'true') {
+    return { skipped: 'disabled' };
+  }
+
+  // Mutex: prevent the every-minute cron and a manual trigger from
+  // double-fetching the same shas.
+  const existingLock = await env.MODERATION_KV.get(LOCK_KEY);
+  if (existingLock) {
+    return { skipped: 'locked' };
+  }
+  await env.MODERATION_KV.put(LOCK_KEY, String(Date.now()), { expirationTtl: LOCK_TTL_S });
+
+  try {
+    const rowsLimit = Math.max(1, Math.min(
+      limit ?? Number(env.BACKFILL_ROWS_PER_TICK ?? '200'),
+      500,
+    ));
+    const retryAfter = new Date(Date.now() - RETRY_AFTER_DAYS * 24 * 3600 * 1000).toISOString();
+
+    const rows = (await env.BLOSSOM_DB.prepare(`
+      SELECT sha256
+      FROM moderation_results
+      WHERE event_id IS NULL
+        AND (lookup_attempted_at IS NULL OR lookup_attempted_at < ?)
+      ORDER BY moderated_at DESC
+      LIMIT ?
+    `).bind(retryAfter, rowsLimit).all()).results || [];
+
+    let updated = 0;
+    let missing = 0;
+    let errored = 0;
+
+    const queue = [...rows];
+
+    async function worker() {
+      while (queue.length > 0) {
+        const row = queue.shift();
+        if (!row) continue;
+        const attemptedAt = now();
+        let lookup;
+        try {
+          lookup = await fetchLookup(row.sha256);
+        } catch {
+          errored++;
+          continue;
+        }
+        if (!lookup) {
+          // 404 from funnelcake. Record the attempt so we don't
+          // re-poll for RETRY_AFTER_DAYS days.
+          await env.BLOSSOM_DB.prepare(
+            `UPDATE moderation_results
+             SET lookup_attempted_at = ?
+             WHERE sha256 = ? AND event_id IS NULL`,
+          ).bind(attemptedAt, row.sha256).run();
+          missing++;
+          continue;
+        }
+        const ctx = lookup.nostrContext || {};
+        await env.BLOSSOM_DB.prepare(
+          `UPDATE moderation_results SET
+             event_id = COALESCE(?, event_id),
+             title = COALESCE(?, title),
+             author = COALESCE(?, author),
+             content_url = COALESCE(?, content_url),
+             published_at = COALESCE(?, published_at),
+             lookup_attempted_at = ?
+           WHERE sha256 = ? AND event_id IS NULL`,
+        ).bind(
+          lookup.eventId || null,
+          ctx.title || null,
+          ctx.author || null,
+          lookup.videoUrl || ctx.url || null,
+          ctx.publishedAt != null ? String(ctx.publishedAt) : null,
+          attemptedAt,
+          row.sha256,
+        ).run();
+        updated++;
+      }
+    }
+
+    await Promise.all(Array.from({ length: concurrency }, worker));
+
+    return { picked: rows.length, updated, missing, errored };
+  } finally {
+    await env.MODERATION_KV.delete(LOCK_KEY);
+  }
+}

--- a/src/admin/backfill-lookup-columns.test.mjs
+++ b/src/admin/backfill-lookup-columns.test.mjs
@@ -1,0 +1,176 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Tests for runBackfill — KV-mutex'd cron worker that fills legacy
+// ABOUTME: moderation_results lookup columns from funnelcake.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { env } from 'cloudflare:test';
+import { runBackfill } from './backfill-lookup-columns.mjs';
+
+const SHA_A = 'a'.repeat(64);
+const SHA_B = 'b'.repeat(64);
+
+async function seedTable() {
+  await env.BLOSSOM_DB.prepare(`CREATE TABLE IF NOT EXISTS moderation_results (
+    sha256 TEXT PRIMARY KEY,
+    action TEXT NOT NULL,
+    moderated_at TEXT,
+    event_id TEXT,
+    title TEXT,
+    author TEXT,
+    content_url TEXT,
+    published_at TEXT,
+    lookup_attempted_at TEXT
+  )`).run();
+  await env.BLOSSOM_DB.prepare(`DELETE FROM moderation_results`).run();
+}
+
+beforeEach(async () => {
+  await seedTable();
+  await env.MODERATION_KV.delete('backfill:lock');
+});
+
+async function insertLegacy(sha256, override = {}) {
+  await env.BLOSSOM_DB.prepare(
+    `INSERT INTO moderation_results (sha256, action, moderated_at, event_id, title, author, content_url, published_at, lookup_attempted_at)
+     VALUES (?,?,?,?,?,?,?,?,?)`,
+  ).bind(
+    sha256,
+    'REVIEW',
+    override.moderated_at || '2024-01-01T00:00:00Z',
+    override.event_id || null,
+    override.title || null,
+    override.author || null,
+    override.content_url || null,
+    override.published_at || null,
+    override.lookup_attempted_at || null,
+  ).run();
+}
+
+const FUNNEL_HIT = {
+  eventId: 'e'.repeat(64),
+  videoUrl: 'https://media.divine.video/v.mp4',
+  uploadedBy: 'p'.repeat(64),
+  nostrContext: {
+    title: 'Hi',
+    author: 'Alice',
+    publishedAt: 1700000000,
+    url: 'https://media.divine.video/v.mp4',
+  },
+};
+
+describe('runBackfill', () => {
+  it('returns skipped when BACKFILL_ENABLED is not "true"', async () => {
+    const result = await runBackfill(
+      { ...env, BACKFILL_ENABLED: 'false' },
+      { fetchLookup: () => null },
+    );
+    expect(result).toEqual({ skipped: 'disabled' });
+  });
+
+  it('updates a legacy row using the funnelcake lookup shape', async () => {
+    await insertLegacy(SHA_A);
+    const fetchLookup = vi.fn().mockResolvedValue(FUNNEL_HIT);
+    const result = await runBackfill(
+      { ...env, BACKFILL_ENABLED: 'true' },
+      { fetchLookup, concurrency: 1 },
+    );
+    expect(result).toMatchObject({ picked: 1, updated: 1, missing: 0, errored: 0 });
+    const row = await env.BLOSSOM_DB.prepare(
+      'SELECT event_id, title, author, content_url, published_at, lookup_attempted_at FROM moderation_results WHERE sha256 = ?',
+    ).bind(SHA_A).first();
+    expect(row.event_id).toBe(FUNNEL_HIT.eventId);
+    expect(row.title).toBe('Hi');
+    expect(row.author).toBe('Alice');
+    expect(row.content_url).toBe('https://media.divine.video/v.mp4');
+    expect(row.published_at).toBe('1700000000');
+    expect(row.lookup_attempted_at).not.toBeNull();
+  });
+
+  it('idempotent: a second run on the same row is a no-op (event_id already set)', async () => {
+    await insertLegacy(SHA_A);
+    const fetchLookup = vi.fn().mockResolvedValue(FUNNEL_HIT);
+    await runBackfill({ ...env, BACKFILL_ENABLED: 'true' }, { fetchLookup });
+    fetchLookup.mockClear();
+    const result = await runBackfill(
+      { ...env, BACKFILL_ENABLED: 'true' },
+      { fetchLookup },
+    );
+    // No more rows match `event_id IS NULL`, so picked = 0.
+    expect(result.picked).toBe(0);
+    expect(fetchLookup).not.toHaveBeenCalled();
+  });
+
+  it('on funnelcake 404 (null), sets lookup_attempted_at only', async () => {
+    await insertLegacy(SHA_A);
+    const fetchLookup = vi.fn().mockResolvedValue(null);
+    const result = await runBackfill(
+      { ...env, BACKFILL_ENABLED: 'true' },
+      { fetchLookup },
+    );
+    expect(result).toMatchObject({ picked: 1, updated: 0, missing: 1 });
+    const row = await env.BLOSSOM_DB.prepare(
+      'SELECT event_id, lookup_attempted_at FROM moderation_results WHERE sha256 = ?',
+    ).bind(SHA_A).first();
+    expect(row.event_id).toBeNull();
+    expect(row.lookup_attempted_at).not.toBeNull();
+  });
+
+  it('on fetch error, leaves the row unchanged', async () => {
+    await insertLegacy(SHA_A);
+    const fetchLookup = vi.fn().mockRejectedValue(new Error('boom'));
+    const result = await runBackfill(
+      { ...env, BACKFILL_ENABLED: 'true' },
+      { fetchLookup },
+    );
+    expect(result).toMatchObject({ picked: 1, updated: 0, missing: 0, errored: 1 });
+    const row = await env.BLOSSOM_DB.prepare(
+      'SELECT event_id, lookup_attempted_at FROM moderation_results WHERE sha256 = ?',
+    ).bind(SHA_A).first();
+    expect(row.event_id).toBeNull();
+    expect(row.lookup_attempted_at).toBeNull();
+  });
+
+  it('honors limit option', async () => {
+    await insertLegacy(SHA_A);
+    await insertLegacy(SHA_B);
+    const fetchLookup = vi.fn().mockResolvedValue(null);
+    const result = await runBackfill(
+      { ...env, BACKFILL_ENABLED: 'true' },
+      { fetchLookup, limit: 1 },
+    );
+    expect(result.picked).toBe(1);
+  });
+
+  it('mutex: a second run while the lock is held returns skipped:locked', async () => {
+    await insertLegacy(SHA_A);
+    // Pre-set the lock to simulate an in-flight call.
+    await env.MODERATION_KV.put('backfill:lock', String(Date.now()), { expirationTtl: 300 });
+    const fetchLookup = vi.fn().mockResolvedValue(FUNNEL_HIT);
+    const result = await runBackfill(
+      { ...env, BACKFILL_ENABLED: 'true' },
+      { fetchLookup },
+    );
+    expect(result).toEqual({ skipped: 'locked' });
+    expect(fetchLookup).not.toHaveBeenCalled();
+  });
+
+  it('skips rows with a recent lookup_attempted_at (within 7 days)', async () => {
+    const yesterday = new Date(Date.now() - 24 * 3600 * 1000).toISOString();
+    await insertLegacy(SHA_A, { lookup_attempted_at: yesterday });
+    const fetchLookup = vi.fn().mockResolvedValue(null);
+    const result = await runBackfill(
+      { ...env, BACKFILL_ENABLED: 'true' },
+      { fetchLookup },
+    );
+    expect(result.picked).toBe(0);
+    expect(fetchLookup).not.toHaveBeenCalled();
+  });
+
+  it('throws if fetchLookup is not provided', async () => {
+    await expect(
+      runBackfill({ ...env, BACKFILL_ENABLED: 'true' }, {}),
+    ).rejects.toThrow('fetchLookup is required');
+  });
+});

--- a/src/admin/bunny-events.mjs
+++ b/src/admin/bunny-events.mjs
@@ -1,0 +1,76 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Latest-event-per-sha lookup helpers for bunny_webhook_events.
+// ABOUTME: Replaces four hand-rolled correlated subqueries that scanned
+// ABOUTME: the table once per outer row.
+
+const DEFAULT_EXCLUDE_STATUS = ['error', 'deleted'];
+
+/**
+ * Page through the latest event per sha, ordered most-recent-first.
+ * Window-function CTE so each sha appears exactly once and the
+ * non-aggregate columns (hls_url, mp4_url, etc.) come from the row
+ * with the largest received_at — deterministic, unlike GROUP BY +
+ * bare columns.
+ */
+export async function latestBunnyEventBySha(env, options = {}) {
+  const {
+    limit = 50,
+    offset = 0,
+    excludeStatusNames = DEFAULT_EXCLUDE_STATUS,
+  } = options;
+  const placeholders = excludeStatusNames.map(() => '?').join(',');
+  const sql = `
+    WITH ranked AS (
+      SELECT
+        sha256, video_guid, hls_url, mp4_url, thumbnail_url, received_at, status_name,
+        ROW_NUMBER() OVER (PARTITION BY sha256 ORDER BY received_at DESC) AS rn
+      FROM bunny_webhook_events
+      WHERE sha256 IS NOT NULL
+        AND status_name NOT IN (${placeholders})
+    )
+    SELECT sha256, video_guid, hls_url, mp4_url, thumbnail_url, received_at, status_name
+    FROM ranked
+    WHERE rn = 1
+    ORDER BY received_at DESC
+    LIMIT ? OFFSET ?
+  `;
+  const result = await env.BLOSSOM_DB.prepare(sql)
+    .bind(...excludeStatusNames, limit, offset)
+    .all();
+  return result.results || [];
+}
+
+/**
+ * Total distinct shas that pass the exclude filter — i.e. the count
+ * the untriaged paginator needs.
+ */
+export async function countLatestBunnyEvents(env, options = {}) {
+  const { excludeStatusNames = DEFAULT_EXCLUDE_STATUS } = options;
+  const placeholders = excludeStatusNames.map(() => '?').join(',');
+  const sql = `
+    SELECT COUNT(DISTINCT sha256) AS total
+    FROM bunny_webhook_events
+    WHERE sha256 IS NOT NULL
+      AND status_name NOT IN (${placeholders})
+  `;
+  const row = await env.BLOSSOM_DB.prepare(sql).bind(...excludeStatusNames).first();
+  return row?.total || 0;
+}
+
+/**
+ * Latest event for a single sha. Used by getAdminLookupVideo and
+ * getStoredAdminPlaybackCandidates (replaces hand-rolled correlated
+ * subqueries that did MAX(received_at) WHERE sha256 = ? once per call).
+ */
+export async function latestBunnyEventForSha(env, sha256) {
+  const row = await env.BLOSSOM_DB.prepare(`
+    SELECT sha256, video_guid, hls_url, mp4_url, thumbnail_url, received_at, status_name
+    FROM bunny_webhook_events
+    WHERE sha256 = ?
+    ORDER BY received_at DESC
+    LIMIT 1
+  `).bind(sha256).first();
+  return row || null;
+}

--- a/src/admin/bunny-events.test.mjs
+++ b/src/admin/bunny-events.test.mjs
@@ -1,0 +1,106 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Tests for latestBunnyEventBySha — window-function CTE
+// ABOUTME: replacing four hand-rolled correlated subqueries.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { env } from 'cloudflare:test';
+import {
+  latestBunnyEventBySha,
+  latestBunnyEventForSha,
+  countLatestBunnyEvents,
+} from './bunny-events.mjs';
+
+const SHA_A = 'a'.repeat(64);
+const SHA_B = 'b'.repeat(64);
+const SHA_C = 'c'.repeat(64);
+
+async function seed() {
+  // Ensure table exists (migrations may or may not have created it depending on test boot).
+  await env.BLOSSOM_DB.prepare(`CREATE TABLE IF NOT EXISTS bunny_webhook_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    sha256 TEXT,
+    video_guid TEXT,
+    hls_url TEXT,
+    mp4_url TEXT,
+    thumbnail_url TEXT,
+    status TEXT,
+    status_name TEXT,
+    timestamp INTEGER,
+    received_at INTEGER
+  )`).run();
+  await env.BLOSSOM_DB.prepare('DELETE FROM bunny_webhook_events').run();
+
+  // SHA_A: three events, latest at received_at=300 with hls_url='C'
+  await env.BLOSSOM_DB.prepare(
+    `INSERT INTO bunny_webhook_events (sha256, video_guid, hls_url, status_name, received_at) VALUES (?,?,?,?,?)`,
+  ).bind(SHA_A, 'g-a-1', 'A', 'finished', 100).run();
+  await env.BLOSSOM_DB.prepare(
+    `INSERT INTO bunny_webhook_events (sha256, video_guid, hls_url, status_name, received_at) VALUES (?,?,?,?,?)`,
+  ).bind(SHA_A, 'g-a-2', 'B', 'finished', 200).run();
+  await env.BLOSSOM_DB.prepare(
+    `INSERT INTO bunny_webhook_events (sha256, video_guid, hls_url, status_name, received_at) VALUES (?,?,?,?,?)`,
+  ).bind(SHA_A, 'g-a-3', 'C', 'finished', 300).run();
+
+  // SHA_B: latest is at 250
+  await env.BLOSSOM_DB.prepare(
+    `INSERT INTO bunny_webhook_events (sha256, video_guid, hls_url, status_name, received_at) VALUES (?,?,?,?,?)`,
+  ).bind(SHA_B, 'g-b-1', 'X', 'finished', 150).run();
+  await env.BLOSSOM_DB.prepare(
+    `INSERT INTO bunny_webhook_events (sha256, video_guid, hls_url, status_name, received_at) VALUES (?,?,?,?,?)`,
+  ).bind(SHA_B, 'g-b-2', 'Y', 'finished', 250).run();
+
+  // SHA_C: only event is status_name='deleted' — should be excluded.
+  await env.BLOSSOM_DB.prepare(
+    `INSERT INTO bunny_webhook_events (sha256, video_guid, hls_url, status_name, received_at) VALUES (?,?,?,?,?)`,
+  ).bind(SHA_C, 'g-c-1', 'Z', 'deleted', 400).run();
+}
+
+beforeEach(seed);
+
+describe('latestBunnyEventBySha', () => {
+  it('returns one row per sha with the LATEST hls_url (deterministic)', async () => {
+    const rows = await latestBunnyEventBySha(env);
+    const a = rows.find((r) => r.sha256 === SHA_A);
+    const b = rows.find((r) => r.sha256 === SHA_B);
+    expect(a.hls_url).toBe('C');
+    expect(a.received_at).toBe(300);
+    expect(b.hls_url).toBe('Y');
+    expect(b.received_at).toBe(250);
+  });
+
+  it('orders results by received_at DESC across distinct shas', async () => {
+    const rows = await latestBunnyEventBySha(env);
+    expect(rows.map((r) => r.sha256)).toEqual([SHA_A, SHA_B]);
+  });
+
+  it('excludes shas whose latest status is deleted/error', async () => {
+    const rows = await latestBunnyEventBySha(env);
+    expect(rows.find((r) => r.sha256 === SHA_C)).toBeUndefined();
+  });
+
+  it('honors LIMIT and OFFSET', async () => {
+    const first = await latestBunnyEventBySha(env, { limit: 1, offset: 0 });
+    const second = await latestBunnyEventBySha(env, { limit: 1, offset: 1 });
+    expect(first[0].sha256).toBe(SHA_A);
+    expect(second[0].sha256).toBe(SHA_B);
+  });
+});
+
+describe('countLatestBunnyEvents', () => {
+  it('counts distinct shas excluding deleted/error', async () => {
+    expect(await countLatestBunnyEvents(env)).toBe(2);
+  });
+});
+
+describe('latestBunnyEventForSha', () => {
+  it('returns the latest event for the sha', async () => {
+    const row = await latestBunnyEventForSha(env, SHA_A);
+    expect(row.hls_url).toBe('C');
+  });
+  it('returns null for unknown sha', async () => {
+    const row = await latestBunnyEventForSha(env, 'f'.repeat(64));
+    expect(row).toBeNull();
+  });
+});

--- a/src/admin/cache.mjs
+++ b/src/admin/cache.mjs
@@ -1,0 +1,51 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Tiny KV wrapper for caching stat aggregates with non-blocking writes.
+
+const KEY_PREFIX = 'stats:v1:';
+
+/**
+ * Cache the result of an expensive aggregate (e.g. SELECT COUNT/GROUP BY
+ * over moderation_results) in MODERATION_KV with a short TTL. Read is
+ * blocking; write is non-blocking (ctx.waitUntil).
+ *
+ * `?fresh=1` should set `options.fresh = true` to bypass the cache read,
+ * but the helper still writes the fresh value back. This avoids a cache
+ * stampede where many concurrent Refresh clicks all skip-and-recompute:
+ * the first to finish populates KV for the rest.
+ *
+ * @param {object} env - worker env
+ * @param {{waitUntil: (p: Promise<unknown>) => void}} ctx - fetch handler ctx
+ * @param {string} key - cache key suffix (e.g. "admin-stats")
+ * @param {number} ttlSeconds - KV TTL (60 is a reasonable default)
+ * @param {() => Promise<unknown>} compute - the expensive aggregate
+ * @param {{fresh?: boolean}} [options]
+ * @returns {Promise<unknown>}
+ */
+export async function cachedStat(env, ctx, key, ttlSeconds, compute, options = {}) {
+  const fullKey = `${KEY_PREFIX}${key}`;
+  if (!options.fresh) {
+    const cached = await env.MODERATION_KV.get(fullKey);
+    if (cached !== null) {
+      try {
+        return JSON.parse(cached);
+      } catch {
+        // Corrupt cache entry — fall through to recompute.
+      }
+    }
+  }
+  const fresh = await compute();
+  const writePromise = env.MODERATION_KV.put(fullKey, JSON.stringify(fresh), {
+    expirationTtl: ttlSeconds,
+  });
+  // Production: hand the write to ctx.waitUntil and return immediately.
+  // Tests / unusual call sites without ctx: await the write so we don't
+  // throw on `ctx.waitUntil` being undefined.
+  if (ctx && typeof ctx.waitUntil === 'function') {
+    ctx.waitUntil(writePromise);
+  } else {
+    await writePromise;
+  }
+  return fresh;
+}

--- a/src/admin/cache.test.mjs
+++ b/src/admin/cache.test.mjs
@@ -1,0 +1,62 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Tests for cachedStat — KV-backed stat aggregate cache.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { cachedStat } from './cache.mjs';
+import { env } from 'cloudflare:test';
+
+const KEY = 'stats:v1:test';
+
+beforeEach(async () => {
+  await env.MODERATION_KV.delete(KEY);
+});
+
+describe('cachedStat', () => {
+  it('computes on miss and writes via waitUntil', async () => {
+    const compute = vi.fn().mockResolvedValue({ ok: 1 });
+    const writes = [];
+    const waitUntil = (p) => writes.push(p);
+    const result = await cachedStat(env, { waitUntil }, 'test', 60, compute);
+    expect(result).toEqual({ ok: 1 });
+    expect(compute).toHaveBeenCalledTimes(1);
+    expect(writes).toHaveLength(1);
+    await Promise.all(writes);
+    const cached = JSON.parse(await env.MODERATION_KV.get(KEY));
+    expect(cached).toEqual({ ok: 1 });
+  });
+
+  it('returns cached value on hit without calling compute', async () => {
+    await env.MODERATION_KV.put(KEY, JSON.stringify({ ok: 99 }));
+    const compute = vi.fn();
+    const result = await cachedStat(env, { waitUntil: () => {} }, 'test', 60, compute);
+    expect(result).toEqual({ ok: 99 });
+    expect(compute).not.toHaveBeenCalled();
+  });
+
+  it('bypasses cache read when fresh=true but still writes back', async () => {
+    await env.MODERATION_KV.put(KEY, JSON.stringify({ ok: 'stale' }));
+    const compute = vi.fn().mockResolvedValue({ ok: 'fresh' });
+    const writes = [];
+    const waitUntil = (p) => writes.push(p);
+    const result = await cachedStat(env, { waitUntil }, 'test', 60, compute, { fresh: true });
+    expect(result).toEqual({ ok: 'fresh' });
+    expect(compute).toHaveBeenCalledTimes(1);
+    await Promise.all(writes);
+    const cached = JSON.parse(await env.MODERATION_KV.get(KEY));
+    expect(cached).toEqual({ ok: 'fresh' });
+  });
+
+  it('falls through to compute when cached value is corrupt JSON', async () => {
+    await env.MODERATION_KV.put(KEY, '{not valid json');
+    const compute = vi.fn().mockResolvedValue({ ok: 'recovered' });
+    const writes = [];
+    const waitUntil = (p) => writes.push(p);
+    const result = await cachedStat(env, { waitUntil }, 'test', 60, compute);
+    expect(result).toEqual({ ok: 'recovered' });
+    expect(compute).toHaveBeenCalledTimes(1);
+    // Await the recompute write so it doesn't leak past the test.
+    await Promise.all(writes);
+  });
+});

--- a/src/admin/lookup-helpers.mjs
+++ b/src/admin/lookup-helpers.mjs
@@ -1,0 +1,88 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Pure helpers that turn a moderation_results row into the shape
+// ABOUTME: the admin dashboard expects. No side effects, no DB, no fetch.
+
+/**
+ * Columns that must be selected from `moderation_results` for the admin
+ * dashboard's list endpoints to render without a follow-up funnelcake call.
+ *
+ * Migration 004-content-metadata.sql added `event_id, title, author,
+ * content_url, published_at` to the table; before this helper landed, the
+ * dashboard's SELECTs omitted them, which forced enrichAdminLookupVideo()
+ * to fall through to fetchFunnelcakeLookupVideo() for every card on every
+ * page render. Including them here lets the response come straight from D1.
+ */
+export const ADMIN_VIDEO_COLUMNS = [
+  'sha256',
+  'action',
+  'provider',
+  'scores',
+  'categories',
+  'moderated_at',
+  'reviewed_by',
+  'reviewed_at',
+  'uploaded_by',
+  'event_id',
+  'title',
+  'author',
+  'content_url',
+  'published_at',
+];
+
+function safeParseJSON(value, fallback) {
+  if (value == null) return fallback;
+  if (typeof value !== 'string') return value;
+  try { return JSON.parse(value); } catch { return fallback; }
+}
+
+/**
+ * Build the admin-video shape the dashboard JS consumes from a single
+ * moderation_results row. Mirrors buildStoredLookupMetadata's nostrContext
+ * exactly (src/index.mjs ~line 251) so response keys match before/after
+ * the fan-out removal.
+ *
+ * `client` and `content` are not stored in moderation_results; the
+ * single-video lookup endpoint (/admin/api/video/:id) still calls
+ * funnelcake on demand to fill them when a moderator opens the detail
+ * view. List cards do not surface those fields.
+ *
+ * @param {object} row - row from `moderation_results`
+ * @param {{cdnDomain: string}} options
+ * @returns {object}
+ */
+export function buildAdminVideoFromRow(row, { cdnDomain }) {
+  const eventId = row.event_id || null;
+  const publishedAt = row.published_at ? Number.parseInt(row.published_at, 10) : null;
+  const hasContext = Boolean(
+    row.title || row.author || row.content_url || eventId || row.uploaded_by || publishedAt,
+  );
+
+  return {
+    sha256: row.sha256,
+    action: row.action,
+    provider: row.provider || null,
+    scores: safeParseJSON(row.scores, {}),
+    categories: safeParseJSON(row.categories, []),
+    processedAt: row.moderated_at ? new Date(row.moderated_at).getTime() : null,
+    moderated_at: row.moderated_at,
+    reviewed_by: row.reviewed_by || null,
+    reviewed_at: row.reviewed_at || null,
+    uploaded_by: row.uploaded_by || null,
+    eventId,
+    divineUrl: eventId ? `https://divine.video/video/${encodeURIComponent(eventId)}` : null,
+    cdnUrl: `https://${cdnDomain}/${row.sha256}`,
+    nostrContext: hasContext ? {
+      title: row.title || null,
+      author: row.author || null,
+      client: null,
+      content: null,
+      url: row.content_url || null,
+      publishedAt: Number.isFinite(publishedAt) ? publishedAt : null,
+      pubkey: row.uploaded_by ? `${row.uploaded_by.substring(0, 16)}...` : null,
+      eventId,
+      platform: null,
+    } : null,
+  };
+}

--- a/src/admin/lookup-helpers.test.mjs
+++ b/src/admin/lookup-helpers.test.mjs
@@ -1,0 +1,108 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Tests for buildAdminVideoFromRow — pure row→admin-shape mapper.
+
+import { describe, it, expect } from 'vitest';
+import { buildAdminVideoFromRow, ADMIN_VIDEO_COLUMNS } from './lookup-helpers.mjs';
+
+const FULL_ROW = {
+  sha256: 'a'.repeat(64),
+  action: 'REVIEW',
+  provider: 'manual-review',
+  scores: '{"nsfw":0.2}',
+  categories: '["nsfw"]',
+  moderated_at: '2026-05-05T00:00:00Z',
+  reviewed_by: null,
+  reviewed_at: null,
+  uploaded_by: 'b'.repeat(64),
+  event_id: 'c'.repeat(64),
+  title: 'Test Video',
+  author: 'Alice',
+  content_url: 'https://example.com/v.mp4',
+  published_at: '1717200000',
+};
+
+describe('ADMIN_VIDEO_COLUMNS', () => {
+  it('includes the previously-missing metadata columns', () => {
+    expect(ADMIN_VIDEO_COLUMNS).toContain('event_id');
+    expect(ADMIN_VIDEO_COLUMNS).toContain('title');
+    expect(ADMIN_VIDEO_COLUMNS).toContain('author');
+    expect(ADMIN_VIDEO_COLUMNS).toContain('content_url');
+    expect(ADMIN_VIDEO_COLUMNS).toContain('published_at');
+  });
+});
+
+describe('buildAdminVideoFromRow', () => {
+  it('produces a complete video shape from a fully-populated row', () => {
+    const out = buildAdminVideoFromRow(FULL_ROW, { cdnDomain: 'media.divine.video' });
+    expect(out).toMatchObject({
+      sha256: FULL_ROW.sha256,
+      action: 'REVIEW',
+      provider: 'manual-review',
+      eventId: FULL_ROW.event_id,
+      divineUrl: `https://divine.video/video/${FULL_ROW.event_id}`,
+      cdnUrl: `https://media.divine.video/${FULL_ROW.sha256}`,
+      uploaded_by: FULL_ROW.uploaded_by,
+      moderated_at: '2026-05-05T00:00:00Z',
+      reviewed_by: null,
+      reviewed_at: null,
+    });
+    expect(out.scores).toEqual({ nsfw: 0.2 });
+    expect(out.categories).toEqual(['nsfw']);
+    expect(typeof out.processedAt).toBe('number');
+  });
+
+  it('mirrors buildStoredLookupMetadata.nostrContext exactly', () => {
+    const out = buildAdminVideoFromRow(FULL_ROW, { cdnDomain: 'media.divine.video' });
+    expect(out.nostrContext).toEqual({
+      title: 'Test Video',
+      author: 'Alice',
+      client: null,
+      content: null,
+      url: 'https://example.com/v.mp4',
+      publishedAt: 1717200000,
+      pubkey: `${FULL_ROW.uploaded_by.substring(0, 16)}...`,
+      eventId: FULL_ROW.event_id,
+      platform: null,
+    });
+  });
+
+  it('returns null eventId/divineUrl/nostrContext when row has no metadata', () => {
+    const row = {
+      sha256: 'a'.repeat(64),
+      action: 'SAFE',
+      moderated_at: '2026-05-05T00:00:00Z',
+    };
+    const out = buildAdminVideoFromRow(row, { cdnDomain: 'media.divine.video' });
+    expect(out.eventId).toBeNull();
+    expect(out.divineUrl).toBeNull();
+    expect(out.nostrContext).toBeNull();
+  });
+
+  it('handles partial population (uploaded_by alone is enough for context)', () => {
+    const row = {
+      sha256: 'a'.repeat(64),
+      action: 'SAFE',
+      uploaded_by: 'b'.repeat(64),
+      moderated_at: '2026-05-05T00:00:00Z',
+    };
+    const out = buildAdminVideoFromRow(row, { cdnDomain: 'media.divine.video' });
+    expect(out.nostrContext).not.toBeNull();
+    expect(out.nostrContext.title).toBeNull();
+    expect(out.nostrContext.pubkey).toBe(`${row.uploaded_by.substring(0, 16)}...`);
+  });
+
+  it('handles JSON columns gracefully when malformed', () => {
+    const row = {
+      sha256: 'a'.repeat(64),
+      action: 'SAFE',
+      scores: 'not json',
+      categories: '{not array}',
+      moderated_at: '2026-05-05T00:00:00Z',
+    };
+    const out = buildAdminVideoFromRow(row, { cdnDomain: 'media.divine.video' });
+    expect(out.scores).toEqual({});
+    expect(out.categories).toEqual([]);
+  });
+});

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -33,6 +33,7 @@ import { buildDownstreamPublishContext } from './moderation/downstream-publishin
 import { runClassicVineRollback } from './moderation/classic-vine-rollback.mjs';
 import { ADMIN_VIDEO_COLUMNS, buildAdminVideoFromRow } from './admin/lookup-helpers.mjs';
 import { cachedStat } from './admin/cache.mjs';
+import { latestBunnyEventBySha, latestBunnyEventForSha, countLatestBunnyEvents } from './admin/bunny-events.mjs';
 import { notifyBlossom } from './blossom-client.mjs';
 import { handleSyncDelete } from './creator-delete/sync-endpoint.mjs';
 import { handleStatusQuery } from './creator-delete/status-endpoint.mjs';
@@ -1030,15 +1031,7 @@ async function getAdminLookupVideo(identifier, env, options = {}) {
       }, env);
     }
 
-    const untriagedRow = await env.BLOSSOM_DB.prepare(`
-      SELECT sha256, video_guid, hls_url, mp4_url, thumbnail_url, received_at, status_name
-      FROM bunny_webhook_events e1
-      WHERE e1.sha256 = ?
-        AND received_at = (
-          SELECT MAX(received_at) FROM bunny_webhook_events e2 WHERE e2.sha256 = e1.sha256
-        )
-      LIMIT 1
-    `).bind(hash).first();
+    const untriagedRow = await latestBunnyEventForSha(env, hash);
 
     if (untriagedRow && !['error', 'deleted'].includes(untriagedRow.status_name)) {
       let nostrContext = null;
@@ -1143,15 +1136,7 @@ async function getStoredAdminPlaybackCandidates(sha256, env) {
       FROM moderation_results
       WHERE sha256 = ?
     `).bind(sha256).first(),
-    env.BLOSSOM_DB.prepare(`
-      SELECT mp4_url, hls_url
-      FROM bunny_webhook_events e1
-      WHERE e1.sha256 = ?
-        AND received_at = (
-          SELECT MAX(received_at) FROM bunny_webhook_events e2 WHERE e2.sha256 = e1.sha256
-        )
-      LIMIT 1
-    `).bind(sha256).first(),
+    latestBunnyEventForSha(env, sha256),
     env.MODERATION_KV.get(`moderation:${sha256}`)
   ]);
 
@@ -1673,34 +1658,23 @@ export default {
       console.log(`[${requestId}] Fetching untriaged videos: limit=${limit}, offset=${offset}`);
 
       try {
-        // Get recent finished videos from D1, excluding those with later deleted/error status
-        // Uses subquery to get only the LATEST status for each sha256
-        const result = await env.BLOSSOM_DB.prepare(`
-          SELECT sha256, video_guid, hls_url, mp4_url, thumbnail_url, received_at
-          FROM bunny_webhook_events e1
-          WHERE sha256 IS NOT NULL
-            AND received_at = (
-              SELECT MAX(received_at) FROM bunny_webhook_events e2 WHERE e2.sha256 = e1.sha256
-            )
-            AND status_name NOT IN ('error', 'deleted')
-          ORDER BY received_at DESC
-          LIMIT ? OFFSET ?
-        `).bind(limit, offset).all();
+        const rows = await latestBunnyEventBySha(env, { limit, offset });
 
-        // Check which ones are already moderated
-        const unmoderatedRows = [];
-        for (const row of result.results) {
-          const existingResult = await env.MODERATION_KV.get(`moderation:${row.sha256}`);
-          if (!existingResult) {
-            unmoderatedRows.push(row);
-          }
-        }
+        // Filter to rows that haven't been moderated yet. Old code did
+        // a sequential `for` loop with await — this is one parallel batch.
+        const moderationFlags = await Promise.all(
+          rows.map((row) => env.MODERATION_KV.get(`moderation:${row.sha256}`)),
+        );
+        const unmoderatedRows = rows.filter((_, i) => !moderationFlags[i]);
 
-        // Fetch Nostr context in parallel for all unmoderated videos
+        // Fetch Nostr context per unmoderated row, with a 1-hour KV cache
+        // so the next page render doesn't pay the WS roundtrip cost.
         const nostrPromises = unmoderatedRows.map(async (row) => {
+          const cacheKey = `nostr:event:${row.sha256}`;
           try {
-            const event = await fetchNostrEventBySha256(row.sha256, ['wss://relay.divine.video'], env);
-            if (event) {
+            const cached = await env.MODERATION_KV.get(cacheKey);
+            if (cached) {
+              const event = JSON.parse(cached);
               const metadata = parseVideoEventMetadata(event);
               return {
                 sha256: row.sha256,
@@ -1709,7 +1683,21 @@ export default {
                 author: metadata?.author || null,
                 client: metadata?.client || null,
                 content: metadata?.content || event.content || null,
-                pubkey: event.pubkey || null
+                pubkey: event.pubkey || null,
+              };
+            }
+            const event = await fetchNostrEventBySha256(row.sha256, ['wss://relay.divine.video'], env);
+            if (event) {
+              ctx.waitUntil(env.MODERATION_KV.put(cacheKey, JSON.stringify(event), { expirationTtl: 3600 }));
+              const metadata = parseVideoEventMetadata(event);
+              return {
+                sha256: row.sha256,
+                eventId: event.id,
+                title: metadata?.title || null,
+                author: metadata?.author || null,
+                client: metadata?.client || null,
+                content: metadata?.content || event.content || null,
+                pubkey: event.pubkey || null,
               };
             }
           } catch (e) {
@@ -1719,10 +1707,9 @@ export default {
         });
 
         const nostrResults = await Promise.all(nostrPromises);
-        const nostrMap = new Map(nostrResults.map(r => [r.sha256, r]));
+        const nostrMap = new Map(nostrResults.map((r) => [r.sha256, r]));
 
-        // Build videos with Nostr context
-        const videos = unmoderatedRows.map(row => {
+        const videos = unmoderatedRows.map((row) => {
           const nostr = nostrMap.get(row.sha256) || {};
           return {
             sha256: row.sha256,
@@ -1740,32 +1727,21 @@ export default {
               author: nostr.author,
               client: nostr.client,
               content: nostr.content,
-              pubkey: nostr.pubkey ? nostr.pubkey.substring(0, 16) + '...' : null
-            }
+              pubkey: nostr.pubkey ? `${nostr.pubkey.substring(0, 16)}...` : null,
+            },
           };
         });
 
-        // Get total count of untriaged (same logic - latest status not deleted/error)
-        const countResult = await env.BLOSSOM_DB.prepare(`
-          SELECT COUNT(*) as total FROM (
-            SELECT sha256
-            FROM bunny_webhook_events e1
-            WHERE sha256 IS NOT NULL
-              AND received_at = (
-                SELECT MAX(received_at) FROM bunny_webhook_events e2 WHERE e2.sha256 = e1.sha256
-              )
-              AND status_name NOT IN ('error', 'deleted')
-          )
-        `).first();
+        const total = await cachedStat(env, ctx, 'untriaged-total', 60, () => countLatestBunnyEvents(env));
 
         return new Response(JSON.stringify({
           videos,
-          total: countResult?.total || 0,
+          total,
           offset,
           limit,
-          hasMore: offset + limit < (countResult?.total || 0)
+          hasMore: offset + limit < total,
         }), {
-          headers: JSON_HEADERS
+          headers: JSON_HEADERS,
         });
       } catch (error) {
         console.error('[ADMIN] Failed to fetch untriaged videos:', error);

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -34,6 +34,7 @@ import { runClassicVineRollback } from './moderation/classic-vine-rollback.mjs';
 import { ADMIN_VIDEO_COLUMNS, buildAdminVideoFromRow } from './admin/lookup-helpers.mjs';
 import { cachedStat } from './admin/cache.mjs';
 import { latestBunnyEventBySha, latestBunnyEventForSha, countLatestBunnyEvents } from './admin/bunny-events.mjs';
+import { runBackfill } from './admin/backfill-lookup-columns.mjs';
 import { notifyBlossom } from './blossom-client.mjs';
 import { handleSyncDelete } from './creator-delete/sync-endpoint.mjs';
 import { handleStatusQuery } from './creator-delete/status-endpoint.mjs';
@@ -1641,6 +1642,31 @@ export default {
         return new Response(JSON.stringify({ error: error.message }), {
           status: 500,
           headers: JSON_HEADERS
+        });
+      }
+    }
+
+    // Manual trigger for the legacy backfill cron. Useful when ops wants
+    // to dry-run before flipping BACKFILL_ENABLED, or to force-progress
+    // a stalled backfill. Honors BACKFILL_ENABLED.
+    if (url.pathname === '/admin/api/backfill/run' && request.method === 'POST') {
+      const authError = await requireAuth(request, env);
+      if (authError) {
+        console.log(`[${requestId}] Unauthorized access to /admin/api/backfill/run`);
+        return authError;
+      }
+      const count = Math.min(Number(url.searchParams.get('count') || '200'), 500);
+      try {
+        const result = await runBackfill(env, {
+          limit: count,
+          fetchLookup: (sha256) => fetchFunnelcakeLookupVideo(sha256),
+        });
+        return new Response(JSON.stringify(result), { headers: JSON_HEADERS });
+      } catch (error) {
+        console.error(`[${requestId}] Backfill manual run failed:`, error);
+        return new Response(JSON.stringify({ error: error.message }), {
+          status: 500,
+          headers: JSON_HEADERS,
         });
       }
     }
@@ -4487,22 +4513,35 @@ async function runMigration() {
   async scheduled(event, env, ctx) {
     if (event.cron === '* * * * *') {
       // Every-minute: creator-delete pipeline (gated by feature flag)
-      if (env.CREATOR_DELETE_PIPELINE_ENABLED !== 'true') {
-        return;
+      if (env.CREATOR_DELETE_PIPELINE_ENABLED === 'true') {
+        const relayUrl = env.CREATOR_DELETE_RELAY_URL || 'wss://relay.divine.video';
+        try {
+          const result = await runCreatorDeleteCron({
+            db: env.BLOSSOM_DB,
+            kv: env.MODERATION_KV,
+            queryKind5Since: async (sinceSeconds) =>
+              fetchKind5EventsSince(sinceSeconds, relayUrl, env),
+            fetchTargetEvent: (eid) => fetchNostrEventById(eid, [relayUrl], env),
+            callBlossomDelete: (sha256) => notifyBlossom(sha256, 'DELETE', env)
+          });
+          console.log(`[CREATOR-DELETE-CRON] Processed ${result.processed}, errors: ${result.errors.length}`);
+        } catch (e) {
+          console.error('[CREATOR-DELETE-CRON] failed:', e);
+        }
       }
-      const relayUrl = env.CREATOR_DELETE_RELAY_URL || 'wss://relay.divine.video';
+
+      // Every-minute: backfill legacy moderation_results lookup columns.
+      // Gated by BACKFILL_ENABLED. Helper short-circuits when disabled or
+      // when another run holds the KV mutex.
       try {
-        const result = await runCreatorDeleteCron({
-          db: env.BLOSSOM_DB,
-          kv: env.MODERATION_KV,
-          queryKind5Since: async (sinceSeconds) =>
-            fetchKind5EventsSince(sinceSeconds, relayUrl, env),
-          fetchTargetEvent: (eid) => fetchNostrEventById(eid, [relayUrl], env),
-          callBlossomDelete: (sha256) => notifyBlossom(sha256, 'DELETE', env)
+        const result = await runBackfill(env, {
+          fetchLookup: (sha256) => fetchFunnelcakeLookupVideo(sha256),
         });
-        console.log(`[CREATOR-DELETE-CRON] Processed ${result.processed}, errors: ${result.errors.length}`);
+        if (!result.skipped) {
+          console.log(`[BACKFILL] picked=${result.picked} updated=${result.updated} missing=${result.missing} errored=${result.errored}`);
+        }
       } catch (e) {
-        console.error('[CREATOR-DELETE-CRON] failed:', e);
+        console.error('[BACKFILL] failed:', e);
       }
       return;
     }

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -32,6 +32,7 @@ import { notifyAtprotoLabeler } from './atproto/label-webhook.mjs';
 import { buildDownstreamPublishContext } from './moderation/downstream-publishing.mjs';
 import { runClassicVineRollback } from './moderation/classic-vine-rollback.mjs';
 import { ADMIN_VIDEO_COLUMNS, buildAdminVideoFromRow } from './admin/lookup-helpers.mjs';
+import { cachedStat } from './admin/cache.mjs';
 import { notifyBlossom } from './blossom-client.mjs';
 import { handleSyncDelete } from './creator-delete/sync-endpoint.mjs';
 import { handleStatusQuery } from './creator-delete/status-endpoint.mjs';
@@ -1570,94 +1571,54 @@ export default {
       console.log(`[${requestId}] Fetching stats`);
 
       try {
-        // All stats from D1 - fast SQL queries instead of KV iteration
-        const [totalResult, moderationStats, pendingStats] = await Promise.all([
-          // Total videos (excluding deleted/error)
-          env.BLOSSOM_DB.prepare(`
-            SELECT COUNT(DISTINCT sha256) as total
-            FROM bunny_webhook_events
-            WHERE sha256 IS NOT NULL
-              AND status_name NOT IN ('error', 'deleted')
-          `).first(),
-          // Moderation breakdown by action (all, for "Total Moderated" and "Safe" cards)
-          env.BLOSSOM_DB.prepare(`
-            SELECT
-              action,
-              COUNT(*) as count
-            FROM moderation_results
-            GROUP BY action
-          `).all(),
-          // Pending review breakdown (unreviewed, for "AI Flagged" and queue counts)
-          env.BLOSSOM_DB.prepare(`
-            SELECT
-              action,
-              COUNT(*) as count
-            FROM moderation_results
-            WHERE reviewed_by IS NULL
-            GROUP BY action
-          `).all()
-        ]);
+        const fresh = url.searchParams.get('fresh') === '1';
+        const stats = await cachedStat(env, ctx, 'admin-stats', 60, async () => {
+          // All stats from D1 - fast SQL queries instead of KV iteration
+          const [totalResult, moderationStats, pendingStats] = await Promise.all([
+            env.BLOSSOM_DB.prepare(`
+              SELECT COUNT(DISTINCT sha256) as total
+              FROM bunny_webhook_events
+              WHERE sha256 IS NOT NULL
+                AND status_name NOT IN ('error', 'deleted')
+            `).first(),
+            env.BLOSSOM_DB.prepare(`
+              SELECT action, COUNT(*) as count FROM moderation_results GROUP BY action
+            `).all(),
+            env.BLOSSOM_DB.prepare(`
+              SELECT action, COUNT(*) as count FROM moderation_results
+              WHERE reviewed_by IS NULL GROUP BY action
+            `).all(),
+          ]);
 
-        const totalInD1 = totalResult?.total || 0;
-
-        // Parse total moderation stats
-        let totalModerated = 0;
-        let safeCount = 0;
-        let reviewCount = 0;
-        let ageRestrictedCount = 0;
-        let permanentBanCount = 0;
-
-        for (const row of (moderationStats?.results || [])) {
-          const count = row.count || 0;
-          totalModerated += count;
-          switch (row.action) {
-            case 'SAFE': safeCount = count; break;
-            case 'REVIEW': reviewCount = count; break;
-            case 'AGE_RESTRICTED': ageRestrictedCount = count; break;
-            case 'PERMANENT_BAN': permanentBanCount = count; break;
+          const totalInD1 = totalResult?.total || 0;
+          const breakdown = { safe: 0, review: 0, ageRestricted: 0, permanentBan: 0 };
+          let totalModerated = 0;
+          for (const row of (moderationStats?.results || [])) {
+            const count = row.count || 0;
+            totalModerated += count;
+            if (row.action === 'SAFE') breakdown.safe = count;
+            else if (row.action === 'REVIEW') breakdown.review = count;
+            else if (row.action === 'AGE_RESTRICTED') breakdown.ageRestricted = count;
+            else if (row.action === 'PERMANENT_BAN') breakdown.permanentBan = count;
           }
-        }
 
-        // Parse pending review stats (items not yet reviewed by a human)
-        let pendingReviewCount = 0;
-        let pendingQuarantineCount = 0;
-        let pendingAgeRestrictedCount = 0;
-        let pendingPermanentBanCount = 0;
-
-        for (const row of (pendingStats?.results || [])) {
-          const count = row.count || 0;
-          switch (row.action) {
-            case 'REVIEW': pendingReviewCount = count; break;
-            case 'QUARANTINE': pendingQuarantineCount = count; break;
-            case 'AGE_RESTRICTED': pendingAgeRestrictedCount = count; break;
-            case 'PERMANENT_BAN': pendingPermanentBanCount = count; break;
+          const pending = { review: 0, quarantine: 0, ageRestricted: 0, permanentBan: 0 };
+          for (const row of (pendingStats?.results || [])) {
+            const count = row.count || 0;
+            if (row.action === 'REVIEW') pending.review = count;
+            else if (row.action === 'QUARANTINE') pending.quarantine = count;
+            else if (row.action === 'AGE_RESTRICTED') pending.ageRestricted = count;
+            else if (row.action === 'PERMANENT_BAN') pending.permanentBan = count;
           }
-        }
 
-        const pendingFlagged = pendingReviewCount + pendingQuarantineCount + pendingAgeRestrictedCount + pendingPermanentBanCount;
-        const untriaged = Math.max(0, totalInD1 - totalModerated);
+          const pendingFlagged = pending.review + pending.quarantine + pending.ageRestricted + pending.permanentBan;
+          const untriaged = Math.max(0, totalInD1 - totalModerated);
 
-        console.log(`[${requestId}] Stats: total=${totalInD1}, moderated=${totalModerated}, untriaged=${untriaged}, pendingFlagged=${pendingFlagged} in ${Date.now() - startTime}ms`);
-        return new Response(JSON.stringify({
-          totalInD1,
-          totalModerated,
-          untriaged,
-          pendingFlagged,
-          breakdown: {
-            safe: safeCount,
-            review: reviewCount,
-            ageRestricted: ageRestrictedCount,
-            permanentBan: permanentBanCount
-          },
-          pending: {
-            review: pendingReviewCount,
-            quarantine: pendingQuarantineCount,
-            ageRestricted: pendingAgeRestrictedCount,
-            permanentBan: pendingPermanentBanCount
-          }
-        }), {
-          headers: JSON_HEADERS
-        });
+          return { totalInD1, totalModerated, untriaged, pendingFlagged, breakdown, pending };
+        }, { fresh });
+
+        console.log(`[${requestId}] Stats: total=${stats.totalInD1}, moderated=${stats.totalModerated}, untriaged=${stats.untriaged}, pendingFlagged=${stats.pendingFlagged} in ${Date.now() - startTime}ms${fresh ? ' (fresh)' : ''}`);
+        return new Response(JSON.stringify(stats), { headers: JSON_HEADERS });
       } catch (error) {
         console.error(`[${requestId}] Failed to get stats:`, error);
         return new Response(JSON.stringify({ error: error.message }), {
@@ -1677,12 +1638,16 @@ export default {
 
       try {
         const estimatedCostCents = Number(env.HIVE_AI_DETECTION_ESTIMATED_COST_CENTS);
-        const stats = await getAIDetectionStats(env.BLOSSOM_DB, {
-          window: url.searchParams.get('window') || '24h',
-          estimatedCostCents: Number.isFinite(estimatedCostCents) && estimatedCostCents > 0
-            ? estimatedCostCents
-            : null,
-        });
+        const windowValue = url.searchParams.get('window') || '24h';
+        const fresh = url.searchParams.get('fresh') === '1';
+        const stats = await cachedStat(env, ctx, `ai-detection-stats:${windowValue}`, 60, () =>
+          getAIDetectionStats(env.BLOSSOM_DB, {
+            window: windowValue,
+            estimatedCostCents: Number.isFinite(estimatedCostCents) && estimatedCostCents > 0
+              ? estimatedCostCents
+              : null,
+          }),
+          { fresh });
         return new Response(JSON.stringify(stats), {
           headers: JSON_HEADERS
         });

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -31,6 +31,7 @@ import { classifyText, parseVttText } from './moderation/text-classifier.mjs';
 import { notifyAtprotoLabeler } from './atproto/label-webhook.mjs';
 import { buildDownstreamPublishContext } from './moderation/downstream-publishing.mjs';
 import { runClassicVineRollback } from './moderation/classic-vine-rollback.mjs';
+import { ADMIN_VIDEO_COLUMNS, buildAdminVideoFromRow } from './admin/lookup-helpers.mjs';
 import { notifyBlossom } from './blossom-client.mjs';
 import { handleSyncDelete } from './creator-delete/sync-endpoint.mjs';
 import { handleStatusQuery } from './creator-delete/status-endpoint.mjs';
@@ -990,7 +991,7 @@ async function getAdminLookupVideo(identifier, env, options = {}) {
   const cdnUrl = `https://${env.CDN_DOMAIN || 'media.divine.video'}/${hash}`;
   if (hash) {
     const moderatedRow = await env.BLOSSOM_DB.prepare(`
-      SELECT sha256, action, provider, scores, categories, moderated_at, reviewed_by, reviewed_at, review_notes, uploaded_by, raw_response, videoseal
+      SELECT ${ADMIN_VIDEO_COLUMNS.join(', ')}, review_notes, raw_response, videoseal
       FROM moderation_results
       WHERE sha256 = ?
     `).bind(hash).first();
@@ -1506,9 +1507,11 @@ export default {
       const sortParam = url.searchParams.get('sort');
       const orderDirection = sortParam === 'oldest' ? 'ASC' : 'DESC';
 
-      // Query D1 with pagination
+      // Query D1 with pagination. The wide SELECT pulls every column the
+      // dashboard needs so we can render directly from the row — no
+      // per-card funnelcake fetch.
       const query = `
-        SELECT sha256, action, provider, scores, categories, moderated_at, reviewed_by, reviewed_at, uploaded_by
+        SELECT ${ADMIN_VIDEO_COLUMNS.join(', ')}
         FROM moderation_results
         ${whereClause}
         ORDER BY moderated_at ${orderDirection}
@@ -1518,44 +1521,32 @@ export default {
 
       const result = await env.BLOSSOM_DB.prepare(query).bind(...params).all();
       const rows = result.results || [];
-
-      // Check if there are more results
       const hasMore = rows.length > limit;
-      const videoRows = rows.slice(0, limit).map(row => ({
-        sha256: row.sha256,
-        action: row.action,
-        provider: row.provider,
-        scores: row.scores ? JSON.parse(row.scores) : {},
-        categories: row.categories ? JSON.parse(row.categories) : [],
-        processedAt: new Date(row.moderated_at).getTime(),
-        moderated_at: row.moderated_at,
-        reviewed_by: row.reviewed_by,
-        reviewed_at: row.reviewed_at,
-        uploaded_by: row.uploaded_by || null
+      const pageRows = rows.slice(0, limit);
+
+      const videos = pageRows.map((row) => buildAdminVideoFromRow(row, {
+        cdnDomain: env.CDN_DOMAIN || 'media.divine.video',
       }));
 
-      // Reuse the existing relay-aware per-item lookup so dashboard cards can render
-      // publisher/post metadata immediately instead of starting from an "unknown" state.
-      const videos = await Promise.all(videoRows.map(async (video) => {
-        try {
-          const enriched = await getAdminLookupVideo(video.sha256, env);
-          if (!enriched) {
-            return video;
+      // Batch uploader_enforcement lookups: one query for every unique
+      // uploader on this page, instead of one per row.
+      const uploaderPubkeys = [...new Set(videos.map((v) => v.uploaded_by).filter(Boolean))];
+      if (uploaderPubkeys.length > 0) {
+        const placeholders = uploaderPubkeys.map(() => '?').join(',');
+        const enf = await env.BLOSSOM_DB.prepare(
+          `SELECT pubkey, approval_required, relay_banned FROM uploader_enforcement WHERE pubkey IN (${placeholders})`,
+        ).bind(...uploaderPubkeys).all();
+        const byPubkey = new Map((enf.results || []).map((r) => [r.pubkey, r]));
+        for (const v of videos) {
+          if (v.uploaded_by) {
+            v.uploaderEnforcement = byPubkey.get(v.uploaded_by) || {
+              pubkey: v.uploaded_by,
+              approval_required: 0,
+              relay_banned: 0,
+            };
           }
-
-          return {
-            ...video,
-            uploaded_by: enriched.uploaded_by || video.uploaded_by || null,
-            eventId: enriched.eventId || null,
-            divineUrl: enriched.divineUrl || null,
-            lookupId: enriched.lookupId || null,
-            nostrContext: enriched.nostrContext || null
-          };
-        } catch (error) {
-          console.error(`[${requestId}] Failed to enrich dashboard row ${video.sha256}:`, error.message);
-          return video;
         }
-      }));
+      }
 
       console.log(`[${requestId}] Returning ${videos.length} videos in ${Date.now() - startTime}ms`);
       return new Response(JSON.stringify({
@@ -3948,7 +3939,7 @@ async function runMigration() {
         const limit = Math.min(parseInt(url.searchParams.get('limit') || '50', 10), 200);
         const offset = parseInt(url.searchParams.get('offset') || '0', 10);
 
-        let query = 'SELECT sha256, action, provider, scores, moderated_at, reviewed_by, reviewed_at, uploaded_by FROM moderation_results';
+        let query = `SELECT ${ADMIN_VIDEO_COLUMNS.join(', ')} FROM moderation_results`;
         const conditions = [];
         const bindings = [];
 

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -740,7 +740,16 @@ describe('Admin video lookup', () => {
     }
   });
 
-  it('returns mirrored relay context fields in the admin video list payload', async () => {
+  it('returns stored relay context fields in the admin video list without per-row fan-out', async () => {
+    // Contract change (perf/dashboard-speedup):
+    //   /admin/api/videos used to fire one funnelcake REST call per row
+    //   to fill eventId/title/author/etc on every page render. The
+    //   columns were stored in moderation_results all along — we just
+    //   weren't selecting them. Now the handler reads those columns
+    //   directly and never calls funnelcake on the list endpoint.
+    //   Detail view (/admin/api/video/:id) keeps the on-demand
+    //   funnelcake fetch so client/content fields still render when a
+    //   moderator opens a card.
     const originalFetch = globalThis.fetch;
     const originalWebSocket = globalThis.WebSocket;
     const restCalls = [];
@@ -753,35 +762,12 @@ describe('Admin video lookup', () => {
 
     globalThis.fetch = async (url) => {
       restCalls.push(String(url));
-      if (String(url) === `https://relay.divine.video/api/videos/${SHA256}`) {
-        return new Response(JSON.stringify({
-          event: {
-            id: 'd'.repeat(64),
-            pubkey: 'b'.repeat(64),
-            created_at: 1700000000,
-            kind: 34236,
-            tags: [
-              ['d', SHA256],
-              ['title', 'REST title'],
-              ['published_at', '1389756506'],
-              ['imeta', 'url https://media.divine.video/rest-content.mp4', `x ${SHA256}`]
-            ],
-            content: 'REST description',
-            sig: 'e'.repeat(128)
-          },
-          stats: {
-            author_name: 'REST author'
-          }
-        }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' }
-        });
-      }
-
       throw new Error(`Unexpected fetch: ${url}`);
     };
 
     try {
+      // Row with metadata columns populated — dashboard reads these
+      // directly, no funnelcake fetch needed.
       const moderationRow = {
         sha256: SHA256,
         action: 'REVIEW',
@@ -791,7 +777,12 @@ describe('Admin video lookup', () => {
         moderated_at: '2026-03-07T00:00:00.000Z',
         reviewed_by: null,
         reviewed_at: null,
-        uploaded_by: null
+        uploaded_by: 'b'.repeat(64),
+        event_id: 'd'.repeat(64),
+        title: 'REST title',
+        author: 'REST author',
+        content_url: 'https://media.divine.video/rest-content.mp4',
+        published_at: '1389756506'
       };
 
       const response = await worker.fetch(
@@ -812,18 +803,23 @@ describe('Admin video lookup', () => {
           sha256: SHA256,
           uploaded_by: 'b'.repeat(64),
           eventId: 'd'.repeat(64),
-          divineUrl: `https://divine.video/video/${SHA256}`,
+          divineUrl: `https://divine.video/video/${'d'.repeat(64)}`,
           nostrContext: {
             title: 'REST title',
             author: 'REST author',
             url: 'https://media.divine.video/rest-content.mp4',
             publishedAt: 1389756506,
-            content: 'REST description',
+            // client/content are not stored. List view leaves them null;
+            // detail view fills them via on-demand funnelcake.
+            client: null,
+            content: null,
             eventId: 'd'.repeat(64)
           }
         }]
       });
-      expect(restCalls).toEqual([`https://relay.divine.video/api/videos/${SHA256}`]);
+      // Regression gate: if anyone reintroduces the per-row fan-out,
+      // restCalls will not be empty.
+      expect(restCalls).toEqual([]);
     } finally {
       globalThis.fetch = originalFetch;
       globalThis.WebSocket = originalWebSocket;

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -10,6 +10,17 @@ export default defineWorkersConfig({
   test: {
     testTimeout: 30000,
     hookTimeout: 30000,
+    // Scope test discovery to the canonical source/script locations.
+    // Without this, vitest also walks .worktrees/ and .claude/worktrees/
+    // and runs duplicate copies of every test (which can pull in code
+    // referencing schemas/columns that don't exist on the current branch).
+    include: ['src/**/*.test.mjs', 'scripts/**/*.test.mjs'],
+    exclude: [
+      '**/node_modules/**',
+      '**/.worktrees/**',
+      '**/.claude/worktrees/**',
+      '**/.deploy-worktrees/**',
+    ],
     poolOptions: {
       workers: {
         singleWorker: true,

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -118,6 +118,12 @@ RELAY_POLLING_RELAY_URL = "wss://relay.divine.video"  # Relay to poll for new vi
 RELAY_POLLING_LOOKBACK_HOURS = "1"                # How far back to look for events (in hours)
 RELAY_POLLING_LIMIT = "100"                       # Max events to fetch per poll
 
+# Legacy moderation_results lookup-column backfill (perf/dashboard-speedup).
+# Off by default; flip to "true" via `wrangler secret put` after the manual
+# trigger /admin/api/backfill/run has been verified on a small batch.
+BACKFILL_ENABLED = "false"
+BACKFILL_ROWS_PER_TICK = "200"
+
 # Creator-delete pipeline feature flag (default off; flip to "true" via `wrangler secret put` or [vars] once ready)
 CREATOR_DELETE_PIPELINE_ENABLED = "false"
 # Relay used to fetch creator kind 5 delete events and target video events.

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -26,6 +26,7 @@ id = "10af689fc82140ed9159eef3c1c47079"
 binding = "BLOSSOM_DB"
 database_name = "blossom-webhook-events"
 database_id = "829f06cf-294b-4491-8611-30fc53df2589"
+migrations_dir = "migrations"
 
 # Queue producer configuration (for testing)
 [[queues.producers]]


### PR DESCRIPTION
## Why

`moderation.admin.divine.video` was taking 5–15s per page load. Paid moderators sat waiting on every nav, filter change, and refresh. Investigation traced the slowness to four compounding issues; this PR addresses all of them.

Spec: [docs/superpowers/specs/2026-05-05-moderation-dashboard-speedup-design.md](docs/superpowers/specs/2026-05-05-moderation-dashboard-speedup-design.md)
Plan: [docs/superpowers/plans/2026-05-05-moderation-dashboard-speedup-plan.md](docs/superpowers/plans/2026-05-05-moderation-dashboard-speedup-plan.md)

Both went through two rounds of independent review before any code was written.

## What changes

Five performance commits + one config commit + the spec/plan:

1. **`docs:` spec + plan** — design doc and step-by-step implementation plan, both reviewer-approved.
2. **`test:` scope vitest discovery to `src/` and `scripts/`** — `.worktrees/` and `.claude/worktrees/` were duplicating tests and triggering an unhandled error from a stale-schema worktree. No production code change.
3. **`perf:` add composite indexes + `lookup_attempted_at` column** — migration `009-dashboard-speedup-indexes.sql` adds:
   - `idx_moderation_action_date(action, moderated_at DESC)` — kills the TEMP B-TREE FOR ORDER BY on the dashboard's primary list query (verified via EXPLAIN QUERY PLAN).
   - `idx_moderation_uploaded_by_date(uploaded_by, moderated_at DESC)` — supports `buildUploaderHistory`.
   - `idx_bunny_events_sha256_received(sha256, received_at DESC)` — supports the new untriaged CTE.
   - `idx_moderation_unreviewed(action, moderated_at DESC) WHERE reviewed_by IS NULL` — partial index for the FLAGGED filter.
   - `lookup_attempted_at TEXT` column — backfill cron tracking.
   - `wrangler.toml` gets `migrations_dir = "migrations"` so miniflare replays migrations in tests.
   - `scripts/verify-query-plans.mjs` runs EXPLAIN QUERY PLAN against remote D1 and fails if any of the four hot queries regress.
4. **`perf:` kill per-row funnelcake fan-out in `/admin/api/videos`** — the big one. Root cause: `enrichAdminLookupVideo` always fired `fetchFunnelcakeLookupVideo` because the SELECT lists omitted the very columns (`event_id, title, author, content_url, published_at`) that would have populated the early-return fields. With 50 cards/page that was 50 parallel ~1.6s HTTP calls bounded by the Workers 50-subrequest cap. Fix: extract pure `buildAdminVideoFromRow` into `src/admin/lookup-helpers.mjs`, widen the SELECTs, replace `Promise.all(rows.map(getAdminLookupVideo))` with a synchronous mapper, and batch `uploader_enforcement` into a single `WHERE pubkey IN (?,?,…)` query. Per-page round-trips drop from ~150–250 to ~3.
5. **`perf:` KV-cache stats** — `cachedStat` helper (`src/admin/cache.mjs`) wraps `/admin/api/stats`, `/admin/api/ai-detection/stats`, and the untriaged COUNT in a 60s KV cache. `?fresh=1` bypasses the cache read but still writes the fresh value back so concurrent Refresh clicks don't stampede.
6. **`perf:` untriaged endpoint cleanup** — `src/admin/bunny-events.mjs` replaces four hand-rolled `WHERE received_at = (SELECT MAX(received_at) WHERE sha256 = ...)` correlated subqueries with one window-function CTE: `ROW_NUMBER() OVER (PARTITION BY sha256 ORDER BY received_at DESC)`. The natural-looking `GROUP BY sha256 HAVING received_at = MAX(received_at)` form returns nondeterministic non-aggregate columns in SQLite — only when MAX is in the SELECT does the bare-column rule apply. The KV-flag check was changed from sequential `for…of await` to `Promise.all`. Per-row Nostr fetch wrapped in a 1h KV cache (`nostr:event:{sha256}`).
7. **`feat:` backfill cron for legacy rows** — `src/admin/backfill-lookup-columns.mjs` runs every minute (alongside creator-delete), takes up to N legacy rows where `event_id IS NULL`, fetches via funnelcake, and persists. Idempotent (UPDATE WHERE event_id IS NULL), KV-mutex'd against overlap with the manual `/admin/api/backfill/run?count=N` trigger, and gated `BACKFILL_ENABLED=false` by default. ~26h to chew through 316k rows at 200/min.

## Field-level shape change to acknowledge

`nostrContext.client` and `nostrContext.content` used to be filled by the per-row funnelcake fetch. They are not stored in `moderation_results`. After this PR, list cards leave them null. Single-video detail view (`/admin/api/video/:id`) keeps the on-demand funnelcake fetch so opened videos still show those fields. Cards do not surface them.

## Tests

- 4 new test files, 26 new tests:
  - `src/admin/lookup-helpers.test.mjs` (6) — pure helper.
  - `src/admin/cache.test.mjs` (4) — miss/hit/fresh/corrupt-cache.
  - `src/admin/bunny-events.test.mjs` (7) — window CTE correctness, ordering, exclude, COUNT, single-row.
  - `src/admin/backfill-lookup-columns.test.mjs` (9) — happy path, idempotency, 404, error, limit, mutex, retry-skip, disabled flag, missing-DI.
- 1 existing test rewritten: `src/index.test.mjs > "returns mirrored relay context fields..."` → "returns stored relay context fields without per-row fan-out". Asserts zero funnelcake calls (regression gate).
- Full suite: 307/318 passing — same as baseline; the 1 pre-existing unhandled error is unrelated (lives in another test file's setup).

## Performance targets

| Endpoint | Before (observed) | Target (p95) |
|---|---:|---:|
| `/admin/api/videos?limit=50` | 3–10s | < 200ms |
| `/admin/api/stats` | 200–500ms | < 50ms (cached) |
| `/admin/api/untriaged?limit=50` | 1–3s | < 300ms |
| Dashboard mount | 5–15s | < 1.5s |

## Test plan

- [ ] `npm test` passes locally on this branch.
- [ ] After merge → auto-deploy: run `wrangler d1 migrations apply blossom-webhook-events --remote` to apply migration 009.
- [ ] Run `node scripts/verify-query-plans.mjs` against remote D1 — expect 4 ✓.
- [ ] Browser-test `https://moderation.admin.divine.video` — load the dashboard, switch filters, page through. Expect sub-1.5s loads.
- [ ] `curl -w '%{time_total}'` against `/admin/api/videos?limit=50` (with auth) — expect < 0.3s warm.
- [ ] Verify `/admin/api/video/:id` (detail view) still shows `client` and `content` (it now uses the on-demand funnelcake fetch).
- [ ] Manually trigger a 100-row backfill: `POST /admin/api/backfill/run?count=100`. Expect `{ picked: 100, updated: ≤100, missing: ..., errored: 0 }`.
- [ ] Set `BACKFILL_ENABLED=true` via `wrangler secret put`. Watch `SELECT COUNT(*) FROM moderation_results WHERE event_id IS NULL` trend toward 0 over 24-48h.

## Rollback

Each commit is independently revertable.
- Drop indexes: `DROP INDEX idx_moderation_action_date; ...` (one statement each).
- Revert any `perf:` commit and redeploy.
- `BACKFILL_ENABLED=false` halts the backfill mid-stream — no cleanup needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)