### PR TITLE
feat: add DELETE to validActions on /api/v1/moderate

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -3925,7 +3925,7 @@ async function runMigration() {
         }
 
         // Validate action
-        const validActions = ['SAFE', 'REVIEW', 'QUARANTINE', 'AGE_RESTRICTED', 'PERMANENT_BAN'];
+        const validActions = ['SAFE', 'REVIEW', 'QUARANTINE', 'AGE_RESTRICTED', 'PERMANENT_BAN', 'DELETE'];
         if (!validActions.includes(action.toUpperCase())) {
           return new Response(JSON.stringify({
             error: `Invalid action. Must be one of: ${validActions.join(', ')}`

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -80,7 +80,9 @@ const API_HOSTNAME = 'moderation-api.divine.video';
 // via env.RELAY_ADMIN_URL if needed for staging or rollback.
 const DEFAULT_RELAY_ADMIN_URL = 'https://api-relay-prod.divine.video';
 const JSON_HEADERS = { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' };
-const VALID_MODERATION_ACTIONS = new Set(['SAFE', 'REVIEW', 'QUARANTINE', 'AGE_RESTRICTED', 'PERMANENT_BAN']);
+const MODERATION_ACTIONS = ['SAFE', 'REVIEW', 'QUARANTINE', 'AGE_RESTRICTED', 'PERMANENT_BAN', 'DELETE'];
+const ADMIN_MODERATION_ACTIONS = MODERATION_ACTIONS.filter((action) => action !== 'DELETE');
+const VALID_MODERATION_ACTIONS = new Set(MODERATION_ACTIONS);
 
 // ETags for admin HTML pages — computed once at module load, change only on deploy.
 // Allows browsers to cache the HTML but revalidate on every request (304 if unchanged).
@@ -944,7 +946,7 @@ async function enrichAdminLookupVideo(video, env) {
   return enriched;
 }
 
-const UPLOADER_HISTORY_ACTIONS = ['SAFE', 'REVIEW', 'QUARANTINE', 'AGE_RESTRICTED', 'PERMANENT_BAN'];
+const UPLOADER_HISTORY_ACTIONS = MODERATION_ACTIONS;
 
 function extractReasonFromRow(row) {
   if (row.review_notes) return row.review_notes;
@@ -1994,8 +1996,8 @@ export default {
       const { action, reason, scores, videoUrl, uploadedBy } = await request.json();
 
       // Validate action
-      if (!['SAFE', 'REVIEW', 'QUARANTINE', 'AGE_RESTRICTED', 'PERMANENT_BAN'].includes(action)) {
-        return new Response(JSON.stringify({ error: 'Invalid action. Must be SAFE, REVIEW, QUARANTINE, AGE_RESTRICTED, or PERMANENT_BAN' }), {
+      if (!ADMIN_MODERATION_ACTIONS.includes(action)) {
+        return new Response(JSON.stringify({ error: `Invalid action. Must be ${ADMIN_MODERATION_ACTIONS.join(', ')}` }), {
           status: 400,
           headers: { 'Content-Type': 'application/json' }
         });
@@ -3925,10 +3927,9 @@ async function runMigration() {
         }
 
         // Validate action
-        const validActions = ['SAFE', 'REVIEW', 'QUARANTINE', 'AGE_RESTRICTED', 'PERMANENT_BAN', 'DELETE'];
-        if (!validActions.includes(action.toUpperCase())) {
+        if (!VALID_MODERATION_ACTIONS.has(action.toUpperCase())) {
           return new Response(JSON.stringify({
-            error: `Invalid action. Must be one of: ${validActions.join(', ')}`
+            error: `Invalid action. Must be one of: ${MODERATION_ACTIONS.join(', ')}`
           }), {
             status: 400,
             headers: { 'Content-Type': 'application/json' }

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -1880,6 +1880,85 @@ describe('notifyBlossom integration via admin moderate endpoint', () => {
     }
   });
 
+  it('accepts DELETE for /api/v1/moderate and skips relay-side enforcement', async () => {
+    const sha256 = 'd'.repeat(64);
+    const kvStore = new Map();
+    const moderationWrites = [];
+    let relayFetchCalled = false;
+    const env = {
+      ALLOW_DEV_ACCESS: 'true',
+      SERVICE_API_TOKEN: 'test-service-token',
+      BLOSSOM_WEBHOOK_URL: 'https://mock-blossom.test/admin/moderate',
+      BLOSSOM_WEBHOOK_SECRET: 'test-webhook-secret',
+      FUNNELCAKE_ADMIN_URL: 'https://mock-relay.test',
+      BLOSSOM_DB: createDbMock({
+        moderationResults: new Map([[sha256, {
+          sha256,
+          action: 'REVIEW',
+          provider: 'hiveai',
+          scores: JSON.stringify({}),
+          categories: JSON.stringify([]),
+          moderated_at: '2026-03-12T00:00:00.000Z',
+          reviewed_by: null,
+          reviewed_at: null,
+          event_id: 'e'.repeat(64)
+        }]]),
+        moderationWrites
+      }),
+      MODERATION_KV: {
+        store: kvStore,
+        async get(key) { return kvStore.get(key) ?? null; },
+        async put(key, value) { kvStore.set(key, value); },
+        async delete(key) { kvStore.delete(key); },
+        async list() { return { keys: [], list_complete: true, cursor: null }; }
+      },
+      MODERATION_QUEUE: { async send() {} },
+    };
+
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = async (url, init) => {
+      if (url === 'https://mock-blossom.test/admin/moderate') {
+        return new Response(JSON.stringify({ success: true }), { status: 200 });
+      }
+      if (typeof url === 'string' && url.startsWith('https://mock-relay.test/')) {
+        relayFetchCalled = true;
+        throw new Error('relay should not be called for DELETE');
+      }
+      return origFetch(url, init);
+    };
+
+    try {
+      const response = await worker.fetch(
+        new Request('https://moderation-api.divine.video/api/v1/moderate', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': 'Bearer test-service-token',
+          },
+          body: JSON.stringify({
+            sha256,
+            action: 'DELETE',
+            reason: 'creator deleted via kind-5',
+            source: 'relay-manager',
+          }),
+        }),
+        env
+      );
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.success).toBe(true);
+      expect(data.action).toBe('DELETE');
+      expect(data.blossom_notified).toBe(true);
+      expect(data.relay_notified).toBe(false);
+      expect(relayFetchCalled).toBe(false);
+      expect(moderationWrites).toHaveLength(1);
+      expect(moderationWrites[0].bindings[1]).toBe('DELETE');
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
   it('returns 502 when Blossom webhook fails for /admin/api/moderate', async () => {
     const sha256 = 'b'.repeat(64);
     const kvStore = new Map();

--- a/src/relay-notifier.mjs
+++ b/src/relay-notifier.mjs
@@ -49,7 +49,7 @@ function buildNip98Token(privateKeyHex, method, url, bodyBytes) {
  *
  * @param {string} sha256Hex Video sha256 (carried for logging only)
  * @param {string|null} eventId Relay event id (kind 34236). Required.
- * @param {string} action SAFE | REVIEW | QUARANTINE | AGE_RESTRICTED | PERMANENT_BAN
+ * @param {string} action SAFE | REVIEW | QUARANTINE | AGE_RESTRICTED | PERMANENT_BAN | DELETE
  * @param {Object} env Worker env. Reads FUNNELCAKE_ADMIN_URL, NOSTR_PRIVATE_KEY.
  * @param {typeof fetch} [fetcher] Injected fetch for testing.
  * @returns {Promise<{success: boolean, skipped?: boolean, reason?: string, error?: string}>}
@@ -66,6 +66,11 @@ export async function notifyRelay(sha256Hex, eventId, action, env, fetcher = fet
   if (action === 'REVIEW') {
     // REVIEW is internal — content stays publicly accessible until a moderator decides.
     return { success: true, skipped: true, reason: 'REVIEW is internal-only' };
+  }
+  if (action === 'DELETE') {
+    // Creator kind-5 deletes already handled relay-side removal before this
+    // moderation API path mirrors the terminal blob state into Blossom.
+    return { success: true, skipped: true, reason: 'DELETE assumes relay-side removal already happened' };
   }
   if (!eventId) {
     return { success: true, skipped: true, reason: 'no event_id on moderation result' };

--- a/src/uploader-history.test.mjs
+++ b/src/uploader-history.test.mjs
@@ -173,7 +173,8 @@ describe('GET /admin/api/uploader/:pubkey', () => {
       REVIEW: 1,
       QUARANTINE: 0,
       AGE_RESTRICTED: 0,
-      PERMANENT_BAN: 1
+      PERMANENT_BAN: 1,
+      DELETE: 0
     });
     expect(body.recentFlagged).toHaveLength(2);
     expect(body.recentFlagged[0].action).toBe('PERMANENT_BAN');
@@ -205,7 +206,8 @@ describe('GET /admin/api/uploader/:pubkey', () => {
       REVIEW: 0,
       QUARANTINE: 0,
       AGE_RESTRICTED: 0,
-      PERMANENT_BAN: 0
+      PERMANENT_BAN: 0,
+      DELETE: 0
     });
     expect(body.recentFlagged).toEqual([]);
     expect(body.dmCount).toBe(0);
@@ -229,7 +231,8 @@ describe('GET /admin/api/uploader/:pubkey', () => {
           { sha256: sha(2), uploaded_by: PUBKEY, action: 'REVIEW', moderated_at: '2026-01-02T00:00:00.000Z' },
           { sha256: sha(3), uploaded_by: PUBKEY, action: 'QUARANTINE', moderated_at: '2026-01-03T00:00:00.000Z' },
           { sha256: sha(4), uploaded_by: PUBKEY, action: 'AGE_RESTRICTED', moderated_at: '2026-01-04T00:00:00.000Z' },
-          { sha256: sha(5), uploaded_by: PUBKEY, action: 'PERMANENT_BAN', moderated_at: '2026-01-05T00:00:00.000Z' }
+          { sha256: sha(5), uploaded_by: PUBKEY, action: 'PERMANENT_BAN', moderated_at: '2026-01-05T00:00:00.000Z' },
+          { sha256: sha(6), uploaded_by: PUBKEY, action: 'DELETE', moderated_at: '2026-01-06T00:00:00.000Z' }
         ]
       })
     });
@@ -247,8 +250,9 @@ describe('GET /admin/api/uploader/:pubkey', () => {
       REVIEW: 1,
       QUARANTINE: 1,
       AGE_RESTRICTED: 1,
-      PERMANENT_BAN: 1
+      PERMANENT_BAN: 1,
+      DELETE: 1
     });
-    expect(body.totals.videos).toBe(5);
+    expect(body.totals.videos).toBe(6);
   });
 });


### PR DESCRIPTION
## Summary

- Adds `DELETE` to the `validActions` array on the `/api/v1/moderate` endpoint
- `BLOSSOM_ACTION_MAP` already maps `DELETE` -> `DELETE` -- the only thing blocking DELETE requests was this validation array
- Prerequisite for relay-manager deletion alignment work (composable moderation actions, age review integration)

## Test plan

- [ ] `npx vitest run` passes (1,241 tests, all green)
- [ ] Deploy to production, verify `/api/v1/moderate` accepts `action: "DELETE"` for a test hash