### PR TITLE
fix(admin): show video thumbnails before playback

### DIFF
--- a/src/admin/dashboard-ui.test.mjs
+++ b/src/admin/dashboard-ui.test.mjs
@@ -29,4 +29,10 @@ describe('dashboard provenance UI hooks', () => {
     expect(dashboardHTML).toContain('AI Detection');
     expect(dashboardHTML).toContain('Estimated spend avoided');
   });
+
+  it('renders poster thumbnails before video playback starts', () => {
+    expect(dashboardHTML).toContain('const cardThumbUrl = escapeHtml(video.thumbnailUrl || `https://media.divine.video/${sha256}.jpg`);');
+    expect(dashboardHTML).toContain('src="${cardThumbUrl}"');
+    expect(dashboardHTML).toContain('openVideoModal');
+  });
 });

--- a/src/admin/dashboard.html
+++ b/src/admin/dashboard.html
@@ -3968,6 +3968,7 @@
       const actionClass = action.toLowerCase();
 
       const playableVideoUrl = getPreferredPlaybackUrl(video);
+      const cardThumbUrl = escapeHtml(video.thumbnailUrl || `https://media.divine.video/${sha256}.jpg`);
 
       // Get all scores, sort by value (highest first), and filter out zero scores
       const scoreEntries = Object.entries(scores || {})
@@ -4063,7 +4064,7 @@
       return `
         <div class="video-card ${actionClass}" data-sha256="${sha256}">
           <div class="video-thumbnail">
-            <img class="video-card-thumb" src="https://media.divine.video/${sha256}.jpg" loading="lazy" alt="" onclick="openVideoModal('${sha256}')" onerror="handleVideoThumbError(this, '${sha256}')">
+            <img class="video-card-thumb" src="${cardThumbUrl}" loading="lazy" alt="" onclick="openVideoModal('${sha256}')" onerror="handleVideoThumbError(this, '${sha256}')">
             <div class="video-overlay">
               <span class="badge ${actionClass}">${action}</span>
               ${manualOverride ? '<span class="badge override-badge">MANUAL</span>' : ''}

--- a/src/admin/lookup-helpers.mjs
+++ b/src/admin/lookup-helpers.mjs
@@ -73,6 +73,7 @@ export function buildAdminVideoFromRow(row, { cdnDomain }) {
     eventId,
     divineUrl: eventId ? `https://divine.video/video/${encodeURIComponent(eventId)}` : null,
     cdnUrl: `https://${cdnDomain}/${row.sha256}`,
