### PR TITLE
perf: fast-path public moderation status lookups

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1365,6 +1365,48 @@ async function handleLegacyStatus(sha256, env) {
   });
 }
 
+async function handlePublicCheckResult(url, env) {
+  const sha256 = url.pathname.split('/')[2];
+  const d1Result = await env.BLOSSOM_DB.prepare(`
+    SELECT sha256, action, provider, scores, categories, moderated_at, reviewed_by, reviewed_at, videoseal
+    FROM moderation_results
+    WHERE sha256 = ?
+  `).bind(sha256).first();
+
+  if (!d1Result) {
+    return corsResponse(new Response(JSON.stringify({
+      sha256,
+      status: 'unknown',
+      moderated: false,
+      blocked: false,
+      age_restricted: false
+    }, null, 2), {
+      headers: { 'Content-Type': 'application/json' }
+    }));
+  }
+
+  const action = d1Result.action;
+  return corsResponse(new Response(JSON.stringify({
+    sha256,
+    status: action.toLowerCase(),
+    moderated: true,
+    blocked: action === 'PERMANENT_BAN',
+    quarantined: action === 'QUARANTINE',
+    age_restricted: action === 'AGE_RESTRICTED',
+    needs_review: action === 'REVIEW' || action === 'QUARANTINE' || action === 'PERMANENT_BAN',
+    action,
+    provider: d1Result.provider,
+    scores: d1Result.scores ? JSON.parse(d1Result.scores) : null,
+    categories: d1Result.categories ? JSON.parse(d1Result.categories) : null,
+    videoseal: parseMaybeJson(d1Result.videoseal, null),
+    moderated_at: d1Result.moderated_at,
+    reviewed_by: d1Result.reviewed_by,
+    reviewed_at: d1Result.reviewed_at
+  }, null, 2), {
+    headers: { 'Content-Type': 'application/json' }
+  }));
+}
+
 export default {
   /**
    * HTTP handler for testing and admin dashboard
@@ -1404,6 +1446,13 @@ export default {
     if (!isLocalRequest && hostname === API_HOSTNAME && !isApiSurfacePath(url.pathname)) {
       const expectedHost = url.pathname.startsWith('/admin') ? ADMIN_HOSTNAME : API_HOSTNAME;
       return hostMismatchResponse(requestId, hostname, url.pathname, expectedHost);
+    }
+
+    if (url.pathname.startsWith('/check-result/')) {
+      if (request.method === 'OPTIONS') {
+        return corsResponse(new Response(null, { status: 204 }));
+      }
+      return handlePublicCheckResult(url, env);
     }
 
     await initUploaderEnforcementTable(env.BLOSSOM_DB);
@@ -4001,52 +4050,6 @@ async function runMigration() {
           headers: { 'Content-Type': 'application/json' }
         });
       }
-    }
-
-    // Check moderation result
-    if (url.pathname.startsWith('/check-result/')) {
-      const sha256 = url.pathname.split('/')[2];
-
-      // Query D1 for moderation result
-      const d1Result = await env.BLOSSOM_DB.prepare(`
-        SELECT sha256, action, provider, scores, categories, moderated_at, reviewed_by, reviewed_at, videoseal
-        FROM moderation_results
-        WHERE sha256 = ?
-      `).bind(sha256).first();
-
-      if (!d1Result) {
-        return corsResponse(new Response(JSON.stringify({
-          sha256,
-          status: 'unknown',
-          moderated: false,
-          blocked: false,
-          age_restricted: false
-        }, null, 2), {
-          headers: { 'Content-Type': 'application/json' }
-        }));
-      }
-
-      // Simplified response for external tools
-      const action = d1Result.action;
-      return corsResponse(new Response(JSON.stringify({
-        sha256,
-        status: action.toLowerCase(),
-        moderated: true,
-        blocked: action === 'PERMANENT_BAN',
-        quarantined: action === 'QUARANTINE',
-        age_restricted: action === 'AGE_RESTRICTED',
-        needs_review: action === 'REVIEW' || action === 'QUARANTINE' || action === 'PERMANENT_BAN',
-        action,
-        provider: d1Result.provider,
-        scores: d1Result.scores ? JSON.parse(d1Result.scores) : null,
-        categories: d1Result.categories ? JSON.parse(d1Result.categories) : null,
-        videoseal: parseMaybeJson(d1Result.videoseal, null),
-        moderated_at: d1Result.moderated_at,
-        reviewed_by: d1Result.reviewed_by,
-        reviewed_at: d1Result.reviewed_at
-      }, null, 2), {
-        headers: { 'Content-Type': 'application/json' }
-      }));
     }
 
     // API: Canonical moderation vocabulary (public, no auth required)

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1366,7 +1366,12 @@ async function handleLegacyStatus(sha256, env) {
 }
 
 async function handlePublicCheckResult(url, env) {
-  const sha256 = url.pathname.split('/')[2];
+  const rawSha256 = url.pathname.split('/')[2];
+  if (!rawSha256 || !/^[0-9a-f]{64}$/i.test(rawSha256)) {
+    return corsResponse(jsonResponse(400, { error: 'Invalid sha256' }));
+  }
+
+  const sha256 = rawSha256.toLowerCase();
   const d1Result = await env.BLOSSOM_DB.prepare(`
     SELECT sha256, action, provider, scores, categories, moderated_at, reviewed_by, reviewed_at, videoseal
     FROM moderation_results

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -20,9 +20,11 @@ function createDbMock({
   aiDetectionRecentRows = [],
   moderationWrites = [],
   reporterCount = 1,
+  onPrepare = null,
 } = {}) {
   return {
     prepare(sql) {
+      onPrepare?.(sql);
       let bindings = [];
 
       return {
@@ -148,6 +150,58 @@ describe('HTTP hostname routing', () => {
       action: 'SAFE',
       status: 'safe'
     });
+  });
+
+  it('serves public moderation status without schema initialization', async () => {
+    const preparedSql = [];
+    const env = createEnv({
+      BLOSSOM_DB: createDbMock({
+        moderationResults: new Map([[SHA256, {
+          sha256: SHA256,
+          action: 'SAFE',
+          provider: 'hiveai',
+          scores: JSON.stringify({ nudity: 0.01 }),
+          categories: JSON.stringify(['safe']),
+          moderated_at: '2026-03-07T00:00:00.000Z',
+          reviewed_by: null,
+          reviewed_at: null
+        }]]),
+        onPrepare(sql) {
+          preparedSql.push(sql);
+        }
+      })
+    });
+
+    const response = await worker.fetch(
+      new Request(`https://moderation-api.divine.video/check-result/${SHA256}`),
+      env
+    );
+
+    expect(response.status).toBe(200);
+    expect(preparedSql.some((sql) => /CREATE\s+(?:TABLE|INDEX)/i.test(sql))).toBe(false);
+    expect(preparedSql).toHaveLength(1);
+  });
+
+  it('serves public moderation preflight without database access', async () => {
+    const preparedSql = [];
+    const env = createEnv({
+      BLOSSOM_DB: createDbMock({
+        onPrepare(sql) {
+          preparedSql.push(sql);
+        }
+      })
+    });
+
+    const response = await worker.fetch(
+      new Request(`https://moderation-api.divine.video/check-result/${SHA256}`, {
+        method: 'OPTIONS'
+      }),
+      env
+    );
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
+    expect(preparedSql).toHaveLength(0);
   });
 
   it('rejects admin routes on moderation-api host', async () => {

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -182,6 +182,56 @@ describe('HTTP hostname routing', () => {
     expect(preparedSql).toHaveLength(1);
   });
 
+  it('normalizes mixed-case public moderation status hashes', async () => {
+    const env = createEnv({
+      BLOSSOM_DB: createDbMock({
+        moderationResults: new Map([[SHA256, {
+          sha256: SHA256,
+          action: 'SAFE',
+          provider: 'hiveai',
+          scores: JSON.stringify({ nudity: 0.01 }),
+          categories: JSON.stringify(['safe']),
+          moderated_at: '2026-03-07T00:00:00.000Z',
+          reviewed_by: null,
+          reviewed_at: null
+        }]])
+      })
+    });
+
+    const response = await worker.fetch(
+      new Request(`https://moderation-api.divine.video/check-result/${SHA256.toUpperCase()}`),
+      env
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      sha256: SHA256,
+      moderated: true,
+      action: 'SAFE',
+      status: 'safe'
+    });
+  });
+
+  it('rejects malformed public moderation status hashes without database access', async () => {
+    const preparedSql = [];
+    const env = createEnv({
+      BLOSSOM_DB: createDbMock({
+        onPrepare(sql) {
+          preparedSql.push(sql);
+        }
+      })
+    });
+
+    const response = await worker.fetch(
+      new Request('https://moderation-api.divine.video/check-result/not-a-sha'),
+      env
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: 'Invalid sha256' });
+    expect(preparedSql).toHaveLength(0);
+  });
+
   it('serves public moderation preflight without database access', async () => {
     const preparedSql = [];
     const env = createEnv({

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -2733,6 +2733,7 @@ describe('RD auto-escalation cron integration', () => {
 
     const env = {
       REALITY_DEFENDER_API_KEY: 'fake-rd-key',
+      RELAY_POLLING_ENABLED: 'false',
       REPORT_POLLING_ENABLED: 'false',
       BLOSSOM_WEBHOOK_URL: 'https://mock-blossom.test/admin/moderate',
       BLOSSOM_WEBHOOK_SECRET: 'test-secret',
@@ -2843,6 +2844,7 @@ describe('RD auto-escalation cron integration', () => {
 
     const env = {
       REALITY_DEFENDER_API_KEY: 'fake-rd-key',
+      RELAY_POLLING_ENABLED: 'false',
       REPORT_POLLING_ENABLED: 'false',
       BLOSSOM_WEBHOOK_URL: 'https://mock-blossom.test/admin/moderate',
       BLOSSOM_WEBHOOK_SECRET: 'test-secret',
@@ -2918,6 +2920,7 @@ describe('RD auto-escalation cron integration', () => {
 
     const env = {
       REALITY_DEFENDER_API_KEY: 'fake-rd-key',
+      RELAY_POLLING_ENABLED: 'false',
       REPORT_POLLING_ENABLED: 'false',
       BLOSSOM_WEBHOOK_URL: 'https://mock-blossom.test/admin/moderate',
       BLOSSOM_DB: {
@@ -2992,6 +2995,7 @@ describe('RD auto-escalation cron integration', () => {
 
     const env = {
       REALITY_DEFENDER_API_KEY: 'fake-rd-key',
+      RELAY_POLLING_ENABLED: 'false',
       REPORT_POLLING_ENABLED: 'false',
       BLOSSOM_DB: {
         prepare() {
@@ -4001,6 +4005,7 @@ describe('Transcript reprocess cron integration', () => {
       CDN_DOMAIN: 'media.divine.video',
       BLOSSOM_WEBHOOK_URL: 'https://mock-blossom.test/admin/moderate',
       TRANSCRIPT_REPROCESS_MAX_AGE_DAYS: '7',
+      RELAY_POLLING_ENABLED: 'false',
       REPORT_POLLING_ENABLED: 'false',
       BLOSSOM_DB: {
         prepare(sql) {


### PR DESCRIPTION
## Summary
- Move public `/check-result/:sha` handling ahead of unrelated per-request schema initialization.
- Add a zero-DB `OPTIONS /check-result/:sha` fast path for public moderation status preflight.
- Validate and normalize public status SHA-256 path parameters before querying D1.
- Add regression tests proving public status lookup/preflight avoid schema setup and malformed hashes avoid DB access.

## Motivation
Moderation status checks are on the playback path and need to be fast for clients. The worker was doing unrelated D1 table/index initialization before serving public status lookups. While isolating that route, this also aligns public `/check-result/:sha` behavior with the legacy status endpoint so mixed-case hex hashes resolve correctly and malformed path values return `400` before any database work.

## Linked issue
Closes #176

## Manual validation
- [x] `npx vitest run src/index.test.mjs` — 149 passed
- [x] `npm run lint` — passed for 162 module files and 4 HTML files
- [x] `npx vitest run src/moderation/pipeline.test.mjs` — 23 passed
- [x] `npx wrangler deploy --dry-run` — succeeded
- [!] `npm test` — exited non-zero with Vitest worker `Timeout calling "onTaskUpdate"` after 350/363 tests and no assertion failures; the remaining `src/moderation/pipeline.test.mjs` file passes when run directly