### PR TITLE
fix(admin-video): per-fetch try/catch + KV-cache nostr fallback

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -2758,9 +2758,19 @@ export default {
       try {
         const upstreamRequestInit = buildAdminVideoProxyRequestInit(request);
 
-        // CDN fetch (unauthenticated) — works for SAFE/unmoderated content
-        const cdnResponse = await fetch(cdnUrl, upstreamRequestInit);
-        if (cdnResponse.ok) {
+        // CDN fetch (unauthenticated) — works for SAFE/unmoderated content.
+        // Per-fetch try/catch: a network error here MUST NOT abort the
+        // whole chain — every later fallback (admin bypass, stored
+        // candidates, nostr imeta) is exactly what's supposed to cover for
+        // a flaky CDN. Without this guard one DNS hiccup or origin
+        // timeout produced a 500 on a video that other paths could serve.
+        let cdnResponse = null;
+        try {
+          cdnResponse = await fetch(cdnUrl, upstreamRequestInit);
+        } catch (cdnFetchError) {
+          console.warn(`[ADMIN] CDN fetch threw for ${sha256}: ${cdnFetchError.message}`);
+        }
+        if (cdnResponse && cdnResponse.ok) {
           const contentType = cdnResponse.headers.get('Content-Type') || 'video/mp4';
 
           // If the format is browser-playable, serve directly
@@ -2772,35 +2782,54 @@ export default {
           // Non-browser format (e.g. video/3gpp, video/x-matroska) — try transcoded 720p MP4 from Blossom
           console.log(`[ADMIN] CDN returned non-playable ${contentType}, trying transcoded 720p for ${sha256}`);
           const transcodeUrl = `https://${cdnDomain}/${sha256}/720p.mp4`;
-          const transcodeResponse = await fetch(transcodeUrl, upstreamRequestInit);
-          if (transcodeResponse.ok) {
-            console.log(`[ADMIN] Serving transcoded 720p MP4 for ${sha256}`);
-            return createAdminVideoProxyResponse(transcodeResponse, 'cdn-transcode');
+          try {
+            const transcodeResponse = await fetch(transcodeUrl, upstreamRequestInit);
+            if (transcodeResponse.ok) {
+              console.log(`[ADMIN] Serving transcoded 720p MP4 for ${sha256}`);
+              return createAdminVideoProxyResponse(transcodeResponse, 'cdn-transcode');
+            }
+            console.warn(`[ADMIN] Transcoded 720p not available (${transcodeResponse.status}) for ${sha256}`);
+          } catch (transcodeFetchError) {
+            console.warn(`[ADMIN] Transcoded 720p fetch threw for ${sha256}: ${transcodeFetchError.message}`);
           }
-          console.warn(`[ADMIN] Transcoded 720p not available (${transcodeResponse.status}) for ${sha256}`);
         }
 
-        // CDN returned non-200 or non-playable with no transcode available
-        // Fall back to admin bypass endpoint which serves regardless of moderation status
+        // CDN returned non-200 or non-playable with no transcode available.
+        // Fall back to admin bypass endpoint which serves regardless of
+        // moderation status. Per-fetch try/catch — same reasoning as above.
         if (env.BLOSSOM_WEBHOOK_SECRET) {
-          console.log(`[ADMIN] CDN returned ${cdnResponse.status}, trying admin bypass for ${sha256}`);
-          const bypassResponse = await fetch(
-            adminBypassUrl,
-            buildAdminVideoProxyRequestInit(request, {
-              'Authorization': `Bearer ${env.BLOSSOM_WEBHOOK_SECRET}`
-            })
-          );
-          if (bypassResponse.ok) {
-            console.log(`[ADMIN] Serving video from admin bypass: ${sha256}`);
-            const moderationStatus = bypassResponse.headers.get('X-Moderation-Status');
-            return createAdminVideoProxyResponse(bypassResponse, 'blossom-admin', {
-              'X-Moderation-Status': moderationStatus
-            });
+          const cdnStatus = cdnResponse ? cdnResponse.status : 'threw';
+          console.log(`[ADMIN] CDN returned ${cdnStatus}, trying admin bypass for ${sha256}`);
+          try {
+            const bypassResponse = await fetch(
+              adminBypassUrl,
+              buildAdminVideoProxyRequestInit(request, {
+                'Authorization': `Bearer ${env.BLOSSOM_WEBHOOK_SECRET}`
+              })
+            );
+            if (bypassResponse.ok) {
+              console.log(`[ADMIN] Serving video from admin bypass: ${sha256}`);
+              const moderationStatus = bypassResponse.headers.get('X-Moderation-Status');
+              return createAdminVideoProxyResponse(bypassResponse, 'blossom-admin', {
+                'X-Moderation-Status': moderationStatus
+              });
+            }
+            console.error(`[ADMIN] Admin bypass returned ${bypassResponse.status} for ${sha256}`);
+          } catch (bypassFetchError) {
+            console.warn(`[ADMIN] Admin bypass fetch threw for ${sha256}: ${bypassFetchError.message}`);
           }
-          console.error(`[ADMIN] Admin bypass returned ${bypassResponse.status} for ${sha256}`);
         }
 
-        const storedPlaybackCandidates = await getStoredAdminPlaybackCandidates(sha256, env);
+        // KV/D1 lookup for alternate playback URLs cached at moderate time.
+        // If the helper itself throws (e.g. KV transient error), don't
+        // abort the chain — the nostr imeta fallback below may still
+        // succeed.
+        let storedPlaybackCandidates = [];
+        try {
+          storedPlaybackCandidates = await getStoredAdminPlaybackCandidates(sha256, env);
+        } catch (storedLookupError) {
+          console.warn(`[ADMIN] Stored playback lookup threw for ${sha256}: ${storedLookupError.message}`);
+        }
         for (const candidate of storedPlaybackCandidates) {
           if (candidate.url === cdnUrl || candidate.url === adminBypassUrl) {
             continue;
@@ -2821,31 +2850,46 @@ export default {
         }
 
         // Last-resort fallback: ask the relay for the Nostr event and try
-        // its imeta `url`. This catches the case where the moderation
-        // pipeline stored content_url as the cdn URL (because nostrContext
-        // wasn't captured at moderate time) — that candidate is correctly
-        // skipped above, leaving us with nothing. For external Blossom
-        // videos (Plebs, etc.) the imeta url is the only working source.
+        // its imeta `url`. KV-cached so a 50-card dashboard render doesn't
+        // open 50 parallel WebSockets — each cache miss writes a 5-min
+        // entry (positive imeta url, or sentinel "" for "no event"), so
+        // subsequent requests skip the relay roundtrip entirely.
+        const imetaCacheKey = `admin-video-imeta:${sha256}`;
+        let imetaUrl = null;
         try {
-          const event = await fetchNostrEventBySha256(sha256, ['wss://relay.divine.video'], env);
-          if (event) {
-            const metadata = parseVideoEventMetadata(event);
-            const relayUrl = metadata?.url || null;
-            if (relayUrl && relayUrl !== cdnUrl && relayUrl !== adminBypassUrl) {
-              try {
-                const relayResponse = await fetch(relayUrl, upstreamRequestInit);
-                if (relayResponse.ok) {
-                  console.log(`[ADMIN] Serving video from nostr-imeta-url: ${sha256}`);
-                  return createAdminVideoProxyResponse(relayResponse, 'nostr-imeta-url');
-                }
-                console.warn(`[ADMIN] Nostr imeta url returned ${relayResponse.status} for ${sha256}`);
-              } catch (relayFetchError) {
-                console.warn(`[ADMIN] Nostr imeta url fetch failed for ${sha256}: ${relayFetchError.message}`);
+          const cached = env.MODERATION_KV ? await env.MODERATION_KV.get(imetaCacheKey) : null;
+          if (cached !== null) {
+            imetaUrl = cached === '' ? null : cached;
+          } else {
+            const event = await fetchNostrEventBySha256(sha256, ['wss://relay.divine.video'], env);
+            const metadata = event ? parseVideoEventMetadata(event) : null;
+            imetaUrl = metadata?.url || null;
+            if (env.MODERATION_KV) {
+              const writePromise = env.MODERATION_KV.put(imetaCacheKey, imetaUrl || '', {
+                expirationTtl: 300
+              }).catch((err) => {
+                console.warn(`[ADMIN] imeta cache write failed for ${sha256}: ${err.message}`);
+              });
+              if (ctx && typeof ctx.waitUntil === 'function') {
+                ctx.waitUntil(writePromise);
               }
             }
           }
         } catch (relayLookupError) {
           console.warn(`[ADMIN] Nostr event lookup failed for ${sha256}: ${relayLookupError.message}`);
+        }
+
+        if (imetaUrl && imetaUrl !== cdnUrl && imetaUrl !== adminBypassUrl) {
+          try {
+            const relayResponse = await fetch(imetaUrl, upstreamRequestInit);
+            if (relayResponse.ok) {
+              console.log(`[ADMIN] Serving video from nostr-imeta-url: ${sha256}`);
+              return createAdminVideoProxyResponse(relayResponse, 'nostr-imeta-url');
+            }
+            console.warn(`[ADMIN] Nostr imeta url returned ${relayResponse.status} for ${sha256}`);
+          } catch (relayFetchError) {
+            console.warn(`[ADMIN] Nostr imeta url fetch failed for ${sha256}: ${relayFetchError.message}`);
+          }
         }
 
         return new Response(JSON.stringify({

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -2849,6 +2849,27 @@ export default {
           }
         }
 
+        // GCS direct fallback. The Blossom CDN sits in front of GCS bucket
+        // `divine-blossom-media` (publicly readable). When the CDN returns
+        // 404 because of moderation enforcement / VCL, the underlying
+        // bytes are still on GCS at the same sha256 path. Cheaper than a
+        // relay roundtrip, and works for every divine-hosted upload —
+        // CSAM-handled-upstream-at-GCS still applies.
+        const gcsBucket = env.GCS_BUCKET || 'divine-blossom-media';
+        const gcsUrl = `https://storage.googleapis.com/${gcsBucket}/${sha256}`;
+        if (gcsUrl !== cdnUrl && gcsUrl !== adminBypassUrl) {
+          try {
+            const gcsResponse = await fetch(gcsUrl, upstreamRequestInit);
+            if (gcsResponse.ok) {
+              console.log(`[ADMIN] Serving video from gcs-direct: ${sha256}`);
+              return createAdminVideoProxyResponse(gcsResponse, 'gcs-direct');
+            }
+            console.warn(`[ADMIN] GCS direct returned ${gcsResponse.status} for ${sha256}`);
+          } catch (gcsFetchError) {
+            console.warn(`[ADMIN] GCS direct fetch threw for ${sha256}: ${gcsFetchError.message}`);
+          }
+        }
+
         // Last-resort fallback: ask the relay for the Nostr event and try
         // its imeta `url`. KV-cached so a 50-card dashboard render doesn't
         // open 50 parallel WebSockets — each cache miss writes a 5-min


### PR DESCRIPTION
## Summary

Defense-in-depth on top of #138 + #139, plus a GCS direct fallback.

**Two layers added to `/admin/video/{sha}.mp4` proxy:**

1. **GCS direct fallback** — between stored-`content_url` and the relay-imeta fallback, hit `https://storage.googleapis.com/divine-blossom-media/{sha}` directly. The Blossom CDN sits in front of this bucket and the bucket is publicly readable, so when the CDN returns 404 (moderation enforcement, VCL gates, etc.) the underlying bytes are still reachable without auth or a relay roundtrip. Bucket name configurable via `env.GCS_BUCKET`. CSAM-handled-upstream-at-GCS still applies — these are the same bytes Blossom would have served.

2. **KV-cache the Nostr imeta-url fallback** — the fallback added in #138 opened a fresh WebSocket to relay.divine.video on every miss. With a 50-card dashboard render hitting the proxy in parallel, that meant up to 50 concurrent WS connections per page load — exhausting per-isolate budgets and surfacing as 500/502. Cache the relay lookup result in MODERATION_KV with a 5-min TTL; sentinel empty string represents "no event found" so negative results are also cached. Write goes through `ctx.waitUntil`.

This commit also tightens per-fetch error handling on the upstream chain (CDN, transcode, admin bypass) so a single network hiccup can't 500 the whole request when later fallbacks are exactly designed to cover for it.

**New proxy chain order:**
1. `media.divine.video/{sha}` (CDN, unauthenticated)
2. `media.divine.video/{sha}/720p.mp4` (transcoded MP4 if CDN returned non-playable)
3. `/admin/api/blob/{sha}/content` (admin bypass with secret)
4. Stored `content_url` candidates
5. **NEW:** `storage.googleapis.com/divine-blossom-media/{sha}` (GCS direct)
6. Nostr `imeta` URL via relay (KV-cached)
7. 404

## Test plan

- [x] `npm test -- src/index.test.mjs` (136/136 pass)
- [ ] Deploy and confirm the 500/502 spam in moderator console clears
- [ ] `wrangler tail` shows `[ADMIN] Serving video from gcs-direct` for previously-404ing native videos
- [ ] `wrangler tail` shows `[ADMIN] Serving video from nostr-imeta-url` for external Blossom videos (Plebs, etc.) on cache miss

🤖 Generated with [Claude Code](https://claude.com/claude-code)