### PR TITLE
fix: fall back to Nostr imeta URL when admin video proxy 404s

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -2797,6 +2797,34 @@ export default {
           }
         }
 
+        // Last-resort fallback: ask the relay for the Nostr event and try
+        // its imeta `url`. This catches the case where the moderation
+        // pipeline stored content_url as the cdn URL (because nostrContext
+        // wasn't captured at moderate time) — that candidate is correctly
+        // skipped above, leaving us with nothing. For external Blossom
+        // videos (Plebs, etc.) the imeta url is the only working source.
+        try {
+          const event = await fetchNostrEventBySha256(sha256, ['wss://relay.divine.video'], env);
+          if (event) {
+            const metadata = parseVideoEventMetadata(event);
+            const relayUrl = metadata?.url || null;
+            if (relayUrl && relayUrl !== cdnUrl && relayUrl !== adminBypassUrl) {
+              try {
+                const relayResponse = await fetch(relayUrl, upstreamRequestInit);
+                if (relayResponse.ok) {
+                  console.log(`[ADMIN] Serving video from nostr-imeta-url: ${sha256}`);
+                  return createAdminVideoProxyResponse(relayResponse, 'nostr-imeta-url');
+                }
+                console.warn(`[ADMIN] Nostr imeta url returned ${relayResponse.status} for ${sha256}`);
+              } catch (relayFetchError) {
+                console.warn(`[ADMIN] Nostr imeta url fetch failed for ${sha256}: ${relayFetchError.message}`);
+              }
+            }
+          }
+        } catch (relayLookupError) {
+          console.warn(`[ADMIN] Nostr event lookup failed for ${sha256}: ${relayLookupError.message}`);
+        }
+
         return new Response(JSON.stringify({
           error: 'Video not found',
           sha256
@@ -4478,7 +4506,13 @@ async function runMigration() {
           result.nostrContext?.title || null,
           result.nostrContext?.author || null,
           result.nostrEventId || null,
-          result.nostrContext?.url || result.cdnUrl || null,
+          // Only store the actual upstream URL (Blossom imeta) here.
+          // Falling back to result.cdnUrl writes media.divine.video/{sha},
+          // which is exactly the URL the admin-video proxy already tried
+          // and got 404 from — and the proxy then dedups it out, leaving
+          // no working candidate. Better to leave null so the proxy's
+          // nostr-imeta-url last-resort lookup can run.
+          result.nostrContext?.url || null,
           result.nostrContext?.publishedAt || null,
           JSON.stringify(result.videoseal || null),
           transcriptPending,


### PR DESCRIPTION
## Summary

Hotfix for moderators seeing mass 404/500/502s on `/admin/video/{sha}.mp4`. Many videos can't be served because `content_url` is stored as the divine CDN URL (`media.divine.video/{sha}`) — the exact URL the proxy already tried and got 404 from. The dedup correctly skips that candidate, leaving zero working sources.

- **Proxy fallback:** before returning 404, fetch the Nostr event from `relay.divine.video` and try its imeta `url`. Unblocks external Blossom-hosted videos (Plebs, etc.) immediately.
- **Source fix:** stop writing `cdnUrl` as `content_url` when `nostrContext.url` is missing. Leaving null lets the fallback run instead of poisoning the stored candidate for future requests.

## Test plan

- [x] `npm test -- src/index.test.mjs` (136/136 pass)
- [ ] Deploy and verify a previously-404ing sha now serves
- [ ] Confirm `[ADMIN] Serving video from nostr-imeta-url:` shows up in worker logs
- [ ] Confirm new moderation results land with `content_url` either as the imeta url or null (never the cdn url)

🤖 Generated with [Claude Code](https://claude.com/claude-code)