### PR TITLE
fix: stop preloading every video on the moderation dashboard

### DIFF
--- a/src/admin/dashboard.html
+++ b/src/admin/dashboard.html
@@ -3121,7 +3121,7 @@
 
       return '<div class="video-card triage" data-sha256="' + sha256 + '" style="border-color: #8b5cf6;">' +
         '<div class="video-thumbnail">' +
-          '<video src="' + videoUrl + '" muted loop preload="metadata" poster="' + thumbUrl + '" controls onmouseenter="this.play()" onmouseleave="this.pause(); this.currentTime=0;"></video>' +
+          '<video src="' + videoUrl + '" muted loop preload="none" poster="' + thumbUrl + '" controls onmouseenter="this.play()" onmouseleave="this.pause(); this.currentTime=0;"></video>' +
           '<div class="video-overlay">' +
             '<span class="badge" style="background: #8b5cf6;">NEW</span>' +
           '</div>' +
@@ -3986,7 +3986,7 @@
       return `
         <div class="video-card ${actionClass}" data-sha256="${sha256}">
           <div class="video-thumbnail">
-            <video src="${playableVideoUrl}" muted loop preload="auto" controls onmouseenter="this.play()" onmouseleave="this.pause()"></video>
+            <video src="${playableVideoUrl}" muted loop preload="none" controls onmouseenter="this.play()" onmouseleave="this.pause()"></video>
             <div class="video-overlay">
               <span class="badge ${actionClass}">${action}</span>
               ${manualOverride ? '<span class="badge override-badge">MANUAL</span>' : ''}


### PR DESCRIPTION
## Summary

Each dashboard page renders 50 video cards. Two `<video>` elements used `preload="metadata"` / `preload="auto"`, which made the browser fire 50 parallel range requests against `/admin/video/{sha}.mp4` immediately on render. With #138's new Nostr-relay imeta-url fallback, every miss also pays for a relay round-trip — multiplying the load storm.

Switch both to `preload="none"`. The existing `onmouseenter=\"this.play()\"` triggers the actual fetch on demand, so playback UX is unchanged but initial load drops to zero video fetches.

## Test plan

- [ ] Open `/admin/dashboard?action=REVIEW` and confirm the page settles quickly
- [ ] Network tab: zero `/admin/video/*.mp4` requests until you hover a card
- [ ] Hover a card → video starts playing as before
- [ ] Triage tab still shows posters and plays on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)