### PR TITLE
ci: use 16-core GitHub runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,7 @@ permissions:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
-
+    runs-on: ubuntu-24.04-16core
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -37,8 +36,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
-
+    runs-on: ubuntu-24.04-16core
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -77,7 +75,7 @@ jobs:
 
   deploy:
     name: Deploy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-16core
     needs: [lint, test]
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     timeout-minutes: 60


### PR DESCRIPTION
## Summary
- move Ubuntu GitHub Actions jobs from `ubuntu-latest` to the org-hosted `ubuntu-24.04-16core` runner
- keep workflow logic unchanged; this only changes runner capacity
- rebase onto current `main` so the Vitest flake retry preservation remains in the final workflow

## Motivation
Reduce CI/build lead time across Divine repos. The org runner `ubuntu-24.04-16core` is configured as Ubuntu 24.04, 16 cores, 64 GB RAM, max 50 concurrent runners.

## Linked issue
Closes #175

## Manual validation
- Parsed changed workflow YAML with Ruby
- Ran `git diff --check -- .github/workflows`
- Verified the rebased PR diff only changes CI runner labels and removes stray blank lines
- Refreshed GitHub checks on commit `ae05d87`: Lint passed, Test passed, semantic PR passed, CLA passed; Deploy skipped as expected for pull_request events