### PR TITLE
feat: ingest relay reports for moderation review

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Content moderation service for Divine 6-second videos using Sightengine API and 
   - **QUARANTINE**: High risk content, blocked immediately
 - **AI-Generated Content Detection**: Identifies AI-generated videos to maintain authentic content policy
 - **Late Transcript Reprocessing**: Tracks `202 Pending` transcript runs and reprocesses them on cron when transcripts are ready
-- **Nostr Integration**: Publishes NIP-56 (kind 1984) events for human moderation
+- **Nostr Integration**: Publishes and ingests NIP-56 (kind 1984) report events for human moderation
 - **Cost Optimized**: ~$0.003 per 6-second video
 - **Full Test Coverage**: 40 tests covering all components
 
@@ -28,7 +28,7 @@ Moderation Worker
   ├─> Detection (NSFW, Violence, AI-Generated)
   ├─> Classification (SAFE/REVIEW/QUARANTINE)
   ├─> KV Storage (results + quarantine flags)
-  └─> Nostr Events (relay3.openvine.co for human review)
+  └─> Nostr Events (human review reports)
 ```
 
 ## Quick Start
@@ -247,7 +247,31 @@ Published as NIP-56 (kind 1984) reporting events:
 }
 ```
 
-**Note**: Nostr kind 1984 events are currently blocked by relay3.openvine.co. Core moderation continues to function; human review notifications temporarily unavailable until relay configuration is updated.
+### Inbound relay reports
+
+The Worker also ingests public NIP-56 reports from Nostr. On the five-minute cron,
+the report poller reads kind `1984` events from `REPORT_POLLING_RELAY_URL`
+(`wss://relay.divine.video` in production). By default, accepted inbound reports
+must come from the diVine client: `RELAY_REPORTS_REQUIRE_DIVINE_CLIENT=true`
+requires a `client` tag value of `divine`.
+
+Accepted reports are resolved through their target `e` tag. The poller fetches
+that target event, extracts the reported media SHA, and records the same
+`user_reports` and `moderation_results` rows used by authenticated
+`POST /api/v1/report` submissions. This keeps relay-originated report review on
+the same moderation path as API-originated report review.
+
+Operational KV keys:
+
+- `report-poller:last-poll`: checkpoint timestamp for the next bounded relay query
+- `report-poller:last-run`: summary of the most recent report polling cron run
+- `report-poller:last-error`: most recent report polling cron error
+- `report-poller:processed:<event_id>`: idempotence marker for a processed or terminally skipped report event
+
+Checkpointing is conservative. The Worker advances `report-poller:last-poll`
+only to safe terminal report timestamps. Retryable failures and saturated relay
+pages do not advance the checkpoint, so the next cron can retry without skipping
+unprocessed reports.
 
 ## Cost Breakdown
 

--- a/README.md
+++ b/README.md
@@ -257,9 +257,10 @@ requires a `client` tag value of `divine`.
 
 Accepted reports are resolved through their target `e` tag. The poller fetches
 that target event, extracts the reported media SHA, and records the same
-`user_reports` and `moderation_results` rows used by authenticated
-`POST /api/v1/report` submissions. This keeps relay-originated report review on
-the same moderation path as API-originated report review.
+`user_reports` and `moderation_results` review rows used by authenticated
+`POST /api/v1/report` submissions. Relay-originated reports are review-only:
+they do not auto-escalate to `AGE_RESTRICTED` because relay client tags and
+reporter pubkeys are public, self-asserted signals.
 
 Operational KV keys:
 
@@ -269,9 +270,10 @@ Operational KV keys:
 - `report-poller:processed:<event_id>`: idempotence marker for a processed or terminally skipped report event
 
 Checkpointing is conservative. The Worker advances `report-poller:last-poll`
-only to safe terminal report timestamps. Retryable failures and saturated relay
-pages do not advance the checkpoint, so the next cron can retry without skipping
-unprocessed reports.
+only to safe terminal report timestamps. Retryable failures do not advance the
+checkpoint. Saturated relay pages record a `resumeUntil` boundary in
+`report-poller:last-run`, so the next cron can continue paging older reports
+without pretending the whole window is safely checkpointed.
 
 ## Cost Breakdown
 

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -13,6 +13,7 @@ import { verifyZeroTrustJWT } from './admin/zerotrust.mjs';
 import { getConfiguredBearerTokens, authenticateApiRequest, apiUnauthorizedResponse, authSourceFromVerification, verifyLegacyBearerAuth } from './auth-api.mjs';
 import { fetchNostrEventBySha256, fetchNostrVideoEventsByDTag, parseVideoEventMetadata, fetchKind5EventsSince, fetchNostrEventById } from './nostr/relay-client.mjs';
 import { pollRelayForVideos, getLastPollTimestamp, setLastPollTimestamp, getPollingStatus } from './nostr/relay-poller.mjs';
+import { getLastReportPollTimestamp, pollRelayForReports, setLastReportPollTimestamp } from './nostr/report-poller.mjs';
 import { getPublicKey } from 'nostr-tools/pure';
 import { hexToBytes, bytesToHex } from '@noble/hashes/utils';
 import dashboardHTML from './admin/dashboard.html';
@@ -4749,6 +4750,58 @@ async function runMigration() {
             }));
           } catch (kvError) {
             console.error('[RELAY-POLLER] Failed to store error:', kvError);
+          }
+        }
+      }
+
+      if (env.REPORT_POLLING_ENABLED === 'false') {
+        console.log('[REPORT-POLLER] Report polling is disabled, skipping');
+      } else {
+        try {
+          let since = await getLastReportPollTimestamp(env);
+
+          if (!since) {
+            const lookbackHours = parseInt(env.REPORT_POLLING_LOOKBACK_HOURS || '24', 10);
+            since = Math.floor(Date.now() / 1000) - (lookbackHours * 3600);
+            console.log(`[REPORT-POLLER] First report poll run, looking back ${lookbackHours} hours`);
+          } else {
+            console.log(`[REPORT-POLLER] Continuing report polling from ${new Date(since * 1000).toISOString()}`);
+          }
+
+          const relays = env.REPORT_POLLING_RELAY_URL
+            ? [env.REPORT_POLLING_RELAY_URL]
+            : env.RELAY_POLLING_RELAY_URL
+              ? [env.RELAY_POLLING_RELAY_URL]
+              : ['wss://relay.divine.video'];
+
+          const results = await pollRelayForReports(env, {
+            since,
+            limit: parseInt(env.REPORT_POLLING_LIMIT || '100', 10),
+            relays,
+          });
+
+          await setLastReportPollTimestamp(env, Math.floor(Date.now() / 1000), {
+            totalReports: results.totalReports,
+            recorded: results.recorded,
+            alreadyProcessed: results.alreadyProcessed,
+            skipped: results.skipped,
+            targetUnavailable: results.targetUnavailable,
+            errors: results.errors.length,
+            trigger: 'cron',
+          });
+
+          console.log(`[REPORT-POLLER] Cron complete: ${results.totalReports} reports found, ${results.recorded} recorded, ${results.skipped} skipped, ${results.targetUnavailable} target unavailable, ${results.errors.length} errors`);
+        } catch (error) {
+          console.error('[REPORT-POLLER] Cron poll failed:', error);
+
+          try {
+            await env.MODERATION_KV.put('report-poller:last-error', JSON.stringify({
+              error: error.message,
+              stack: error.stack,
+              timestamp: new Date().toISOString(),
+            }));
+          } catch (kvError) {
+            console.error('[REPORT-POLLER] Failed to store error:', kvError);
           }
         }
       }

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -4788,6 +4788,7 @@ async function runMigration() {
             targetUnavailable: results.targetUnavailable,
             errors: results.errors.length,
             safeCheckpoint: results.safeCheckpoint,
+            saturated: results.saturated,
             trigger: 'cron',
           };
 

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -2685,11 +2685,24 @@ export default {
     }
 
     // Get report polling status