+    thumbnailUrl: row.thumbnail_url || null,
     nostrContext: hasContext ? {
       title: row.title || null,
       author: row.author || null,

--- a/src/admin/lookup-helpers.test.mjs
+++ b/src/admin/lookup-helpers.test.mjs
@@ -21,6 +21,7 @@ const FULL_ROW = {
   author: 'Alice',
   content_url: 'https://example.com/v.mp4',
   published_at: '1717200000',
+  thumbnail_url: 'https://example.com/thumb.jpg',
 };
 
 describe('ADMIN_VIDEO_COLUMNS', () => {
@@ -43,6 +44,7 @@ describe('buildAdminVideoFromRow', () => {
       eventId: FULL_ROW.event_id,
       divineUrl: `https://divine.video/video/${FULL_ROW.event_id}`,
       cdnUrl: `https://media.divine.video/${FULL_ROW.sha256}`,
+      thumbnailUrl: 'https://example.com/thumb.jpg',
       uploaded_by: FULL_ROW.uploaded_by,
       moderated_at: '2026-05-05T00:00:00Z',
       reviewed_by: null,

--- a/src/admin/swipe-review-ui.test.mjs
+++ b/src/admin/swipe-review-ui.test.mjs
@@ -21,4 +21,9 @@ describe('swipe review provenance UI hooks', () => {
     expect(swipeReviewHTML).toContain('Invalid Proof');
     expect(swipeReviewHTML).toContain('c2pa-badge');
   });
+
+  it('renders poster thumbnails before video playback starts', () => {
+    expect(swipeReviewHTML).toContain('const posterUrl = escapeHtml(video.thumbnailUrl || \'\');');
+    expect(swipeReviewHTML).toContain('poster="${posterUrl}"');
+  });
 });

--- a/src/admin/swipe-review.html
+++ b/src/admin/swipe-review.html
@@ -1428,6 +1428,7 @@
     function createVideoCard(video) {
       const { sha256, scores, detailedCategories, isUntriaged, classifierSummary } = video;
       const videoUrl = '/admin/video/' + sha256 + '.mp4';
+      const posterUrl = escapeHtml(video.thumbnailUrl || '');
       const provenanceHTML = renderProvenanceSummary(video.provenance, video.c2pa);
 
       const scoreEntries = Object.entries(scores || {})
@@ -1488,7 +1489,7 @@
             <div class="review-primary-layout">
               <div class="review-media-column">
                 <div class="video-wrapper">
-                  <video src="${videoUrl}" controls loop preload="auto"></video>
+                  <video src="${videoUrl}" controls loop preload="auto" poster="${posterUrl}"></video>
                 </div>
               </div>
 

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1494,18 +1494,18 @@ export default {
       const params = [];
 
       if (actionFilter === 'FLAGGED') {
-        conditions.push("action IN ('REVIEW', 'AGE_RESTRICTED', 'PERMANENT_BAN') AND reviewed_by IS NULL");
+        conditions.push("m.action IN ('REVIEW', 'AGE_RESTRICTED', 'PERMANENT_BAN') AND m.reviewed_by IS NULL");
       } else if (actionFilter === 'QUARANTINE') {
-        conditions.push("action IN ('AGE_RESTRICTED', 'PERMANENT_BAN') AND reviewed_by IS NULL");
+        conditions.push("m.action IN ('AGE_RESTRICTED', 'PERMANENT_BAN') AND m.reviewed_by IS NULL");
       } else if (actionFilter !== 'all') {
-        conditions.push('action = ?');
+        conditions.push('m.action = ?');
         params.push(actionFilter.toUpperCase());
       }
 
       // Date filter — exclude old test content from review queues
       const sinceParam = url.searchParams.get('since');
       if (sinceParam) {
-        conditions.push('moderated_at >= ?');
+        conditions.push('m.moderated_at >= ?');
         params.push(sinceParam);
       }
 
@@ -1517,12 +1517,27 @@ export default {
 
       // Query D1 with pagination. The wide SELECT pulls every column the
       // dashboard needs so we can render directly from the row — no
-      // per-card funnelcake fetch.
+      // per-card funnelcake fetch. The latest Bunny webhook row provides
+      // thumbnail_url for pre-play video posters without touching public
+      // playback or moderation data.
       const query = `
-        SELECT ${ADMIN_VIDEO_COLUMNS.join(', ')}
-        FROM moderation_results
+        WITH latest_bunny AS (
+          SELECT sha256, thumbnail_url
+          FROM (
+            SELECT
+              sha256,
+              thumbnail_url,
+              ROW_NUMBER() OVER (PARTITION BY sha256 ORDER BY received_at DESC) AS rn
+            FROM bunny_webhook_events
+            WHERE sha256 IS NOT NULL
+          )
+          WHERE rn = 1
+        )
+        SELECT ${ADMIN_VIDEO_COLUMNS.map((column) => `m.${column}`).join(', ')}, latest_bunny.thumbnail_url
+        FROM moderation_results m
+        LEFT JOIN latest_bunny ON latest_bunny.sha256 = m.sha256
         ${whereClause}
-        ORDER BY moderated_at ${orderDirection}
+        ORDER BY m.moderated_at ${orderDirection}
         LIMIT ? OFFSET ?
       `;
       params.push(limit + 1, offset); // Fetch one extra to check if more exist

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -68,7 +68,7 @@ function createDbMock({
           return null;
         },
         async all() {
-          if (sql.includes('FROM moderation_results') && sql.includes('ORDER BY moderated_at')) {
+          if (sql.includes('FROM moderation_results') && /ORDER BY\s+(?:m\.)?moderated_at/i.test(sql)) {
             return { results: moderationListRows };
           }
           if (sql.includes('FROM ai_detection_events') && sql.includes("event_type = 'policy_decision'")) {
@@ -842,7 +842,8 @@ describe('Admin video lookup', () => {
         title: 'REST title',
         author: 'REST author',
         content_url: 'https://media.divine.video/rest-content.mp4',
-        published_at: '1389756506'
+        published_at: '1389756506',
+        thumbnail_url: 'https://media.divine.video/thumb.jpg'
       };
 
       const response = await worker.fetch(
@@ -862,6 +863,7 @@ describe('Admin video lookup', () => {
         videos: [{
           sha256: SHA256,
           uploaded_by: 'b'.repeat(64),
+          thumbnailUrl: 'https://media.divine.video/thumb.jpg',
           eventId: 'd'.repeat(64),
           divineUrl: `https://divine.video/video/${'d'.repeat(64)}`,
           nostrContext: {


### PR DESCRIPTION
## Summary
- Include latest Blossom/Bunny thumbnail URLs in `/admin/api/videos` responses.
- Render dashboard cards from the resolved thumbnail URL, with the existing generated `.jpg` fallback.
- Add poster thumbnails to quick-review video playback and regression coverage for both admin review UIs.

## Motivation
Moderators should see the video thumbnail before tapping/clicking to play, instead of a blank player surface.

## Linked issue
None.

## Manual validation plan
- `npm run lint`
- `npm test -- src/admin/lookup-helpers.test.mjs src/admin/dashboard-ui.test.mjs src/admin/swipe-review-ui.test.mjs src/index.test.mjs`

## Notes
A full `npm test` run was attempted before opening this PR, but it is currently blocked by unrelated pre-existing untracked `src/backfill-decisions-route.test.mjs` failures in this workspace (`/admin/api/backfill/decisions` returns the default API response instead of the test JSON). The focused regression suite and lint pass after rebasing onto `origin/main`.