### PR TITLE
fix: show Blossom thumbnails as posters on video cards

### DIFF
--- a/src/admin/dashboard.html
+++ b/src/admin/dashboard.html
@@ -4000,7 +4000,7 @@
       return `
         <div class="video-card ${actionClass}" data-sha256="${sha256}">
           <div class="video-thumbnail">
-            <video src="${playableVideoUrl}" muted loop preload="none" controls onmouseenter="this.play()" onmouseleave="this.pause()"></video>
+            <video src="${playableVideoUrl}" muted loop preload="none" poster="https://media.divine.video/${sha256}.jpg" controls onmouseenter="this.play()" onmouseleave="this.pause()"></video>
             <div class="video-overlay">
               <span class="badge ${actionClass}">${action}</span>
               ${manualOverride ? '<span class="badge override-badge">MANUAL</span>' : ''}


### PR DESCRIPTION
## Summary

#139 changed video preload from `"auto"` to `"none"` to stop the 50-parallel video fetch storm on dashboard render. Side effect: the regular `createVideoCard()` had no `poster` attribute and was relying on `preload="auto"` to decode and display a first frame — without that, cards now show black boxes until you hover.

Add `poster="https://media.divine.video/{sha}.jpg"`. Blossom auto-generates thumbnails keyed by the video sha (verified: HTTP 200 with real JPEG bytes for SAFE videos). For external Blossom imports the URL 404s and the poster simply doesn't render — graceful degradation, no console errors.

This restores the visual moderation experience without re-introducing the video preload storm.

## Test plan

- [ ] Reload `/admin/dashboard?action=REVIEW` — cards now show thumbnails for divine-uploaded videos
- [ ] Network tab: `GET media.divine.video/{sha}.jpg` per card (cheap, cached at edge), still zero `/admin/video/*.mp4` until hover
- [ ] Hover a card — video plays as before
- [ ] External-Blossom imports (REVIEW) without a divine thumbnail show black boxes (acceptable — those videos can't be played either)

🤖 Generated with [Claude Code](https://claude.com/claude-code)