-    if (url.pathname === '/admin/api/report-polling/status' && request.method === 'GET') {
+    if (url.pathname === '/admin/api/report-polling/status') {
       const authError = await requireAuth(request, env);
       if (authError) {
         console.log(`[${requestId}] Unauthorized access to report-polling/status`);
         return authError;
+      }
+
+      if (request.method !== 'GET') {
+        return new Response(JSON.stringify({
+          error: 'Method not allowed',
+          allowedMethods: ['GET'],
+        }), {
+          status: 405,
+          headers: {
+            'Content-Type': 'application/json',
+            'Allow': 'GET',
+          },
+        });
       }
 
       console.log(`[${requestId}] Fetching report polling status`);

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -4780,15 +4780,30 @@ async function runMigration() {
             relays,
           });
 
-          await setLastReportPollTimestamp(env, Math.floor(Date.now() / 1000), {
+          const pollStats = {
             totalReports: results.totalReports,
             recorded: results.recorded,
             alreadyProcessed: results.alreadyProcessed,
             skipped: results.skipped,
             targetUnavailable: results.targetUnavailable,
             errors: results.errors.length,
+            safeCheckpoint: results.safeCheckpoint,
             trigger: 'cron',
-          });
+          };
+
+          if (results.safeCheckpoint) {
+            await setLastReportPollTimestamp(env, results.safeCheckpoint, pollStats);
+          } else {
+            console.log('[REPORT-POLLER] No safe checkpoint from this run; leaving report checkpoint unchanged');
+            try {
+              await env.MODERATION_KV.put('report-poller:last-run', JSON.stringify({
+                ...pollStats,
+                timestamp: new Date().toISOString(),
+              }));
+            } catch (kvError) {
+              console.error('[REPORT-POLLER] Failed to store last run stats:', kvError);
+            }
+          }
 
           console.log(`[REPORT-POLLER] Cron complete: ${results.totalReports} reports found, ${results.recorded} recorded, ${results.skipped} skipped, ${results.targetUnavailable} target unavailable, ${results.errors.length} errors`);
         } catch (error) {

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -4777,6 +4777,7 @@ async function runMigration() {
           const results = await pollRelayForReports(env, {
             since,
             limit: parseInt(env.REPORT_POLLING_LIMIT || '100', 10),
+            maxPages: parseInt(env.REPORT_POLLING_MAX_PAGES || '5', 10),
             relays,
           });
 

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -2685,7 +2685,7 @@ export default {
     }
 
     // Get report polling status
-    if (url.pathname === '/admin/api/report-polling/status') {
+    if (url.pathname === '/admin/api/report-polling/status' && request.method === 'GET') {
       const authError = await requireAuth(request, env);
       if (authError) {
         console.log(`[${requestId}] Unauthorized access to report-polling/status`);

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -18,13 +18,14 @@ import { hexToBytes, bytesToHex } from '@noble/hashes/utils';
 import dashboardHTML from './admin/dashboard.html';
 import swipeReviewHTML from './admin/swipe-review.html';
 import messagesHTML from './admin/messages.html';
-import { initReportsTable, addReport, isAiReportType, isNsfwReportType } from './reports.mjs';
+import { initReportsTable } from './reports.mjs';
 import { initUploaderEnforcementTable, getUploaderEnforcement, setUploaderEnforcement, applyUploaderEnforcementToResult } from './uploader-enforcement.mjs';
 import { formatForStorage, formatForGorse, formatForFunnelcake } from './classification/pipeline.mjs';
 import { extractTopics, topicsToLabels, topicsToWeightedFeatures } from './classification/topic-extractor.mjs';
 import { classifyModerationResult, getKVThresholds, kvThresholdsToEnv, setKVThresholds, DEFAULT_THRESHOLDS } from './moderation/classifier.mjs';
 import { shouldForceAIDetection } from './moderation/ai-detection-policy.mjs';
-import { buildAIOutcomeEvent, buildAIPolicyDecisionEvent, buildAIReportEvent, getAIDetectionStats, initAIDetectionEventsTable, recordAIDetectionEvent } from './moderation/ai-detection-events.mjs';
+import { buildAIOutcomeEvent, buildAIPolicyDecisionEvent, getAIDetectionStats, initAIDetectionEventsTable, recordAIDetectionEvent } from './moderation/ai-detection-events.mjs';
+import { recordReportForReview } from './moderation/report-review.mjs';
 import { isValidSha256, isValidLookupIdentifier, isValidPubkey, parseMaybeJson, getEventTagValue, parseImetaParams, extractShaFromUrl, extractMediaShaFromEvent } from './validation.mjs';
 import { parseRetryAfterSeconds } from './http-utils.mjs';
 import { classifyText, parseVttText } from './moderation/text-classifier.mjs';
@@ -3755,92 +3756,21 @@ async function runMigration() {
         }
         const sha256 = rawSha;
 
-        const result = await addReport(env.BLOSSOM_DB, { sha256, reporter_pubkey, report_type, reason });
+        const result = await recordReportForReview(env.BLOSSOM_DB, {
+          sha256,
+          reporterPubkey: reporter_pubkey,
+          reportType: report_type,
+          reason,
+          source: 'user-report',
+        });
 
-        console.log(`[API] Report added: ${sha256} by ${reporter_pubkey.substring(0, 16)}... distinctReporters=${result.distinctReporterCount}`);
+        console.log(`[API] Recorded ${result.action} from user report for ${sha256} (type=${report_type}, distinctReporters=${result.distinctReporterCount})`);
 
-        // Write a moderation_results row directly so the team's FLAGGED dashboard
-        // (action IN REVIEW/AGE_RESTRICTED/PERMANENT_BAN AND reviewed_by IS NULL)
-        // surfaces the reported item.
-        //
-        // Policy:
-        //   - Non-NSFW report (single tier): action = REVIEW
-        //   - NSFW report: action = REVIEW on first reporter; auto AGE_RESTRICTED
-        //     once 2+ DISTINCT reporter_pubkeys have flagged the same sha256.
-        //     The 2-distinct-reporter floor defends against single-token griefing
-        //     where one API caller could otherwise auto age-restrict any sha256
-        //     by varying the reporter_pubkey field.
-        //
-        // ON CONFLICT short-circuits if a moderator already reviewed the row
-        // (reviewed_by IS NOT NULL) so human decisions are never overwritten.
-        const isNsfw = isNsfwReportType(report_type);
-        const reportAction = (isNsfw && result.distinctReporterCount >= 2) ? 'AGE_RESTRICTED' : 'REVIEW';
-        const nowIso = new Date().toISOString();
-        const reportCategories = isNsfw ? ['adult'] : [];
-        try {
-          await env.BLOSSOM_DB.prepare(`
-            INSERT INTO moderation_results (
-              sha256, action, provider, scores, categories, raw_response, moderated_at, reviewed_by, reviewed_at, review_notes, uploaded_by
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT(sha256) DO UPDATE SET
-              action = CASE
-                WHEN moderation_results.reviewed_by IS NOT NULL THEN moderation_results.action
-                WHEN moderation_results.action = 'PERMANENT_BAN' THEN moderation_results.action
-                WHEN excluded.action = 'AGE_RESTRICTED' AND moderation_results.action IN ('SAFE', 'REVIEW') THEN excluded.action
-                WHEN excluded.action = 'REVIEW' AND moderation_results.action = 'SAFE' THEN excluded.action
-                ELSE moderation_results.action
-              END,
-              provider = CASE
-                WHEN moderation_results.reviewed_by IS NOT NULL THEN moderation_results.provider
-                ELSE excluded.provider
-              END,
-              categories = CASE
-                WHEN moderation_results.reviewed_by IS NOT NULL THEN moderation_results.categories
-                ELSE excluded.categories
-              END,
-              moderated_at = CASE
-                WHEN moderation_results.reviewed_by IS NOT NULL THEN moderation_results.moderated_at
-                ELSE excluded.moderated_at
-              END
-          `).bind(
-            sha256,
-            reportAction,
-            'user-report',
-            JSON.stringify({}),
-            JSON.stringify(reportCategories),
-            JSON.stringify({
-              source: 'user-report',
-              reportType: report_type,
-              reportedBy: reporter_pubkey,
-              distinctReporterCount: result.distinctReporterCount,
-              reason: reason ?? null,
-            }),
-            nowIso,
-            null,
-            null,
-            null,
-            null,
-          ).run();
-          console.log(`[API] Recorded ${reportAction} from user report for ${sha256} (type=${report_type}, nsfw=${isNsfw}, distinctReporters=${result.distinctReporterCount})`);
-        } catch (writeErr) {
-          console.error(`[API] Failed to write moderation row for reported ${sha256}:`, writeErr.message);
-        }
-
-        // Preserve existing AI-detection telemetry: AI-typed reports still record
-        // an ai_detection_events row so dashboards keep their report counts.
-        if (isAiReportType(report_type)) {
-          try {
-            await recordAIDetectionEvent(env.BLOSSOM_DB, buildAIReportEvent({
-              sha256,
-              reportType: report_type,
-              createdAt: nowIso,
-            }));
-          } catch (eventErr) {
-            console.error(`[API] Failed to record AI report event for ${sha256}:`, eventErr.message);
-          }
-        }
-
-        return new Response(JSON.stringify({ success: true, ...result }), {
+        return new Response(JSON.stringify({
+          success: true,
+          escalate: result.escalate,
+          distinctReporterCount: result.distinctReporterCount,
+        }), {
           headers: { 'Content-Type': 'application/json' }
         });
       } catch (error) {

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -13,7 +13,7 @@ import { verifyZeroTrustJWT } from './admin/zerotrust.mjs';
 import { getConfiguredBearerTokens, authenticateApiRequest, apiUnauthorizedResponse, authSourceFromVerification, verifyLegacyBearerAuth } from './auth-api.mjs';
 import { fetchNostrEventBySha256, fetchNostrVideoEventsByDTag, parseVideoEventMetadata, fetchKind5EventsSince, fetchNostrEventById } from './nostr/relay-client.mjs';
 import { pollRelayForVideos, getLastPollTimestamp, setLastPollTimestamp, getPollingStatus } from './nostr/relay-poller.mjs';
-import { getLastReportPollTimestamp, pollRelayForReports, setLastReportPollTimestamp } from './nostr/report-poller.mjs';
+import { getLastReportPollTimestamp, getReportPollingStatus, pollRelayForReports, setLastReportPollTimestamp } from './nostr/report-poller.mjs';
 import { getPublicKey } from 'nostr-tools/pure';
 import { hexToBytes, bytesToHex } from '@noble/hashes/utils';
 import dashboardHTML from './admin/dashboard.html';
@@ -2678,6 +2678,22 @@ export default {
 
       console.log(`[${requestId}] Fetching relay polling status`);
       const status = await getPollingStatus(env);
+
+      return new Response(JSON.stringify(status), {
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+
+    // Get report polling status
+    if (url.pathname === '/admin/api/report-polling/status') {
+      const authError = await requireAuth(request, env);
+      if (authError) {
+        console.log(`[${requestId}] Unauthorized access to report-polling/status`);
+        return authError;
+      }
+
+      console.log(`[${requestId}] Fetching report polling status`);
+      const status = await getReportPollingStatus(env);
 
       return new Response(JSON.stringify(status), {
         headers: { 'Content-Type': 'application/json' }

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -13,7 +13,7 @@ import { verifyZeroTrustJWT } from './admin/zerotrust.mjs';
 import { getConfiguredBearerTokens, authenticateApiRequest, apiUnauthorizedResponse, authSourceFromVerification, verifyLegacyBearerAuth } from './auth-api.mjs';
 import { fetchNostrEventBySha256, fetchNostrVideoEventsByDTag, parseVideoEventMetadata, fetchKind5EventsSince, fetchNostrEventById } from './nostr/relay-client.mjs';
 import { pollRelayForVideos, getLastPollTimestamp, setLastPollTimestamp, getPollingStatus } from './nostr/relay-poller.mjs';
-import { getLastReportPollTimestamp, getReportPollingStatus, pollRelayForReports, setLastReportPollTimestamp } from './nostr/report-poller.mjs';
+import { getLastReportPollTimestamp, getReportLastRun, getReportPollingStatus, pollRelayForReports, setLastReportPollTimestamp } from './nostr/report-poller.mjs';
 import { getPublicKey } from 'nostr-tools/pure';
 import { hexToBytes, bytesToHex } from '@noble/hashes/utils';
 import dashboardHTML from './admin/dashboard.html';
@@ -4803,8 +4803,17 @@ async function runMigration() {
               ? [env.RELAY_POLLING_RELAY_URL]
               : ['wss://relay.divine.video'];
 
+          const lastRun = await getReportLastRun(env);
+          const resumeUntil = Number.isInteger(lastRun?.resumeUntil) && lastRun.resumeUntil > since
+            ? lastRun.resumeUntil
+            : null;
+          if (resumeUntil) {
+            console.log(`[REPORT-POLLER] Resuming saturated report polling page until ${new Date(resumeUntil * 1000).toISOString()}`);
+          }
+
           const results = await pollRelayForReports(env, {
             since,
+            ...(resumeUntil ? { until: resumeUntil } : {}),
             limit: parseInt(env.REPORT_POLLING_LIMIT || '100', 10),
             maxPages: parseInt(env.REPORT_POLLING_MAX_PAGES || '5', 10),
             relays,
@@ -4819,21 +4828,25 @@ async function runMigration() {
             errors: results.errors.length,
             safeCheckpoint: results.safeCheckpoint,
             saturated: results.saturated,
+            resumeUntil: results.resumeUntil,
             trigger: 'cron',
           };
 
           if (results.safeCheckpoint) {
             await setLastReportPollTimestamp(env, results.safeCheckpoint, pollStats);
-          } else {
+          }
+
+          try {
+            await env.MODERATION_KV.put('report-poller:last-run', JSON.stringify({
+              ...pollStats,
+              timestamp: new Date().toISOString(),
+            }));
+          } catch (kvError) {
+            console.error('[REPORT-POLLER] Failed to store last run stats:', kvError);
+          }
+
+          if (!results.safeCheckpoint) {
             console.log('[REPORT-POLLER] No safe checkpoint from this run; leaving report checkpoint unchanged');
-            try {
-              await env.MODERATION_KV.put('report-poller:last-run', JSON.stringify({
-                ...pollStats,
-                timestamp: new Date().toISOString(),
-              }));
-            } catch (kvError) {
-              console.error('[REPORT-POLLER] Failed to store last run stats:', kvError);
-            }
           }
 
           console.log(`[REPORT-POLLER] Cron complete: ${results.totalReports} reports found, ${results.recorded} recorded, ${results.skipped} skipped, ${results.targetUnavailable} target unavailable, ${results.errors.length} errors`);

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -104,6 +104,7 @@ function createEnv(overrides = {}) {
     MODERATION_QUEUE: {
       async send() {}
     },
+    REPORT_POLLING_ENABLED: 'false',
     CDN_DOMAIN: 'media.divine.video',
     ...overrides
   };
@@ -2676,6 +2677,7 @@ describe('RD auto-escalation cron integration', () => {
 
     const env = {
       REALITY_DEFENDER_API_KEY: 'fake-rd-key',
+      REPORT_POLLING_ENABLED: 'false',
       BLOSSOM_WEBHOOK_URL: 'https://mock-blossom.test/admin/moderate',
       BLOSSOM_WEBHOOK_SECRET: 'test-secret',
       BLOSSOM_DB: {
@@ -2785,6 +2787,7 @@ describe('RD auto-escalation cron integration', () => {
 
     const env = {
       REALITY_DEFENDER_API_KEY: 'fake-rd-key',
+      REPORT_POLLING_ENABLED: 'false',
       BLOSSOM_WEBHOOK_URL: 'https://mock-blossom.test/admin/moderate',
       BLOSSOM_WEBHOOK_SECRET: 'test-secret',
       BLOSSOM_DB: {
@@ -2859,6 +2862,7 @@ describe('RD auto-escalation cron integration', () => {
 
     const env = {
       REALITY_DEFENDER_API_KEY: 'fake-rd-key',
+      REPORT_POLLING_ENABLED: 'false',
       BLOSSOM_WEBHOOK_URL: 'https://mock-blossom.test/admin/moderate',
       BLOSSOM_DB: {
         prepare() {
@@ -2932,6 +2936,7 @@ describe('RD auto-escalation cron integration', () => {
 
     const env = {
       REALITY_DEFENDER_API_KEY: 'fake-rd-key',
+      REPORT_POLLING_ENABLED: 'false',
       BLOSSOM_DB: {
         prepare() {
           return {
@@ -2987,12 +2992,155 @@ describe('RD auto-escalation cron integration', () => {
   });
 });
 
+describe('Report polling cron integration', () => {
+  it('runs inbound report polling and records kind 1984 reports for review', async () => {
+    const targetEventId = '1'.repeat(64);
+    const reportEventId = '2'.repeat(64);
+    const reporterPubkey = '3'.repeat(64);
+    const uploaderPubkey = '4'.repeat(64);
+    const sha256 = '5'.repeat(64);
+    const moderationWrites = [];
+    const kvStore = new Map();
+    const websocketRequests = [];
+
+    const env = createEnv({
+      RELAY_POLLING_ENABLED: 'false',
+      REPORT_POLLING_ENABLED: 'true',
+      REPORT_POLLING_RELAY_URL: 'wss://reports.example.test',
+      REPORT_POLLING_LOOKBACK_HOURS: '24',
+      REPORT_POLLING_LIMIT: '100',
+      RELAY_REPORTS_REQUIRE_DIVINE_CLIENT: 'true',
+      BLOSSOM_DB: createDbMock({ moderationWrites }),
+      MODERATION_KV: {
+        async get(key) {
+          return kvStore.get(key) ?? null;
+        },
+        async put(key, value, options) {
+          kvStore.set(key, JSON.stringify({ value, options }));
+        },
+        async delete(key) {
+          kvStore.delete(key);
+        },
+        async list() {
+          return { keys: [], list_complete: true, cursor: null };
+        },
+      },
+    });
+
+    const originalFetch = globalThis.fetch;
+    const OriginalWebSocket = globalThis.WebSocket;
+
+    globalThis.fetch = async (url) => {
+      if (url === `https://reports.example.test/api/event/${targetEventId}`) {
+        return new Response(JSON.stringify({
+          id: targetEventId,
+          kind: 34236,
+          pubkey: uploaderPubkey,
+          created_at: 1778692000,
+          tags: [['d', sha256], ['imeta', `x ${sha256}`, 'm video/mp4']],
+          content: '',
+          sig: '6'.repeat(128),
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response('{}', { status: 404 });
+    };
+
+    globalThis.WebSocket = class {
+      constructor(url) {
+        this.url = url;
+        this.listeners = {};
+        setTimeout(() => this.listeners.open?.({}), 0);
+      }
+
+      addEventListener(type, listener) {
+        this.listeners[type] = listener;
+      }
+
+      send(payload) {
+        const message = JSON.parse(payload);
+        if (message[0] !== 'REQ') {
+          return;
+        }
+
+        websocketRequests.push({ url: this.url, message });
+        const subscriptionId = message[1];
+        setTimeout(() => {
+          this.listeners.message?.({
+            data: JSON.stringify(['EVENT', subscriptionId, {
+              id: reportEventId,
+              kind: 1984,
+              pubkey: reporterPubkey,
+              created_at: 1778692782,
+              tags: [
+                ['e', targetEventId, 'other'],
+                ['client', 'diVine'],
+                ['l', 'NS-aiGenerated', 'social.nos.ontology'],
+              ],
+              content: 'Reason: aiGenerated',
+              sig: '7'.repeat(128),
+            }]),
+          });
+          this.listeners.message?.({ data: JSON.stringify(['EOSE', subscriptionId]) });
+        }, 0);
+      }
+
+      close() {
+        this.listeners.close?.({});
+      }
+    };
+
+    try {
+      await worker.scheduled(
+        { cron: '*/5 * * * *', scheduledTime: Date.now() },
+        env,
+        { waitUntil: () => {} },
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+      globalThis.WebSocket = OriginalWebSocket;
+    }
+
+    expect(websocketRequests).toHaveLength(1);
+    expect(websocketRequests[0].url).toBe('wss://reports.example.test');
+    expect(websocketRequests[0].message[2]).toMatchObject({
+      kinds: [1984],
+      limit: 100,
+    });
+
+    expect(moderationWrites).toHaveLength(1);
+    expect(moderationWrites[0].bindings[0]).toBe(sha256);
+    expect(moderationWrites[0].bindings[1]).toBe('REVIEW');
+    expect(moderationWrites[0].bindings[2]).toBe('user-report');
+    expect(moderationWrites[0].bindings[10]).toBe(uploaderPubkey);
+    expect(JSON.parse(moderationWrites[0].bindings[5])).toMatchObject({
+      source: 'relay-report',
+      reportType: 'ai_generated',
+      reportEventId,
+      targetEventId,
+    });
+
+    expect(kvStore.has('report-poller:last-poll')).toBe(true);
+    const checkpoint = JSON.parse(JSON.parse(kvStore.get('report-poller:last-poll')).value);
+    expect(checkpoint).toMatchObject({
+      totalReports: 1,
+      recorded: 1,
+      alreadyProcessed: 0,
+      skipped: 0,
+      targetUnavailable: 0,
+      errors: 0,
+      trigger: 'cron',
+    });
+    expect(kvStore.has(`report-poller:processed:${reportEventId}`)).toBe(true);
+  });
+});
+
 describe('Transcript reprocess cron integration', () => {
   function createTranscriptReprocessEnv({ moderationRow, kvStore, blossomPayloads, envOverrides = {} }) {
     return {
       CDN_DOMAIN: 'media.divine.video',
       BLOSSOM_WEBHOOK_URL: 'https://mock-blossom.test/admin/moderate',
       TRANSCRIPT_REPROCESS_MAX_AGE_DAYS: '7',
+      REPORT_POLLING_ENABLED: 'false',
       BLOSSOM_DB: {
         prepare(sql) {
           let bindings = [];

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -3491,7 +3491,7 @@ describe('Report polling cron integration', () => {
       RELAY_POLLING_ENABLED: 'false',
       REPORT_POLLING_ENABLED: 'true',
       REPORT_POLLING_RELAY_URL: 'wss://reports.example.test',
-      REPORT_POLLING_LIMIT: '2',
+      REPORT_POLLING_LIMIT: '3',
       REPORT_POLLING_MAX_PAGES: '5',
       BLOSSOM_DB: createDbMock(),
       MODERATION_KV: {
@@ -3551,13 +3551,22 @@ describe('Report polling cron integration', () => {
         const filter = message[2];
         websocketRequests.push({ url: this.url, filter });
         const subscriptionId = message[1];
-        const reports = filter.until === 1778692782
+        const reports = filter.until === 1778692783
           ? [
             {
               id: 'c'.repeat(64),
               kind: 1984,
               pubkey: reporterPubkey,
-              created_at: 1778692782,
+              created_at: 1778692783,
+              tags: [['e', targetEventId, 'other'], ['client', 'diVine']],
+              content: 'Reason: spam',
+              sig: '7'.repeat(128),
+            },
+            {
+              id: 'd'.repeat(64),
+              kind: 1984,
+              pubkey: reporterPubkey,
+              created_at: 1778692783,
               tags: [['e', targetEventId, 'other'], ['client', 'diVine']],
               content: 'Reason: spam',
               sig: '7'.repeat(128),
@@ -3568,13 +3577,22 @@ describe('Report polling cron integration', () => {
               id: 'a'.repeat(64),
               kind: 1984,
               pubkey: reporterPubkey,
-              created_at: 1778692784,
+              created_at: 1778692785,
               tags: [['e', targetEventId, 'other'], ['client', 'diVine']],
               content: 'Reason: spam',
               sig: '7'.repeat(128),
             },
             {
               id: 'b'.repeat(64),
+              kind: 1984,
+              pubkey: reporterPubkey,
+              created_at: 1778692783,
+              tags: [['e', targetEventId, 'other'], ['client', 'diVine']],
+              content: 'Reason: spam',
+              sig: '7'.repeat(128),
+            },
+            {
+              id: 'c'.repeat(64),
               kind: 1984,
               pubkey: reporterPubkey,
               created_at: 1778692783,
@@ -3613,20 +3631,20 @@ describe('Report polling cron integration', () => {
     expect(websocketRequests).toEqual([
       {
         url: 'wss://reports.example.test',
-        filter: expect.objectContaining({ kinds: [1984], limit: 2 }),
+        filter: expect.objectContaining({ kinds: [1984], limit: 3 }),
       },
       {
         url: 'wss://reports.example.test',
-        filter: expect.objectContaining({ kinds: [1984], limit: 2, until: 1778692782 }),
+        filter: expect.objectContaining({ kinds: [1984], limit: 3, until: 1778692783 }),
       },
     ]);
     expect(checkpointWrites).toHaveLength(1);
     expect(checkpointWrites[0]).toMatchObject({
-      timestamp: 1778692784,
-      totalReports: 3,
-      recorded: 3,
+      timestamp: 1778692785,
+      totalReports: 4,
+      recorded: 4,
       saturated: false,
-      safeCheckpoint: 1778692784,
+      safeCheckpoint: 1778692785,
       trigger: 'cron',
     });
   });

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -3044,6 +3044,42 @@ describe('Report polling cron integration', () => {
     });
   });
 
+  it('does not return report polling status for POST requests', async () => {
+    const env = createEnv({
+      ALLOW_DEV_ACCESS: 'true',
+      REPORT_POLLING_ENABLED: 'true',
+      MODERATION_KV: {
+        async get(key) {
+          if (key === 'report-poller:last-poll') {
+            return JSON.stringify({
+              timestamp: 1778692782,
+              lastPollAt: '2026-05-13T17:20:00.000Z',
+              totalReports: 3,
+              recorded: 2,
+              errors: 1,
+            });
+          }
+          return null;
+        },
+        async put() {},
+        async delete() {},
+        async list() { return { keys: [], list_complete: true, cursor: null }; },
+      },
+    });
+
+    const response = await worker.fetch(
+      new Request('https://moderation.admin.divine.video/admin/api/report-polling/status', {
+        method: 'POST',
+      }),
+      env,
+    );
+
+    expect(response.headers.get('Content-Type') || '').not.toContain('application/json');
+    const body = await response.text();
+    expect(body).not.toContain('"totalReports":3');
+    expect(body).not.toContain('"recorded":2');
+  });
+
   it('runs inbound report polling and records kind 1984 reports for review', async () => {
     const targetEventId = '1'.repeat(64);
     const reportEventId = '2'.repeat(64);

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -3351,6 +3351,132 @@ describe('Report polling cron integration', () => {
     });
     expect(checkpointWrites[0].timestamp).not.toBe(nowSeconds);
   });
+
+  it('does not advance report checkpoint when the report page is saturated', async () => {
+    const targetEventId = '1'.repeat(64);
+    const reportEventId = '2'.repeat(64);
+    const reporterPubkey = '3'.repeat(64);
+    const uploaderPubkey = '4'.repeat(64);
+    const sha256 = '5'.repeat(64);
+    const reportCreatedAt = 1778692782;
+    const previousCheckpoint = 1778600000;
+    const kvStore = new Map([[
+      'report-poller:last-poll',
+      JSON.stringify({ timestamp: previousCheckpoint, lastPollAt: '2026-05-12T00:00:00.000Z' }),
+    ]]);
+    const checkpointWrites = [];
+    const lastRunWrites = [];
+
+    const env = createEnv({
+      RELAY_POLLING_ENABLED: 'false',
+      REPORT_POLLING_ENABLED: 'true',
+      REPORT_POLLING_RELAY_URL: 'wss://reports.example.test',
+      REPORT_POLLING_LIMIT: '1',
+      BLOSSOM_DB: createDbMock(),
+      MODERATION_KV: {
+        async get(key) {
+          return kvStore.get(key) ?? null;
+        },
+        async put(key, value, options) {
+          if (key === 'report-poller:last-poll') {
+            checkpointWrites.push(JSON.parse(value));
+          }
+          if (key === 'report-poller:last-run') {
+            lastRunWrites.push(JSON.parse(value));
+          }
+          kvStore.set(key, value);
+        },
+        async delete(key) {
+          kvStore.delete(key);
+        },
+        async list() {
+          return { keys: [], list_complete: true, cursor: null };
+        },
+      },
+    });
+
+    const originalFetch = globalThis.fetch;
+    const OriginalWebSocket = globalThis.WebSocket;
+
+    globalThis.fetch = async (url) => {
+      if (url === `https://reports.example.test/api/event/${targetEventId}`) {
+        return new Response(JSON.stringify({
+          id: targetEventId,
+          kind: 34236,
+          pubkey: uploaderPubkey,
+          created_at: 1778692000,
+          tags: [['d', sha256], ['imeta', `x ${sha256}`, 'm video/mp4']],
+          content: '',
+          sig: '6'.repeat(128),
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response('{}', { status: 404 });
+    };
+
+    globalThis.WebSocket = class {
+      constructor(url) {
+        this.url = url;
+        this.listeners = {};
+        queueMicrotask(() => this.listeners.open?.({}));
+      }
+
+      addEventListener(type, listener) {
+        this.listeners[type] = listener;
+      }
+
+      send(payload) {
+        const message = JSON.parse(payload);
+        if (message[0] !== 'REQ') {
+          return;
+        }
+        const subscriptionId = message[1];
+        queueMicrotask(() => {
+          this.listeners.message?.({
+            data: JSON.stringify(['EVENT', subscriptionId, {
+              id: reportEventId,
+              kind: 1984,
+              pubkey: reporterPubkey,
+              created_at: reportCreatedAt,
+              tags: [
+                ['e', targetEventId, 'other'],
+                ['client', 'diVine'],
+                ['l', 'NS-aiGenerated', 'social.nos.ontology'],
+              ],
+              content: 'Reason: aiGenerated',
+              sig: '7'.repeat(128),
+            }]),
+          });
+          this.listeners.message?.({ data: JSON.stringify(['EOSE', subscriptionId]) });
+        });
+      }
+
+      close() {
+        this.listeners.close?.({});
+      }
+    };
+
+    try {
+      await worker.scheduled(
+        { cron: '*/5 * * * *', scheduledTime: Date.now() },
+        env,
+        { waitUntil: () => {} },
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+      globalThis.WebSocket = OriginalWebSocket;
+    }
+
+    expect(checkpointWrites).toHaveLength(0);
+    expect(JSON.parse(kvStore.get('report-poller:last-poll')).timestamp).toBe(previousCheckpoint);
+    expect(lastRunWrites).toHaveLength(1);
+    expect(lastRunWrites[0]).toMatchObject({
+      totalReports: 1,
+      recorded: 1,
+      saturated: true,
+      safeCheckpoint: null,
+      trigger: 'cron',
+    });
+  });
 });
 
 describe('Transcript reprocess cron integration', () => {

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -3132,6 +3132,225 @@ describe('Report polling cron integration', () => {
     });
     expect(kvStore.has(`report-poller:processed:${reportEventId}`)).toBe(true);
   });
+
+  it('does not advance report checkpoint to now when a target is unavailable', async () => {
+    const targetEventId = '1'.repeat(64);
+    const reportEventId = '2'.repeat(64);
+    const reporterPubkey = '3'.repeat(64);
+    const previousCheckpoint = 1778600000;
+    const reportCreatedAt = 1778692782;
+    const nowSeconds = 1778729000;
+    const kvStore = new Map([[
+      'report-poller:last-poll',
+      JSON.stringify({ timestamp: previousCheckpoint, lastPollAt: '2026-05-12T00:00:00.000Z' }),
+    ]]);
+    const checkpointWrites = [];
+
+    const env = createEnv({
+      RELAY_POLLING_ENABLED: 'false',
+      REPORT_POLLING_ENABLED: 'true',
+      REPORT_POLLING_RELAY_URL: 'wss://reports.example.test',
+      BLOSSOM_DB: createDbMock(),
+      MODERATION_KV: {
+        async get(key) {
+          return kvStore.get(key) ?? null;
+        },
+        async put(key, value, options) {
+          if (key === 'report-poller:last-poll') {
+            checkpointWrites.push(JSON.parse(value));
+          }
+          kvStore.set(key, value);
+        },
+        async delete(key) {
+          kvStore.delete(key);
+        },
+        async list() {
+          return { keys: [], list_complete: true, cursor: null };
+        },
+      },
+    });
+
+    const originalFetch = globalThis.fetch;
+    const OriginalWebSocket = globalThis.WebSocket;
+
+    globalThis.fetch = async (url) => {
+      if (url === `https://reports.example.test/api/event/${targetEventId}`) {
+        return new Response('not found', { status: 404 });
+      }
+      return new Response('{}', { status: 404 });
+    };
+
+    globalThis.WebSocket = class {
+      constructor(url) {
+        this.url = url;
+        this.listeners = {};
+        queueMicrotask(() => this.listeners.open?.({}));
+      }
+
+      addEventListener(type, listener) {
+        this.listeners[type] = listener;
+      }
+
+      send(payload) {
+        const message = JSON.parse(payload);
+        if (message[0] !== 'REQ') {
+          return;
+        }
+        const subscriptionId = message[1];
+        queueMicrotask(() => {
+          this.listeners.message?.({
+            data: JSON.stringify(['EVENT', subscriptionId, {
+              id: reportEventId,
+              kind: 1984,
+              pubkey: reporterPubkey,
+              created_at: reportCreatedAt,
+              tags: [['e', targetEventId, 'other'], ['client', 'diVine']],
+              content: 'Reason: spam',
+              sig: '7'.repeat(128),
+            }]),
+          });
+          this.listeners.message?.({ data: JSON.stringify(['EOSE', subscriptionId]) });
+        });
+      }
+
+      close() {
+        this.listeners.close?.({});
+      }
+    };
+
+    try {
+      await worker.scheduled(
+        { cron: '*/5 * * * *', scheduledTime: nowSeconds * 1000 },
+        env,
+        { waitUntil: () => {} },
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+      globalThis.WebSocket = OriginalWebSocket;
+    }
+
+    expect(checkpointWrites).toHaveLength(0);
+    expect(JSON.parse(kvStore.get('report-poller:last-poll')).timestamp).toBe(previousCheckpoint);
+    expect(kvStore.has(`report-poller:processed:${reportEventId}`)).toBe(false);
+  });
+
+  it('advances report checkpoint to terminal report timestamp instead of Date.now', async () => {
+    const targetEventId = '1'.repeat(64);
+    const reportEventId = '2'.repeat(64);
+    const reporterPubkey = '3'.repeat(64);
+    const uploaderPubkey = '4'.repeat(64);
+    const sha256 = '5'.repeat(64);
+    const reportCreatedAt = 1778692782;
+    const nowSeconds = 1778729000;
+    const kvStore = new Map();
+    const checkpointWrites = [];
+
+    const env = createEnv({
+      RELAY_POLLING_ENABLED: 'false',
+      REPORT_POLLING_ENABLED: 'true',
+      REPORT_POLLING_RELAY_URL: 'wss://reports.example.test',
+      BLOSSOM_DB: createDbMock(),
+      MODERATION_KV: {
+        async get(key) {
+          return kvStore.get(key) ?? null;
+        },
+        async put(key, value, options) {
+          if (key === 'report-poller:last-poll') {
+            checkpointWrites.push(JSON.parse(value));
+          }
+          kvStore.set(key, value);
+        },
+        async delete(key) {
+          kvStore.delete(key);
+        },
+        async list() {
+          return { keys: [], list_complete: true, cursor: null };
+        },
+      },
+    });
+
+    const originalFetch = globalThis.fetch;
+    const OriginalWebSocket = globalThis.WebSocket;
+
+    globalThis.fetch = async (url) => {
+      if (url === `https://reports.example.test/api/event/${targetEventId}`) {
+        return new Response(JSON.stringify({
+          id: targetEventId,
+          kind: 34236,
+          pubkey: uploaderPubkey,
+          created_at: 1778692000,
+          tags: [['d', sha256], ['imeta', `x ${sha256}`, 'm video/mp4']],
+          content: '',
+          sig: '6'.repeat(128),
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response('{}', { status: 404 });
+    };
+
+    globalThis.WebSocket = class {
+      constructor(url) {
+        this.url = url;
+        this.listeners = {};
+        queueMicrotask(() => this.listeners.open?.({}));
+      }
+
+      addEventListener(type, listener) {
+        this.listeners[type] = listener;
+      }
+
+      send(payload) {
+        const message = JSON.parse(payload);
+        if (message[0] !== 'REQ') {
+          return;
+        }
+        const subscriptionId = message[1];
+        queueMicrotask(() => {
+          this.listeners.message?.({
+            data: JSON.stringify(['EVENT', subscriptionId, {
+              id: reportEventId,
+              kind: 1984,
+              pubkey: reporterPubkey,
+              created_at: reportCreatedAt,
+              tags: [
+                ['e', targetEventId, 'other'],
+                ['client', 'diVine'],
+                ['l', 'NS-aiGenerated', 'social.nos.ontology'],
+              ],
+              content: 'Reason: aiGenerated',
+              sig: '7'.repeat(128),
+            }]),
+          });
+          this.listeners.message?.({ data: JSON.stringify(['EOSE', subscriptionId]) });
+        });
+      }
+
+      close() {
+        this.listeners.close?.({});
+      }
+    };
+
+    try {
+      await worker.scheduled(
+        { cron: '*/5 * * * *', scheduledTime: nowSeconds * 1000 },
+        env,
+        { waitUntil: () => {} },
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+      globalThis.WebSocket = OriginalWebSocket;
+    }
+
+    expect(checkpointWrites).toHaveLength(1);
+    expect(checkpointWrites[0]).toMatchObject({
+      timestamp: reportCreatedAt,
+      safeCheckpoint: reportCreatedAt,
+      totalReports: 1,
+      recorded: 1,
+      errors: 0,
+      trigger: 'cron',
+    });
+    expect(checkpointWrites[0].timestamp).not.toBe(nowSeconds);
+  });
 });
 
 describe('Transcript reprocess cron integration', () => {

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -2993,6 +2993,57 @@ describe('RD auto-escalation cron integration', () => {
 });
 
 describe('Report polling cron integration', () => {
+  it('allows admins to read report polling status', async () => {
+    const env = createEnv({
+      ALLOW_DEV_ACCESS: 'true',
+      REPORT_POLLING_ENABLED: 'true',
+      MODERATION_KV: {
+        async get(key) {
+          if (key === 'report-poller:last-poll') {
+            return JSON.stringify({
+              timestamp: 1778692782,
+              lastPollAt: '2026-05-13T17:20:00.000Z',
+              totalReports: 3,
+              recorded: 2,
+              errors: 1,
+            });
+          }
+          if (key === 'report-poller:last-run') {
+            return JSON.stringify({
+              lastRunAt: '2026-05-13T17:25:00.000Z',
+              saturated: true,
+              safeCheckpoint: null,
+            });
+          }
+          return null;
+        },
+        async put() {},
+        async delete() {},
+        async list() { return { keys: [], list_complete: true, cursor: null }; },
+      },
+    });
+
+    const response = await worker.fetch(
+      new Request('https://moderation.admin.divine.video/admin/api/report-polling/status'),
+      env,
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      enabled: true,
+      timestamp: 1778692782,
+      lastPollAt: '2026-05-13T17:20:00.000Z',
+      totalReports: 3,
+      recorded: 2,
+      errors: 1,
+      lastRun: {
+        lastRunAt: '2026-05-13T17:25:00.000Z',
+        saturated: true,
+        safeCheckpoint: null,
+      },
+    });
+  });
+
   it('runs inbound report polling and records kind 1984 reports for review', async () => {
     const targetEventId = '1'.repeat(64);
     const reportEventId = '2'.repeat(64);

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -3477,6 +3477,159 @@ describe('Report polling cron integration', () => {
       trigger: 'cron',
     });
   });
+
+  it('advances report checkpoint when bounded drain resolves saturation', async () => {
+    const targetEventId = '1'.repeat(64);
+    const reporterPubkey = '3'.repeat(64);
+    const uploaderPubkey = '4'.repeat(64);
+    const sha256 = '5'.repeat(64);
+    const kvStore = new Map();
+    const checkpointWrites = [];
+    const websocketRequests = [];
+
+    const env = createEnv({
+      RELAY_POLLING_ENABLED: 'false',
+      REPORT_POLLING_ENABLED: 'true',
+      REPORT_POLLING_RELAY_URL: 'wss://reports.example.test',
+      REPORT_POLLING_LIMIT: '2',
+      REPORT_POLLING_MAX_PAGES: '5',
+      BLOSSOM_DB: createDbMock(),
+      MODERATION_KV: {
+        async get(key) {
+          return kvStore.get(key) ?? null;
+        },
+        async put(key, value, options) {
+          if (key === 'report-poller:last-poll') {
+            checkpointWrites.push(JSON.parse(value));
+          }
+          kvStore.set(key, value);
+        },
+        async delete(key) {
+          kvStore.delete(key);
+        },
+        async list() {
+          return { keys: [], list_complete: true, cursor: null };
+        },
+      },
+    });
+
+    const originalFetch = globalThis.fetch;
+    const OriginalWebSocket = globalThis.WebSocket;
+
+    globalThis.fetch = async (url) => {
+      if (url === `https://reports.example.test/api/event/${targetEventId}`) {
+        return new Response(JSON.stringify({
+          id: targetEventId,
+          kind: 34236,
+          pubkey: uploaderPubkey,
+          created_at: 1778692000,
+          tags: [['d', sha256], ['imeta', `x ${sha256}`, 'm video/mp4']],
+          content: '',
+          sig: '6'.repeat(128),
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response('{}', { status: 404 });
+    };
+
+    globalThis.WebSocket = class {
+      constructor(url) {
+        this.url = url;
+        this.listeners = {};
+        queueMicrotask(() => this.listeners.open?.({}));
+      }
+
+      addEventListener(type, listener) {
+        this.listeners[type] = listener;
+      }
+
+      send(payload) {
+        const message = JSON.parse(payload);
+        if (message[0] !== 'REQ') {
+          return;
+        }
+
+        const filter = message[2];
+        websocketRequests.push({ url: this.url, filter });
+        const subscriptionId = message[1];
+        const reports = filter.until === 1778692782
+          ? [
+            {
+              id: 'c'.repeat(64),
+              kind: 1984,
+              pubkey: reporterPubkey,
+              created_at: 1778692782,
+              tags: [['e', targetEventId, 'other'], ['client', 'diVine']],
+              content: 'Reason: spam',
+              sig: '7'.repeat(128),
+            },
+          ]
+          : [
+            {
+              id: 'a'.repeat(64),
+              kind: 1984,
+              pubkey: reporterPubkey,
+              created_at: 1778692784,
+              tags: [['e', targetEventId, 'other'], ['client', 'diVine']],
+              content: 'Reason: spam',
+              sig: '7'.repeat(128),
+            },
+            {
+              id: 'b'.repeat(64),
+              kind: 1984,
+              pubkey: reporterPubkey,
+              created_at: 1778692783,
+              tags: [['e', targetEventId, 'other'], ['client', 'diVine']],
+              content: 'Reason: spam',
+              sig: '7'.repeat(128),
+            },
+          ];
+
+        queueMicrotask(() => {
+          for (const report of reports) {
+            this.listeners.message?.({
+              data: JSON.stringify(['EVENT', subscriptionId, report]),
+            });
+          }
+          this.listeners.message?.({ data: JSON.stringify(['EOSE', subscriptionId]) });
+        });
+      }
+
+      close() {
+        this.listeners.close?.({});
+      }
+    };
+
+    try {
+      await worker.scheduled(
+        { cron: '*/5 * * * *', scheduledTime: Date.now() },
+        env,
+        { waitUntil: () => {} },
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+      globalThis.WebSocket = OriginalWebSocket;
+    }
+
+    expect(websocketRequests).toEqual([
+      {
+        url: 'wss://reports.example.test',
+        filter: expect.objectContaining({ kinds: [1984], limit: 2 }),
+      },
+      {
+        url: 'wss://reports.example.test',
+        filter: expect.objectContaining({ kinds: [1984], limit: 2, until: 1778692782 }),
+      },
+    ]);
+    expect(checkpointWrites).toHaveLength(1);
+    expect(checkpointWrites[0]).toMatchObject({
+      timestamp: 1778692784,
+      totalReports: 3,
+      recorded: 3,
+      saturated: false,
+      safeCheckpoint: 1778692784,
+      trigger: 'cron',
+    });
+  });
 });
 
 describe('Transcript reprocess cron integration', () => {

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -3010,7 +3010,9 @@ describe('Report polling cron integration', () => {
           }
           if (key === 'report-poller:last-run') {
             return JSON.stringify({
-              lastRunAt: '2026-05-13T17:25:00.000Z',
+              timestamp: '2026-05-13T17:25:00.000Z',
+              totalReports: 3,
+              recorded: 2,
               saturated: true,
               safeCheckpoint: null,
             });
@@ -3037,14 +3039,16 @@ describe('Report polling cron integration', () => {
       recorded: 2,
       errors: 1,
       lastRun: {
-        lastRunAt: '2026-05-13T17:25:00.000Z',
+        timestamp: '2026-05-13T17:25:00.000Z',
+        totalReports: 3,
+        recorded: 2,
         saturated: true,
         safeCheckpoint: null,
       },
     });
   });
 
-  it('does not return report polling status for POST requests', async () => {
+  it('returns method not allowed for POST report polling status requests', async () => {
     const env = createEnv({
       ALLOW_DEV_ACCESS: 'true',
       REPORT_POLLING_ENABLED: 'true',
@@ -3074,10 +3078,13 @@ describe('Report polling cron integration', () => {
       env,
     );
 
-    expect(response.headers.get('Content-Type') || '').not.toContain('application/json');
-    const body = await response.text();
-    expect(body).not.toContain('"totalReports":3');
-    expect(body).not.toContain('"recorded":2');
+    expect(response.status).toBe(405);
+    expect(response.headers.get('Allow')).toBe('GET');
+    expect(response.headers.get('Content-Type') || '').toContain('application/json');
+    await expect(response.json()).resolves.toEqual({
+      error: 'Method not allowed',
+      allowedMethods: ['GET'],
+    });
   });
 
   it('runs inbound report polling and records kind 1984 reports for review', async () => {

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -3572,6 +3572,201 @@ describe('Report polling cron integration', () => {
     });
   });
 
+  it('continues report polling from a saturated resume boundary', async () => {
+    const previousCheckpoint = 1778600000;
+    const resumeUntil = 1778692781;
+    const kvStore = new Map([
+      ['report-poller:last-poll', JSON.stringify({ timestamp: previousCheckpoint, lastPollAt: '2026-05-12T00:00:00.000Z' })],
+      ['report-poller:last-run', JSON.stringify({ saturated: true, safeCheckpoint: null, resumeUntil })],
+    ]);
+    const websocketRequests = [];
+
+    const env = createEnv({
+      RELAY_POLLING_ENABLED: 'false',
+      REPORT_POLLING_ENABLED: 'true',
+      REPORT_POLLING_RELAY_URL: 'wss://reports.example.test',
+      REPORT_POLLING_LIMIT: '50',
+      BLOSSOM_DB: createDbMock(),
+      MODERATION_KV: {
+        async get(key) {
+          return kvStore.get(key) ?? null;
+        },
+        async put(key, value) {
+          kvStore.set(key, value);
+        },
+        async delete(key) {
+          kvStore.delete(key);
+        },
+        async list() {
+          return { keys: [], list_complete: true, cursor: null };
+        },
+      },
+    });
+
+    const OriginalWebSocket = globalThis.WebSocket;
+    globalThis.WebSocket = class {
+      constructor() {
+        this.listeners = {};
+        queueMicrotask(() => this.listeners.open?.({}));
+      }
+
+      addEventListener(type, listener) {
+        this.listeners[type] = listener;
+      }
+
+      send(payload) {
+        const message = JSON.parse(payload);
+        if (message[0] !== 'REQ') {
+          return;
+        }
+        websocketRequests.push(message);
+        const subscriptionId = message[1];
+        queueMicrotask(() => {
+          this.listeners.message?.({ data: JSON.stringify(['EOSE', subscriptionId]) });
+        });
+      }
+
+      close() {
+        this.listeners.close?.({});
+      }
+    };
+
+    try {
+      await worker.scheduled(
+        { cron: '*/5 * * * *', scheduledTime: Date.now() },
+        env,
+        { waitUntil: () => {} },
+      );
+    } finally {
+      globalThis.WebSocket = OriginalWebSocket;
+    }
+
+    expect(websocketRequests).toHaveLength(1);
+    expect(websocketRequests[0][2]).toEqual({
+      kinds: [1984],
+      since: previousCheckpoint,
+      until: resumeUntil,
+      limit: 50,
+    });
+  });
+
+  it('clears stale saturated resume boundaries after a successful resume checkpoint', async () => {
+    const previousCheckpoint = 1778600000;
+    const resumeUntil = 1778692781;
+    const targetEventId = '1'.repeat(64);
+    const reportEventId = '2'.repeat(64);
+    const reporterPubkey = '3'.repeat(64);
+    const uploaderPubkey = '4'.repeat(64);
+    const sha256 = '5'.repeat(64);
+    const kvStore = new Map([
+      ['report-poller:last-poll', JSON.stringify({ timestamp: previousCheckpoint, lastPollAt: '2026-05-12T00:00:00.000Z' })],
+      ['report-poller:last-run', JSON.stringify({ saturated: true, safeCheckpoint: null, resumeUntil })],
+    ]);
+    const lastRunWrites = [];
+
+    const env = createEnv({
+      RELAY_POLLING_ENABLED: 'false',
+      REPORT_POLLING_ENABLED: 'true',
+      REPORT_POLLING_RELAY_URL: 'wss://reports.example.test',
+      REPORT_POLLING_LIMIT: '50',
+      BLOSSOM_DB: createDbMock(),
+      MODERATION_KV: {
+        async get(key) {
+          return kvStore.get(key) ?? null;
+        },
+        async put(key, value) {
+          if (key === 'report-poller:last-run') {
+            lastRunWrites.push(JSON.parse(value));
+          }
+          kvStore.set(key, value);
+        },
+        async delete(key) {
+          kvStore.delete(key);
+        },
+        async list() {
+          return { keys: [], list_complete: true, cursor: null };
+        },
+      },
+    });
+
+    const originalFetch = globalThis.fetch;
+    const OriginalWebSocket = globalThis.WebSocket;
+
+    globalThis.fetch = async (url) => {
+      if (url === `https://reports.example.test/api/event/${targetEventId}`) {
+        return new Response(JSON.stringify({
+          id: targetEventId,
+          kind: 34236,
+          pubkey: uploaderPubkey,
+          tags: [['d', sha256], ['imeta', `x ${sha256}`, 'm video/mp4']],
+          content: '',
+          sig: '6'.repeat(128),
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response('{}', { status: 404 });
+    };
+
+    globalThis.WebSocket = class {
+      constructor() {
+        this.listeners = {};
+        queueMicrotask(() => this.listeners.open?.({}));
+      }
+
+      addEventListener(type, listener) {
+        this.listeners[type] = listener;
+      }
+
+      send(payload) {
+        const message = JSON.parse(payload);
+        if (message[0] !== 'REQ') {
+          return;
+        }
+        const subscriptionId = message[1];
+        queueMicrotask(() => {
+          this.listeners.message?.({
+            data: JSON.stringify(['EVENT', subscriptionId, {
+              id: reportEventId,
+              kind: 1984,
+              pubkey: reporterPubkey,
+              created_at: 1778692780,
+              tags: [['e', targetEventId, 'nudity'], ['client', 'diVine']],
+              content: '',
+              sig: '7'.repeat(128),
+            }]),
+          });
+          this.listeners.message?.({ data: JSON.stringify(['EOSE', subscriptionId]) });
+        });
+      }
+
+      close() {
+        this.listeners.close?.({});
+      }
+    };
+
+    try {
+      await worker.scheduled(
+        { cron: '*/5 * * * *', scheduledTime: Date.now() },
+        env,
+        { waitUntil: () => {} },
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+      globalThis.WebSocket = OriginalWebSocket;
+    }
+
+    expect(JSON.parse(kvStore.get('report-poller:last-poll'))).toMatchObject({
+      timestamp: 1778692780,
+      saturated: false,
+      resumeUntil: null,
+    });
+    expect(lastRunWrites).toHaveLength(1);
+    expect(lastRunWrites[0]).toMatchObject({
+      safeCheckpoint: 1778692780,
+      saturated: false,
+      resumeUntil: null,
+    });
+  });
+
   it('advances report checkpoint when bounded drain resolves saturation', async () => {
     const targetEventId = '1'.repeat(64);
     const reporterPubkey = '3'.repeat(64);

--- a/src/moderation/report-review.mjs
+++ b/src/moderation/report-review.mjs
@@ -1,0 +1,100 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Shared user-report recording for HTTP and Nostr relay report ingestion
+// ABOUTME: Writes user_reports, moderation_results, and AI report telemetry consistently
+
+import { addReport, isAiReportType, isNsfwReportType } from '../reports.mjs';
+import { buildAIReportEvent, recordAIDetectionEvent } from './ai-detection-events.mjs';
+
+export async function recordReportForReview(db, {
+  sha256,
+  reporterPubkey,
+  reportType,
+  reason = null,
+  source = 'user-report',
+  reportedAt = null,
+  reportEventId = null,
+  targetEventId = null,
+  uploadedBy = null,
+} = {}) {
+  const result = await addReport(db, {
+    sha256,
+    reporter_pubkey: reporterPubkey,
+    report_type: reportType,
+    reason,
+    created_at: reportedAt,
+  });
+
+  const isNsfw = isNsfwReportType(reportType);
+  const action = (isNsfw && result.distinctReporterCount >= 2) ? 'AGE_RESTRICTED' : 'REVIEW';
+  const moderatedAt = reportedAt || new Date().toISOString();
+  const categories = isNsfw ? ['adult'] : [];
+
+  await db.prepare(`
+    INSERT INTO moderation_results (
+      sha256, action, provider, scores, categories, raw_response, moderated_at, reviewed_by, reviewed_at, review_notes, uploaded_by
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(sha256) DO UPDATE SET
+      action = CASE
+        WHEN moderation_results.reviewed_by IS NOT NULL THEN moderation_results.action
+        WHEN moderation_results.action = 'PERMANENT_BAN' THEN moderation_results.action
+        WHEN excluded.action = 'AGE_RESTRICTED' AND moderation_results.action IN ('SAFE', 'REVIEW') THEN excluded.action
+        WHEN excluded.action = 'REVIEW' AND moderation_results.action = 'SAFE' THEN excluded.action
+        ELSE moderation_results.action
+      END,
+      provider = CASE
+        WHEN moderation_results.reviewed_by IS NOT NULL THEN moderation_results.provider
+        ELSE excluded.provider
+      END,
+      categories = CASE
+        WHEN moderation_results.reviewed_by IS NOT NULL THEN moderation_results.categories
+        ELSE excluded.categories
+      END,
+      moderated_at = CASE
+        WHEN moderation_results.reviewed_by IS NOT NULL THEN moderation_results.moderated_at
+        ELSE excluded.moderated_at
+      END,
+      uploaded_by = CASE
+        WHEN moderation_results.uploaded_by IS NULL THEN excluded.uploaded_by
+        ELSE moderation_results.uploaded_by
+      END
+  `).bind(
+    sha256,
+    action,
+    'user-report',
+    JSON.stringify({}),
+    JSON.stringify(categories),
+    JSON.stringify({
+      source,
+      reportType,
+      reportedBy: reporterPubkey,
+      distinctReporterCount: result.distinctReporterCount,
+      reason,
+      reportEventId,
+      targetEventId,
+    }),
+    moderatedAt,
+    null,
+    null,
+    null,
+    uploadedBy,
+  ).run();
+
+  let aiTelemetryRecorded = false;
+  if (isAiReportType(reportType)) {
+    await recordAIDetectionEvent(db, buildAIReportEvent({
+      sha256,
+      reportType,
+      createdAt: moderatedAt,
+    }));
+    aiTelemetryRecorded = true;
+  }
+
+  return {
+    success: true,
+    ...result,
+    action,
+    aiTelemetryRecorded,
+  };
+}

--- a/src/moderation/report-review.mjs
+++ b/src/moderation/report-review.mjs
@@ -30,71 +30,88 @@ export async function recordReportForReview(db, {
   const action = (isNsfw && result.distinctReporterCount >= 2) ? 'AGE_RESTRICTED' : 'REVIEW';
   const moderatedAt = reportedAt || new Date().toISOString();
   const categories = isNsfw ? ['adult'] : [];
+  let moderationResultRecorded = false;
+  let moderationResultError = null;
 
-  await db.prepare(`
-    INSERT INTO moderation_results (
-      sha256, action, provider, scores, categories, raw_response, moderated_at, reviewed_by, reviewed_at, review_notes, uploaded_by
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    ON CONFLICT(sha256) DO UPDATE SET
-      action = CASE
-        WHEN moderation_results.reviewed_by IS NOT NULL THEN moderation_results.action
-        WHEN moderation_results.action = 'PERMANENT_BAN' THEN moderation_results.action
-        WHEN excluded.action = 'AGE_RESTRICTED' AND moderation_results.action IN ('SAFE', 'REVIEW') THEN excluded.action
-        WHEN excluded.action = 'REVIEW' AND moderation_results.action = 'SAFE' THEN excluded.action
-        ELSE moderation_results.action
-      END,
-      provider = CASE
-        WHEN moderation_results.reviewed_by IS NOT NULL THEN moderation_results.provider
-        ELSE excluded.provider
-      END,
-      categories = CASE
-        WHEN moderation_results.reviewed_by IS NOT NULL THEN moderation_results.categories
-        ELSE excluded.categories
-      END,
-      moderated_at = CASE
-        WHEN moderation_results.reviewed_by IS NOT NULL THEN moderation_results.moderated_at
-        ELSE excluded.moderated_at
-      END,
-      uploaded_by = CASE
-        WHEN moderation_results.uploaded_by IS NULL THEN excluded.uploaded_by
-        ELSE moderation_results.uploaded_by
-      END
-  `).bind(
-    sha256,
-    action,
-    'user-report',
-    JSON.stringify({}),
-    JSON.stringify(categories),
-    JSON.stringify({
-      source,
-      reportType,
-      reportedBy: reporterPubkey,
-      distinctReporterCount: result.distinctReporterCount,
-      reason,
-      reportEventId,
-      targetEventId,
-    }),
-    moderatedAt,
-    null,
-    null,
-    null,
-    uploadedBy,
-  ).run();
+  try {
+    await db.prepare(`
+      INSERT INTO moderation_results (
+        sha256, action, provider, scores, categories, raw_response, moderated_at, reviewed_by, reviewed_at, review_notes, uploaded_by
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(sha256) DO UPDATE SET
+        action = CASE
+          WHEN moderation_results.reviewed_by IS NOT NULL THEN moderation_results.action
+          WHEN moderation_results.action = 'PERMANENT_BAN' THEN moderation_results.action
+          WHEN excluded.action = 'AGE_RESTRICTED' AND moderation_results.action IN ('SAFE', 'REVIEW') THEN excluded.action
+          WHEN excluded.action = 'REVIEW' AND moderation_results.action = 'SAFE' THEN excluded.action
+          ELSE moderation_results.action
+        END,
+        provider = CASE
+          WHEN moderation_results.reviewed_by IS NOT NULL THEN moderation_results.provider
+          ELSE excluded.provider
+        END,
+        categories = CASE
+          WHEN moderation_results.reviewed_by IS NOT NULL THEN moderation_results.categories
+          ELSE excluded.categories
+        END,
+        moderated_at = CASE
+          WHEN moderation_results.reviewed_by IS NOT NULL THEN moderation_results.moderated_at
+          ELSE excluded.moderated_at
+        END,
+        uploaded_by = CASE
+          WHEN moderation_results.uploaded_by IS NULL THEN excluded.uploaded_by
+          ELSE moderation_results.uploaded_by
+        END
+    `).bind(
+      sha256,
+      action,
+      'user-report',
+      JSON.stringify({}),
+      JSON.stringify(categories),
+      JSON.stringify({
+        source,
+        reportType,
+        reportedBy: reporterPubkey,
+        distinctReporterCount: result.distinctReporterCount,
+        reason,
+        reportEventId,
+        targetEventId,
+      }),
+      moderatedAt,
+      null,
+      null,
+      null,
+      uploadedBy,
+    ).run();
+    moderationResultRecorded = true;
+  } catch (error) {
+    moderationResultError = error?.message || String(error);
+    console.error(`[REPORT_REVIEW] Failed to write moderation row for reported ${sha256}:`, moderationResultError);
+  }
 
   let aiTelemetryRecorded = false;
+  let aiTelemetryError = null;
   if (isAiReportType(reportType)) {
-    await recordAIDetectionEvent(db, buildAIReportEvent({
-      sha256,
-      reportType,
-      createdAt: moderatedAt,
-    }));
-    aiTelemetryRecorded = true;
+    try {
+      await recordAIDetectionEvent(db, buildAIReportEvent({
+        sha256,
+        reportType,
+        createdAt: moderatedAt,
+      }));
+      aiTelemetryRecorded = true;
+    } catch (error) {
+      aiTelemetryError = error?.message || String(error);
+      console.error(`[REPORT_REVIEW] Failed to record AI report event for ${sha256}:`, aiTelemetryError);
+    }
   }
 
   return {
     success: true,
     ...result,
     action,
+    moderationResultRecorded,
+    moderationResultError,
     aiTelemetryRecorded,
+    aiTelemetryError,
   };
 }

--- a/src/moderation/report-review.mjs
+++ b/src/moderation/report-review.mjs
@@ -17,6 +17,7 @@ export async function recordReportForReview(db, {
   reportEventId = null,
   targetEventId = null,
   uploadedBy = null,
+  allowAutoAgeRestrict = source === 'user-report',
 } = {}) {
   const result = await addReport(db, {
     sha256,
@@ -27,7 +28,7 @@ export async function recordReportForReview(db, {
   });
 
   const isNsfw = isNsfwReportType(reportType);
-  const action = (isNsfw && result.distinctReporterCount >= 2) ? 'AGE_RESTRICTED' : 'REVIEW';
+  const action = (allowAutoAgeRestrict && isNsfw && result.distinctReporterCount >= 2) ? 'AGE_RESTRICTED' : 'REVIEW';
   const moderatedAt = reportedAt || new Date().toISOString();
   const categories = isNsfw ? ['adult'] : [];
   let moderationResultRecorded = false;

--- a/src/moderation/report-review.test.mjs
+++ b/src/moderation/report-review.test.mjs
@@ -112,7 +112,24 @@ describe('recordReportForReview', () => {
     });
   });
 
-  it('writes AGE_RESTRICTED and adult category for the second distinct NSFW report', async () => {
+  it('writes AGE_RESTRICTED and adult category for the second distinct authenticated NSFW report', async () => {
+    const moderationWrites = [];
+    const db = createDbMock({ moderationWrites, reporterCount: 2 });
+
+    const result = await recordReportForReview(db, {
+      sha256: SHA,
+      reporterPubkey: REPORTER,
+      reportType: 'nudity',
+      source: 'user-report',
+    });
+
+    expect(result.action).toBe('AGE_RESTRICTED');
+    expect(moderationWrites).toHaveLength(1);
+    expect(moderationWrites[0].bindings[1]).toBe('AGE_RESTRICTED');
+    expect(JSON.parse(moderationWrites[0].bindings[4])).toEqual(['adult']);
+  });
+
+  it('keeps relay-origin NSFW reports in REVIEW even with multiple distinct reporters', async () => {
     const moderationWrites = [];
     const db = createDbMock({ moderationWrites, reporterCount: 2 });
 
@@ -123,9 +140,10 @@ describe('recordReportForReview', () => {
       source: 'relay-report',
     });
 
-    expect(result.action).toBe('AGE_RESTRICTED');
+    expect(result.action).toBe('REVIEW');
+    expect(result.distinctReporterCount).toBe(2);
     expect(moderationWrites).toHaveLength(1);
-    expect(moderationWrites[0].bindings[1]).toBe('AGE_RESTRICTED');
+    expect(moderationWrites[0].bindings[1]).toBe('REVIEW');
     expect(JSON.parse(moderationWrites[0].bindings[4])).toEqual(['adult']);
   });
 

--- a/src/moderation/report-review.test.mjs
+++ b/src/moderation/report-review.test.mjs
@@ -10,7 +10,14 @@ import { recordReportForReview } from './report-review.mjs';
 const SHA = 'a'.repeat(64);
 const REPORTER = 'b'.repeat(64);
 
-function createDbMock({ reporterCount = 1, moderationWrites = [], userReportWrites = [], aiDetectionEvents = [] } = {}) {
+function createDbMock({
+  reporterCount = 1,
+  moderationWrites = [],
+  userReportWrites = [],
+  aiDetectionEvents = [],
+  failModerationWrite = false,
+  failAiTelemetryWrite = false,
+} = {}) {
   return {
     prepare(sql) {
       let bindings = [];
@@ -24,9 +31,15 @@ function createDbMock({ reporterCount = 1, moderationWrites = [], userReportWrit
             userReportWrites.push({ sql, bindings: [...bindings] });
           }
           if (/INSERT INTO moderation_results/i.test(sql)) {
+            if (failModerationWrite) {
+              throw new Error('moderation write failed');
+            }
             moderationWrites.push({ sql, bindings: [...bindings] });
           }
           if (/INSERT OR IGNORE INTO ai_detection_events/i.test(sql)) {
+            if (failAiTelemetryWrite) {
+              throw new Error('ai telemetry write failed');
+            }
             aiDetectionEvents.push({
               event_key: bindings[0],
               sha256: bindings[1],
@@ -138,5 +151,43 @@ describe('recordReportForReview', () => {
       ai_detection_forced: 1,
       report_type: 'ai_generated',
     });
+  });
+
+  it('returns success with non-fatal moderation write failure details after addReport succeeds', async () => {
+    const userReportWrites = [];
+    const db = createDbMock({ userReportWrites, failModerationWrite: true });
+
+    await expect(recordReportForReview(db, {
+      sha256: SHA,
+      reporterPubkey: REPORTER,
+      reportType: 'violence',
+      source: 'user-report',
+    })).resolves.toMatchObject({
+      success: true,
+      action: 'REVIEW',
+      distinctReporterCount: 1,
+      moderationResultRecorded: false,
+      moderationResultError: 'moderation write failed',
+    });
+    expect(userReportWrites).toHaveLength(1);
+  });
+
+  it('returns success and aiTelemetryRecorded false when AI telemetry write fails', async () => {
+    const aiDetectionEvents = [];
+    const db = createDbMock({ aiDetectionEvents, failAiTelemetryWrite: true });
+
+    await expect(recordReportForReview(db, {
+      sha256: SHA,
+      reporterPubkey: REPORTER,
+      reportType: 'ai_generated',
+      source: 'user-report',
+    })).resolves.toMatchObject({
+      success: true,
+      action: 'REVIEW',
+      distinctReporterCount: 1,
+      aiTelemetryRecorded: false,
+      aiTelemetryError: 'ai telemetry write failed',
+    });
+    expect(aiDetectionEvents).toHaveLength(0);
   });
 });

--- a/src/moderation/report-review.test.mjs
+++ b/src/moderation/report-review.test.mjs
@@ -1,0 +1,142 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Tests shared user-report recording into D1 review rows
+// ABOUTME: Ensures HTTP and relay report ingestion use identical moderation policy
+
+import { describe, expect, it } from 'vitest';
+import { recordReportForReview } from './report-review.mjs';
+
+const SHA = 'a'.repeat(64);
+const REPORTER = 'b'.repeat(64);
+
+function createDbMock({ reporterCount = 1, moderationWrites = [], userReportWrites = [], aiDetectionEvents = [] } = {}) {
+  return {
+    prepare(sql) {
+      let bindings = [];
+      return {
+        bind(...args) {
+          bindings = args;
+          return this;
+        },
+        async run() {
+          if (/INSERT OR IGNORE INTO user_reports/i.test(sql)) {
+            userReportWrites.push({ sql, bindings: [...bindings] });
+          }
+          if (/INSERT INTO moderation_results/i.test(sql)) {
+            moderationWrites.push({ sql, bindings: [...bindings] });
+          }
+          if (/INSERT OR IGNORE INTO ai_detection_events/i.test(sql)) {
+            aiDetectionEvents.push({
+              event_key: bindings[0],
+              sha256: bindings[1],
+              event_type: bindings[2],
+              policy_reason: bindings[3],
+              ai_detection_forced: bindings[6],
+              report_type: bindings[9],
+            });
+          }
+          return { success: true };
+        },
+        async first() {
+          if (/COUNT\(DISTINCT reporter_pubkey\)/i.test(sql)) {
+            return { cnt: reporterCount };
+          }
+          return null;
+        },
+      };
+    },
+  };
+}
+
+describe('recordReportForReview', () => {
+  it('writes REVIEW for a single non-NSFW report with report metadata and uploader', async () => {
+    const moderationWrites = [];
+    const userReportWrites = [];
+    const db = createDbMock({ moderationWrites, userReportWrites });
+
+    const result = await recordReportForReview(db, {
+      sha256: SHA,
+      reporterPubkey: REPORTER,
+      reportType: 'violence',
+      reason: 'reported from relay',
+      source: 'relay-report',
+      reportedAt: '2026-05-13T17:19:42.000Z',
+      reportEventId: 'c'.repeat(64),
+      targetEventId: 'd'.repeat(64),
+      uploadedBy: 'e'.repeat(64),
+    });
+
+    expect(result).toMatchObject({
+      success: true,
+      action: 'REVIEW',
+      distinctReporterCount: 1,
+      aiTelemetryRecorded: false,
+    });
+    expect(userReportWrites).toHaveLength(1);
+    expect(userReportWrites[0].bindings).toEqual([
+      SHA,
+      REPORTER,
+      'violence',
+      'reported from relay',
+      '2026-05-13T17:19:42.000Z',
+    ]);
+    expect(moderationWrites).toHaveLength(1);
+    expect(moderationWrites[0].sql).toMatch(/uploaded_by = CASE/i);
+    expect(moderationWrites[0].sql).toMatch(/moderation_results\.uploaded_by IS NULL/i);
+    expect(moderationWrites[0].bindings[0]).toBe(SHA);
+    expect(moderationWrites[0].bindings[1]).toBe('REVIEW');
+    expect(moderationWrites[0].bindings[2]).toBe('user-report');
+    expect(moderationWrites[0].bindings[10]).toBe('e'.repeat(64));
+    expect(JSON.parse(moderationWrites[0].bindings[5])).toMatchObject({
+      source: 'relay-report',
+      reportType: 'violence',
+      reportedBy: REPORTER,
+      distinctReporterCount: 1,
+      reason: 'reported from relay',
+      reportEventId: 'c'.repeat(64),
+      targetEventId: 'd'.repeat(64),
+    });
+  });
+
+  it('writes AGE_RESTRICTED and adult category for the second distinct NSFW report', async () => {
+    const moderationWrites = [];
+    const db = createDbMock({ moderationWrites, reporterCount: 2 });
+
+    const result = await recordReportForReview(db, {
+      sha256: SHA,
+      reporterPubkey: REPORTER,
+      reportType: 'nudity',
+      source: 'relay-report',
+    });
+
+    expect(result.action).toBe('AGE_RESTRICTED');
+    expect(moderationWrites).toHaveLength(1);
+    expect(moderationWrites[0].bindings[1]).toBe('AGE_RESTRICTED');
+    expect(JSON.parse(moderationWrites[0].bindings[4])).toEqual(['adult']);
+  });
+
+  it('records AI telemetry for AI report types', async () => {
+    const moderationWrites = [];
+    const aiDetectionEvents = [];
+    const db = createDbMock({ moderationWrites, aiDetectionEvents });
+
+    const result = await recordReportForReview(db, {
+      sha256: SHA,
+      reporterPubkey: REPORTER,
+      reportType: 'ai_generated',
+      source: 'relay-report',
+      reportedAt: '2026-05-13T17:19:42.000Z',
+    });
+
+    expect(result.aiTelemetryRecorded).toBe(true);
+    expect(aiDetectionEvents).toHaveLength(1);
+    expect(aiDetectionEvents[0]).toMatchObject({
+      sha256: SHA,
+      event_type: 'user_report',
+      policy_reason: 'report_forced_ai_detection',
+      ai_detection_forced: 1,
+      report_type: 'ai_generated',
+    });
+  });
+});

--- a/src/nostr/report-poller.mjs
+++ b/src/nostr/report-poller.mjs
@@ -8,6 +8,8 @@ import { extractMediaShaFromEvent, getEventTagValue } from '../validation.mjs';
 
 const VIDEO_KINDS = new Set([34235, 34236]);
 const PROCESSED_PREFIX = 'report-poller:processed:';
+const TERMINAL_SKIP_TTL_SECONDS = 60 * 60 * 24 * 90;
+const RECORDED_TTL_SECONDS = 60 * 60 * 24 * 180;
 
 export const REPORT_CHECKPOINT_KEY = 'report-poller:last-poll';
 
@@ -69,4 +71,92 @@ export function shouldAcceptReportTarget(targetEvent) {
 
 export function processedReportKey(reportEventId) {
   return `${PROCESSED_PREFIX}${reportEventId}`;
+}
+
+async function markProcessed(kv, key, payload, expirationTtl) {
+  await kv.put(key, JSON.stringify({
+    ...payload,
+    processedAt: new Date().toISOString(),
+  }), { expirationTtl });
+}
+
+export async function processReportEvent(reportEvent, {
+  kv,
+  requireDivineClient = true,
+  fetchTargetEvent,
+  recordReport,
+} = {}) {
+  if (!reportEvent?.id || !/^[0-9a-f]{64}$/i.test(reportEvent.id)) {
+    return { status: 'skipped_invalid_report_id' };
+  }
+
+  const reportEventId = reportEvent.id.toLowerCase();
+  const processedKey = processedReportKey(reportEventId);
+  const alreadyProcessed = await kv.get(processedKey);
+  if (alreadyProcessed) {
+    return { status: 'already_processed' };
+  }
+
+  if (requireDivineClient && !isDivineClientReport(reportEvent)) {
+    await markProcessed(kv, processedKey, {
+      status: 'skipped_non_divine_client',
+    }, TERMINAL_SKIP_TTL_SECONDS);
+    return { status: 'skipped_non_divine_client' };
+  }
+
+  const targetEventId = extractReportTargetEventId(reportEvent);
+  if (!targetEventId) {
+    await markProcessed(kv, processedKey, {
+      status: 'skipped_missing_target',
+    }, TERMINAL_SKIP_TTL_SECONDS);
+    return { status: 'skipped_missing_target' };
+  }
+
+  const targetEvent = await fetchTargetEvent(targetEventId);
+  if (!targetEvent) {
+    return { status: 'target_unavailable', targetEventId };
+  }
+
+  if (!shouldAcceptReportTarget(targetEvent)) {
+    await markProcessed(kv, processedKey, {
+      status: 'skipped_non_video_target',
+      targetEventId,
+    }, TERMINAL_SKIP_TTL_SECONDS);
+    return { status: 'skipped_non_video_target', targetEventId };
+  }
+
+  const sha256 = extractMediaShaFromEvent(targetEvent);
+  const reportType = extractReportType(reportEvent);
+  const reportedAt = typeof reportEvent.created_at === 'number' && Number.isFinite(reportEvent.created_at)
+    ? new Date(reportEvent.created_at * 1000).toISOString()
+    : new Date().toISOString();
+
+  const recordResult = await recordReport({
+    sha256,
+    reporterPubkey: reportEvent.pubkey,
+    reportType,
+    reason: reportEvent.content || null,
+    source: 'relay-report',
+    reportedAt,
+    reportEventId,
+    targetEventId,
+    uploadedBy: targetEvent.pubkey || null,
+  });
+
+  await markProcessed(kv, processedKey, {
+    status: 'recorded',
+    sha256,
+    reportType,
+    targetEventId,
+    action: recordResult.action,
+  }, RECORDED_TTL_SECONDS);
+
+  return {
+    status: 'recorded',
+    sha256,
+    reportType,
+    targetEventId,
+    action: recordResult.action,
+    distinctReporterCount: recordResult.distinctReporterCount,
+  };
 }

--- a/src/nostr/report-poller.mjs
+++ b/src/nostr/report-poller.mjs
@@ -210,6 +210,7 @@ export async function pollRelayForReports(env, options = {}) {
     reports: [],
     maxTerminalCreatedAt: null,
     safeCheckpoint: null,
+    saturated: false,
   };
   const terminalCreatedAts = [];
   const retryableCreatedAts = [];
@@ -221,6 +222,9 @@ export async function pollRelayForReports(env, options = {}) {
     try {
       const reports = await fetchReports(relayUrl, { since, limit }, env);
       console.log(`[REPORT-POLLER] Fetched ${reports.length} reports from ${relayUrl}`);
+      if (reports.length >= limit) {
+        results.saturated = true;
+      }
 
       for (const report of reports) {
         results.totalReports++;
@@ -281,7 +285,7 @@ export async function pollRelayForReports(env, options = {}) {
   const earliestRetryableCreatedAt = retryableCreatedAts.length > 0
     ? Math.min(...retryableCreatedAts)
     : null;
-  const safeTerminalCreatedAts = hasUnboundedRetryableError
+  const safeTerminalCreatedAts = hasUnboundedRetryableError || results.saturated
     ? []
     : terminalCreatedAts.filter((createdAt) =>
       earliestRetryableCreatedAt === null || createdAt < earliestRetryableCreatedAt

--- a/src/nostr/report-poller.mjs
+++ b/src/nostr/report-poller.mjs
@@ -268,11 +268,26 @@ export async function pollRelayForReports(env, options = {}) {
               } else {
                 hasUnboundedRetryableError = true;
               }
+            } else if (outcome.status === 'review_record_failed') {
+              results.errors.push({
+                reportId: report?.id || null,
+                error: outcome.error || 'moderation result write failed',
+                status: outcome.status,
+              });
+              if (reportCreatedAt !== null) {
+                retryableCreatedAts.push(reportCreatedAt);
+              } else {
+                hasUnboundedRetryableError = true;
+              }
             } else {
               results.skipped++;
             }
 
-            if (outcome.status !== 'target_unavailable' && reportCreatedAt !== null) {
+            if (
+              outcome.status !== 'target_unavailable'
+              && outcome.status !== 'review_record_failed'
+              && reportCreatedAt !== null
+            ) {
               terminalCreatedAts.push(reportCreatedAt);
             }
           } catch (error) {
@@ -425,6 +440,16 @@ export async function processReportEvent(reportEvent, {
     targetEventId,
     uploadedBy: targetEvent.pubkey || null,
   });
+
+  if (recordResult?.moderationResultRecorded === false) {
+    return {
+      status: 'review_record_failed',
+      sha256,
+      reportType,
+      targetEventId,
+      error: recordResult.moderationResultError || 'moderation result write failed',
+    };
+  }
 
   await markProcessed(kv, processedKey, {
     status: 'recorded',

--- a/src/nostr/report-poller.mjs
+++ b/src/nostr/report-poller.mjs
@@ -75,7 +75,7 @@ export function processedReportKey(reportEventId) {
   return `${PROCESSED_PREFIX}${reportEventId}`;
 }
 
-export async function fetchReportsFromRelay(relayUrl, { since, limit }, env = {}) {
+export async function fetchReportsFromRelay(relayUrl, { since, until, limit }, env = {}) {
   return new Promise((resolve, reject) => {
     const reports = [];
     let ws;
@@ -112,7 +112,10 @@ export async function fetchReportsFromRelay(relayUrl, { since, limit }, env = {}
 
       ws.addEventListener('open', () => {
         const filter = { kinds: [1984], since, limit };
-        console.log(`[REPORT-POLLER] Sending REQ to ${relayUrl}: kinds=[1984], since=${since}, limit=${limit}`);
+        if (Number.isInteger(until)) {
+          filter.until = until;
+        }
+        console.log(`[REPORT-POLLER] Sending REQ to ${relayUrl}: kinds=[1984], since=${since}, until=${filter.until ?? '<none>'}, limit=${limit}`);
         ws.send(JSON.stringify(['REQ', subscriptionId, filter]));
       });
 
@@ -189,6 +192,7 @@ export async function pollRelayForReports(env, options = {}) {
   const {
     since = Math.floor(Date.now() / 1000) - 3600,
     limit = 100,
+    maxPages = parseInt(env.REPORT_POLLING_MAX_PAGES || '5', 10),
     relays = ['wss://relay.divine.video'],
     fetchReportsFromRelay: injectedFetchReportsFromRelay,
     fetchTargetEvent: injectedFetchTargetEvent,
@@ -214,63 +218,92 @@ export async function pollRelayForReports(env, options = {}) {
   };
   const terminalCreatedAts = [];
   const retryableCreatedAts = [];
+  const seenReportIds = new Set();
   let hasUnboundedRetryableError = false;
+  const pageLimit = Number.isFinite(maxPages) && maxPages > 0 ? Math.floor(maxPages) : 5;
 
   console.log(`[REPORT-POLLER] Starting poll from ${relays.join(', ')} since ${new Date(since * 1000).toISOString()}`);
 
   for (const relayUrl of relays) {
     try {
-      const reports = await fetchReports(relayUrl, { since, limit }, env);
-      console.log(`[REPORT-POLLER] Fetched ${reports.length} reports from ${relayUrl}`);
-      if (reports.length >= limit) {
-        results.saturated = true;
-      }
+      let until = null;
+      for (let page = 1; page <= pageLimit; page++) {
+        const query = Number.isInteger(until) ? { since, limit, until } : { since, limit };
+        const reports = await fetchReports(relayUrl, query, env);
+        console.log(`[REPORT-POLLER] Fetched ${reports.length} reports from ${relayUrl} page ${page}`);
 
-      for (const report of reports) {
-        results.totalReports++;
-        const reportCreatedAt = Number.isInteger(report?.created_at) && report.created_at > 0
-          ? report.created_at
-          : null;
+        for (const report of reports) {
+          const reportId = typeof report?.id === 'string' ? report.id.toLowerCase() : null;
+          if (reportId && seenReportIds.has(reportId)) {
+            continue;
+          }
+          if (reportId) {
+            seenReportIds.add(reportId);
+          }
 
-        try {
-          const outcome = await processReportEvent(report, {
-            kv: env.MODERATION_KV,
-            requireDivineClient,
-            fetchTargetEvent,
-            recordReport,
-          });
+          results.totalReports++;
+          const reportCreatedAt = Number.isInteger(report?.created_at) && report.created_at > 0
+            ? report.created_at
+            : null;
 
-          results.reports.push(outcome);
-          if (outcome.status === 'recorded') {
-            results.recorded++;
-          } else if (outcome.status === 'already_processed') {
-            results.alreadyProcessed++;
-          } else if (outcome.status === 'target_unavailable') {
-            results.targetUnavailable++;
+          try {
+            const outcome = await processReportEvent(report, {
+              kv: env.MODERATION_KV,
+              requireDivineClient,
+              fetchTargetEvent,
+              recordReport,
+            });
+
+            results.reports.push(outcome);
+            if (outcome.status === 'recorded') {
+              results.recorded++;
+            } else if (outcome.status === 'already_processed') {
+              results.alreadyProcessed++;
+            } else if (outcome.status === 'target_unavailable') {
+              results.targetUnavailable++;
+              if (reportCreatedAt !== null) {
+                retryableCreatedAts.push(reportCreatedAt);
+              } else {
+                hasUnboundedRetryableError = true;
+              }
+            } else {
+              results.skipped++;
+            }
+
+            if (outcome.status !== 'target_unavailable' && reportCreatedAt !== null) {
+              terminalCreatedAts.push(reportCreatedAt);
+            }
+          } catch (error) {
+            console.error(`[REPORT-POLLER] Failed to process report ${report?.id || '<missing-id>'}:`, error);
+            results.errors.push({
+              reportId: report?.id || null,
+              error: error?.message || String(error),
+            });
             if (reportCreatedAt !== null) {
               retryableCreatedAts.push(reportCreatedAt);
             } else {
               hasUnboundedRetryableError = true;
             }
-          } else {
-            results.skipped++;
-          }
-
-          if (outcome.status !== 'target_unavailable' && reportCreatedAt !== null) {
-            terminalCreatedAts.push(reportCreatedAt);
-          }
-        } catch (error) {
-          console.error(`[REPORT-POLLER] Failed to process report ${report?.id || '<missing-id>'}:`, error);
-          results.errors.push({
-            reportId: report?.id || null,
-            error: error?.message || String(error),
-          });
-          if (reportCreatedAt !== null) {
-            retryableCreatedAts.push(reportCreatedAt);
-          } else {
-            hasUnboundedRetryableError = true;
           }
         }
+
+        if (reports.length < limit) {
+          break;
+        }
+
+        if (page >= pageLimit) {
+          results.saturated = true;
+          break;
+        }
+
+        const createdAts = reports
+          .map((report) => report?.created_at)
+          .filter((createdAt) => Number.isInteger(createdAt) && createdAt > 0);
+        if (createdAts.length === 0) {
+          results.saturated = true;
+          break;
+        }
+        until = Math.min(...createdAts) - 1;
       }
     } catch (error) {
       console.error(`[REPORT-POLLER] Failed to poll ${relayUrl}:`, error);

--- a/src/nostr/report-poller.mjs
+++ b/src/nostr/report-poller.mjs
@@ -232,6 +232,7 @@ export async function pollRelayForReports(env, options = {}) {
         const reports = await fetchReports(relayUrl, query, env);
         console.log(`[REPORT-POLLER] Fetched ${reports.length} reports from ${relayUrl} page ${page}`);
 
+        let pageNewReportIds = 0;
         for (const report of reports) {
           const reportId = typeof report?.id === 'string' ? report.id.toLowerCase() : null;
           if (reportId && seenReportIds.has(reportId)) {
@@ -239,6 +240,7 @@ export async function pollRelayForReports(env, options = {}) {
           }
           if (reportId) {
             seenReportIds.add(reportId);
+            pageNewReportIds++;
           }
 
           results.totalReports++;
@@ -291,6 +293,11 @@ export async function pollRelayForReports(env, options = {}) {
           break;
         }
 
+        if (pageNewReportIds === 0) {
+          results.saturated = true;
+          break;
+        }
+
         if (page >= pageLimit) {
           results.saturated = true;
           break;
@@ -303,14 +310,7 @@ export async function pollRelayForReports(env, options = {}) {
           results.saturated = true;
           break;
         }
-        const minCreatedAt = Math.min(...createdAts);
-        const maxCreatedAt = Math.max(...createdAts);
-        const minCreatedAtCount = createdAts.filter((createdAt) => createdAt === minCreatedAt).length;
-        if (minCreatedAt === maxCreatedAt || minCreatedAtCount > 1) {
-          results.saturated = true;
-          break;
-        }
-        until = minCreatedAt - 1;
+        until = Math.min(...createdAts);
       }
     } catch (error) {
       console.error(`[REPORT-POLLER] Failed to poll ${relayUrl}:`, error);

--- a/src/nostr/report-poller.mjs
+++ b/src/nostr/report-poller.mjs
@@ -14,6 +14,7 @@ const TERMINAL_SKIP_TTL_SECONDS = 60 * 60 * 24 * 90;
 const RECORDED_TTL_SECONDS = 60 * 60 * 24 * 180;
 
 export const REPORT_CHECKPOINT_KEY = 'report-poller:last-poll';
+export const REPORT_LAST_RUN_KEY = 'report-poller:last-run';
 
 export function extractReportTargetEventId(reportEvent) {
   for (const tag of reportEvent?.tags || []) {
@@ -186,6 +187,42 @@ export async function setLastReportPollTimestamp(env, timestamp, stats = {}) {
   } catch (error) {
     console.error('[REPORT-POLLER] Failed to store last poll timestamp:', error);
   }
+}
+
+async function getReportLastRun(env) {
+  try {
+    const data = await env.MODERATION_KV.get(REPORT_LAST_RUN_KEY);
+    return data ? JSON.parse(data) : null;
+  } catch (error) {
+    console.error('[REPORT-POLLER] Failed to get last report poll run:', error);
+    return null;
+  }
+}
+
+export async function getReportPollingStatus(env) {
+  const enabled = env.REPORT_POLLING_ENABLED !== 'false';
+  const lastRun = await getReportLastRun(env);
+
+  try {
+    const data = await env.MODERATION_KV.get(REPORT_CHECKPOINT_KEY);
+    if (data) {
+      return {
+        enabled,
+        ...JSON.parse(data),
+        ...(lastRun ? { lastRun } : {}),
+      };
+    }
+  } catch (error) {
+    console.error('[REPORT-POLLER] Failed to get report polling status:', error);
+  }
+
+  return {
+    enabled,
+    timestamp: null,
+    lastPollAt: null,
+    message: 'No report polls completed yet',
+    ...(lastRun ? { lastRun } : {}),
+  };
 }
 
 export async function pollRelayForReports(env, options = {}) {

--- a/src/nostr/report-poller.mjs
+++ b/src/nostr/report-poller.mjs
@@ -208,7 +208,12 @@ export async function pollRelayForReports(env, options = {}) {
     targetUnavailable: 0,
     errors: [],
     reports: [],
+    maxTerminalCreatedAt: null,
+    safeCheckpoint: null,
   };
+  const terminalCreatedAts = [];
+  const retryableCreatedAts = [];
+  let hasUnboundedRetryableError = false;
 
   console.log(`[REPORT-POLLER] Starting poll from ${relays.join(', ')} since ${new Date(since * 1000).toISOString()}`);
 
@@ -219,6 +224,9 @@ export async function pollRelayForReports(env, options = {}) {
 
       for (const report of reports) {
         results.totalReports++;
+        const reportCreatedAt = Number.isInteger(report?.created_at) && report.created_at > 0
+          ? report.created_at
+          : null;
 
         try {
           const outcome = await processReportEvent(report, {
@@ -235,8 +243,17 @@ export async function pollRelayForReports(env, options = {}) {
             results.alreadyProcessed++;
           } else if (outcome.status === 'target_unavailable') {
             results.targetUnavailable++;
+            if (reportCreatedAt !== null) {
+              retryableCreatedAts.push(reportCreatedAt);
+            } else {
+              hasUnboundedRetryableError = true;
+            }
           } else {
             results.skipped++;
+          }
+
+          if (outcome.status !== 'target_unavailable' && reportCreatedAt !== null) {
+            terminalCreatedAts.push(reportCreatedAt);
           }
         } catch (error) {
           console.error(`[REPORT-POLLER] Failed to process report ${report?.id || '<missing-id>'}:`, error);
@@ -244,6 +261,11 @@ export async function pollRelayForReports(env, options = {}) {
             reportId: report?.id || null,
             error: error?.message || String(error),
           });
+          if (reportCreatedAt !== null) {
+            retryableCreatedAts.push(reportCreatedAt);
+          } else {
+            hasUnboundedRetryableError = true;
+          }
         }
       }
     } catch (error) {
@@ -252,7 +274,22 @@ export async function pollRelayForReports(env, options = {}) {
         relay: relayUrl,
         error: error?.message || String(error),
       });
+      hasUnboundedRetryableError = true;
     }
+  }
+
+  const earliestRetryableCreatedAt = retryableCreatedAts.length > 0
+    ? Math.min(...retryableCreatedAts)
+    : null;
+  const safeTerminalCreatedAts = hasUnboundedRetryableError
+    ? []
+    : terminalCreatedAts.filter((createdAt) =>
+      earliestRetryableCreatedAt === null || createdAt < earliestRetryableCreatedAt
+    );
+
+  if (safeTerminalCreatedAts.length > 0) {
+    results.maxTerminalCreatedAt = Math.max(...safeTerminalCreatedAts);
+    results.safeCheckpoint = results.maxTerminalCreatedAt;
   }
 
   console.log(`[REPORT-POLLER] Poll complete: ${results.totalReports} reports, ${results.recorded} recorded, ${results.skipped} skipped`);

--- a/src/nostr/report-poller.mjs
+++ b/src/nostr/report-poller.mjs
@@ -189,7 +189,7 @@ export async function setLastReportPollTimestamp(env, timestamp, stats = {}) {
   }
 }
 
-async function getReportLastRun(env) {
+export async function getReportLastRun(env) {
   try {
     const data = await env.MODERATION_KV.get(REPORT_LAST_RUN_KEY);
     return data ? JSON.parse(data) : null;
@@ -228,6 +228,7 @@ export async function getReportPollingStatus(env) {
 export async function pollRelayForReports(env, options = {}) {
   const {
     since = Math.floor(Date.now() / 1000) - 3600,
+    until: initialUntil = null,
     limit = 100,
     maxPages = parseInt(env.REPORT_POLLING_MAX_PAGES || '5', 10),
     relays = ['wss://relay.divine.video'],
@@ -252,22 +253,27 @@ export async function pollRelayForReports(env, options = {}) {
     maxTerminalCreatedAt: null,
     safeCheckpoint: null,
     saturated: false,
+    resumeUntil: null,
   };
   const terminalCreatedAts = [];
   const retryableCreatedAts = [];
   const seenReportIds = new Set();
   let hasUnboundedRetryableError = false;
   const pageLimit = Number.isFinite(maxPages) && maxPages > 0 ? Math.floor(maxPages) : 5;
+  const startUntil = Number.isInteger(initialUntil) && initialUntil > 0 ? initialUntil : null;
 
   console.log(`[REPORT-POLLER] Starting poll from ${relays.join(', ')} since ${new Date(since * 1000).toISOString()}`);
 
   for (const relayUrl of relays) {
     try {
-      let until = null;
+      let until = startUntil;
       for (let page = 1; page <= pageLimit; page++) {
         const query = Number.isInteger(until) ? { since, limit, until } : { since, limit };
         const reports = await fetchReports(relayUrl, query, env);
         console.log(`[REPORT-POLLER] Fetched ${reports.length} reports from ${relayUrl} page ${page}`);
+        const createdAts = reports
+          .map((report) => report?.created_at)
+          .filter((createdAt) => Number.isInteger(createdAt) && createdAt > 0);
 
         let pageNewReportIds = 0;
         for (const report of reports) {
@@ -347,17 +353,16 @@ export async function pollRelayForReports(env, options = {}) {
 
         if (pageNewReportIds === 0) {
           results.saturated = true;
+          results.resumeUntil = resumeUntilFromPage(until, createdAts, true);
           break;
         }
 
         if (page >= pageLimit) {
           results.saturated = true;
+          results.resumeUntil = resumeUntilFromPage(until, createdAts, false);
           break;
         }
 
-        const createdAts = reports
-          .map((report) => report?.created_at)
-          .filter((createdAt) => Number.isInteger(createdAt) && createdAt > 0);
         if (createdAts.length === 0) {
           results.saturated = true;
           break;
@@ -391,6 +396,19 @@ export async function pollRelayForReports(env, options = {}) {
   console.log(`[REPORT-POLLER] Poll complete: ${results.totalReports} reports, ${results.recorded} recorded, ${results.skipped} skipped`);
 
   return results;
+}
+
+function resumeUntilFromPage(currentUntil, createdAts, duplicateOnlyPage) {
+  if (createdAts.length === 0) {
+    return null;
+  }
+
+  const minCreatedAt = Math.min(...createdAts);
+  if (duplicateOnlyPage && Number.isInteger(currentUntil) && minCreatedAt >= currentUntil) {
+    return currentUntil;
+  }
+
+  return minCreatedAt;
 }
 
 async function markProcessed(kv, key, payload, expirationTtl) {

--- a/src/nostr/report-poller.mjs
+++ b/src/nostr/report-poller.mjs
@@ -303,7 +303,14 @@ export async function pollRelayForReports(env, options = {}) {
           results.saturated = true;
           break;
         }
-        until = Math.min(...createdAts) - 1;
+        const minCreatedAt = Math.min(...createdAts);
+        const maxCreatedAt = Math.max(...createdAts);
+        const minCreatedAtCount = createdAts.filter((createdAt) => createdAt === minCreatedAt).length;
+        if (minCreatedAt === maxCreatedAt || minCreatedAtCount > 1) {
+          results.saturated = true;
+          break;
+        }
+        until = minCreatedAt - 1;
       }
     } catch (error) {
       console.error(`[REPORT-POLLER] Failed to poll ${relayUrl}:`, error);

--- a/src/nostr/report-poller.mjs
+++ b/src/nostr/report-poller.mjs
@@ -132,6 +132,14 @@ export async function fetchReportsFromRelay(relayUrl, { since, limit }, env = {}
             finish(reports);
           }
 
+          if (data[0] === 'CLOSED' && data[1] === subscriptionId) {
+            const reason = typeof data[2] === 'string' && data[2] ? data[2] : 'unknown reason';
+            try {
+              ws.close();
+            } catch {}
+            finish(new Error(`Relay closed subscription ${subscriptionId}: ${reason}`));
+          }
+
           if (data[0] === 'NOTICE') {
             console.log(`[REPORT-POLLER] Relay notice: ${data[1]}`);
           }
@@ -274,6 +282,21 @@ export async function processReportEvent(reportEvent, {
   const alreadyProcessed = await kv.get(processedKey);
   if (alreadyProcessed) {
     return { status: 'already_processed' };
+  }
+
+  if (reportEvent.kind !== 1984) {
+    await markProcessed(kv, processedKey, {
+      status: 'skipped_non_report_kind',
+      kind: reportEvent.kind ?? null,
+    }, TERMINAL_SKIP_TTL_SECONDS);
+    return { status: 'skipped_non_report_kind' };
+  }
+
+  if (!reportEvent.pubkey || !/^[0-9a-f]{64}$/i.test(reportEvent.pubkey)) {
+    await markProcessed(kv, processedKey, {
+      status: 'skipped_invalid_reporter_pubkey',
+    }, TERMINAL_SKIP_TTL_SECONDS);
+    return { status: 'skipped_invalid_reporter_pubkey' };
   }
 
   if (requireDivineClient && !isDivineClientReport(reportEvent)) {

--- a/src/nostr/report-poller.mjs
+++ b/src/nostr/report-poller.mjs
@@ -1,0 +1,72 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Inbound NIP-56 report poller for relay.divine.video
+// ABOUTME: Converts kind 1984 relay reports into moderation review records
+
+import { extractMediaShaFromEvent, getEventTagValue } from '../validation.mjs';
+
+const VIDEO_KINDS = new Set([34235, 34236]);
+const PROCESSED_PREFIX = 'report-poller:processed:';
+
+export const REPORT_CHECKPOINT_KEY = 'report-poller:last-poll';
+
+export function extractReportTargetEventId(reportEvent) {
+  for (const tag of reportEvent?.tags || []) {
+    if (tag[0] === 'e' && typeof tag[1] === 'string' && /^[0-9a-f]{64}$/i.test(tag[1])) {
+      return tag[1].toLowerCase();
+    }
+  }
+  return null;
+}
+
+function normalizeReportType(value) {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const normalized = value.trim().toLowerCase().replace(/\s+/g, '_').replace(/-/g, '_');
+  if (!normalized) {
+    return null;
+  }
+
+  if (
+    normalized === 'aigenerated'
+    || normalized === 'ai_generated'
+    || normalized === 'ns_aigenerated'
+    || normalized === 'aigenerated_content'
+    || normalized === 'ai_generated_content'
+  ) {
+    return 'ai_generated';
+  }
+
+  return normalized;
+}
+
+export function extractReportType(reportEvent) {
+  const tags = reportEvent?.tags || [];
+  const eMarker = tags.find((tag) => tag[0] === 'e' && tag[2])?.[2];
+  const pMarker = tags.find((tag) => tag[0] === 'p' && tag[2])?.[2];
+  const label = tags.find((tag) => tag[0] === 'l' && tag[1])?.[1];
+  const content = typeof reportEvent?.content === 'string' ? reportEvent.content : '';
+  const reasonMatch = content.match(/^Reason:\s*([^\n\r]+)/im);
+
+  return normalizeReportType(label)
+    || normalizeReportType(reasonMatch?.[1])
+    || normalizeReportType(eMarker)
+    || normalizeReportType(pMarker)
+    || 'other';
+}
+
+export function isDivineClientReport(reportEvent) {
+  const client = getEventTagValue(reportEvent?.tags || [], 'client');
+  return typeof client === 'string' && client.toLowerCase() === 'divine';
+}
+
+export function shouldAcceptReportTarget(targetEvent) {
+  return VIDEO_KINDS.has(targetEvent?.kind) && Boolean(extractMediaShaFromEvent(targetEvent));
+}
+
+export function processedReportKey(reportEventId) {
+  return `${PROCESSED_PREFIX}${reportEventId}`;
+}

--- a/src/nostr/report-poller.mjs
+++ b/src/nostr/report-poller.mjs
@@ -5,6 +5,8 @@
 // ABOUTME: Converts kind 1984 relay reports into moderation review records
 
 import { extractMediaShaFromEvent, getEventTagValue } from '../validation.mjs';
+import { recordReportForReview } from '../moderation/report-review.mjs';
+import { fetchNostrEventById } from './relay-client.mjs';
 
 const VIDEO_KINDS = new Set([34235, 34236]);
 const PROCESSED_PREFIX = 'report-poller:processed:';
@@ -71,6 +73,183 @@ export function shouldAcceptReportTarget(targetEvent) {
 
 export function processedReportKey(reportEventId) {
   return `${PROCESSED_PREFIX}${reportEventId}`;
+}
+
+export async function fetchReportsFromRelay(relayUrl, { since, limit }, env = {}) {
+  return new Promise((resolve, reject) => {
+    const reports = [];
+    let ws;
+    let settled = false;
+    const timeout = setTimeout(() => {
+      try {
+        if (ws) ws.close();
+      } catch {}
+      finish(reports);
+    }, 30000);
+
+    function finish(resultOrError) {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+
+      if (resultOrError instanceof Error) {
+        reject(resultOrError);
+        return;
+      }
+
+      resolve(resultOrError);
+    }
+
+    try {
+      if (env.CF_ACCESS_CLIENT_ID && env.CF_ACCESS_CLIENT_SECRET) {
+        console.log(`[REPORT-POLLER] Connecting to ${relayUrl} with CF Access credentials`);
+      }
+
+      ws = new WebSocket(relayUrl);
+      const subscriptionId = `report-poll-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+      ws.addEventListener('open', () => {
+        const filter = { kinds: [1984], since, limit };
+        console.log(`[REPORT-POLLER] Sending REQ to ${relayUrl}: kinds=[1984], since=${since}, limit=${limit}`);
+        ws.send(JSON.stringify(['REQ', subscriptionId, filter]));
+      });
+
+      ws.addEventListener('message', (msg) => {
+        try {
+          const data = JSON.parse(msg.data);
+
+          if (data[0] === 'EVENT' && data[1] === subscriptionId) {
+            reports.push(data[2]);
+          }
+
+          if (data[0] === 'EOSE' && data[1] === subscriptionId) {
+            try {
+              ws.send(JSON.stringify(['CLOSE', subscriptionId]));
+              ws.close();
+            } catch {}
+            finish(reports);
+          }
+
+          if (data[0] === 'NOTICE') {
+            console.log(`[REPORT-POLLER] Relay notice: ${data[1]}`);
+          }
+        } catch (error) {
+          console.error('[REPORT-POLLER] Failed to parse relay message:', error);
+        }
+      });
+
+      ws.addEventListener('error', (error) => {
+        finish(new Error(`WebSocket error: ${error.message || 'Unknown error'}`));
+      });
+
+      ws.addEventListener('close', () => {
+        finish(reports);
+      });
+    } catch (error) {
+      finish(error instanceof Error ? error : new Error('WebSocket setup failed'));
+    }
+  });
+}
+
+export async function getLastReportPollTimestamp(env) {
+  try {
+    const data = await env.MODERATION_KV.get(REPORT_CHECKPOINT_KEY);
+    if (data) {
+      return JSON.parse(data).timestamp;
+    }
+  } catch (error) {
+    console.error('[REPORT-POLLER] Failed to get last poll timestamp:', error);
+  }
+  return null;
+}
+
+export async function setLastReportPollTimestamp(env, timestamp, stats = {}) {
+  try {
+    await env.MODERATION_KV.put(REPORT_CHECKPOINT_KEY, JSON.stringify({
+      timestamp,
+      lastPollAt: new Date().toISOString(),
+      ...stats,
+    }));
+  } catch (error) {
+    console.error('[REPORT-POLLER] Failed to store last poll timestamp:', error);
+  }
+}
+
+export async function pollRelayForReports(env, options = {}) {
+  const {
+    since = Math.floor(Date.now() / 1000) - 3600,
+    limit = 100,
+    relays = ['wss://relay.divine.video'],
+    fetchReportsFromRelay: injectedFetchReportsFromRelay,
+    fetchTargetEvent: injectedFetchTargetEvent,
+    recordReport: injectedRecordReport,
+  } = options;
+
+  const fetchReports = injectedFetchReportsFromRelay || fetchReportsFromRelay;
+  const fetchTargetEvent = injectedFetchTargetEvent || ((eventId) => fetchNostrEventById(eventId, relays, env));
+  const recordReport = injectedRecordReport || ((payload) => recordReportForReview(env.BLOSSOM_DB, payload));
+  const requireDivineClient = env.RELAY_REPORTS_REQUIRE_DIVINE_CLIENT !== 'false';
+
+  const results = {
+    totalReports: 0,
+    recorded: 0,
+    alreadyProcessed: 0,
+    skipped: 0,
+    targetUnavailable: 0,
+    errors: [],
+    reports: [],
+  };
+
+  console.log(`[REPORT-POLLER] Starting poll from ${relays.join(', ')} since ${new Date(since * 1000).toISOString()}`);
+
+  for (const relayUrl of relays) {
+    try {
+      const reports = await fetchReports(relayUrl, { since, limit }, env);
+      console.log(`[REPORT-POLLER] Fetched ${reports.length} reports from ${relayUrl}`);
+
+      for (const report of reports) {
+        results.totalReports++;
+
+        try {
+          const outcome = await processReportEvent(report, {
+            kv: env.MODERATION_KV,
+            requireDivineClient,
+            fetchTargetEvent,
+            recordReport,
+          });
+
+          results.reports.push(outcome);
+          if (outcome.status === 'recorded') {
+            results.recorded++;
+          } else if (outcome.status === 'already_processed') {
+            results.alreadyProcessed++;
+          } else if (outcome.status === 'target_unavailable') {
+            results.targetUnavailable++;
+          } else {
+            results.skipped++;
+          }
+        } catch (error) {
+          console.error(`[REPORT-POLLER] Failed to process report ${report?.id || '<missing-id>'}:`, error);
+          results.errors.push({
+            reportId: report?.id || null,
+            error: error?.message || String(error),
+          });
+        }
+      }
+    } catch (error) {
+      console.error(`[REPORT-POLLER] Failed to poll ${relayUrl}:`, error);
+      results.errors.push({
+        relay: relayUrl,
+        error: error?.message || String(error),
+      });
+    }
+  }
+
+  console.log(`[REPORT-POLLER] Poll complete: ${results.totalReports} reports, ${results.recorded} recorded, ${results.skipped} skipped`);
+
+  return results;
 }
 
 async function markProcessed(kv, key, payload, expirationTtl) {

--- a/src/nostr/report-poller.test.mjs
+++ b/src/nostr/report-poller.test.mjs
@@ -4,13 +4,16 @@
 // ABOUTME: Tests inbound NIP-56 report parsing and processing
 // ABOUTME: Covers kind 1984 target resolution, report type mapping, and idempotence
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   extractReportTargetEventId,
   extractReportType,
+  getLastReportPollTimestamp,
   isDivineClientReport,
+  pollRelayForReports,
   processReportEvent,
   processedReportKey,
+  setLastReportPollTimestamp,
   shouldAcceptReportTarget,
 } from './report-poller.mjs';
 
@@ -256,5 +259,123 @@ describe('processReportEvent', () => {
     expect(recorded).toHaveLength(0);
     expect(kv.store.has(processedReportKey(REPORT_EVENT_ID))).toBe(false);
     expect(kv.puts).toHaveLength(0);
+  });
+});
+
+describe('report polling checkpoint', () => {
+  it('stores and reads a separate report poll checkpoint', async () => {
+    const kv = createKv(new Map([['relay-poller:last-poll', JSON.stringify({ timestamp: 123 })]]));
+
+    await setLastReportPollTimestamp({ MODERATION_KV: kv }, 1778692782, {
+      totalReports: 3,
+      recorded: 2,
+      skipped: 1,
+    });
+
+    await expect(getLastReportPollTimestamp({ MODERATION_KV: kv })).resolves.toBe(1778692782);
+    expect(JSON.parse(kv.store.get('report-poller:last-poll'))).toMatchObject({
+      timestamp: 1778692782,
+      totalReports: 3,
+      recorded: 2,
+      skipped: 1,
+    });
+    expect(JSON.parse(kv.store.get('relay-poller:last-poll'))).toEqual({ timestamp: 123 });
+  });
+});
+
+describe('report polling', () => {
+  it('processes fetched reports and returns counters', async () => {
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const kv = createKv(new Map([[processedReportKey('b'.repeat(64)), '{"status":"recorded"}']]));
+    const db = {};
+    const targetUnavailableId = '1'.repeat(64);
+    const reports = [
+      {
+        id: REPORT_EVENT_ID,
+        kind: 1984,
+        pubkey: REPORTER,
+        created_at: 1778692782,
+        tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'diVine']],
+        content: '',
+      },
+      {
+        id: 'b'.repeat(64),
+        kind: 1984,
+        pubkey: REPORTER,
+        created_at: 1778692783,
+        tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'diVine']],
+        content: '',
+      },
+      {
+        id: '3'.repeat(64),
+        kind: 1984,
+        pubkey: REPORTER,
+        created_at: 1778692784,
+        tags: [['client', 'diVine']],
+        content: '',
+      },
+      {
+        id: '4'.repeat(64),
+        kind: 1984,
+        pubkey: REPORTER,
+        created_at: 1778692785,
+        tags: [['e', targetUnavailableId, 'spam'], ['client', 'diVine']],
+        content: '',
+      },
+      {
+        id: '5'.repeat(64),
+        kind: 1984,
+        pubkey: REPORTER,
+        created_at: 1778692786,
+        tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'diVine']],
+        content: '',
+      },
+    ];
+
+    try {
+      const result = await pollRelayForReports({
+        BLOSSOM_DB: db,
+        MODERATION_KV: kv,
+        RELAY_REPORTS_REQUIRE_DIVINE_CLIENT: 'true',
+      }, {
+        since: 1778680000,
+        limit: 50,
+        relays: ['wss://relay.divine.video'],
+        fetchReportsFromRelay: async (relayUrl, query, env) => {
+          expect(relayUrl).toBe('wss://relay.divine.video');
+          expect(query).toEqual({ since: 1778680000, limit: 50 });
+          expect(env.BLOSSOM_DB).toBe(db);
+          return reports;
+        },
+        fetchTargetEvent: async (eventId) => (eventId === targetUnavailableId ? null : TARGET),
+        recordReport: async (payload) => {
+          if (payload.reportEventId === '5'.repeat(64)) {
+            throw new Error('record failed');
+          }
+          return { success: true, action: 'REVIEW', distinctReporterCount: 1 };
+        },
+      });
+
+      expect(result).toMatchObject({
+        totalReports: 5,
+        recorded: 1,
+        alreadyProcessed: 1,
+        skipped: 1,
+        targetUnavailable: 1,
+      });
+      expect(result.reports).toEqual([
+        expect.objectContaining({ status: 'recorded' }),
+        { status: 'already_processed' },
+        { status: 'skipped_missing_target' },
+        { status: 'target_unavailable', targetEventId: targetUnavailableId },
+      ]);
+      expect(result.errors).toEqual([
+        { reportId: '5'.repeat(64), error: 'record failed' },
+      ]);
+    } finally {
+      consoleLog.mockRestore();
+      consoleError.mockRestore();
+    }
   });
 });

--- a/src/nostr/report-poller.test.mjs
+++ b/src/nostr/report-poller.test.mjs
@@ -477,6 +477,8 @@ describe('report polling', () => {
         alreadyProcessed: 1,
         skipped: 1,
         targetUnavailable: 1,
+        safeCheckpoint: 1778692784,
+        maxTerminalCreatedAt: 1778692784,
       });
       expect(result.reports).toEqual([
         expect.objectContaining({ status: 'recorded' }),
@@ -490,6 +492,65 @@ describe('report polling', () => {
     } finally {
       consoleLog.mockRestore();
       consoleError.mockRestore();
+    }
+  });
+
+  it('uses the newest terminal report timestamp as the safe checkpoint when every report is terminal', async () => {
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const kv = createKv(new Map([[processedReportKey('b'.repeat(64)), '{"status":"recorded"}']]));
+    const reports = [
+      {
+        id: REPORT_EVENT_ID,
+        kind: 1984,
+        pubkey: REPORTER,
+        created_at: 1778692782,
+        tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'diVine']],
+        content: '',
+      },
+      {
+        id: 'b'.repeat(64),
+        kind: 1984,
+        pubkey: REPORTER,
+        created_at: 1778692783,
+        tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'diVine']],
+        content: '',
+      },
+      {
+        id: '3'.repeat(64),
+        kind: 1984,
+        pubkey: REPORTER,
+        created_at: 1778692784,
+        tags: [['client', 'diVine']],
+        content: '',
+      },
+    ];
+
+    try {
+      const result = await pollRelayForReports({
+        BLOSSOM_DB: {},
+        MODERATION_KV: kv,
+        RELAY_REPORTS_REQUIRE_DIVINE_CLIENT: 'true',
+      }, {
+        since: 1778680000,
+        limit: 3,
+        relays: ['wss://relay.divine.video'],
+        fetchReportsFromRelay: async () => reports,
+        fetchTargetEvent: async () => TARGET,
+        recordReport: async () => ({ success: true, action: 'REVIEW', distinctReporterCount: 1 }),
+      });
+
+      expect(result).toMatchObject({
+        totalReports: 3,
+        recorded: 1,
+        alreadyProcessed: 1,
+        skipped: 1,
+        targetUnavailable: 0,
+        safeCheckpoint: 1778692784,
+        maxTerminalCreatedAt: 1778692784,
+      });
+      expect(result.errors).toEqual([]);
+    } finally {
+      consoleLog.mockRestore();
     }
   });
 });

--- a/src/nostr/report-poller.test.mjs
+++ b/src/nostr/report-poller.test.mjs
@@ -1,0 +1,93 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Tests inbound NIP-56 report parsing and processing
+// ABOUTME: Covers kind 1984 target resolution, report type mapping, and idempotence
+
+import { describe, expect, it } from 'vitest';
+import {
+  extractReportTargetEventId,
+  extractReportType,
+  isDivineClientReport,
+  shouldAcceptReportTarget,
+} from './report-poller.mjs';
+
+const TARGET_EVENT_ID = 'a'.repeat(64);
+
+describe('kind 1984 parsing', () => {
+  it('extracts target event id from the first valid e tag', () => {
+    expect(extractReportTargetEventId({
+      kind: 1984,
+      tags: [
+        ['e', '../not-hex', 'spam'],
+        ['e', TARGET_EVENT_ID, 'nudity'],
+        ['e', 'b'.repeat(64), 'violence'],
+      ],
+    })).toBe(TARGET_EVENT_ID);
+  });
+
+  it('ignores malformed e tag ids', () => {
+    expect(extractReportTargetEventId({
+      kind: 1984,
+      tags: [['e', '../not-hex', 'nudity']],
+    })).toBeNull();
+  });
+
+  it('uses NIP-56 e-tag marker as report type', () => {
+    expect(extractReportType({
+      kind: 1984,
+      tags: [['e', TARGET_EVENT_ID, 'nudity']],
+      content: '',
+    })).toBe('nudity');
+  });
+
+  it('maps diVine aiGenerated label to ai_generated', () => {
+    expect(extractReportType({
+      kind: 1984,
+      tags: [
+        ['e', TARGET_EVENT_ID, 'other'],
+        ['L', 'social.nos.ontology'],
+        ['l', 'NS-aiGenerated', 'social.nos.ontology'],
+      ],
+      content: 'CONTENT REPORT - NIP-56\nReason: aiGenerated\nDetails: AI-Generated Content',
+    })).toBe('ai_generated');
+  });
+
+  it('detects reports from the diVine client tag', () => {
+    expect(isDivineClientReport({
+      kind: 1984,
+      tags: [['client', 'diVine']],
+    })).toBe(true);
+  });
+
+  it('rejects non-diVine client reports when the client tag is absent', () => {
+    expect(isDivineClientReport({
+      kind: 1984,
+      tags: [['client', 'Amethyst']],
+    })).toBe(false);
+
+    expect(isDivineClientReport({
+      kind: 1984,
+      tags: [],
+    })).toBe(false);
+  });
+
+  it('accepts only video target events with a media sha', () => {
+    expect(shouldAcceptReportTarget({
+      kind: 34236,
+      tags: [['d', 'b'.repeat(64)], ['imeta', `x ${'b'.repeat(64)}`, 'm video/mp4']],
+    })).toBe(true);
+
+    expect(shouldAcceptReportTarget({
+      kind: 34235,
+      tags: [['x', 'c'.repeat(64)]],
+    })).toBe(true);
+  });
+
+  it('rejects non-video target events', () => {
+    expect(shouldAcceptReportTarget({
+      kind: 1,
+      tags: [['e', TARGET_EVENT_ID]],
+    })).toBe(false);
+  });
+});

--- a/src/nostr/report-poller.test.mjs
+++ b/src/nostr/report-poller.test.mjs
@@ -900,6 +900,7 @@ describe('report polling', () => {
         recorded: 4,
         saturated: true,
         safeCheckpoint: null,
+        resumeUntil: 1778692781,
       });
       expect(result.maxTerminalCreatedAt).toBeNull();
     } finally {
@@ -977,6 +978,7 @@ describe('report polling', () => {
         recorded: 2,
         saturated: true,
         safeCheckpoint: null,
+        resumeUntil: 1778692784,
       });
       expect(result.maxTerminalCreatedAt).toBeNull();
       expect(result.errors).toEqual([]);
@@ -1074,9 +1076,59 @@ describe('report polling', () => {
         recorded: 3,
         saturated: true,
         safeCheckpoint: null,
+        resumeUntil: 1778692784,
       });
       expect(result.maxTerminalCreatedAt).toBeNull();
       expect(result.errors).toEqual([]);
+    } finally {
+      consoleLog.mockRestore();
+    }
+  });
+
+  it('starts from a stored saturated resume boundary when provided', async () => {
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const kv = createKv();
+    const fetchCalls = [];
+
+    try {
+      const result = await pollRelayForReports({
+        BLOSSOM_DB: {},
+        MODERATION_KV: kv,
+        RELAY_REPORTS_REQUIRE_DIVINE_CLIENT: 'true',
+      }, {
+        since: 1778680000,
+        until: 1778692781,
+        limit: 2,
+        maxPages: 5,
+        relays: ['wss://relay.divine.video'],
+        fetchReportsFromRelay: async (relayUrl, query) => {
+          fetchCalls.push({ relayUrl, query });
+          return [
+            {
+              id: REPORT_EVENT_ID,
+              kind: 1984,
+              pubkey: REPORTER,
+              created_at: 1778692780,
+              tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'diVine']],
+              content: '',
+            },
+          ];
+        },
+        fetchTargetEvent: async () => TARGET,
+        recordReport: async () => ({ success: true, action: 'REVIEW', distinctReporterCount: 1 }),
+      });
+
+      expect(fetchCalls[0]).toEqual({
+        relayUrl: 'wss://relay.divine.video',
+        query: { since: 1778680000, limit: 2, until: 1778692781 },
+      });
+      expect(result).toMatchObject({
+        totalReports: 1,
+        recorded: 1,
+        saturated: false,
+        safeCheckpoint: 1778692780,
+        resumeUntil: null,
+      });
     } finally {
       consoleLog.mockRestore();
     }

--- a/src/nostr/report-poller.test.mjs
+++ b/src/nostr/report-poller.test.mjs
@@ -532,7 +532,7 @@ describe('report polling', () => {
         RELAY_REPORTS_REQUIRE_DIVINE_CLIENT: 'true',
       }, {
         since: 1778680000,
-        limit: 3,
+        limit: 4,
         relays: ['wss://relay.divine.video'],
         fetchReportsFromRelay: async () => reports,
         fetchTargetEvent: async () => TARGET,
@@ -548,6 +548,55 @@ describe('report polling', () => {
         safeCheckpoint: 1778692784,
         maxTerminalCreatedAt: 1778692784,
       });
+      expect(result.errors).toEqual([]);
+    } finally {
+      consoleLog.mockRestore();
+    }
+  });
+
+  it('does not expose a safe checkpoint when a relay returns a saturated page', async () => {
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const kv = createKv();
+    const reports = [
+      {
+        id: REPORT_EVENT_ID,
+        kind: 1984,
+        pubkey: REPORTER,
+        created_at: 1778692782,
+        tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'diVine']],
+        content: '',
+      },
+      {
+        id: 'b'.repeat(64),
+        kind: 1984,
+        pubkey: REPORTER,
+        created_at: 1778692783,
+        tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'diVine']],
+        content: '',
+      },
+    ];
+
+    try {
+      const result = await pollRelayForReports({
+        BLOSSOM_DB: {},
+        MODERATION_KV: kv,
+        RELAY_REPORTS_REQUIRE_DIVINE_CLIENT: 'true',
+      }, {
+        since: 1778680000,
+        limit: 2,
+        relays: ['wss://relay.divine.video'],
+        fetchReportsFromRelay: async () => reports,
+        fetchTargetEvent: async () => TARGET,
+        recordReport: async () => ({ success: true, action: 'REVIEW', distinctReporterCount: 1 }),
+      });
+
+      expect(result).toMatchObject({
+        totalReports: 2,
+        recorded: 2,
+        saturated: true,
+        safeCheckpoint: null,
+      });
+      expect(result.maxTerminalCreatedAt).toBeNull();
       expect(result.errors).toEqual([]);
     } finally {
       consoleLog.mockRestore();

--- a/src/nostr/report-poller.test.mjs
+++ b/src/nostr/report-poller.test.mjs
@@ -747,4 +747,126 @@ describe('report polling', () => {
       consoleLog.mockRestore();
     }
   });
+
+  it('treats a saturated same-timestamp page as unsafe and does not skip that timestamp boundary', async () => {
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const kv = createKv();
+    const fetchCalls = [];
+    const reports = [
+      {
+        id: REPORT_EVENT_ID,
+        kind: 1984,
+        pubkey: REPORTER,
+        created_at: 1778692784,
+        tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'diVine']],
+        content: '',
+      },
+      {
+        id: 'b'.repeat(64),
+        kind: 1984,
+        pubkey: REPORTER,
+        created_at: 1778692784,
+        tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'diVine']],
+        content: '',
+      },
+    ];
+
+    try {
+      const result = await pollRelayForReports({
+        BLOSSOM_DB: {},
+        MODERATION_KV: kv,
+        RELAY_REPORTS_REQUIRE_DIVINE_CLIENT: 'true',
+      }, {
+        since: 1778680000,
+        limit: 2,
+        maxPages: 5,
+        relays: ['wss://relay.divine.video'],
+        fetchReportsFromRelay: async (relayUrl, query) => {
+          fetchCalls.push({ relayUrl, query });
+          return query.until === undefined ? reports : [];
+        },
+        fetchTargetEvent: async () => TARGET,
+        recordReport: async () => ({ success: true, action: 'REVIEW', distinctReporterCount: 1 }),
+      });
+
+      expect(fetchCalls).toEqual([
+        { relayUrl: 'wss://relay.divine.video', query: { since: 1778680000, limit: 2 } },
+      ]);
+      expect(result).toMatchObject({
+        totalReports: 2,
+        recorded: 2,
+        saturated: true,
+        safeCheckpoint: null,
+      });
+      expect(result.maxTerminalCreatedAt).toBeNull();
+      expect(result.errors).toEqual([]);
+    } finally {
+      consoleLog.mockRestore();
+    }
+  });
+
+  it('treats a saturated page with duplicate lower-boundary timestamps as unsafe', async () => {
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const kv = createKv();
+    const fetchCalls = [];
+    const reports = [
+      {
+        id: REPORT_EVENT_ID,
+        kind: 1984,
+        pubkey: REPORTER,
+        created_at: 1778692785,
+        tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'diVine']],
+        content: '',
+      },
+      {
+        id: 'b'.repeat(64),
+        kind: 1984,
+        pubkey: REPORTER,
+        created_at: 1778692784,
+        tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'diVine']],
+        content: '',
+      },
+      {
+        id: '1'.repeat(64),
+        kind: 1984,
+        pubkey: REPORTER,
+        created_at: 1778692784,
+        tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'diVine']],
+        content: '',
+      },
+    ];
+
+    try {
+      const result = await pollRelayForReports({
+        BLOSSOM_DB: {},
+        MODERATION_KV: kv,
+        RELAY_REPORTS_REQUIRE_DIVINE_CLIENT: 'true',
+      }, {
+        since: 1778680000,
+        limit: 3,
+        maxPages: 5,
+        relays: ['wss://relay.divine.video'],
+        fetchReportsFromRelay: async (relayUrl, query) => {
+          fetchCalls.push({ relayUrl, query });
+          return query.until === undefined ? reports : [];
+        },
+        fetchTargetEvent: async () => TARGET,
+        recordReport: async () => ({ success: true, action: 'REVIEW', distinctReporterCount: 1 }),
+      });
+
+      expect(fetchCalls).toEqual([
+        { relayUrl: 'wss://relay.divine.video', query: { since: 1778680000, limit: 3 } },
+      ]);
+      expect(result).toMatchObject({
+        totalReports: 3,
+        recorded: 3,
+        saturated: true,
+        safeCheckpoint: null,
+      });
+      expect(result.maxTerminalCreatedAt).toBeNull();
+      expect(result.errors).toEqual([]);
+    } finally {
+      consoleLog.mockRestore();
+    }
+  });
 });

--- a/src/nostr/report-poller.test.mjs
+++ b/src/nostr/report-poller.test.mjs
@@ -603,7 +603,7 @@ describe('report polling', () => {
     }
   });
 
-  it('drains saturated pages with until and exposes a checkpoint when the final page is not saturated', async () => {
+  it('drains saturated pages with inclusive until overlap and exposes a checkpoint when the final page is not saturated', async () => {
     const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
     const kv = createKv();
     const fetchCalls = [];
@@ -613,7 +613,7 @@ describe('report polling', () => {
           id: REPORT_EVENT_ID,
           kind: 1984,
           pubkey: REPORTER,
-          created_at: 1778692784,
+          created_at: 1778692785,
           tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'diVine']],
           content: '',
         },
@@ -625,13 +625,29 @@ describe('report polling', () => {
           tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'diVine']],
           content: '',
         },
+        {
+          id: '2'.repeat(64),
+          kind: 1984,
+          pubkey: REPORTER,
+          created_at: 1778692783,
+          tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'diVine']],
+          content: '',
+        },
       ]],
-      [1778692782, [
+      [1778692783, [
+        {
+          id: '2'.repeat(64),
+          kind: 1984,
+          pubkey: REPORTER,
+          created_at: 1778692783,
+          tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'diVine']],
+          content: '',
+        },
         {
           id: '3'.repeat(64),
           kind: 1984,
           pubkey: REPORTER,
-          created_at: 1778692782,
+          created_at: 1778692783,
           tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'diVine']],
           content: '',
         },
@@ -645,7 +661,7 @@ describe('report polling', () => {
         RELAY_REPORTS_REQUIRE_DIVINE_CLIENT: 'true',
       }, {
         since: 1778680000,
-        limit: 2,
+        limit: 3,
         maxPages: 5,
         relays: ['wss://relay.divine.video'],
         fetchReportsFromRelay: async (relayUrl, query) => {
@@ -657,15 +673,15 @@ describe('report polling', () => {
       });
 
       expect(fetchCalls).toEqual([
-        { relayUrl: 'wss://relay.divine.video', query: { since: 1778680000, limit: 2 } },
-        { relayUrl: 'wss://relay.divine.video', query: { since: 1778680000, limit: 2, until: 1778692782 } },
+        { relayUrl: 'wss://relay.divine.video', query: { since: 1778680000, limit: 3 } },
+        { relayUrl: 'wss://relay.divine.video', query: { since: 1778680000, limit: 3, until: 1778692783 } },
       ]);
       expect(result).toMatchObject({
-        totalReports: 3,
-        recorded: 3,
+        totalReports: 4,
+        recorded: 4,
         saturated: false,
-        safeCheckpoint: 1778692784,
-        maxTerminalCreatedAt: 1778692784,
+        safeCheckpoint: 1778692785,
+        maxTerminalCreatedAt: 1778692785,
       });
       expect(result.errors).toEqual([]);
     } finally {
@@ -696,12 +712,12 @@ describe('report polling', () => {
           content: '',
         },
       ]],
-      [1778692782, [
+      [1778692783, [
         {
           id: '3'.repeat(64),
           kind: 1984,
           pubkey: REPORTER,
-          created_at: 1778692782,
+          created_at: 1778692783,
           tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'diVine']],
           content: '',
         },
@@ -735,7 +751,7 @@ describe('report polling', () => {
       });
 
       expect(fetchCalls).toHaveLength(2);
-      expect(fetchCalls[1].query.until).toBe(1778692782);
+      expect(fetchCalls[1].query.until).toBe(1778692783);
       expect(result).toMatchObject({
         totalReports: 4,
         recorded: 4,
@@ -748,28 +764,48 @@ describe('report polling', () => {
     }
   });
 
-  it('treats a saturated same-timestamp page as unsafe and does not skip that timestamp boundary', async () => {
+  it('keeps saturation when an inclusive overlap page only returns duplicate report ids', async () => {
     const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
     const kv = createKv();
     const fetchCalls = [];
-    const reports = [
-      {
-        id: REPORT_EVENT_ID,
-        kind: 1984,
-        pubkey: REPORTER,
-        created_at: 1778692784,
-        tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'diVine']],
-        content: '',
-      },
-      {
-        id: 'b'.repeat(64),
-        kind: 1984,
-        pubkey: REPORTER,
-        created_at: 1778692784,
-        tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'diVine']],
-        content: '',
-      },
-    ];
+    const reportsByUntil = new Map([
+      [undefined, [
+        {
+          id: REPORT_EVENT_ID,
+          kind: 1984,
+          pubkey: REPORTER,
+          created_at: 1778692784,
+          tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'diVine']],
+          content: '',
+        },
+        {
+          id: 'b'.repeat(64),
+          kind: 1984,
+          pubkey: REPORTER,
+          created_at: 1778692784,
+          tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'diVine']],
+          content: '',
+        },
+      ]],
+      [1778692784, [
+        {
+          id: REPORT_EVENT_ID,
+          kind: 1984,
+          pubkey: REPORTER,
+          created_at: 1778692784,
+          tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'diVine']],
+          content: '',
+        },
+        {
+          id: 'b'.repeat(64),
+          kind: 1984,
+          pubkey: REPORTER,
+          created_at: 1778692784,
+          tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'diVine']],
+          content: '',
+        },
+      ]],
+    ]);
 
     try {
       const result = await pollRelayForReports({
@@ -783,7 +819,7 @@ describe('report polling', () => {
         relays: ['wss://relay.divine.video'],
         fetchReportsFromRelay: async (relayUrl, query) => {
           fetchCalls.push({ relayUrl, query });
-          return query.until === undefined ? reports : [];
+          return reportsByUntil.get(query.until);
         },
         fetchTargetEvent: async () => TARGET,
         recordReport: async () => ({ success: true, action: 'REVIEW', distinctReporterCount: 1 }),
@@ -791,6 +827,7 @@ describe('report polling', () => {
 
       expect(fetchCalls).toEqual([
         { relayUrl: 'wss://relay.divine.video', query: { since: 1778680000, limit: 2 } },
+        { relayUrl: 'wss://relay.divine.video', query: { since: 1778680000, limit: 2, until: 1778692784 } },
       ]);
       expect(result).toMatchObject({
         totalReports: 2,
@@ -805,35 +842,65 @@ describe('report polling', () => {
     }
   });
 
-  it('treats a saturated page with duplicate lower-boundary timestamps as unsafe', async () => {
+  it('keeps fetching same-timestamp full pages until overlap stops discovering new report ids', async () => {
     const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
     const kv = createKv();
     const fetchCalls = [];
-    const reports = [
-      {
-        id: REPORT_EVENT_ID,
-        kind: 1984,
-        pubkey: REPORTER,
-        created_at: 1778692785,
-        tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'diVine']],
-        content: '',
-      },
-      {
-        id: 'b'.repeat(64),
-        kind: 1984,
-        pubkey: REPORTER,
-        created_at: 1778692784,
-        tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'diVine']],
-        content: '',
-      },
-      {
-        id: '1'.repeat(64),
-        kind: 1984,
-        pubkey: REPORTER,
-        created_at: 1778692784,
-        tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'diVine']],
-        content: '',
-      },
+    const overlappingPages = [
+      [
+        {
+          id: REPORT_EVENT_ID,
+          kind: 1984,
+          pubkey: REPORTER,
+          created_at: 1778692784,
+          tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'diVine']],
+          content: '',
+        },
+        {
+          id: 'b'.repeat(64),
+          kind: 1984,
+          pubkey: REPORTER,
+          created_at: 1778692784,
+          tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'diVine']],
+          content: '',
+        },
+      ],
+      [
+        {
+          id: 'b'.repeat(64),
+          kind: 1984,
+          pubkey: REPORTER,
+          created_at: 1778692784,
+          tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'diVine']],
+          content: '',
+        },
+        {
+          id: '1'.repeat(64),
+          kind: 1984,
+          pubkey: REPORTER,
+          created_at: 1778692784,
+          tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'diVine']],
+          content: '',
+        },
+      ],
+      [
+        {
+          id: 'b'.repeat(64),
+          kind: 1984,
+          pubkey: REPORTER,
+          created_at: 1778692784,
+          tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'diVine']],
+          content: '',
+        },
+        {
+          id: '1'.repeat(64),
+          kind: 1984,
+          pubkey: REPORTER,
+          created_at: 1778692784,
+          tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'diVine']],
+          content: '',
+        },
+      ],
     ];
 
     try {
@@ -843,19 +910,21 @@ describe('report polling', () => {
         RELAY_REPORTS_REQUIRE_DIVINE_CLIENT: 'true',
       }, {
         since: 1778680000,
-        limit: 3,
+        limit: 2,
         maxPages: 5,
         relays: ['wss://relay.divine.video'],
         fetchReportsFromRelay: async (relayUrl, query) => {
           fetchCalls.push({ relayUrl, query });
-          return query.until === undefined ? reports : [];
+          return overlappingPages[fetchCalls.length - 1] ?? [];
         },
         fetchTargetEvent: async () => TARGET,
         recordReport: async () => ({ success: true, action: 'REVIEW', distinctReporterCount: 1 }),
       });
 
       expect(fetchCalls).toEqual([
-        { relayUrl: 'wss://relay.divine.video', query: { since: 1778680000, limit: 3 } },
+        { relayUrl: 'wss://relay.divine.video', query: { since: 1778680000, limit: 2 } },
+        { relayUrl: 'wss://relay.divine.video', query: { since: 1778680000, limit: 2, until: 1778692784 } },
+        { relayUrl: 'wss://relay.divine.video', query: { since: 1778680000, limit: 2, until: 1778692784 } },
       ]);
       expect(result).toMatchObject({
         totalReports: 3,

--- a/src/nostr/report-poller.test.mjs
+++ b/src/nostr/report-poller.test.mjs
@@ -9,10 +9,38 @@ import {
   extractReportTargetEventId,
   extractReportType,
   isDivineClientReport,
+  processReportEvent,
+  processedReportKey,
   shouldAcceptReportTarget,
 } from './report-poller.mjs';
 
 const TARGET_EVENT_ID = 'a'.repeat(64);
+const REPORT_EVENT_ID = 'c'.repeat(64);
+const REPORTER = 'd'.repeat(64);
+const SHA = 'e'.repeat(64);
+const UPLOADER = 'f'.repeat(64);
+const TARGET = {
+  id: TARGET_EVENT_ID,
+  kind: 34236,
+  pubkey: UPLOADER,
+  tags: [['d', SHA], ['imeta', `x ${SHA}`, 'm video/mp4']],
+};
+
+function createKv(existing = new Map()) {
+  const store = new Map(existing);
+  const puts = [];
+  return {
+    store,
+    puts,
+    async get(key) {
+      return store.get(key) ?? null;
+    },
+    async put(key, value, options) {
+      puts.push({ key, value, options });
+      store.set(key, value);
+    },
+  };
+}
 
 describe('kind 1984 parsing', () => {
   it('extracts target event id from the first valid e tag', () => {
@@ -89,5 +117,144 @@ describe('kind 1984 parsing', () => {
       kind: 1,
       tags: [['e', TARGET_EVENT_ID]],
     })).toBe(false);
+  });
+});
+
+describe('processReportEvent', () => {
+  it('resolves a diVine report target and records it for review', async () => {
+    const kv = createKv();
+    const recorded = [];
+
+    const result = await processReportEvent({
+      id: REPORT_EVENT_ID,
+      kind: 1984,
+      pubkey: REPORTER,
+      created_at: 1778692782,
+      tags: [
+        ['e', TARGET_EVENT_ID, 'other'],
+        ['client', 'diVine'],
+        ['l', 'NS-aiGenerated', 'social.nos.ontology'],
+      ],
+      content: 'Reason: aiGenerated',
+    }, {
+      kv,
+      requireDivineClient: true,
+      fetchTargetEvent: async (eventId) => (eventId === TARGET_EVENT_ID ? TARGET : null),
+      recordReport: async (payload) => {
+        recorded.push(payload);
+        return { action: 'REVIEW', distinctReporterCount: 1 };
+      },
+    });
+
+    expect(result).toMatchObject({
+      status: 'recorded',
+      sha256: SHA,
+      reportType: 'ai_generated',
+      targetEventId: TARGET_EVENT_ID,
+      action: 'REVIEW',
+      distinctReporterCount: 1,
+    });
+    expect(recorded).toEqual([{
+      sha256: SHA,
+      reporterPubkey: REPORTER,
+      reportType: 'ai_generated',
+      reason: 'Reason: aiGenerated',
+      source: 'relay-report',
+      reportedAt: '2026-05-13T17:19:42.000Z',
+      reportEventId: REPORT_EVENT_ID,
+      targetEventId: TARGET_EVENT_ID,
+      uploadedBy: UPLOADER,
+    }]);
+    expect(kv.puts).toHaveLength(1);
+    expect(kv.puts[0].key).toBe(processedReportKey(REPORT_EVENT_ID));
+    expect(kv.puts[0].options).toEqual({ expirationTtl: 60 * 60 * 24 * 180 });
+    expect(JSON.parse(kv.store.get(processedReportKey(REPORT_EVENT_ID)))).toMatchObject({
+      status: 'recorded',
+      sha256: SHA,
+      reportType: 'ai_generated',
+      action: 'REVIEW',
+    });
+  });
+
+  it('skips an already processed report without recording again', async () => {
+    const kv = createKv(new Map([[processedReportKey(REPORT_EVENT_ID), '{"status":"recorded"}']]));
+    const calls = { fetchTargetEvent: 0, recordReport: 0 };
+
+    const result = await processReportEvent({
+      id: REPORT_EVENT_ID,
+      kind: 1984,
+      pubkey: REPORTER,
+      created_at: 1778692782,
+      tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'diVine']],
+    }, {
+      kv,
+      requireDivineClient: true,
+      fetchTargetEvent: async () => {
+        calls.fetchTargetEvent++;
+        return TARGET;
+      },
+      recordReport: async () => {
+        calls.recordReport++;
+        return { action: 'REVIEW', distinctReporterCount: 1 };
+      },
+    });
+
+    expect(result.status).toBe('already_processed');
+    expect(calls).toEqual({ fetchTargetEvent: 0, recordReport: 0 });
+    expect(kv.puts).toHaveLength(0);
+  });
+
+  it('skips non-diVine client reports when configured', async () => {
+    const kv = createKv();
+    const recorded = [];
+
+    const result = await processReportEvent({
+      id: REPORT_EVENT_ID,
+      kind: 1984,
+      pubkey: REPORTER,
+      tags: [['e', TARGET_EVENT_ID, 'spam'], ['client', 'Amethyst']],
+    }, {
+      kv,
+      requireDivineClient: true,
+      fetchTargetEvent: async () => TARGET,
+      recordReport: async (payload) => {
+        recorded.push(payload);
+        return { action: 'REVIEW', distinctReporterCount: 1 };
+      },
+    });
+
+    expect(result.status).toBe('skipped_non_divine_client');
+    expect(recorded).toHaveLength(0);
+    expect(kv.puts).toHaveLength(1);
+    expect(kv.puts[0].key).toBe(processedReportKey(REPORT_EVENT_ID));
+    expect(kv.puts[0].options).toEqual({ expirationTtl: 60 * 60 * 24 * 90 });
+    expect(JSON.parse(kv.store.get(processedReportKey(REPORT_EVENT_ID)))).toMatchObject({
+      status: 'skipped_non_divine_client',
+    });
+  });
+
+  it('does not mark a report processed when the target event cannot be fetched', async () => {
+    const kv = createKv();
+    const recorded = [];
+
+    const result = await processReportEvent({
+      id: REPORT_EVENT_ID,
+      kind: 1984,
+      pubkey: REPORTER,
+      tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'diVine']],
+    }, {
+      kv,
+      requireDivineClient: true,
+      fetchTargetEvent: async () => null,
+      recordReport: async (payload) => {
+        recorded.push(payload);
+        return { action: 'REVIEW', distinctReporterCount: 1 };
+      },
+    });
+
+    expect(result).toEqual({ status: 'target_unavailable', targetEventId: TARGET_EVENT_ID });
+    expect(recorded).toHaveLength(0);
+    expect(kv.store.has(processedReportKey(REPORT_EVENT_ID))).toBe(false);
+    expect(kv.puts).toHaveLength(0);
   });
 });

--- a/src/nostr/report-poller.test.mjs
+++ b/src/nostr/report-poller.test.mjs
@@ -443,7 +443,9 @@ describe('ReportPollingStatus', () => {
         errors: 1,
       })],
       ['report-poller:last-run', JSON.stringify({
-        lastRunAt: '2026-05-13T17:25:00.000Z',
+        timestamp: '2026-05-13T17:25:00.000Z',
+        totalReports: 3,
+        recorded: 2,
         saturated: true,
         safeCheckpoint: null,
       })],
@@ -460,7 +462,9 @@ describe('ReportPollingStatus', () => {
       recorded: 2,
       errors: 1,
       lastRun: {
-        lastRunAt: '2026-05-13T17:25:00.000Z',
+        timestamp: '2026-05-13T17:25:00.000Z',
+        totalReports: 3,
+        recorded: 2,
         saturated: true,
         safeCheckpoint: null,
       },

--- a/src/nostr/report-poller.test.mjs
+++ b/src/nostr/report-poller.test.mjs
@@ -9,6 +9,7 @@ import {
   extractReportTargetEventId,
   extractReportType,
   fetchReportsFromRelay,
+  getReportPollingStatus,
   getLastReportPollTimestamp,
   isDivineClientReport,
   pollRelayForReports,
@@ -428,6 +429,56 @@ describe('report polling checkpoint', () => {
       skipped: 1,
     });
     expect(JSON.parse(kv.store.get('relay-poller:last-poll'))).toEqual({ timestamp: 123 });
+  });
+});
+
+describe('ReportPollingStatus', () => {
+  it('returns checkpoint status with last-run details when present', async () => {
+    const kv = createKv(new Map([
+      ['report-poller:last-poll', JSON.stringify({
+        timestamp: 1778692782,
+        lastPollAt: '2026-05-13T17:20:00.000Z',
+        totalReports: 3,
+        recorded: 2,
+        errors: 1,
+      })],
+      ['report-poller:last-run', JSON.stringify({
+        lastRunAt: '2026-05-13T17:25:00.000Z',
+        saturated: true,
+        safeCheckpoint: null,
+      })],
+    ]));
+
+    await expect(getReportPollingStatus({
+      REPORT_POLLING_ENABLED: 'true',
+      MODERATION_KV: kv,
+    })).resolves.toMatchObject({
+      enabled: true,
+      timestamp: 1778692782,
+      lastPollAt: '2026-05-13T17:20:00.000Z',
+      totalReports: 3,
+      recorded: 2,
+      errors: 1,
+      lastRun: {
+        lastRunAt: '2026-05-13T17:25:00.000Z',
+        saturated: true,
+        safeCheckpoint: null,
+      },
+    });
+  });
+
+  it('returns an empty status when no report polls completed yet', async () => {
+    const kv = createKv();
+
+    await expect(getReportPollingStatus({
+      REPORT_POLLING_ENABLED: 'false',
+      MODERATION_KV: kv,
+    })).resolves.toEqual({
+      enabled: false,
+      timestamp: null,
+      lastPollAt: null,
+      message: 'No report polls completed yet',
+    });
   });
 });
 

--- a/src/nostr/report-poller.test.mjs
+++ b/src/nostr/report-poller.test.mjs
@@ -4,10 +4,11 @@
 // ABOUTME: Tests inbound NIP-56 report parsing and processing
 // ABOUTME: Covers kind 1984 target resolution, report type mapping, and idempotence
 
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   extractReportTargetEventId,
   extractReportType,
+  fetchReportsFromRelay,
   getLastReportPollTimestamp,
   isDivineClientReport,
   pollRelayForReports,
@@ -28,6 +29,11 @@ const TARGET = {
   pubkey: UPLOADER,
   tags: [['d', SHA], ['imeta', `x ${SHA}`, 'm video/mp4']],
 };
+const OriginalWebSocket = globalThis.WebSocket;
+
+afterEach(() => {
+  globalThis.WebSocket = OriginalWebSocket;
+});
 
 function createKv(existing = new Map()) {
   const store = new Map(existing);
@@ -236,6 +242,73 @@ describe('processReportEvent', () => {
     });
   });
 
+  it('terminally skips non-kind-1984 events without recording', async () => {
+    const kv = createKv();
+    const calls = { fetchTargetEvent: 0, recordReport: 0 };
+
+    const result = await processReportEvent({
+      id: REPORT_EVENT_ID,
+      kind: 1,
+      pubkey: REPORTER,
+      tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'diVine']],
+      content: '',
+    }, {
+      kv,
+      requireDivineClient: true,
+      fetchTargetEvent: async () => {
+        calls.fetchTargetEvent++;
+        return TARGET;
+      },
+      recordReport: async () => {
+        calls.recordReport++;
+        return { action: 'REVIEW', distinctReporterCount: 1 };
+      },
+    });
+
+    expect(result.status).toBe('skipped_non_report_kind');
+    expect(calls).toEqual({ fetchTargetEvent: 0, recordReport: 0 });
+    expect(kv.puts).toHaveLength(1);
+    expect(kv.puts[0].key).toBe(processedReportKey(REPORT_EVENT_ID));
+    expect(kv.puts[0].options).toEqual({ expirationTtl: 60 * 60 * 24 * 90 });
+    expect(JSON.parse(kv.store.get(processedReportKey(REPORT_EVENT_ID)))).toMatchObject({
+      status: 'skipped_non_report_kind',
+      kind: 1,
+    });
+  });
+
+  it('terminally skips reports with malformed reporter pubkeys without recording', async () => {
+    const kv = createKv();
+    const calls = { fetchTargetEvent: 0, recordReport: 0 };
+
+    const result = await processReportEvent({
+      id: REPORT_EVENT_ID,
+      kind: 1984,
+      pubkey: '../not-hex',
+      tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'diVine']],
+      content: '',
+    }, {
+      kv,
+      requireDivineClient: true,
+      fetchTargetEvent: async () => {
+        calls.fetchTargetEvent++;
+        return TARGET;
+      },
+      recordReport: async () => {
+        calls.recordReport++;
+        return { action: 'REVIEW', distinctReporterCount: 1 };
+      },
+    });
+
+    expect(result.status).toBe('skipped_invalid_reporter_pubkey');
+    expect(calls).toEqual({ fetchTargetEvent: 0, recordReport: 0 });
+    expect(kv.puts).toHaveLength(1);
+    expect(kv.puts[0].key).toBe(processedReportKey(REPORT_EVENT_ID));
+    expect(kv.puts[0].options).toEqual({ expirationTtl: 60 * 60 * 24 * 90 });
+    expect(JSON.parse(kv.store.get(processedReportKey(REPORT_EVENT_ID)))).toMatchObject({
+      status: 'skipped_invalid_reporter_pubkey',
+    });
+  });
+
   it('does not mark a report processed when the target event cannot be fetched', async () => {
     const kv = createKv();
     const recorded = [];
@@ -259,6 +332,47 @@ describe('processReportEvent', () => {
     expect(recorded).toHaveLength(0);
     expect(kv.store.has(processedReportKey(REPORT_EVENT_ID))).toBe(false);
     expect(kv.puts).toHaveLength(0);
+  });
+});
+
+describe('fetchReportsFromRelay', () => {
+  it('rejects when the relay closes the active subscription', async () => {
+    const sent = [];
+
+    globalThis.WebSocket = class {
+      constructor() {
+        this.listeners = new Map();
+        queueMicrotask(() => this.emit('open', {}));
+      }
+
+      addEventListener(type, listener) {
+        this.listeners.set(type, listener);
+      }
+
+      send(message) {
+        sent.push(JSON.parse(message));
+        const [, subscriptionId] = JSON.parse(message);
+        this.emit('message', {
+          data: JSON.stringify(['CLOSED', subscriptionId, 'blocked: auth-required']),
+        });
+      }
+
+      close() {}
+
+      emit(type, event) {
+        this.listeners.get(type)?.(event);
+      }
+    };
+
+    await expect(fetchReportsFromRelay('wss://relay.example', {
+      since: 1778680000,
+      limit: 50,
+    })).rejects.toThrow('blocked: auth-required');
+    expect(sent[0]).toEqual([
+      'REQ',
+      expect.any(String),
+      { kinds: [1984], since: 1778680000, limit: 50 },
+    ]);
   });
 });
 

--- a/src/nostr/report-poller.test.mjs
+++ b/src/nostr/report-poller.test.mjs
@@ -602,4 +602,149 @@ describe('report polling', () => {
       consoleLog.mockRestore();
     }
   });
+
+  it('drains saturated pages with until and exposes a checkpoint when the final page is not saturated', async () => {
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const kv = createKv();
+    const fetchCalls = [];
+    const reportsByUntil = new Map([
+      [undefined, [
+        {
+          id: REPORT_EVENT_ID,
+          kind: 1984,
+          pubkey: REPORTER,
+          created_at: 1778692784,
+          tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'diVine']],
+          content: '',
+        },
+        {
+          id: 'b'.repeat(64),
+          kind: 1984,
+          pubkey: REPORTER,
+          created_at: 1778692783,
+          tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'diVine']],
+          content: '',
+        },
+      ]],
+      [1778692782, [
+        {
+          id: '3'.repeat(64),
+          kind: 1984,
+          pubkey: REPORTER,
+          created_at: 1778692782,
+          tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'diVine']],
+          content: '',
+        },
+      ]],
+    ]);
+
+    try {
+      const result = await pollRelayForReports({
+        BLOSSOM_DB: {},
+        MODERATION_KV: kv,
+        RELAY_REPORTS_REQUIRE_DIVINE_CLIENT: 'true',
+      }, {
+        since: 1778680000,
+        limit: 2,
+        maxPages: 5,
+        relays: ['wss://relay.divine.video'],
+        fetchReportsFromRelay: async (relayUrl, query) => {
+          fetchCalls.push({ relayUrl, query });
+          return reportsByUntil.get(query.until);
+        },
+        fetchTargetEvent: async () => TARGET,
+        recordReport: async () => ({ success: true, action: 'REVIEW', distinctReporterCount: 1 }),
+      });
+
+      expect(fetchCalls).toEqual([
+        { relayUrl: 'wss://relay.divine.video', query: { since: 1778680000, limit: 2 } },
+        { relayUrl: 'wss://relay.divine.video', query: { since: 1778680000, limit: 2, until: 1778692782 } },
+      ]);
+      expect(result).toMatchObject({
+        totalReports: 3,
+        recorded: 3,
+        saturated: false,
+        safeCheckpoint: 1778692784,
+        maxTerminalCreatedAt: 1778692784,
+      });
+      expect(result.errors).toEqual([]);
+    } finally {
+      consoleLog.mockRestore();
+    }
+  });
+
+  it('keeps saturation and suppresses checkpoint when max pages are all full', async () => {
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const kv = createKv();
+    const fetchCalls = [];
+    const reportsByUntil = new Map([
+      [undefined, [
+        {
+          id: REPORT_EVENT_ID,
+          kind: 1984,
+          pubkey: REPORTER,
+          created_at: 1778692784,
+          tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'diVine']],
+          content: '',
+        },
+        {
+          id: 'b'.repeat(64),
+          kind: 1984,
+          pubkey: REPORTER,
+          created_at: 1778692783,
+          tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'diVine']],
+          content: '',
+        },
+      ]],
+      [1778692782, [
+        {
+          id: '3'.repeat(64),
+          kind: 1984,
+          pubkey: REPORTER,
+          created_at: 1778692782,
+          tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'diVine']],
+          content: '',
+        },
+        {
+          id: '4'.repeat(64),
+          kind: 1984,
+          pubkey: REPORTER,
+          created_at: 1778692781,
+          tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'diVine']],
+          content: '',
+        },
+      ]],
+    ]);
+
+    try {
+      const result = await pollRelayForReports({
+        BLOSSOM_DB: {},
+        MODERATION_KV: kv,
+        RELAY_REPORTS_REQUIRE_DIVINE_CLIENT: 'true',
+      }, {
+        since: 1778680000,
+        limit: 2,
+        maxPages: 2,
+        relays: ['wss://relay.divine.video'],
+        fetchReportsFromRelay: async (relayUrl, query) => {
+          fetchCalls.push({ relayUrl, query });
+          return reportsByUntil.get(query.until);
+        },
+        fetchTargetEvent: async () => TARGET,
+        recordReport: async () => ({ success: true, action: 'REVIEW', distinctReporterCount: 1 }),
+      });
+
+      expect(fetchCalls).toHaveLength(2);
+      expect(fetchCalls[1].query.until).toBe(1778692782);
+      expect(result).toMatchObject({
+        totalReports: 4,
+        recorded: 4,
+        saturated: true,
+        safeCheckpoint: null,
+      });
+      expect(result.maxTerminalCreatedAt).toBeNull();
+    } finally {
+      consoleLog.mockRestore();
+    }
+  });
 });

--- a/src/nostr/report-poller.test.mjs
+++ b/src/nostr/report-poller.test.mjs
@@ -185,6 +185,40 @@ describe('processReportEvent', () => {
     });
   });
 
+  it('does not mark a report processed when review row recording fails inside the helper', async () => {
+    const kv = createKv();
+
+    const result = await processReportEvent({
+      id: REPORT_EVENT_ID,
+      kind: 1984,
+      pubkey: REPORTER,
+      created_at: 1778692782,
+      tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'diVine']],
+      content: 'Needs review',
+    }, {
+      kv,
+      requireDivineClient: true,
+      fetchTargetEvent: async () => TARGET,
+      recordReport: async () => ({
+        success: true,
+        action: 'REVIEW',
+        distinctReporterCount: 1,
+        moderationResultRecorded: false,
+        moderationResultError: 'D1 write failed',
+      }),
+    });
+
+    expect(result).toMatchObject({
+      status: 'review_record_failed',
+      sha256: SHA,
+      reportType: 'nudity',
+      targetEventId: TARGET_EVENT_ID,
+      error: 'D1 write failed',
+    });
+    expect(kv.store.has(processedReportKey(REPORT_EVENT_ID))).toBe(false);
+    expect(kv.puts).toHaveLength(0);
+  });
+
   it('skips an already processed report without recording again', async () => {
     const kv = createKv(new Map([[processedReportKey(REPORT_EVENT_ID), '{"status":"recorded"}']]));
     const calls = { fetchTargetEvent: 0, recordReport: 0 };
@@ -549,6 +583,60 @@ describe('report polling', () => {
         maxTerminalCreatedAt: 1778692784,
       });
       expect(result.errors).toEqual([]);
+    } finally {
+      consoleLog.mockRestore();
+    }
+  });
+
+  it('does not expose a safe checkpoint when review row recording fails inside the helper', async () => {
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const kv = createKv();
+
+    try {
+      const result = await pollRelayForReports({
+        BLOSSOM_DB: {},
+        MODERATION_KV: kv,
+        RELAY_REPORTS_REQUIRE_DIVINE_CLIENT: 'true',
+      }, {
+        since: 1778680000,
+        limit: 10,
+        relays: ['wss://relay.divine.video'],
+        fetchReportsFromRelay: async () => [{
+          id: REPORT_EVENT_ID,
+          kind: 1984,
+          pubkey: REPORTER,
+          created_at: 1778692782,
+          tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'diVine']],
+          content: 'Needs review',
+        }],
+        fetchTargetEvent: async () => TARGET,
+        recordReport: async () => ({
+          success: true,
+          action: 'REVIEW',
+          distinctReporterCount: 1,
+          moderationResultRecorded: false,
+          moderationResultError: 'D1 write failed',
+        }),
+      });
+
+      expect(result).toMatchObject({
+        totalReports: 1,
+        recorded: 0,
+        safeCheckpoint: null,
+        maxTerminalCreatedAt: null,
+      });
+      expect(result.reports).toEqual([
+        expect.objectContaining({
+          status: 'review_record_failed',
+          sha256: SHA,
+          reportType: 'nudity',
+          error: 'D1 write failed',
+        }),
+      ]);
+      expect(result.errors).toEqual([
+        { reportId: REPORT_EVENT_ID, error: 'D1 write failed', status: 'review_record_failed' },
+      ]);
+      expect(kv.store.has(processedReportKey(REPORT_EVENT_ID))).toBe(false);
     } finally {
       consoleLog.mockRestore();
     }

--- a/src/reports.mjs
+++ b/src/reports.mjs
@@ -28,14 +28,14 @@ export async function initReportsTable(db) {
  * 2 unique reporters before auto AGE_RESTRICTED to defend against single-token
  * griefing).
  * @param {D1Database} db
- * @param {{sha256: string, reporter_pubkey: string, report_type: string, reason?: string}} report
+ * @param {{sha256: string, reporter_pubkey: string, report_type: string, reason?: string, created_at?: string}} report
  * @returns {Promise<{escalate: 'AGE_RESTRICTED'|'REVIEW'|null, distinctReporterCount: number}>}
  */
-export async function addReport(db, { sha256, reporter_pubkey, report_type, reason }) {
+export async function addReport(db, { sha256, reporter_pubkey, report_type, reason, created_at }) {
   await db.prepare(`
-    INSERT OR IGNORE INTO user_reports (sha256, reporter_pubkey, report_type, reason)
-    VALUES (?, ?, ?, ?)
-  `).bind(sha256, reporter_pubkey, report_type, reason ?? null).run();
+    INSERT OR IGNORE INTO user_reports (sha256, reporter_pubkey, report_type, reason, created_at)
+    VALUES (?, ?, ?, ?, COALESCE(?, CURRENT_TIMESTAMP))
+  `).bind(sha256, reporter_pubkey, report_type, reason ?? null, created_at ?? null).run();
 
   const row = await db.prepare(`
     SELECT COUNT(DISTINCT reporter_pubkey) AS cnt

--- a/src/reports.test.mjs
+++ b/src/reports.test.mjs
@@ -113,6 +113,54 @@ describe('reports', () => {
       const count = await getReportCount(db, SHA256);
       expect(count).toBe(2);
     });
+
+    it('stores an explicit created_at timestamp when provided', async () => {
+      const sha256 = 'a'.repeat(64);
+      const reporter = 'b'.repeat(64);
+      const createdAt = '2026-05-13T17:19:42.000Z';
+
+      await addReport(env.BLOSSOM_DB, {
+        sha256,
+        reporter_pubkey: reporter,
+        report_type: 'ai_generated',
+        reason: 'reported from kind 1984',
+        created_at: createdAt,
+      });
+
+      const row = await env.BLOSSOM_DB.prepare(`
+        SELECT sha256, reporter_pubkey, report_type, reason, created_at
+        FROM user_reports
+        WHERE sha256 = ? AND reporter_pubkey = ?
+      `).bind(sha256, reporter).first();
+
+      expect(row).toMatchObject({
+        sha256,
+        reporter_pubkey: reporter,
+        report_type: 'ai_generated',
+        reason: 'reported from kind 1984',
+        created_at: createdAt,
+      });
+    });
+
+    it('keeps CURRENT_TIMESTAMP behavior when created_at is omitted', async () => {
+      const sha256 = 'c'.repeat(64);
+      const reporter = 'd'.repeat(64);
+
+      await addReport(env.BLOSSOM_DB, {
+        sha256,
+        reporter_pubkey: reporter,
+        report_type: 'nudity',
+      });
+
+      const row = await env.BLOSSOM_DB.prepare(`
+        SELECT created_at
+        FROM user_reports
+        WHERE sha256 = ? AND reporter_pubkey = ?
+      `).bind(sha256, reporter).first();
+
+      expect(typeof row.created_at).toBe('string');
+      expect(row.created_at.length).toBeGreaterThan(0);
+    });
   });
 
   describe('escalation thresholds', () => {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -118,6 +118,11 @@ RELAY_POLLING_ENABLED = "true"                    # Enable/disable relay polling
 RELAY_POLLING_RELAY_URL = "wss://relay.divine.video"  # Relay to poll for new video events
 RELAY_POLLING_LOOKBACK_HOURS = "1"                # How far back to look for events (in hours)
 RELAY_POLLING_LIMIT = "100"                       # Max events to fetch per poll
+REPORT_POLLING_ENABLED = "true"                   # Enable/disable inbound NIP-56 report polling
+REPORT_POLLING_RELAY_URL = "wss://relay.divine.video" # Relay to poll for kind 1984 reports
+REPORT_POLLING_LOOKBACK_HOURS = "24"              # How far back to look for reports on first run
+REPORT_POLLING_LIMIT = "100"                      # Max reports to fetch per poll
+RELAY_REPORTS_REQUIRE_DIVINE_CLIENT = "true"      # Only ingest reports tagged as sent by diVine
 
 # Funnelcake admin URL — destination for notifyRelay() NIP-98 add/remove
 # webhooks against /api/moderation/quarantine. Empty string = relay-side

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -122,6 +122,7 @@ REPORT_POLLING_ENABLED = "true"                   # Enable/disable inbound NIP-5
 REPORT_POLLING_RELAY_URL = "wss://relay.divine.video" # Relay to poll for kind 1984 reports
 REPORT_POLLING_LOOKBACK_HOURS = "24"              # How far back to look for reports on first run
 REPORT_POLLING_LIMIT = "100"                      # Max reports to fetch per poll
+REPORT_POLLING_MAX_PAGES = "5"                    # Max bounded pages to drain per report poll
 RELAY_REPORTS_REQUIRE_DIVINE_CLIENT = "true"      # Only ingest reports tagged as sent by diVine
 
 # Funnelcake admin URL — destination for notifyRelay() NIP-98 add/remove


### PR DESCRIPTION
## Summary
- Add inbound NIP-56/kind 1984 report polling from `relay.divine.video` on cron.
- Resolve reported target events to media hashes and write `user_reports` plus unreviewed `moderation_results` rows for human review.
- Add safe checkpointing, saturated-page resume handling, idempotence markers, and an admin status endpoint for report polling.
- Document the relay report polling keys and behavior.

## Motivation
Fresh kind 1984 reports are present on the relay, but production has no report-poller KV state and no new `user_reports` after 2026-05-05. The deployed worker only has authenticated `/api/v1/report`; it does not yet ingest public relay reports, so reported videos never reach the moderation review queue.

## Linked Issue
- None. Investigation from report ingestion outage.

## Manual Validation
- Queried production D1: `user_reports` latest row is 2026-05-05 and no `relay-report` moderation rows exist.
- Queried `wss://relay.divine.video` for kind 1984 reports from the last 24h; found fresh diVine reports.
- Dry-ran the report poller against the live relay with mocked D1 writes; 10 report sample would record 5 review rows, skip 2 non-diVine client reports, and retry 3 missing targets.
- `npm test -- src/nostr/report-poller.test.mjs src/moderation/report-review.test.mjs src/reports.test.mjs`
- `npm test -- src/index.test.mjs`
- `npm run lint`

## Deployment Notes
- No deploy performed from this PR branch.
- After deployment, verify `report-poller:last-run` and `report-poller:last-poll` appear in `MODERATION_KV`, then check `/admin/api/videos?action=FLAGGED` for new `provider='user-report'` rows.