### PR TITLE
feat(dm): round out the moderation compose experience — start, resolve, template, send

### DIFF
--- a/docs/superpowers/plans/2026-06-03-moderator-compose-new-dm.md
+++ b/docs/superpowers/plans/2026-06-03-moderator-compose-new-dm.md
@@ -1,0 +1,889 @@
+# Moderator-initiated DM compose — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a moderator start a brand-new DM from the Messages inbox by addressing a recipient via pasted npub/hex or a verified nip-05, optionally pre-filling an existing template, with new/empty threads rendering cleanly.
+
+**Architecture:** All recipient resolution happens **server-side** in one new endpoint (`GET /admin/api/recipient/resolve`). It decodes a bare hex pubkey or an `npub` deterministically (reusing the worker's existing `nostr-tools`, so no new dependency and no browser bech32 lib), and resolves a `user@domain` nip-05 against the domain's `.well-known/nostr.json` for an authoritative pubkey. The send path, NIP-17 wrapping, relay discovery, and `dm_log` storage are unchanged. Templates reuse the existing `dm-sender.mjs` functions, exposed for manual selection. One bugfix: the thread GET returns `200 {messages:[]}` instead of `404` for never-messaged users.
+
+> **Deviation from spec (intentional):** the design doc described decoding npub/hex client-side "with no network call." `messages.html` has no client-side nostr-tools/bech32 library and the design forbids new dependencies, so npub/hex decode is done server-side in the same resolve endpoint as nip-05. User-facing behavior is identical (deterministic decode for keys, verification for nip-05); only the decode location moved.
+
+**Tech Stack:** Cloudflare Workers (ESM `.mjs`), `nostr-tools` (`nip19` for npub decode), Vitest, Cloudflare KV (`MODERATION_KV`), static admin HTML with inline JS.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|----------------|
+| `src/nostr/nip05.mjs` | **New.** `parseNip05()` + `resolveNip05()` — verify a `user@domain` against `.well-known/nostr.json`, KV-cached. |
+| `src/nostr/nip05.test.mjs` | **New.** Unit tests for the resolver (mocked `fetch` + mock KV). |
+| `src/nostr/dm-sender.mjs` | **Modify.** Add `COMPOSE_TEMPLATES` + `renderComposeTemplate()`, reusing existing `TEMPLATES`/`selectTemplate`. |
+| `src/nostr/dm-sender.test.mjs` | **Modify.** Add tests for the two new exports. |
+| `src/index.mjs` | **Modify.** Import `nip19.decode`; add `GET /admin/api/recipient/resolve`; add `GET /admin/api/dm-templates`; change empty-thread `GET /admin/api/messages/{pubkey}` from 404 to `200 {messages:[]}`. |
+| `src/index.test.mjs` | **Modify.** Add route tests for the two new endpoints + the 404→200 change. |
+| `src/admin/messages.html` | **Modify.** "New Message" button, recipient bar (calls resolve endpoint), confirmation line, template dropdown, friendlier empty-thread copy. |
+| `src/admin/messages-ui.test.mjs` | **New.** `toContain` assertions for the new UI hooks (mirrors `swipe-review-ui.test.mjs`). |
+
+Shared test fixtures used below:
+- `RECIPIENT_HEX = '00000000000000000000000000000000000000000000000000000000000000ab'`
+- `RECIPIENT_NPUB = 'npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqz4s0z660k'` (decodes to `RECIPIENT_HEX`)
+
+---
+
+## Task 1: nip-05 resolver module
+
+**Files:**
+- Create: `src/nostr/nip05.mjs`
+- Test: `src/nostr/nip05.test.mjs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/nostr/nip05.test.mjs`:
+
+```js
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Tests for resolveNip05 / parseNip05 — well-known verification + KV cache.
+// ABOUTME: Mocks global fetch; no real network.
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { parseNip05, resolveNip05 } from './nip05.mjs';
+import { createMockKV } from '../test/helpers.mjs';
+
+const HEX = '00000000000000000000000000000000000000000000000000000000000000ab';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('parseNip05', () => {
+  it('splits a valid address', () => {
+    expect(parseNip05('alice@divine.video')).toEqual({ name: 'alice', domain: 'divine.video' });
+  });
+  it('rejects input without @', () => {
+    expect(parseNip05('alice')).toBeNull();
+  });
+  it('rejects bad local-part chars', () => {
+    expect(parseNip05('al ice@divine.video')).toBeNull();
+  });
+  it('rejects non-string', () => {
+    expect(parseNip05(null)).toBeNull();
+  });
+});
+
+describe('resolveNip05', () => {
+  it('returns the authoritative pubkey when names[name] is valid hex', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ names: { alice: HEX } }),
+    }));
+    const env = { MODERATION_KV: createMockKV() };
+    const result = await resolveNip05('alice@divine.video', env);
+    expect(result).toEqual({ pubkey: HEX, address: 'alice@divine.video', domain: 'divine.video' });
+    expect(fetch).toHaveBeenCalledWith(
+      'https://divine.video/.well-known/nostr.json?name=alice',
+      expect.objectContaining({ headers: expect.any(Object) }),
+    );
+  });
+
+  it('returns null when the name is absent', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => ({ names: {} }) }));
+    const result = await resolveNip05('ghost@divine.video', { MODERATION_KV: createMockKV() });
+    expect(result).toBeNull();
+  });
+
+  it('returns null on non-200', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 404, json: async () => ({}) }));
+    const result = await resolveNip05('alice@divine.video', { MODERATION_KV: createMockKV() });
+    expect(result).toBeNull();
+  });
+
+  it('returns null for malformed address and never fetches', async () => {
+    const spy = vi.fn();
+    vi.stubGlobal('fetch', spy);
+    const result = await resolveNip05('not-an-address', { MODERATION_KV: createMockKV() });
+    expect(result).toBeNull();
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('serves a cached positive result without fetching again', async () => {
+    const kv = createMockKV({ 'nip05:alice@divine.video': JSON.stringify({ pubkey: HEX }) });
+    const spy = vi.fn();
+    vi.stubGlobal('fetch', spy);
+    const result = await resolveNip05('alice@divine.video', { MODERATION_KV: kv });
+    expect(result).toEqual({ pubkey: HEX, address: 'alice@divine.video', domain: 'divine.video' });
+    expect(spy).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/nostr/nip05.test.mjs`
+Expected: FAIL — `Failed to resolve import "./nip05.mjs"`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/nostr/nip05.mjs`:
+
+```js
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Resolves a nip-05 "user@domain" to an authoritative hex pubkey via the
+// ABOUTME: domain's .well-known/nostr.json. KV-cached (1h). null on any failure.
+
+const NIP05_CACHE_TTL = 3600; // 1 hour
+const FETCH_TIMEOUT_MS = 5000;
+
+const LOCAL_PART_RE = /^[a-z0-9._-]+$/i;
+const DOMAIN_RE = /^[a-z0-9.-]+\.[a-z]{2,}$/i;
+const HEX64_RE = /^[0-9a-f]{64}$/i;
+
+/**
+ * Parse "user@domain" into { name, domain } or null if malformed.
+ * @param {string} address
+ * @returns {{name: string, domain: string} | null}
+ */
+export function parseNip05(address) {
+  if (typeof address !== 'string') return null;
+  const trimmed = address.trim();
+  const at = trimmed.lastIndexOf('@');
+  if (at <= 0 || at === trimmed.length - 1) return null;
+  const name = trimmed.slice(0, at);
+  const domain = trimmed.slice(at + 1).toLowerCase();
+  if (!LOCAL_PART_RE.test(name) || !DOMAIN_RE.test(domain)) return null;
+  return { name, domain };
+}
+
+/**
+ * Resolve a nip-05 address to an authoritative hex pubkey.
+ * Returns { pubkey, address, domain } or null.
+ * @param {string} address - "user@domain"
+ * @param {Object} env - Cloudflare env (uses MODERATION_KV for caching)
+ */
+export async function resolveNip05(address, env) {
+  const parsed = parseNip05(address);
+  if (!parsed) return null;
+  const { name, domain } = parsed;
+  const canonical = `${name}@${domain}`;
+  const cacheKey = `nip05:${canonical.toLowerCase()}`;
+
+  if (env?.MODERATION_KV) {
+    try {
+      const cached = await env.MODERATION_KV.get(cacheKey);
+      if (cached !== null) {
+        const { pubkey } = JSON.parse(cached);
+        return pubkey ? { pubkey, address: canonical, domain } : null;
+      }
+    } catch { /* ignore cache read errors */ }
+  }
+
+  let pubkey = null;
+  try {
+    const url = `https://${domain}/.well-known/nostr.json?name=${encodeURIComponent(name)}`;
+    const res = await fetch(url, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      headers: { Accept: 'application/json' },
+    });
+    if (res.ok) {
+      const json = await res.json();
+      const found = json?.names?.[name];
+      if (typeof found === 'string' && HEX64_RE.test(found)) {
+        pubkey = found.toLowerCase();
+      }
+    }
+  } catch (err) {
+    console.error('[NIP05] resolve failed:', err.message);
+  }
+
+  if (env?.MODERATION_KV) {
+    try {
+      await env.MODERATION_KV.put(cacheKey, JSON.stringify({ pubkey: pubkey || null }), {
+        expirationTtl: NIP05_CACHE_TTL,
+      });
+    } catch { /* ignore cache write errors */ }
+  }
+
+  return pubkey ? { pubkey, address: canonical, domain } : null;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/nostr/nip05.test.mjs`
+Expected: PASS (all 9 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nostr/nip05.mjs src/nostr/nip05.test.mjs
+git commit -m "feat(dm): add verified nip-05 resolver (.well-known/nostr.json)"
+```
+
+---
+
+## Task 2: Recipient resolve endpoint
+
+**Files:**
+- Modify: `src/index.mjs` (add import near line 17; add route alongside the other `/admin/api/messages` routes, ~line 3490)
+- Test: `src/index.test.mjs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/index.test.mjs` (inside the top-level `describe`, after an existing block). Reuse the file's local `createEnv`; bypass auth with `ALLOW_DEV_ACCESS: 'true'`:
+
+```js
+describe('GET /admin/api/recipient/resolve', () => {
+  const HEX = '00000000000000000000000000000000000000000000000000000000000000ab';
+  const NPUB = 'npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqz4s0z660k';
+
+  it('resolves a bare hex pubkey', async () => {
+    const res = await worker.fetch(
+      new Request('https://moderation.admin.divine.video/admin/api/recipient/resolve?input=' + HEX),
+      createEnv({ ALLOW_DEV_ACCESS: 'true' }),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ pubkey: HEX, source: 'hex' });
+  });
+
+  it('decodes an npub', async () => {
+    const res = await worker.fetch(
+      new Request('https://moderation.admin.divine.video/admin/api/recipient/resolve?input=' + NPUB),
+      createEnv({ ALLOW_DEV_ACCESS: 'true' }),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ pubkey: HEX, source: 'npub' });
+  });
+
+  it('400s an invalid npub', async () => {
+    const res = await worker.fetch(
+      new Request('https://moderation.admin.divine.video/admin/api/recipient/resolve?input=npub1notreal'),
+      createEnv({ ALLOW_DEV_ACCESS: 'true' }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('verifies a nip-05 via well-known', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => ({ names: { alice: HEX } }) }));
+    const res = await worker.fetch(
+      new Request('https://moderation.admin.divine.video/admin/api/recipient/resolve?input=alice@divine.video'),
+      createEnv({ ALLOW_DEV_ACCESS: 'true' }),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ pubkey: HEX, source: 'nip05', address: 'alice@divine.video' });
+    vi.unstubAllGlobals();
+  });
+
+  it('404s an unknown nip-05', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => ({ names: {} }) }));
+    const res = await worker.fetch(
+      new Request('https://moderation.admin.divine.video/admin/api/recipient/resolve?input=ghost@divine.video'),
+      createEnv({ ALLOW_DEV_ACCESS: 'true' }),
+    );
+    expect(res.status).toBe(404);
+    vi.unstubAllGlobals();
+  });
+
+  it('400s empty input', async () => {
+    const res = await worker.fetch(
+      new Request('https://moderation.admin.divine.video/admin/api/recipient/resolve'),
+      createEnv({ ALLOW_DEV_ACCESS: 'true' }),
+    );
+    expect(res.status).toBe(400);
+  });
+});
+```
+
+Ensure `vi` is imported at the top of `src/index.test.mjs` (it imports from `vitest`; add `vi` to the import list if absent).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/index.test.mjs -t "recipient/resolve"`
+Expected: FAIL — hex case returns 404 (route not found) instead of 200.
+
+- [ ] **Step 3a: Add the nip19 import**
+
+In `src/index.mjs`, near the existing `import { getPublicKey } from 'nostr-tools/pure';` (line 17), add:
+
+```js
+import { decode as decodeNip19 } from 'nostr-tools/nip19';
+```
+
+- [ ] **Step 3b: Add the route**
+
+In `src/index.mjs`, immediately after the `POST /admin/api/messages/{pubkey}` route block (the one that calls `sendModeratorReply`, ~line 3493), add:
+
+```js
+    // Admin API: Resolve a recipient (hex / npub / verified nip-05) to a hex pubkey.
+    // Display-name lookup is intentionally NOT supported — see
+    // docs/superpowers/specs/2026-06-03-moderator-compose-new-dm-design.md (Non-goals).
+    if (url.pathname === '/admin/api/recipient/resolve' && request.method === 'GET') {
+      const authError = await requireAuth(request, env);
+      if (authError) return authError;
+
+      const input = (url.searchParams.get('input') || '').trim();
+      if (!input) {
+        return new Response(JSON.stringify({ error: 'input is required' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+      }
+      // 1. Bare hex pubkey
+      if (/^[0-9a-f]{64}$/i.test(input)) {
+        return new Response(JSON.stringify({ pubkey: input.toLowerCase(), source: 'hex' }), { headers: { 'Content-Type': 'application/json' } });
+      }
+      // 2. npub (deterministic decode)
+      if (input.startsWith('npub1')) {
+        try {
+          const decoded = decodeNip19(input);
+          if (decoded.type === 'npub' && typeof decoded.data === 'string') {
+            return new Response(JSON.stringify({ pubkey: decoded.data, source: 'npub' }), { headers: { 'Content-Type': 'application/json' } });
+          }
+        } catch { /* fall through to 400 */ }
+        return new Response(JSON.stringify({ error: 'invalid npub' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+      }
+      // 3. nip-05 (verified against the domain's well-known)
+      if (input.includes('@')) {
+        const { resolveNip05 } = await import('./nostr/nip05.mjs');
+        const resolved = await resolveNip05(input, env);
+        if (!resolved) {
+          return new Response(JSON.stringify({ error: 'not found' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
+        }
+        return new Response(JSON.stringify({ pubkey: resolved.pubkey, address: resolved.address, domain: resolved.domain, source: 'nip05' }), { headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response(JSON.stringify({ error: 'invalid input' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/index.test.mjs -t "recipient/resolve"`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/index.mjs src/index.test.mjs
+git commit -m "feat(dm): add /admin/api/recipient/resolve (hex/npub/verified nip-05)"
+```
+
+---
+
+## Task 3: Compose templates (reuse existing templates)
+
+**Files:**
+- Modify: `src/nostr/dm-sender.mjs` (add exports after `getReportOutcomeMessage`, ~line 188)
+- Test: `src/nostr/dm-sender.test.mjs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/nostr/dm-sender.test.mjs`:
+
+```js
+import { COMPOSE_TEMPLATES, renderComposeTemplate } from './dm-sender.mjs';
+
+describe('COMPOSE_TEMPLATES / renderComposeTemplate', () => {
+  it('exposes the four creator-facing templates and excludes report-outcome', () => {
+    const keys = COMPOSE_TEMPLATES.map(t => t.key);
+    expect(keys).toEqual(['PERMANENT_BAN', 'AGE_RESTRICTED', 'QUARANTINE', 'ACCOUNT_SUSPENDED']);
+    expect(keys).not.toContain('REPORT_OUTCOME_ACTION');
+    COMPOSE_TEMPLATES.forEach(t => expect(typeof t.label).toBe('string'));
+  });
+
+  it('renders without a video (null-safe) using the generic subject', () => {
+    const body = renderComposeTemplate('PERMANENT_BAN');
+    expect(body).toContain('Your content');
+    expect(body).not.toContain('divine.video/video/'); // no content link when sha256 is null
+  });
+
+  it('renders ACCOUNT_SUSPENDED with no args', () => {
+    const body = renderComposeTemplate('ACCOUNT_SUSPENDED');
+    expect(body).toContain('account has been suspended');
+  });
+
+  it('category specialization matches selectTemplate output', () => {
+    const sha = '11'.repeat(32);
+    expect(renderComposeTemplate('PERMANENT_BAN', { category: 'nudity', sha256: sha }))
+      .toBe(selectTemplate('PERMANENT_BAN', null, 'nudity', sha));
+  });
+
+  it('returns null for an unknown key', () => {
+    expect(renderComposeTemplate('NOPE')).toBeNull();
+  });
+});
+```
+
+If `selectTemplate` is not already imported in this test file, add it to the existing `import { ... } from './dm-sender.mjs';` line.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/nostr/dm-sender.test.mjs -t "COMPOSE_TEMPLATES"`
+Expected: FAIL — `COMPOSE_TEMPLATES`/`renderComposeTemplate` are not exported.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/nostr/dm-sender.mjs`, after `getReportOutcomeMessage` (~line 188), add:
+
+```js
+// --- Manual compose templates ---
+// Creator-facing templates a moderator may pre-fill when composing by hand.
+// Excludes REPORT_OUTCOME_* (reporter-facing auto-sends with a different signature).
+// Single source of truth: these reuse TEMPLATES/selectTemplate verbatim.
+export const COMPOSE_TEMPLATES = [
+  { key: 'PERMANENT_BAN', label: 'Content removed' },
+  { key: 'AGE_RESTRICTED', label: 'Content age-restricted' },
+  { key: 'QUARANTINE', label: 'Content under review' },
+  { key: 'ACCOUNT_SUSPENDED', label: 'Account suspended' },
+];
+
+/**
+ * Render a compose template to editable text. Null-safe for compose with no video.
+ * @param {string} key - one of COMPOSE_TEMPLATES[].key
+ * @param {{category?: string|null, sha256?: string|null, title?: string|null, publishedAt?: string|null}} [opts]
+ * @returns {string|null} rendered body, or null for an unknown key
+ */
+export function renderComposeTemplate(key, opts = {}) {
+  const { category = null, sha256 = null, title = null, publishedAt = null } = opts;
+  if (!TEMPLATES[key]) return null;
+  return selectTemplate(key, null, category, sha256, title, publishedAt);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/nostr/dm-sender.test.mjs -t "COMPOSE_TEMPLATES"`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nostr/dm-sender.mjs src/nostr/dm-sender.test.mjs
+git commit -m "feat(dm): expose creator-facing templates for manual compose"
+```
+
+---
+
+## Task 4: dm-templates endpoint
+
+**Files:**
+- Modify: `src/index.mjs` (add route after the recipient/resolve route)
+- Test: `src/index.test.mjs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/index.test.mjs`:
+
+```js
+describe('GET /admin/api/dm-templates', () => {
+  it('returns the creator-facing templates with rendered bodies', async () => {
+    const res = await worker.fetch(
+      new Request('https://moderation.admin.divine.video/admin/api/dm-templates'),
+      createEnv({ ALLOW_DEV_ACCESS: 'true' }),
+    );
+    expect(res.status).toBe(200);
+    const templates = await res.json();
+    expect(templates.map(t => t.key)).toEqual(['PERMANENT_BAN', 'AGE_RESTRICTED', 'QUARANTINE', 'ACCOUNT_SUSPENDED']);
+    templates.forEach(t => {
+      expect(typeof t.label).toBe('string');
+      expect(typeof t.body).toBe('string');
+      expect(t.body.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('threads video context into the body when sha256 is given', async () => {
+    const sha = '22'.repeat(32);
+    const res = await worker.fetch(
+      new Request('https://moderation.admin.divine.video/admin/api/dm-templates?sha256=' + sha),
+      createEnv({ ALLOW_DEV_ACCESS: 'true' }),
+    );
+    const templates = await res.json();
+    const ban = templates.find(t => t.key === 'PERMANENT_BAN');
+    expect(ban.body).toContain('divine.video/video/' + sha);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/index.test.mjs -t "dm-templates"`
+Expected: FAIL — route returns 404.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/index.mjs`, immediately after the `recipient/resolve` route block, add:
+
+```js
+    // Admin API: List creator-facing DM templates (rendered, optionally with video context).
+    if (url.pathname === '/admin/api/dm-templates' && request.method === 'GET') {
+      const authError = await requireAuth(request, env);
+      if (authError) return authError;
+
+      const sha256 = url.searchParams.get('sha256') || null;
+      const title = url.searchParams.get('title') || null;
+      const publishedAt = url.searchParams.get('publishedAt') || null;
+      const category = url.searchParams.get('category') || null;
+      const { COMPOSE_TEMPLATES, renderComposeTemplate } = await import('./nostr/dm-sender.mjs');
+      const templates = COMPOSE_TEMPLATES.map(t => ({
+        key: t.key,
+        label: t.label,
+        body: renderComposeTemplate(t.key, { category, sha256, title, publishedAt }),
+      }));
+      return new Response(JSON.stringify(templates), { headers: { 'Content-Type': 'application/json' } });
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/index.test.mjs -t "dm-templates"`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/index.mjs src/index.test.mjs
+git commit -m "feat(dm): add /admin/api/dm-templates endpoint"
+```
+
+---
+
+## Task 5: Empty-thread 404 → 200 fix
+
+**Files:**
+- Modify: `src/index.mjs` (the `GET /admin/api/messages/{pubkey}` block, ~line 3467-3477)
+- Test: `src/index.test.mjs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/index.test.mjs`. `createDbMock()` (already defined in the file) returns no conversation for an arbitrary pubkey, so `getConversationByPubkey` yields null:
+
+```js
+describe('GET /admin/api/messages/{pubkey} for an unknown pubkey', () => {
+  it('returns 200 with an empty messages array (not 404)', async () => {
+    const HEX = '00000000000000000000000000000000000000000000000000000000000000ab';
+    const res = await worker.fetch(
+      new Request('https://moderation.admin.divine.video/admin/api/messages/' + HEX),
+      createEnv({ ALLOW_DEV_ACCESS: 'true' }),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ messages: [] });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/index.test.mjs -t "unknown pubkey"`
+Expected: FAIL — currently returns 404 `{error:'No conversation found'}`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/index.mjs`, in the `GET /admin/api/messages/{pubkey}` block, replace:
+
+```js
+      if (!messages) {
+        return new Response(JSON.stringify({ error: 'No conversation found' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
+      }
+```
+
+with:
+
+```js
+      if (!messages) {
+        // Never-messaged recipient: return an empty thread (200) so the compose UI
+        // can render for new conversations instead of showing a load error.
+        return new Response(JSON.stringify({ messages: [] }), { headers: { 'Content-Type': 'application/json' } });
+      }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/index.test.mjs -t "unknown pubkey"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/index.mjs src/index.test.mjs
+git commit -m "fix(dm): return empty thread (200) for never-messaged recipients"
+```
+
+---
+
+## Task 6: Messages UI — New Message, recipient bar, templates, empty copy
+
+**Files:**
+- Modify: `src/admin/messages.html`
+- Test: `src/admin/messages-ui.test.mjs` (new)
+
+This task is split into small steps. The inline JS reuses the existing `selectConversation(pubkey)`, `profileCache`, and `escapeHtml`. Manual validation at the end covers behavior that the string-level UI test cannot.
+
+- [ ] **Step 1: Write the failing UI test**
+
+Create `src/admin/messages-ui.test.mjs` (mirrors `swipe-review-ui.test.mjs`):
+
+```js
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { describe, expect, it } from 'vitest';
+import messagesHTML from './messages.html';
+
+describe('messages UI — new message compose hooks', () => {
+  it('has a New Message button and recipient bar', () => {
+    expect(messagesHTML).toContain('New Message');
+    expect(messagesHTML).toContain('openNewMessage');
+    expect(messagesHTML).toContain('recipient-input');
+    expect(messagesHTML).toContain('resolveRecipient');
+  });
+
+  it('calls the recipient resolve endpoint', () => {
+    expect(messagesHTML).toContain('/admin/api/recipient/resolve?input=');
+  });
+
+  it('has a template picker wired to the templates endpoint', () => {
+    expect(messagesHTML).toContain('template-select');
+    expect(messagesHTML).toContain('/admin/api/dm-templates');
+    expect(messagesHTML).toContain('loadTemplates');
+  });
+
+  it('uses the friendlier empty-thread copy', () => {
+    expect(messagesHTML).toContain('No messages yet');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/admin/messages-ui.test.mjs`
+Expected: FAIL — none of the strings exist yet.
+
+- [ ] **Step 3: Add the "New Message" button + recipient bar markup**
+
+In `src/admin/messages.html`, replace the header-actions block:
+
+```html
+    <div class="header-actions">
+      <a href="/admin/dashboard">Back to Dashboard</a>
+      <button class="btn-primary" onclick="refreshAll()">Refresh</button>
+    </div>
+```
+
+with:
+
+```html
+    <div class="header-actions">
+      <a href="/admin/dashboard">Back to Dashboard</a>
+      <button class="btn-primary" onclick="openNewMessage()">New Message</button>
+      <button class="btn-primary" onclick="refreshAll()">Refresh</button>
+    </div>
+```
+
+Then add a recipient bar just inside the thread panel — replace:
+
+```html
+      <div class="empty-state" id="thread-placeholder">
+        Select a conversation to view messages
+      </div>
+```
+
+with:
+
+```html
+      <div class="empty-state" id="thread-placeholder">
+        Select a conversation, or start a New Message
+      </div>
+      <div id="new-recipient-bar" style="display:none; padding:12px; border-bottom:1px solid #333;">
+        <input type="text" id="recipient-input" placeholder="npub, hex pubkey, or user@domain (nip-05)"
+          style="width:60%;" onkeydown="if(event.key==='Enter'){event.preventDefault();resolveRecipient();}">
+        <button class="btn-primary" onclick="resolveRecipient()">Start</button>
+        <span id="recipient-status" style="margin-left:10px; font-size:13px;"></span>
+      </div>
+```
+
+- [ ] **Step 4: Add the template picker markup**
+
+In `src/admin/messages.html`, in the `compose-extras` block, replace:
+
+```html
+          <div class="compose-extras">
+            <label>Link video:</label>
+            <input type="text" id="compose-sha256" placeholder="sha256 (optional)">
+          </div>
+```
+
+with:
+
+```html
+          <div class="compose-extras">
+            <label>Template:</label>
+            <select id="template-select" onchange="applyTemplate(this.value)">
+              <option value="">— none —</option>
+            </select>
+            <label>Link video:</label>
+            <input type="text" id="compose-sha256" placeholder="sha256 (optional)">
+          </div>
+```
+
+- [ ] **Step 5: Add the JS — New Message flow, recipient resolution, templates**
+
+In `src/admin/messages.html`, inside the `<script>` block (after the existing `selectConversation` function), add:
+
+```js
+    // --- New Message compose ---
+
+    function openNewMessage() {
+      const bar = document.getElementById('new-recipient-bar');
+      bar.style.display = 'block';
+      document.getElementById('recipient-status').textContent = '';
+      const input = document.getElementById('recipient-input');
+      input.value = '';
+      input.focus();
+    }
+
+    async function resolveRecipient() {
+      const input = document.getElementById('recipient-input').value.trim();
+      const status = document.getElementById('recipient-status');
+      if (!input) return;
+      status.style.color = '#888';
+      status.textContent = 'Resolving…';
+      try {
+        const res = await fetch('/admin/api/recipient/resolve?input=' + encodeURIComponent(input));
+        if (!res.ok) {
+          status.style.color = '#e66';
+          status.textContent = res.status === 404
+            ? "Couldn't verify that nip-05. If you have their npub or pubkey, paste it instead."
+            : 'Invalid recipient. Paste an npub, hex pubkey, or user@domain.';
+          return;
+        }
+        const data = await res.json();
+        const label = data.source === 'nip05'
+          ? '✓ ' + escapeHtml(data.address) + ' (verified via ' + escapeHtml(data.domain) + ')'
+          : '✓ ' + truncatePubkey(data.pubkey);
+        status.style.color = '#6c6';
+        status.innerHTML = label;
+        document.getElementById('new-recipient-bar').style.display = 'none';
+        await fetchProfiles([data.pubkey]);
+        await selectConversation(data.pubkey);
+      } catch (err) {
+        status.style.color = '#e66';
+        status.textContent = 'Resolution failed. Try again.';
+        console.error('resolveRecipient error:', err);
+      }
+    }
+
+    // --- Templates ---
+
+    let templateCache = [];
+
+    async function loadTemplates() {
+      const sha = document.getElementById('compose-sha256')?.value?.trim();
+      const qs = sha ? '?sha256=' + encodeURIComponent(sha) : '';
+      try {
+        const res = await fetch('/admin/api/dm-templates' + qs);
+        if (!res.ok) return;
+        templateCache = await res.json();
+        const select = document.getElementById('template-select');
+        select.innerHTML = '<option value="">— none —</option>'
+          + templateCache.map((t, i) => '<option value="' + i + '">' + escapeHtml(t.label) + '</option>').join('');
+      } catch (err) {
+        console.error('loadTemplates error:', err);
+      }
+    }
+
+    function applyTemplate(index) {
+      if (index === '') return;
+      const tpl = templateCache[Number(index)];
+      if (tpl && tpl.body) {
+        document.getElementById('compose-input').value = tpl.body;
+      }
+    }
+```
+
+- [ ] **Step 6: Call loadTemplates at init and fix the empty-thread copy**
+
+In `src/admin/messages.html`, in the `init()` function (near the bottom, where `fetchConversations()` and the `preselectedPubkey` handling live), add a `loadTemplates();` call. For example change:
+
+```js
+      async function init() {
+        await fetchConversations();
+        if (preselectedPubkey) {
+```
+
+to:
+
+```js
+      async function init() {
+        await fetchConversations();
+        loadTemplates();
+        if (preselectedPubkey) {
+```
+
+(If the init structure differs, just ensure `loadTemplates()` runs once on load.)
+
+Then update the empty-thread copy in `renderThread()` — replace:
+
+```js
+        el.textContent = 'No messages in this conversation';
+```
+
+with:
+
+```js
+        el.textContent = 'No messages yet — start the conversation';
+```
+
+- [ ] **Step 7: Run the UI test to verify it passes**
+
+Run: `npx vitest run src/admin/messages-ui.test.mjs`
+Expected: PASS (4 tests).
+
+- [ ] **Step 8: Manual validation (wrangler dev)**
+
+```bash
+ALLOW_DEV_ACCESS=true npm run dev
+```
+
+Open `http://localhost:8787/admin/messages` and verify:
+- "New Message" button reveals the recipient bar.
+- Paste the test hex `00000000000000000000000000000000000000000000000000000000000000ab` → shows ✓ + opens an empty thread with "No messages yet — start the conversation"; compose box is usable.
+- Paste an invalid string (e.g. `nope`) → red error pointing to npub/pubkey.
+- Type a known good nip-05 (e.g. a real `user@divine.video`) → ✓ verified line; an unknown one → the "Couldn't verify…" message.
+- Template dropdown lists the four templates; selecting one fills the compose box with editable text; "— none —" leaves it as-is.
+- Sending to a freshly-resolved recipient posts and the message appears in the thread.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/admin/messages.html src/admin/messages-ui.test.mjs
+git commit -m "feat(dm): New Message compose with verified recipient + template picker"
+```
+
+---
+
+## Task 7: Full suite + lint
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `npm test`
+Expected: all tests pass (including the new files).
+
+- [ ] **Step 2: Run lint**
+
+Run: `npm run lint`
+Expected: clean. Fix any issues the linter flags in the changed files only.
+
+- [ ] **Step 3: Commit any lint fixes (if needed)**
+
+```bash
+git add -A
+git commit -m "chore(dm): lint fixes for compose feature"
+```
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** recipient picker (Tasks 1-2), templates reuse (Tasks 3-4), 404→200 fix (Task 5), UI incl. context deep-links preserved + friendly empty state (Task 6). Attribution/non-goals are documentation, already in the committed spec.
+- **No display-name search:** enforced by design — the only resolve paths are hex, npub, and verified nip-05. A code comment on the route points back to the spec's Non-goals.
+- **Type/name consistency:** `resolveNip05`/`parseNip05`, `COMPOSE_TEMPLATES`/`renderComposeTemplate`, route paths `/admin/api/recipient/resolve` and `/admin/api/dm-templates`, and the response field `source` are used identically across tasks and tests.
+- **No new dependencies** (`nostr-tools` already present); **no schema/migration** changes.

--- a/docs/superpowers/specs/2026-06-03-moderator-compose-new-dm-design.md
+++ b/docs/superpowers/specs/2026-06-03-moderator-compose-new-dm-design.md
@@ -1,0 +1,269 @@
+# Moderator-initiated DM compose ("New Message" from Moderation)
+
+**Date:** 2026-06-03
+**Status:** Design — pending review
+**Repo:** divine-moderation-service
+
+## Problem
+
+A moderator cannot start a brand-new DM to a user from the Messages inbox. Today the
+only way to reach someone is to reply within an existing conversation, or to follow a
+context deep-link ("Message Creator →" on a video card) that hands the recipient
+pubkey in via `?pubkey=`. There is no affordance to pick an arbitrary recipient and
+start composing.
+
+This blocks proactive outreach "from Moderation" that a moderator might want to
+initiate (welcomes, policy clarifications, appeals follow-up, account questions) when
+there is no inbound message and no specific video to anchor on.
+
+### Verified current state
+
+The backend is already capable; the gap is the UI plus one API behavior:
+
+| Layer | Capable of new outbound DM today? |
+|-------|-----------------------------------|
+| Send (`sendModeratorReply`, `dm-sender.mjs`) | Yes — accepts any hex pubkey, NIP-17 gift-wrap (kind 1059), NIP-65 relay discovery, logs outbound-first to `dm_log` |
+| API `POST /admin/api/messages/{pubkey}` | Yes — sends to any pubkey, no prior-conversation check |
+| API `GET /admin/api/messages/{pubkey}` | **No** — returns 404 when no conversation exists |
+| Messages UI (`messages.html`) | **No** — left panel only lists/filters *existing* conversations; no "New Message" entry point; no way to address a never-messaged user |
+
+Because `GET` returns 404 for a never-messaged user and `loadThread()` renders any
+non-OK response as "Failed to load messages," even the existing "Message Creator →"
+deep-link looks broken when the creator has no prior conversation.
+
+## Attribution / history
+
+The DM subsystem is a joint effort, not a single author's:
+
+- **Rabble (Evan Henshaw-Plath)** — NIP-17 DM foundation + API/admin host split (#24);
+  first cut of category templates, profile resolution, and the messages UI scaffold,
+  plus the `docs/dm-gaps-plan.md` roadmap (#28); QUARANTINE relay notify (#133).
+- **Matthew Bradley** — unify signing to `NOSTR_PRIVATE_KEY` (#31); **rewrite the DM
+  templates for clarity + content links (#45)** — this is the template code we reuse
+  here; reporter notifications (#47); `/api/v1/notify` (#53); null-guard (#61);
+  **"make moderation messages UI actually work" (#109)** — the messages UI that
+  functions today.
+- **Liz Sweigart** — dead offender-tracking cleanup (#81).
+- **Seydi Charyyev** — moderation-dm-plan docs cleanup (#123).
+
+This feature builds on all of the above. It is not "finishing Rabble's Gap 1" — it
+**exposes the existing #45 action-templates to a human composer** (a different shape
+than either Rabble's plan or the automated decision path).
+
+## Goals
+
+1. A moderator can start a new DM from the Messages inbox by addressing a recipient
+   one of two impersonation-safe ways: **paste an npub/hex pubkey**, or **type a full
+   nip-05 (`user@domain`) that we verify** against the domain before composing. The
+   existing context deep-links continue to work.
+2. The moderator can **pre-fill from an existing template** (reused, editable) or write
+   free-text.
+3. New / empty threads render cleanly instead of as an error, repairing both the new
+   flow and the existing "Message Creator →" deep-link.
+
+## Non-goals
+
+- **No display-name or fuzzy search.** Display names and `name` fields in kind-0
+  profiles are unverified, non-unique, and spoofable; letting a moderator believe they
+  found a user by display name risks messaging an impersonator (telling the wrong
+  person their content was removed, or revealing a moderation action). Recipient
+  resolution is restricted to a verifiable identifier: a pubkey/npub, or a nip-05
+  resolved against its domain.
+- No change to the automated moderation-decision DM path (`selectTemplate` firing on
+  BAN/AGE_RESTRICTED/QUARANTINE). That stays as-is.
+- No new outreach-specific template copy. We reuse the existing templates verbatim
+  (see "Template reuse" caveat).
+- No bulk / broadcast messaging.
+- No change to NIP-17 wrapping, signing identity, relay discovery, or rate limiting.
+
+## Design
+
+### Component 1 — Recipient resolution (UI + one new endpoint)
+
+A "New Message" button in the Messages header opens a single recipient input with two
+resolution paths and nothing else — no suggestions, no display-name matching:
+
+1. **Paste npub/hex.** Input decodes as a valid `npub` (bech32 → hex) or is exactly
+   64 hex chars. The key *is* the identity, so this needs no verification. Invalid /
+   key-like-but-malformed input (bad checksum, wrong length) shows inline validation
+   and does not proceed.
+2. **Type a full nip-05 (`user@domain`) — verified.** On submit, the worker resolves
+   the address against the domain's `.well-known/nostr.json` and returns the
+   authoritative pubkey, or "no such user." This is what NIP-05 verification means: a
+   `nip05` value stored in someone's kind-0 profile is only a *claim* and is
+   spoofable, so we never trust an indexed nip-05 — we resolve it at the source. Only a
+   successful resolution yields a recipient.
+
+If a nip-05 doesn't resolve and the moderator is confident the user is real, the
+fallback is to paste their npub/pubkey (path 1). The error copy points them there:
+"Couldn't verify `<address>`. If you have their npub or pubkey, paste it instead."
+
+On success the UI shows a confirmation line before composing, e.g.
+`✓ alice@divine.video → npub1…8a3 (verified via divine.video)`, then calls the
+existing `selectConversation(hex)`, which reveals the working compose box and loads the
+thread. No new send path is needed — `POST /admin/api/messages/{pubkey}` already
+handles new recipients.
+
+**New backend helper** — `src/nostr/nip05.mjs`:
+
+```js
+// Resolve "user@domain" to an authoritative hex pubkey via the domain's
+// .well-known/nostr.json. Returns { pubkey } or null (not found / malformed /
+// unreachable). https only; well-known path only.
+export async function resolveNip05(address, env) { ... }
+```
+
+Resolution rules:
+- Split on the last `@`; validate local part chars (`a-z0-9-_.`) and a plausible
+  domain. Reject otherwise (no fetch).
+- Fetch `https://{domain}/.well-known/nostr.json?name={urlencoded name}`.
+- Read `json.names[name]`; require a 64-hex pubkey. Missing → not found.
+- Short KV cache (1h) keyed by address, since nip-05 → pubkey can change and a
+  moderation tool values freshness; cache nulls briefly to avoid hammering.
+
+**New route** in `src/index.mjs` (auth-gated like the other `/admin/api/*` routes):
+
+```
+GET /admin/api/nip05/resolve?address=user@domain
+  -> 200 { pubkey, address, domain }   on verified resolution
+  -> 404 { error: 'not found' }        when the domain has no such name
+  -> 400 { error: 'invalid address' }  for malformed input
+```
+
+No Funnelcake / profile-search dependency is introduced.
+
+### Component 2 — Template picker (reuse existing #45 templates)
+
+The existing templates in `dm-sender.mjs` are functions
+`(reason, sha256, title, publishedAt)` and are already null-safe for compose with no
+attached video: `contentSubject(null)` → "Your content", `postedDate(null)` → "",
+`contentLink(null)` → bare newline.
+
+**Expose the creator-facing subset for manual selection.** Add to `dm-sender.mjs`:
+
+```js
+// Templates a moderator may pre-fill manually. Excludes REPORT_OUTCOME_* (reporter-
+// facing auto-sends with a different signature) and is the single source of truth
+// shared with the automated path.
+export const COMPOSE_TEMPLATES = [
+  { key: 'PERMANENT_BAN',     label: 'Content removed' },
+  { key: 'AGE_RESTRICTED',    label: 'Content age-restricted' },
+  { key: 'QUARANTINE',        label: 'Content under review' },
+  { key: 'ACCOUNT_SUSPENDED', label: 'Account suspended' },
+];
+
+// Render a compose template to editable text. category is optional and only
+// specializes the "was found to {reason}" clause for the three content actions.
+export function renderComposeTemplate(key, { category = null, sha256 = null,
+  title = null, publishedAt = null } = {}) {
+  // ACCOUNT_SUSPENDED takes no args; the rest go through selectTemplate so category
+  // and content-link handling stay identical to the automated path.
+}
+```
+
+**New route** in `src/index.mjs`:
+
+```
+GET /admin/api/dm-templates?sha256=&title=&publishedAt=&category=
+  -> 200 [{ key, label, body }]   // body rendered (with optional video context)
+```
+
+When the picker is opened from a plain New Message (no video context), `body` renders
+with the generic subject and no content link. When opened from a video deep-link, the
+sha256/title/publishedAt can be threaded through so the body pre-fills the link.
+
+**UI:** a template dropdown above the compose textarea. Selecting an entry inserts its
+`body` into the (editable) textarea; the moderator can edit or replace it. Default is
+empty (free-text).
+
+#### Template reuse caveat (documented tradeoff)
+
+These templates are **moderation-outcome notifications**, not general outreach copy.
+Reusing them for a proactive message to a user who has had no moderation action is
+mechanically fine (null-safe) but the wording assumes an event occurred. Per the
+decision to reuse rather than author a new set, the dropdown is framed as
+"pre-fill & edit" — the moderator is expected to edit when the context doesn't match.
+If proactive-outreach-specific templates are wanted later, they can be added to
+`COMPOSE_TEMPLATES` without structural change.
+
+### Component 3 — Empty-thread fix
+
+Change `GET /admin/api/messages/{pubkey}` (`index.mjs`) to return
+`200 { messages: [] }` instead of `404` when `getConversationByPubkey` finds nothing.
+Update `loadThread()` (`messages.html`) so a non-OK response still surfaces an error,
+but an empty list renders a friendly empty state ("No messages yet — start the
+conversation") rather than "Failed to load messages." This repairs the new-message
+flow and the pre-existing "Message Creator →" deep-link for never-messaged creators.
+
+## Data flow (new message)
+
+```
+New Message → paste npub/hex            → (decode, no network)
+            → or type full nip-05       → GET /admin/api/nip05/resolve
+                                          → .well-known/nostr.json → authoritative pubkey
+   → confirm recipient → selectConversation(hex)
+   → (optional) pick template → GET /admin/api/dm-templates → insert editable body
+   → edit / free-text
+   → Send → POST /admin/api/messages/{hex}
+          → sendModeratorReply()  [existing, unchanged]
+          → NIP-17 gift-wrap (kind 1059) from NOSTR_PRIVATE_KEY
+          → NIP-65 relay discovery → publish → log outbound-first to dm_log
+```
+
+## Error handling / edge cases
+
+- Invalid npub / wrong-length hex → inline validation, no send.
+- Malformed nip-05 (no `@`, bad chars) → 400, inline message, no fetch.
+- nip-05 not found / domain unreachable → "Couldn't verify `<address>`. If you have
+  their npub or pubkey, paste it instead." (steers to the paste fallback).
+- Per-recipient rate limit (5 / 60s, warn-only) is unchanged.
+- Self-message: out of scope; no guard added (a moderator messaging the Moderation
+  account is harmless and logged like any other).
+- SSRF note: the `.well-known` fetch targets a moderator-supplied domain. The action
+  is admin-authenticated, restricted to `https` + the fixed well-known path, so the
+  exposure is minimal; documented here so it isn't a silent surprise.
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `src/index.mjs` | Add `GET /admin/api/nip05/resolve`; add `GET /admin/api/dm-templates`; change empty-thread `GET /admin/api/messages/{pubkey}` from 404 to `200 {messages:[]}` |
+| `src/nostr/nip05.mjs` | New — `resolveNip05(address, env)` via `.well-known/nostr.json`, KV-cached, `null` on failure |
+| `src/nostr/dm-sender.mjs` | Add `COMPOSE_TEMPLATES` + `renderComposeTemplate()`, reusing existing `TEMPLATES`/`selectTemplate` |
+| `src/admin/messages.html` | "New Message" button; recipient input (paste npub/hex OR verified nip-05, with confirmation line); template dropdown over compose; friendly empty-thread copy |
+| tests | `resolveNip05` (mock well-known), both new routes, the 404→200 change, `renderComposeTemplate` |
+
+No new dependencies. No Funnelcake dependency. No schema/migration changes (`dm_log`
+already supports outbound-first rows).
+
+## Testing
+
+Following the repo's vitest patterns:
+
+- `resolveNip05` — returns `{pubkey}` when `names[name]` is a valid 64-hex; returns
+  `null` for missing name, non-200, malformed JSON, or malformed address; never fetches
+  on malformed input.
+- `GET /admin/api/nip05/resolve` — auth required; 200 on verified, 404 on not-found,
+  400 on malformed.
+- `GET /admin/api/dm-templates` — returns the creator-facing set; renders with and
+  without video context; excludes REPORT_OUTCOME_*.
+- `renderComposeTemplate` — null-safe (no sha256/title) and category specialization
+  matches `selectTemplate` output for the same inputs.
+- `GET /admin/api/messages/{pubkey}` — returns `200 {messages:[]}` (not 404) for an
+  unknown pubkey; still returns the thread for a known one.
+
+## Relationship to `docs/dm-gaps-plan.md`
+
+- Gap 2 (profile resolution) and Gap 4 (Message Creator link) already shipped.
+- Gap 3 shipped as client-side filtering of existing conversations. This design
+  deliberately does **not** extend it to display-name search; recipient resolution is
+  verified-identifier-only (npub/hex or verified nip-05) for moderation-safety reasons.
+- Gap 1 templates exist (action-driven, automated, policy URLs intentionally omitted);
+  this **exposes** them to a human composer rather than building new ones.
+
+## Open questions
+
+None blocking. Future, non-blocking: proactive-outreach-specific template copy;
+enabling the defined-but-omitted policy links once those pages exist (tracked by the
+`dm-sender.mjs:81` NOTE and `2026-03-19-dm-alignment-design.md`); optional verified
+nip-05 typeahead if discovery convenience is later wanted (must verify on selection).

--- a/src/admin/messages-ui.test.mjs
+++ b/src/admin/messages-ui.test.mjs
@@ -1,0 +1,28 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { describe, expect, it } from 'vitest';
+import messagesHTML from './messages.html';
+
+describe('messages UI — new message compose hooks', () => {
+  it('has a New Message button and recipient bar', () => {
+    expect(messagesHTML).toContain('New Message');
+    expect(messagesHTML).toContain('openNewMessage');
+    expect(messagesHTML).toContain('recipient-input');
+    expect(messagesHTML).toContain('resolveRecipient');
+  });
+
+  it('calls the recipient resolve endpoint', () => {
+    expect(messagesHTML).toContain('/admin/api/recipient/resolve?input=');
+  });
+
+  it('has a template picker wired to the templates endpoint', () => {
+    expect(messagesHTML).toContain('template-select');
+    expect(messagesHTML).toContain('/admin/api/dm-templates');
+    expect(messagesHTML).toContain('loadTemplates');
+  });
+
+  it('uses the friendlier empty-thread copy', () => {
+    expect(messagesHTML).toContain('No messages yet');
+  });
+});

--- a/src/admin/messages.html
+++ b/src/admin/messages.html
@@ -471,7 +471,7 @@
         Select a conversation, or start a New Message
       </div>
       <div id="new-recipient-bar" style="display:none; padding:12px; border-bottom:1px solid #333;">
-        <input type="text" id="recipient-input" placeholder="npub, hex pubkey, or user@domain (nip-05)"
+        <input type="text" id="recipient-input" placeholder="@username.divine.video, npub, hex pubkey, or user@domain"
           style="width:60%;" onkeydown="if(event.key==='Enter'){event.preventDefault();resolveRecipient();}">
         <button class="btn-primary" onclick="resolveRecipient()">Start</button>
         <span id="recipient-status" style="margin-left:10px; font-size:13px;"></span>
@@ -851,7 +851,7 @@
         }
         const data = await res.json();
         const label = data.source === 'nip05'
-          ? '✓ ' + escapeHtml(data.address) + ' (verified via ' + escapeHtml(data.domain) + ')'
+          ? '✓ ' + escapeHtml(data.display || data.address) + ' (verified)'
           : '✓ ' + truncatePubkey(data.pubkey);
         status.style.color = '#6c6';
         status.innerHTML = label;

--- a/src/admin/messages.html
+++ b/src/admin/messages.html
@@ -825,6 +825,7 @@
     // --- New Message compose ---
 
     function openNewMessage() {
+      document.getElementById('thread-placeholder').style.display = 'none';
       const bar = document.getElementById('new-recipient-bar');
       bar.style.display = 'block';
       document.getElementById('recipient-status').textContent = '';
@@ -855,6 +856,7 @@
         status.style.color = '#6c6';
         status.innerHTML = label;
         document.getElementById('new-recipient-bar').style.display = 'none';
+        status.textContent = '';
         await fetchProfiles([data.pubkey]);
         await selectConversation(data.pubkey);
       } catch (err) {
@@ -884,11 +886,19 @@
     }
 
     function applyTemplate(index) {
+      const select = document.getElementById('template-select');
       if (index === '') return;
       const tpl = templateCache[Number(index)];
       if (tpl && tpl.body) {
-        document.getElementById('compose-input').value = tpl.body;
+        const composeInput = document.getElementById('compose-input');
+        if (composeInput.value.trim() && !confirm('Replace your current draft with this template?')) {
+          select.value = '';
+          return;
+        }
+        composeInput.value = tpl.body;
       }
+      // Reset to "— none —" so re-selecting the same template re-fires onchange.
+      select.value = '';
     }
 
     // --- Auto-resize textarea ---

--- a/src/admin/messages.html
+++ b/src/admin/messages.html
@@ -793,7 +793,10 @@
           body: JSON.stringify(body)
         });
 
-        if (!res.ok) throw new Error('Failed to send message');
+        if (!res.ok) {
+          const errBody = await res.json().catch(() => ({}));
+          throw new Error(errBody.error || 'Failed to send message');
+        }
 
         input.value = '';
         sha256Input.value = '';

--- a/src/admin/messages.html
+++ b/src/admin/messages.html
@@ -681,9 +681,16 @@
 
     // --- Select conversation & load thread ---
 
-    async function selectConversation(pubkey) {
+    async function selectConversation(pubkey, opts = {}) {
       selectedPubkey = pubkey;
       renderConversations();
+
+      // Dismiss the New Message recipient bar unless we just resolved from it
+      // (resolveRecipient keeps it to show the verified confirmation).
+      if (!opts.keepRecipientBar) {
+        document.getElementById('new-recipient-bar').style.display = 'none';
+        document.getElementById('recipient-status').textContent = '';
+      }
 
       document.getElementById('thread-placeholder').style.display = 'none';
       const content = document.getElementById('thread-content');
@@ -858,10 +865,10 @@
           : '✓ ' + truncatePubkey(data.pubkey);
         status.style.color = '#6c6';
         status.innerHTML = label;
-        document.getElementById('new-recipient-bar').style.display = 'none';
-        status.textContent = '';
+        // Keep the bar + verified confirmation visible as a "to:" indicator;
+        // selectConversation dismisses it when the moderator navigates elsewhere.
         await fetchProfiles([data.pubkey]);
-        await selectConversation(data.pubkey);
+        await selectConversation(data.pubkey, { keepRecipientBar: true });
       } catch (err) {
         status.style.color = '#e66';
         status.textContent = 'Resolution failed. Try again.';

--- a/src/admin/messages.html
+++ b/src/admin/messages.html
@@ -444,6 +444,7 @@
     <h1>Messages</h1>
     <div class="header-actions">
       <a href="/admin/dashboard">Back to Dashboard</a>
+      <button class="btn-primary" onclick="openNewMessage()">New Message</button>
       <button class="btn-primary" onclick="refreshAll()">Refresh</button>
     </div>
   </div>
@@ -467,7 +468,13 @@
     <!-- Right Panel -->
     <div class="thread-panel" id="thread-panel">
       <div class="empty-state" id="thread-placeholder">
-        Select a conversation to view messages
+        Select a conversation, or start a New Message
+      </div>
+      <div id="new-recipient-bar" style="display:none; padding:12px; border-bottom:1px solid #333;">
+        <input type="text" id="recipient-input" placeholder="npub, hex pubkey, or user@domain (nip-05)"
+          style="width:60%;" onkeydown="if(event.key==='Enter'){event.preventDefault();resolveRecipient();}">
+        <button class="btn-primary" onclick="resolveRecipient()">Start</button>
+        <span id="recipient-status" style="margin-left:10px; font-size:13px;"></span>
       </div>
       <div id="thread-content" style="display: none; flex-direction: column; height: 100%;">
         <div class="thread-header">
@@ -486,6 +493,10 @@
             <button class="send-btn" id="send-btn" onclick="sendMessage()">Send</button>
           </div>
           <div class="compose-extras">
+            <label>Template:</label>
+            <select id="template-select" onchange="applyTemplate(this.value)">
+              <option value="">— none —</option>
+            </select>
             <label>Link video:</label>
             <input type="text" id="compose-sha256" placeholder="sha256 (optional)">
           </div>
@@ -727,7 +738,7 @@
       if (!messages.length) {
         const el = document.createElement('div');
         el.className = 'empty-state';
-        el.textContent = 'No messages in this conversation';
+        el.textContent = 'No messages yet — start the conversation';
         container.appendChild(el);
         return;
       }
@@ -811,6 +822,75 @@
       }
     }
 
+    // --- New Message compose ---
+
+    function openNewMessage() {
+      const bar = document.getElementById('new-recipient-bar');
+      bar.style.display = 'block';
+      document.getElementById('recipient-status').textContent = '';
+      const input = document.getElementById('recipient-input');
+      input.value = '';
+      input.focus();
+    }
+
+    async function resolveRecipient() {
+      const input = document.getElementById('recipient-input').value.trim();
+      const status = document.getElementById('recipient-status');
+      if (!input) return;
+      status.style.color = '#888';
+      status.textContent = 'Resolving…';
+      try {
+        const res = await fetch('/admin/api/recipient/resolve?input=' + encodeURIComponent(input));
+        if (!res.ok) {
+          status.style.color = '#e66';
+          status.textContent = res.status === 404
+            ? "Couldn't verify that nip-05. If you have their npub or pubkey, paste it instead."
+            : 'Invalid recipient. Paste an npub, hex pubkey, or user@domain.';
+          return;
+        }
+        const data = await res.json();
+        const label = data.source === 'nip05'
+          ? '✓ ' + escapeHtml(data.address) + ' (verified via ' + escapeHtml(data.domain) + ')'
+          : '✓ ' + truncatePubkey(data.pubkey);
+        status.style.color = '#6c6';
+        status.innerHTML = label;
+        document.getElementById('new-recipient-bar').style.display = 'none';
+        await fetchProfiles([data.pubkey]);
+        await selectConversation(data.pubkey);
+      } catch (err) {
+        status.style.color = '#e66';
+        status.textContent = 'Resolution failed. Try again.';
+        console.error('resolveRecipient error:', err);
+      }
+    }
+
+    // --- Templates ---
+
+    let templateCache = [];
+
+    async function loadTemplates() {
+      const sha = document.getElementById('compose-sha256')?.value?.trim();
+      const qs = sha ? '?sha256=' + encodeURIComponent(sha) : '';
+      try {
+        const res = await fetch('/admin/api/dm-templates' + qs);
+        if (!res.ok) return;
+        templateCache = await res.json();
+        const select = document.getElementById('template-select');
+        select.innerHTML = '<option value="">— none —</option>'
+          + templateCache.map((t, i) => '<option value="' + i + '">' + escapeHtml(t.label) + '</option>').join('');
+      } catch (err) {
+        console.error('loadTemplates error:', err);
+      }
+    }
+
+    function applyTemplate(index) {
+      if (index === '') return;
+      const tpl = templateCache[Number(index)];
+      if (tpl && tpl.body) {
+        document.getElementById('compose-input').value = tpl.body;
+      }
+    }
+
     // --- Auto-resize textarea ---
 
     document.getElementById('compose-input').addEventListener('input', function() {
@@ -824,6 +904,7 @@
       const preselectedPubkey = urlParams.get('pubkey');
 
       await fetchConversations();
+      loadTemplates();
 
       if (preselectedPubkey) {
         // Fetch profile for the preselected pubkey if not already cached

--- a/src/admin/messages.html
+++ b/src/admin/messages.html
@@ -498,7 +498,7 @@
               <option value="">— none —</option>
             </select>
             <label>Link video:</label>
-            <input type="text" id="compose-sha256" placeholder="sha256 (optional)">
+            <input type="text" id="compose-sha256" placeholder="sha256 (optional)" onchange="loadTemplates()">
           </div>
         </div>
       </div>

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -15,6 +15,7 @@ import { fetchNostrEventBySha256, fetchNostrVideoEventsByDTag, parseVideoEventMe
 import { pollRelayForVideos, getLastPollTimestamp, setLastPollTimestamp, getPollingStatus } from './nostr/relay-poller.mjs';
 import { getLastReportPollTimestamp, getReportLastRun, getReportPollingStatus, pollRelayForReports, setLastReportPollTimestamp } from './nostr/report-poller.mjs';
 import { getPublicKey } from 'nostr-tools/pure';
+import { decode as decodeNip19 } from 'nostr-tools/nip19';
 import { hexToBytes, bytesToHex } from '@noble/hashes/utils';
 import dashboardHTML from './admin/dashboard.html';
 import swipeReviewHTML from './admin/swipe-review.html';
@@ -3490,6 +3491,43 @@ async function runMigration() {
       const { sendModeratorReply } = await import('./nostr/dm-sender.mjs');
       await sendModeratorReply(pubkey, message, sha256 || null, env, null);
       return new Response(JSON.stringify({ success: true }), { headers: { 'Content-Type': 'application/json' } });
+    }
+
+    // Admin API: Resolve a recipient (hex / npub / verified nip-05) to a hex pubkey.
+    // Display-name lookup is intentionally NOT supported — see
+    // docs/superpowers/specs/2026-06-03-moderator-compose-new-dm-design.md (Non-goals).
+    if (url.pathname === '/admin/api/recipient/resolve' && request.method === 'GET') {
+      const authError = await requireAuth(request, env);
+      if (authError) return authError;
+
+      const input = (url.searchParams.get('input') || '').trim();
+      if (!input) {
+        return new Response(JSON.stringify({ error: 'input is required' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+      }
+      // 1. Bare hex pubkey
+      if (/^[0-9a-f]{64}$/i.test(input)) {
+        return new Response(JSON.stringify({ pubkey: input.toLowerCase(), source: 'hex' }), { headers: { 'Content-Type': 'application/json' } });
+      }
+      // 2. npub (deterministic decode)
+      if (input.startsWith('npub1')) {
+        try {
+          const decoded = decodeNip19(input);
+          if (decoded.type === 'npub' && typeof decoded.data === 'string') {
+            return new Response(JSON.stringify({ pubkey: decoded.data, source: 'npub' }), { headers: { 'Content-Type': 'application/json' } });
+          }
+        } catch { /* fall through to 400 */ }
+        return new Response(JSON.stringify({ error: 'invalid npub' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+      }
+      // 3. nip-05 (verified against the domain's well-known)
+      if (input.includes('@')) {
+        const { resolveNip05 } = await import('./nostr/nip05.mjs');
+        const resolved = await resolveNip05(input, env);
+        if (!resolved) {
+          return new Response(JSON.stringify({ error: 'not found' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
+        }
+        return new Response(JSON.stringify({ pubkey: resolved.pubkey, address: resolved.address, domain: resolved.domain, source: 'nip05' }), { headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response(JSON.stringify({ error: 'invalid input' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
     }
 
     // Admin API: Resolve Nostr profiles for pubkeys

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -3491,8 +3491,13 @@ async function runMigration() {
         return new Response(JSON.stringify({ error: 'message is required' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
       }
       const { sendModeratorReply } = await import('./nostr/dm-sender.mjs');
-      await sendModeratorReply(pubkey, message, sha256 || null, env, null);
-      return new Response(JSON.stringify({ success: true }), { headers: { 'Content-Type': 'application/json' } });
+      // Honor the send result so the compose UI can surface real failures
+      // (e.g. no relays reachable) instead of silently reporting success.
+      const result = await sendModeratorReply(pubkey, message, sha256 || null, env, null);
+      if (!result || result.sent !== true) {
+        return new Response(JSON.stringify({ error: result?.reason || 'Failed to send message' }), { status: 502, headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response(JSON.stringify({ success: true, relaysPublished: result.relaysPublished }), { headers: { 'Content-Type': 'application/json' } });
     }
 
     // Admin API: Resolve a recipient (hex / npub / verified nip-05) to a hex pubkey.

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -3520,16 +3520,16 @@ async function runMigration() {
         } catch { /* fall through to 400 */ }
         return new Response(JSON.stringify({ error: 'invalid npub' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
       }
-      // 3. nip-05 (verified against the domain's well-known)
-      if (input.includes('@')) {
-        const { resolveNip05 } = await import('./nostr/nip05.mjs');
-        const resolved = await resolveNip05(input, env);
-        if (!resolved) {
-          return new Response(JSON.stringify({ error: 'not found' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
-        }
-        return new Response(JSON.stringify({ pubkey: resolved.pubkey, address: resolved.address, domain: resolved.domain, source: 'nip05' }), { headers: { 'Content-Type': 'application/json' } });
+      // 3. nip-05 / divine handle — anything that isn't a raw key. Accepts the
+      //    forms moderators see on profiles (@mjb.divine.video, @mjb), bare
+      //    handles, canonical user@domain, and cross-domain nip-05. Normalization
+      //    + verification against the domain's well-known live in nostr/nip05.mjs.
+      const { resolveNip05 } = await import('./nostr/nip05.mjs');
+      const resolved = await resolveNip05(input, env);
+      if (!resolved) {
+        return new Response(JSON.stringify({ error: 'not found' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
       }
-      return new Response(JSON.stringify({ error: 'invalid input' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+      return new Response(JSON.stringify({ pubkey: resolved.pubkey, address: resolved.address, display: resolved.display, domain: resolved.domain, source: 'nip05' }), { headers: { 'Content-Type': 'application/json' } });
     }
 
     // Admin API: List creator-facing DM templates (rendered, optionally with video context).

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -3530,6 +3530,24 @@ async function runMigration() {
       return new Response(JSON.stringify({ error: 'invalid input' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
     }
 
+    // Admin API: List creator-facing DM templates (rendered, optionally with video context).
+    if (url.pathname === '/admin/api/dm-templates' && request.method === 'GET') {
+      const authError = await requireAuth(request, env);
+      if (authError) return authError;
+
+      const sha256 = url.searchParams.get('sha256') || null;
+      const title = url.searchParams.get('title') || null;
+      const publishedAt = url.searchParams.get('publishedAt') || null;
+      const category = url.searchParams.get('category') || null;
+      const { COMPOSE_TEMPLATES, renderComposeTemplate } = await import('./nostr/dm-sender.mjs');
+      const templates = COMPOSE_TEMPLATES.map(t => ({
+        key: t.key,
+        label: t.label,
+        body: renderComposeTemplate(t.key, { category, sha256, title, publishedAt }),
+      }));
+      return new Response(JSON.stringify(templates), { headers: { 'Content-Type': 'application/json' } });
+    }
+
     // Admin API: Resolve Nostr profiles for pubkeys
     if (url.pathname === '/admin/api/profiles' && request.method === 'GET') {
       const authError = await requireAuth(request, env);

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -3473,7 +3473,9 @@ async function runMigration() {
       const { getConversationByPubkey } = await import('./nostr/dm-store.mjs');
       const messages = await getConversationByPubkey(env.BLOSSOM_DB, pubkey);
       if (!messages) {
-        return new Response(JSON.stringify({ error: 'No conversation found' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
+        // Never-messaged recipient: return an empty thread (200) so the compose UI
+        // can render for new conversations instead of showing a load error.
+        return new Response(JSON.stringify({ messages: [] }), { headers: { 'Content-Type': 'application/json' } });
       }
       return new Response(JSON.stringify(messages), { headers: { 'Content-Type': 'application/json' } });
     }

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -7121,6 +7121,22 @@ describe('GET /admin/api/recipient/resolve', () => {
     vi.unstubAllGlobals();
   });
 
+  it('resolves a divine handle (@user.divine.video) to the subdomain identity with a friendly display', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => ({ names: { _: HEX } }) }));
+    const res = await worker.fetch(
+      new Request('https://moderation.admin.divine.video/admin/api/recipient/resolve?input=' + encodeURIComponent('@mjb.divine.video')),
+      createEnv({ ALLOW_DEV_ACCESS: 'true' }),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      pubkey: HEX,
+      source: 'nip05',
+      address: '_@mjb.divine.video',
+      display: '@mjb.divine.video',
+    });
+    vi.unstubAllGlobals();
+  });
+
   it('404s an unknown nip-05', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => ({ names: {} }) }));
     const res = await worker.fetch(

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -7140,6 +7140,18 @@ describe('GET /admin/api/recipient/resolve', () => {
   });
 });
 
+describe('GET /admin/api/messages/{pubkey} for an unknown pubkey', () => {
+  it('returns 200 with an empty messages array (not 404)', async () => {
+    const HEX = '00000000000000000000000000000000000000000000000000000000000000ab';
+    const res = await worker.fetch(
+      new Request('https://moderation.admin.divine.video/admin/api/messages/' + HEX),
+      createEnv({ ALLOW_DEV_ACCESS: 'true' }),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ messages: [] });
+  });
+});
+
 describe('GET /admin/api/dm-templates', () => {
   it('returns the creator-facing templates with rendered bodies', async () => {
     const res = await worker.fetch(

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -7160,7 +7160,7 @@ describe('GET /admin/api/dm-templates', () => {
     );
     expect(res.status).toBe(200);
     const templates = await res.json();
-    expect(templates.map(t => t.key)).toEqual(['PERMANENT_BAN', 'AGE_RESTRICTED', 'QUARANTINE', 'ACCOUNT_SUSPENDED']);
+    expect(templates.map(t => t.key)).toEqual(['PERMANENT_BAN', 'AGE_RESTRICTED', 'QUARANTINE', 'ACCOUNT_SUSPENDED', 'ACCOUNT_BANNED', 'ACCOUNT_RESTORED']);
     templates.forEach(t => {
       expect(typeof t.label).toBe('string');
       expect(typeof t.body).toBe('string');

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -7152,6 +7152,24 @@ describe('GET /admin/api/messages/{pubkey} for an unknown pubkey', () => {
   });
 });
 
+describe('POST /admin/api/messages/{pubkey} when the send fails', () => {
+  it('returns 502 with a reason instead of a silent success', async () => {
+    const HEX = '00000000000000000000000000000000000000000000000000000000000000ab';
+    // No NOSTR_PRIVATE_KEY in the env -> sendModeratorReply returns {sent:false},
+    // so the route must surface the failure rather than report success.
+    const res = await worker.fetch(
+      new Request('https://moderation.admin.divine.video/admin/api/messages/' + HEX, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: 'hello there' }),
+      }),
+      createEnv({ ALLOW_DEV_ACCESS: 'true' }),
+    );
+    expect(res.status).toBe(502);
+    expect((await res.json()).error).toBeTruthy();
+  });
+});
+
 describe('GET /admin/api/dm-templates', () => {
   it('returns the creator-facing templates with rendered bodies', async () => {
     const res = await worker.fetch(

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -7079,3 +7079,63 @@ describe('age restricted preview reports real blossom drift', () => {
     }
   });
 });
+
+describe('GET /admin/api/recipient/resolve', () => {
+  const HEX = '00000000000000000000000000000000000000000000000000000000000000ab';
+  const NPUB = 'npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqz4s0z660k';
+
+  it('resolves a bare hex pubkey', async () => {
+    const res = await worker.fetch(
+      new Request('https://moderation.admin.divine.video/admin/api/recipient/resolve?input=' + HEX),
+      createEnv({ ALLOW_DEV_ACCESS: 'true' }),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ pubkey: HEX, source: 'hex' });
+  });
+
+  it('decodes an npub', async () => {
+    const res = await worker.fetch(
+      new Request('https://moderation.admin.divine.video/admin/api/recipient/resolve?input=' + NPUB),
+      createEnv({ ALLOW_DEV_ACCESS: 'true' }),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ pubkey: HEX, source: 'npub' });
+  });
+
+  it('400s an invalid npub', async () => {
+    const res = await worker.fetch(
+      new Request('https://moderation.admin.divine.video/admin/api/recipient/resolve?input=npub1notreal'),
+      createEnv({ ALLOW_DEV_ACCESS: 'true' }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('verifies a nip-05 via well-known', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => ({ names: { alice: HEX } }) }));
+    const res = await worker.fetch(
+      new Request('https://moderation.admin.divine.video/admin/api/recipient/resolve?input=alice@divine.video'),
+      createEnv({ ALLOW_DEV_ACCESS: 'true' }),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ pubkey: HEX, source: 'nip05', address: 'alice@divine.video' });
+    vi.unstubAllGlobals();
+  });
+
+  it('404s an unknown nip-05', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => ({ names: {} }) }));
+    const res = await worker.fetch(
+      new Request('https://moderation.admin.divine.video/admin/api/recipient/resolve?input=ghost@divine.video'),
+      createEnv({ ALLOW_DEV_ACCESS: 'true' }),
+    );
+    expect(res.status).toBe(404);
+    vi.unstubAllGlobals();
+  });
+
+  it('400s empty input', async () => {
+    const res = await worker.fetch(
+      new Request('https://moderation.admin.divine.video/admin/api/recipient/resolve'),
+      createEnv({ ALLOW_DEV_ACCESS: 'true' }),
+    );
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -7139,3 +7139,31 @@ describe('GET /admin/api/recipient/resolve', () => {
     expect(res.status).toBe(400);
   });
 });
+
+describe('GET /admin/api/dm-templates', () => {
+  it('returns the creator-facing templates with rendered bodies', async () => {
+    const res = await worker.fetch(
+      new Request('https://moderation.admin.divine.video/admin/api/dm-templates'),
+      createEnv({ ALLOW_DEV_ACCESS: 'true' }),
+    );
+    expect(res.status).toBe(200);
+    const templates = await res.json();
+    expect(templates.map(t => t.key)).toEqual(['PERMANENT_BAN', 'AGE_RESTRICTED', 'QUARANTINE', 'ACCOUNT_SUSPENDED']);
+    templates.forEach(t => {
+      expect(typeof t.label).toBe('string');
+      expect(typeof t.body).toBe('string');
+      expect(t.body.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('threads video context into the body when sha256 is given', async () => {
+    const sha = '22'.repeat(32);
+    const res = await worker.fetch(
+      new Request('https://moderation.admin.divine.video/admin/api/dm-templates?sha256=' + sha),
+      createEnv({ ALLOW_DEV_ACCESS: 'true' }),
+    );
+    const templates = await res.json();
+    const ban = templates.find(t => t.key === 'PERMANENT_BAN');
+    expect(ban.body).toContain('divine.video/video/' + sha);
+  });
+});

--- a/src/nostr/dm-sender.mjs
+++ b/src/nostr/dm-sender.mjs
@@ -205,6 +205,29 @@ export function getReportOutcomeMessage(action, sha256 = null, title = null, pub
   return TEMPLATES.REPORT_OUTCOME_NO_ACTION(sha256, title, publishedAt, reportedAt);
 }
 
+// --- Manual compose templates ---
+// Creator-facing templates a moderator may pre-fill when composing by hand.
+// Excludes REPORT_OUTCOME_* (reporter-facing auto-sends with a different signature).
+// Single source of truth: these reuse TEMPLATES/selectTemplate verbatim.
+export const COMPOSE_TEMPLATES = [
+  { key: 'PERMANENT_BAN', label: 'Content removed' },
+  { key: 'AGE_RESTRICTED', label: 'Content age-restricted' },
+  { key: 'QUARANTINE', label: 'Content under review' },
+  { key: 'ACCOUNT_SUSPENDED', label: 'Account suspended' },
+];
+
+/**
+ * Render a compose template to editable text. Null-safe for compose with no video.
+ * @param {string} key - one of COMPOSE_TEMPLATES[].key
+ * @param {{category?: string|null, sha256?: string|null, title?: string|null, publishedAt?: string|null}} [opts]
+ * @returns {string|null} rendered body, or null for an unknown key
+ */
+export function renderComposeTemplate(key, opts = {}) {
+  const { category = null, sha256 = null, title = null, publishedAt = null } = opts;
+  if (!TEMPLATES[key]) return null;
+  return selectTemplate(key, null, category, sha256, title, publishedAt);
+}
+
 // --- Key Management ---
 
 /**

--- a/src/nostr/dm-sender.mjs
+++ b/src/nostr/dm-sender.mjs
@@ -214,6 +214,12 @@ export const COMPOSE_TEMPLATES = [
   { key: 'AGE_RESTRICTED', label: 'Content age-restricted' },
   { key: 'QUARANTINE', label: 'Content under review' },
   { key: 'ACCOUNT_SUSPENDED', label: 'Account suspended' },
+  // TODO(after #150 lands on main + rebase): add the two new account-state
+  // notices so moderators can hand-send them. They reuse TEMPLATES via
+  // renderComposeTemplate -> selectTemplate and the rendered text stays
+  // editable before sending, so no duplicate copy is needed:
+  //   { key: 'ACCOUNT_BANNED', label: 'Account banned' },
+  //   { key: 'ACCOUNT_RESTORED', label: 'Account restored' },
 ];
 
 /**

--- a/src/nostr/dm-sender.mjs
+++ b/src/nostr/dm-sender.mjs
@@ -389,13 +389,10 @@ async function queryRelayList(pubkey, env) {
     }, RELAY_TIMEOUT_MS);
 
     try {
-      const headers = {};
-      if (env.CF_ACCESS_CLIENT_ID && env.CF_ACCESS_CLIENT_SECRET) {
-        headers['CF-Access-Client-Id'] = env.CF_ACCESS_CLIENT_ID;
-        headers['CF-Access-Client-Secret'] = env.CF_ACCESS_CLIENT_SECRET;
-      }
-
-      ws = new WebSocket(DIVINE_RELAY, { headers });
+      // Workers' WebSocket takes only a subprotocol string/array as the 2nd arg;
+      // an options/headers object throws "protocol header token is invalid" and
+      // the connection silently fails. Connect with the URL alone.
+      ws = new WebSocket(DIVINE_RELAY);
       const relays = [];
       let resolved = false;
 
@@ -506,13 +503,13 @@ function publishToSingleRelay(event, relayUrl, env) {
     }, RELAY_TIMEOUT_MS);
 
     try {
-      const headers = {};
-      if (relayUrl.includes('relay.divine.video') && env.CF_ACCESS_CLIENT_ID && env.CF_ACCESS_CLIENT_SECRET) {
-        headers['CF-Access-Client-Id'] = env.CF_ACCESS_CLIENT_ID;
-        headers['CF-Access-Client-Secret'] = env.CF_ACCESS_CLIENT_SECRET;
-      }
-
-      ws = new WebSocket(relayUrl, { headers });
+      // Cloudflare Workers' WebSocket constructor only accepts a subprotocol
+      // string/array as its 2nd argument. Passing an options/headers object
+      // throws "The protocol header token is invalid", so the connection never
+      // opens and the event never publishes. Custom headers can't be sent on a
+      // Workers WebSocket handshake; connect with the URL alone (same as the
+      // relay-list and profile-resolver paths).
+      ws = new WebSocket(relayUrl);
       let resolved = false;
 
       ws.addEventListener('open', () => {
@@ -739,7 +736,7 @@ export async function sendReportOutcomeDM(reporterPubkey, sha256, action, env, c
       console.log('[DM] DM store not available, skipping log');
     }
 
-    console.log(`[DM] Sent report outcome to ${reporterPubkey.substring(0, 16)}... for ${sha256.substring(0, 16)}... (${success} relays)`);
+    console.log(`[DM] Sent report outcome to ${reporterPubkey.substring(0, 16)}...${sha256 ? ` for ${sha256.substring(0, 16)}...` : ''} (${success} relays)`);
     return { sent: true, relaysPublished: success };
   } catch (err) {
     console.error('[DM] Unexpected error sending report outcome DM:', err.message);
@@ -894,7 +891,7 @@ export async function sendModeratorReply(recipientPubkey, message, sha256, env, 
       console.log('[DM] DM store not available, skipping log');
     }
 
-    console.log(`[DM] Sent moderator reply to ${recipientPubkey.substring(0, 16)}... for ${sha256.substring(0, 16)}... (${success} relays)`);
+    console.log(`[DM] Sent moderator reply to ${recipientPubkey.substring(0, 16)}...${sha256 ? ` for ${sha256.substring(0, 16)}...` : ''} (${success} relays)`);
     return { sent: true, relaysPublished: success };
   } catch (err) {
     console.error('[DM] Unexpected error sending moderator reply:', err.message);

--- a/src/nostr/dm-sender.mjs
+++ b/src/nostr/dm-sender.mjs
@@ -214,12 +214,8 @@ export const COMPOSE_TEMPLATES = [
   { key: 'AGE_RESTRICTED', label: 'Content age-restricted' },
   { key: 'QUARANTINE', label: 'Content under review' },
   { key: 'ACCOUNT_SUSPENDED', label: 'Account suspended' },
-  // TODO(after #150 lands on main + rebase): add the two new account-state
-  // notices so moderators can hand-send them. They reuse TEMPLATES via
-  // renderComposeTemplate -> selectTemplate and the rendered text stays
-  // editable before sending, so no duplicate copy is needed:
-  //   { key: 'ACCOUNT_BANNED', label: 'Account banned' },
-  //   { key: 'ACCOUNT_RESTORED', label: 'Account restored' },
+  { key: 'ACCOUNT_BANNED', label: 'Account banned' },
+  { key: 'ACCOUNT_RESTORED', label: 'Account restored' },
 ];
 
 /**

--- a/src/nostr/dm-sender.test.mjs
+++ b/src/nostr/dm-sender.test.mjs
@@ -569,11 +569,16 @@ describe('DM Sender - notifyReporters', () => {
 });
 
 describe('COMPOSE_TEMPLATES / renderComposeTemplate', () => {
-  it('exposes the four creator-facing templates and excludes report-outcome', () => {
+  it('exposes the six creator-facing templates and excludes report-outcome', () => {
     const keys = COMPOSE_TEMPLATES.map(t => t.key);
-    expect(keys).toEqual(['PERMANENT_BAN', 'AGE_RESTRICTED', 'QUARANTINE', 'ACCOUNT_SUSPENDED']);
+    expect(keys).toEqual(['PERMANENT_BAN', 'AGE_RESTRICTED', 'QUARANTINE', 'ACCOUNT_SUSPENDED', 'ACCOUNT_BANNED', 'ACCOUNT_RESTORED']);
     expect(keys).not.toContain('REPORT_OUTCOME_ACTION');
     COMPOSE_TEMPLATES.forEach(t => expect(typeof t.label).toBe('string'));
+  });
+
+  it('renders the account-state templates with no args', () => {
+    expect(renderComposeTemplate('ACCOUNT_BANNED')).toContain('account has been banned');
+    expect(renderComposeTemplate('ACCOUNT_RESTORED')).toContain('account has been restored');
   });
 
   it('renders without a video (null-safe) using the generic subject', () => {

--- a/src/nostr/dm-sender.test.mjs
+++ b/src/nostr/dm-sender.test.mjs
@@ -16,6 +16,8 @@ import {
   sendModerationDM,
   selectTemplate,
   notifyReporters,
+  COMPOSE_TEMPLATES,
+  renderComposeTemplate,
 } from './dm-sender.mjs';
 
 // Generate a stable test key in hex format (matching production usage)
@@ -563,5 +565,35 @@ describe('DM Sender - notifyReporters', () => {
   it('should skip notification for REVIEW (intermediate state)', async () => {
     const result = await notifyReporters('abc123', 'REVIEW', { NOSTR_PRIVATE_KEY: testHex }, '[TEST]');
     expect(result).toEqual({ notified: 0, failed: 0 });
+  });
+});
+
+describe('COMPOSE_TEMPLATES / renderComposeTemplate', () => {
+  it('exposes the four creator-facing templates and excludes report-outcome', () => {
+    const keys = COMPOSE_TEMPLATES.map(t => t.key);
+    expect(keys).toEqual(['PERMANENT_BAN', 'AGE_RESTRICTED', 'QUARANTINE', 'ACCOUNT_SUSPENDED']);
+    expect(keys).not.toContain('REPORT_OUTCOME_ACTION');
+    COMPOSE_TEMPLATES.forEach(t => expect(typeof t.label).toBe('string'));
+  });
+
+  it('renders without a video (null-safe) using the generic subject', () => {
+    const body = renderComposeTemplate('PERMANENT_BAN');
+    expect(body).toContain('Your content');
+    expect(body).not.toContain('divine.video/video/'); // no content link when sha256 is null
+  });
+
+  it('renders ACCOUNT_SUSPENDED with no args', () => {
+    const body = renderComposeTemplate('ACCOUNT_SUSPENDED');
+    expect(body).toContain('account has been suspended');
+  });
+
+  it('category specialization matches selectTemplate output', () => {
+    const sha = '11'.repeat(32);
+    expect(renderComposeTemplate('PERMANENT_BAN', { category: 'nudity', sha256: sha }))
+      .toBe(selectTemplate('PERMANENT_BAN', null, 'nudity', sha));
+  });
+
+  it('returns null for an unknown key', () => {
+    expect(renderComposeTemplate('NOPE')).toBeNull();
   });
 });

--- a/src/nostr/dm-sender.test.mjs
+++ b/src/nostr/dm-sender.test.mjs
@@ -4,7 +4,7 @@
 // ABOUTME: Tests for DM sender module (dm-sender.mjs)
 // ABOUTME: Verifies message templates, key derivation, rate limiting, and relay discovery
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { generateSecretKey, getPublicKey } from 'nostr-tools/pure';
 import { bytesToHex } from '@noble/hashes/utils';
 import {
@@ -18,6 +18,7 @@ import {
   notifyReporters,
   COMPOSE_TEMPLATES,
   renderComposeTemplate,
+  publishToRelays,
 } from './dm-sender.mjs';
 
 // Generate a stable test key in hex format (matching production usage)
@@ -600,5 +601,38 @@ describe('COMPOSE_TEMPLATES / renderComposeTemplate', () => {
 
   it('returns null for an unknown key', () => {
     expect(renderComposeTemplate('NOPE')).toBeNull();
+  });
+});
+
+describe('publishToRelays — Workers WebSocket construction', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  // Regression guard: Cloudflare Workers' WebSocket constructor only accepts a
+  // subprotocol string/array as its 2nd arg. Passing an options/headers object
+  // throws "protocol header token is invalid", so publishing silently fails and
+  // composed messages never leave the worker. Connect with the URL alone.
+  it('constructs each relay WebSocket with the URL only (no options object)', async () => {
+    const ctorArgs = [];
+    class FakeWS {
+      constructor(...args) {
+        ctorArgs.push(args);
+        this._cbs = {};
+        queueMicrotask(() => {
+          this._cbs.open && this._cbs.open();
+          this._cbs.message && this._cbs.message({ data: JSON.stringify(['OK', 'evt1', true, '']) });
+        });
+      }
+      addEventListener(type, cb) { this._cbs[type] = cb; }
+      send() {}
+      close() {}
+    }
+    vi.stubGlobal('WebSocket', FakeWS);
+
+    const res = await publishToRelays({ id: 'evt1' }, ['wss://relay.example.com'], {});
+
+    expect(res).toEqual({ success: 1, failed: 0 });
+    expect(ctorArgs).toHaveLength(1);
+    expect(ctorArgs[0]).toHaveLength(1); // URL only — the regression guard
+    expect(ctorArgs[0][0]).toBe('wss://relay.example.com');
   });
 });

--- a/src/nostr/dm-sender.test.mjs
+++ b/src/nostr/dm-sender.test.mjs
@@ -20,6 +20,7 @@ import {
   renderComposeTemplate,
   publishToRelays,
 } from './dm-sender.mjs';
+import { createMockKV } from '../test/helpers.mjs';
 
 // Generate a stable test key in hex format (matching production usage)
 const testSecretKey = generateSecretKey();
@@ -636,3 +637,28 @@ describe('publishToRelays — Workers WebSocket construction', () => {
     expect(ctorArgs[0][0]).toBe('wss://relay.example.com');
   });
 });
+
+describe('discoverUserRelays — Workers WebSocket construction', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('constructs the relay-list WebSocket with the URL only', async () => {
+    const ctorArgs = [];
+    class FakeWS {
+      constructor(...args) {
+        ctorArgs.push(args);
+        this._cbs = {};
+        setTimeout(() => this._cbs.error && this._cbs.error(new Error('x')), 0);
+      }
+      addEventListener(type, cb) { this._cbs[type] = cb; }
+      send() {}
+      close() {}
+    }
+    vi.stubGlobal('WebSocket', FakeWS);
+
+    await discoverUserRelays('a'.repeat(64), { MODERATION_KV: createMockKV() });
+
+    expect(ctorArgs.length).toBeGreaterThan(0);
+    ctorArgs.forEach((args) => expect(args).toHaveLength(1));
+  });
+});
+

--- a/src/nostr/nip05.mjs
+++ b/src/nostr/nip05.mjs
@@ -8,6 +8,8 @@ const NIP05_CACHE_TTL = 3600; // 1 hour
 const FETCH_TIMEOUT_MS = 5000;
 
 const LOCAL_PART_RE = /^[a-z0-9._-]+$/i;
+// Deliberately strict allowlist on an egress path: requires an alpha TLD of 2+
+// chars, so trailing dots and punycode (xn--) TLDs are rejected by design.
 const DOMAIN_RE = /^[a-z0-9.-]+\.[a-z]{2,}$/i;
 const HEX64_RE = /^[0-9a-f]{64}$/i;
 
@@ -55,10 +57,17 @@ export async function resolveNip05(address, env) {
     const url = `https://${domain}/.well-known/nostr.json?name=${encodeURIComponent(name)}`;
     const res = await fetch(url, {
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      // NIP-05: "Fetchers MUST ignore any HTTP redirects." Also an SSRF guard —
+      // a moderator-supplied domain could 302 to an internal host, defeating
+      // "resolve at the authoritative source". 'manual' yields an opaque-redirect
+      // response whose res.ok is false, so the if (res.ok) branch returns null.
+      redirect: 'manual',
       headers: { Accept: 'application/json' },
     });
     if (res.ok) {
       const json = await res.json();
+      // NIP-05 local part is case-sensitive; only the domain is lowercased.
+      // Do not lowercase `name` here or resolution breaks for mixed-case names.
       const found = json?.names?.[name];
       if (typeof found === 'string' && HEX64_RE.test(found)) {
         pubkey = found.toLowerCase();

--- a/src/nostr/nip05.mjs
+++ b/src/nostr/nip05.mjs
@@ -1,0 +1,80 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Resolves a nip-05 "user@domain" to an authoritative hex pubkey via the
+// ABOUTME: domain's .well-known/nostr.json. KV-cached (1h). null on any failure.
+
+const NIP05_CACHE_TTL = 3600; // 1 hour
+const FETCH_TIMEOUT_MS = 5000;
+
+const LOCAL_PART_RE = /^[a-z0-9._-]+$/i;
+const DOMAIN_RE = /^[a-z0-9.-]+\.[a-z]{2,}$/i;
+const HEX64_RE = /^[0-9a-f]{64}$/i;
+
+/**
+ * Parse "user@domain" into { name, domain } or null if malformed.
+ * @param {string} address
+ * @returns {{name: string, domain: string} | null}
+ */
+export function parseNip05(address) {
+  if (typeof address !== 'string') return null;
+  const trimmed = address.trim();
+  const at = trimmed.lastIndexOf('@');
+  if (at <= 0 || at === trimmed.length - 1) return null;
+  const name = trimmed.slice(0, at);
+  const domain = trimmed.slice(at + 1).toLowerCase();
+  if (!LOCAL_PART_RE.test(name) || !DOMAIN_RE.test(domain)) return null;
+  return { name, domain };
+}
+
+/**
+ * Resolve a nip-05 address to an authoritative hex pubkey.
+ * Returns { pubkey, address, domain } or null.
+ * @param {string} address - "user@domain"
+ * @param {Object} env - Cloudflare env (uses MODERATION_KV for caching)
+ */
+export async function resolveNip05(address, env) {
+  const parsed = parseNip05(address);
+  if (!parsed) return null;
+  const { name, domain } = parsed;
+  const canonical = `${name}@${domain}`;
+  const cacheKey = `nip05:${canonical.toLowerCase()}`;
+
+  if (env?.MODERATION_KV) {
+    try {
+      const cached = await env.MODERATION_KV.get(cacheKey);
+      if (cached !== null) {
+        const { pubkey } = JSON.parse(cached);
+        return pubkey ? { pubkey, address: canonical, domain } : null;
+      }
+    } catch { /* ignore cache read errors */ }
+  }
+
+  let pubkey = null;
+  try {
+    const url = `https://${domain}/.well-known/nostr.json?name=${encodeURIComponent(name)}`;
+    const res = await fetch(url, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      headers: { Accept: 'application/json' },
+    });
+    if (res.ok) {
+      const json = await res.json();
+      const found = json?.names?.[name];
+      if (typeof found === 'string' && HEX64_RE.test(found)) {
+        pubkey = found.toLowerCase();
+      }
+    }
+  } catch (err) {
+    console.error('[NIP05] resolve failed:', err.message);
+  }
+
+  if (env?.MODERATION_KV) {
+    try {
+      await env.MODERATION_KV.put(cacheKey, JSON.stringify({ pubkey: pubkey || null }), {
+        expirationTtl: NIP05_CACHE_TTL,
+      });
+    } catch { /* ignore cache write errors */ }
+  }
+
+  return pubkey ? { pubkey, address: canonical, domain } : null;
+}

--- a/src/nostr/nip05.mjs
+++ b/src/nostr/nip05.mjs
@@ -13,6 +13,50 @@ const LOCAL_PART_RE = /^[a-z0-9._-]+$/i;
 const DOMAIN_RE = /^[a-z0-9.-]+\.[a-z]{2,}$/i;
 const HEX64_RE = /^[0-9a-f]{64}$/i;
 
+// Divine issues NIP-05 in two equivalent forms, both shown on profiles as
+// "@username.divine.video": username@divine.video (apex) and
+// _@username.divine.video (per-user subdomain). Profiles render the leading-@
+// form, so that is what moderators paste.
+const DIVINE_APEXES = ['divine.video', 'dvine.video'];
+const DEFAULT_DIVINE_APEX = 'divine.video';
+
+/**
+ * Normalize the recipient forms a moderator actually sees into a canonical
+ * "localpart@domain" NIP-05 address. Divine display forms map to the subdomain
+ * identity; canonical and cross-domain forms pass through unchanged:
+ *   @mjb.divine.video  -> _@mjb.divine.video   (profile badge)
+ *   @mjb / mjb         -> _@mjb.divine.video   (bare handle, divine default)
+ *   mjb.divine.video   -> _@mjb.divine.video   (subdomain host, e.g. from URL)
+ *   mjb@divine.video, _@mjb.divine.video, mjb@nos.social -> unchanged
+ * Returns the canonical address string, or null if there's nothing to resolve.
+ * @param {string} raw
+ * @returns {string | null}
+ */
+export function normalizeNip05Input(raw) {
+  if (typeof raw !== 'string') return null;
+  let s = raw.trim();
+  if (s.startsWith('@')) s = s.slice(1).trim();
+  if (!s) return null;
+  if (s.includes('@')) return s;          // already localpart@domain
+  if (s.includes('.')) return `_@${s}`;   // bare host (e.g. mjb.divine.video) -> root id
+  return `_@${s}.${DEFAULT_DIVINE_APEX}`;  // bare handle -> divine subdomain
+}
+
+/**
+ * Friendly display for a resolved divine address ("@username.divine.video"),
+ * matching what profile pages show. Returns null for non-divine addresses.
+ */
+function divineDisplayName(name, domain) {
+  for (const apex of DIVINE_APEXES) {
+    if (name === '_' && domain.endsWith(`.${apex}`)) {
+      const sub = domain.slice(0, -(apex.length + 1));
+      if (sub && !sub.includes('.')) return `@${sub}.${apex}`;
+    }
+    if (domain === apex) return `@${name}.${apex}`;
+  }
+  return null;
+}
+
 /**
  * Parse "user@domain" into { name, domain } or null if malformed.
  * @param {string} address
@@ -36,10 +80,11 @@ export function parseNip05(address) {
  * @param {Object} env - Cloudflare env (uses MODERATION_KV for caching)
  */
 export async function resolveNip05(address, env) {
-  const parsed = parseNip05(address);
+  const parsed = parseNip05(normalizeNip05Input(address));
   if (!parsed) return null;
   const { name, domain } = parsed;
   const canonical = `${name}@${domain}`;
+  const display = divineDisplayName(name, domain) || canonical;
   const cacheKey = `nip05:${canonical.toLowerCase()}`;
 
   if (env?.MODERATION_KV) {
@@ -47,7 +92,7 @@ export async function resolveNip05(address, env) {
       const cached = await env.MODERATION_KV.get(cacheKey);
       if (cached !== null) {
         const { pubkey } = JSON.parse(cached);
-        return pubkey ? { pubkey, address: canonical, domain } : null;
+        return pubkey ? { pubkey, address: canonical, domain, display } : null;
       }
     } catch { /* ignore cache read errors */ }
   }
@@ -85,5 +130,5 @@ export async function resolveNip05(address, env) {
     } catch { /* ignore cache write errors */ }
   }
 
-  return pubkey ? { pubkey, address: canonical, domain } : null;
+  return pubkey ? { pubkey, address: canonical, domain, display } : null;
 }

--- a/src/nostr/nip05.test.mjs
+++ b/src/nostr/nip05.test.mjs
@@ -1,0 +1,75 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Tests for resolveNip05 / parseNip05 — well-known verification + KV cache.
+// ABOUTME: Mocks global fetch; no real network.
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { parseNip05, resolveNip05 } from './nip05.mjs';
+import { createMockKV } from '../test/helpers.mjs';
+
+const HEX = '00000000000000000000000000000000000000000000000000000000000000ab';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('parseNip05', () => {
+  it('splits a valid address', () => {
+    expect(parseNip05('alice@divine.video')).toEqual({ name: 'alice', domain: 'divine.video' });
+  });
+  it('rejects input without @', () => {
+    expect(parseNip05('alice')).toBeNull();
+  });
+  it('rejects bad local-part chars', () => {
+    expect(parseNip05('al ice@divine.video')).toBeNull();
+  });
+  it('rejects non-string', () => {
+    expect(parseNip05(null)).toBeNull();
+  });
+});
+
+describe('resolveNip05', () => {
+  it('returns the authoritative pubkey when names[name] is valid hex', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ names: { alice: HEX } }),
+    }));
+    const env = { MODERATION_KV: createMockKV() };
+    const result = await resolveNip05('alice@divine.video', env);
+    expect(result).toEqual({ pubkey: HEX, address: 'alice@divine.video', domain: 'divine.video' });
+    expect(fetch).toHaveBeenCalledWith(
+      'https://divine.video/.well-known/nostr.json?name=alice',
+      expect.objectContaining({ headers: expect.any(Object) }),
+    );
+  });
+
+  it('returns null when the name is absent', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => ({ names: {} }) }));
+    const result = await resolveNip05('ghost@divine.video', { MODERATION_KV: createMockKV() });
+    expect(result).toBeNull();
+  });
+
+  it('returns null on non-200', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 404, json: async () => ({}) }));
+    const result = await resolveNip05('alice@divine.video', { MODERATION_KV: createMockKV() });
+    expect(result).toBeNull();
+  });
+
+  it('returns null for malformed address and never fetches', async () => {
+    const spy = vi.fn();
+    vi.stubGlobal('fetch', spy);
+    const result = await resolveNip05('not-an-address', { MODERATION_KV: createMockKV() });
+    expect(result).toBeNull();
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('serves a cached positive result without fetching again', async () => {
+    const kv = createMockKV({ 'nip05:alice@divine.video': JSON.stringify({ pubkey: HEX }) });
+    const spy = vi.fn();
+    vi.stubGlobal('fetch', spy);
+    const result = await resolveNip05('alice@divine.video', { MODERATION_KV: kv });
+    expect(result).toEqual({ pubkey: HEX, address: 'alice@divine.video', domain: 'divine.video' });
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/src/nostr/nip05.test.mjs
+++ b/src/nostr/nip05.test.mjs
@@ -5,7 +5,7 @@
 // ABOUTME: Mocks global fetch; no real network.
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { parseNip05, resolveNip05 } from './nip05.mjs';
+import { parseNip05, resolveNip05, normalizeNip05Input } from './nip05.mjs';
 import { createMockKV } from '../test/helpers.mjs';
 
 const HEX = '00000000000000000000000000000000000000000000000000000000000000ab';
@@ -37,7 +37,7 @@ describe('resolveNip05', () => {
     }));
     const env = { MODERATION_KV: createMockKV() };
     const result = await resolveNip05('alice@divine.video', env);
-    expect(result).toEqual({ pubkey: HEX, address: 'alice@divine.video', domain: 'divine.video' });
+    expect(result).toEqual({ pubkey: HEX, address: 'alice@divine.video', domain: 'divine.video', display: '@alice.divine.video' });
     expect(fetch).toHaveBeenCalledWith(
       'https://divine.video/.well-known/nostr.json?name=alice',
       expect.objectContaining({ headers: expect.any(Object) }),
@@ -65,7 +65,8 @@ describe('resolveNip05', () => {
   it('returns null for malformed address and never fetches', async () => {
     const spy = vi.fn();
     vi.stubGlobal('fetch', spy);
-    const result = await resolveNip05('not-an-address', { MODERATION_KV: createMockKV() });
+    // A space in the local part survives normalization but fails parse, so no fetch.
+    const result = await resolveNip05('bad name@divine.video', { MODERATION_KV: createMockKV() });
     expect(result).toBeNull();
     expect(spy).not.toHaveBeenCalled();
   });
@@ -75,7 +76,37 @@ describe('resolveNip05', () => {
     const spy = vi.fn();
     vi.stubGlobal('fetch', spy);
     const result = await resolveNip05('alice@divine.video', { MODERATION_KV: kv });
-    expect(result).toEqual({ pubkey: HEX, address: 'alice@divine.video', domain: 'divine.video' });
+    expect(result).toEqual({ pubkey: HEX, address: 'alice@divine.video', domain: 'divine.video', display: '@alice.divine.video' });
     expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('resolves the divine profile-badge form (@user.divine.video) and echoes the @ display', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ names: { _: HEX } }) });
+    vi.stubGlobal('fetch', fetchMock);
+    const result = await resolveNip05('@mjb.divine.video', { MODERATION_KV: createMockKV() });
+    expect(result).toEqual({ pubkey: HEX, address: '_@mjb.divine.video', domain: 'mjb.divine.video', display: '@mjb.divine.video' });
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://mjb.divine.video/.well-known/nostr.json?name=_',
+      expect.objectContaining({ headers: expect.any(Object) }),
+    );
+  });
+});
+
+describe('normalizeNip05Input', () => {
+  it('maps divine display + bare forms to the subdomain identity', () => {
+    expect(normalizeNip05Input('@mjb.divine.video')).toBe('_@mjb.divine.video');
+    expect(normalizeNip05Input('@mjb')).toBe('_@mjb.divine.video');
+    expect(normalizeNip05Input('mjb')).toBe('_@mjb.divine.video');
+    expect(normalizeNip05Input('mjb.divine.video')).toBe('_@mjb.divine.video');
+  });
+  it('passes canonical and cross-domain forms through unchanged', () => {
+    expect(normalizeNip05Input('mjb@divine.video')).toBe('mjb@divine.video');
+    expect(normalizeNip05Input('_@mjb.divine.video')).toBe('_@mjb.divine.video');
+    expect(normalizeNip05Input('mjb@nos.social')).toBe('mjb@nos.social');
+  });
+  it('returns null for empty / @-only / non-string', () => {
+    expect(normalizeNip05Input('')).toBeNull();
+    expect(normalizeNip05Input('@')).toBeNull();
+    expect(normalizeNip05Input(null)).toBeNull();
   });
 });

--- a/src/nostr/nip05.test.mjs
+++ b/src/nostr/nip05.test.mjs
@@ -56,6 +56,12 @@ describe('resolveNip05', () => {
     expect(result).toBeNull();
   });
 
+  it('returns null when the well-known response is a redirect (not followed)', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 0, type: 'opaqueredirect', json: async () => ({}) }));
+    const result = await resolveNip05('alice@divine.video', { MODERATION_KV: createMockKV() });
+    expect(result).toBeNull();
+  });
+
   it('returns null for malformed address and never fetches', async () => {
     const spy = vi.fn();
     vi.stubGlobal('fetch', spy);


### PR DESCRIPTION
Rounds out the moderation **compose** experience in the Messages inbox, oriented toward the communication layer the **under-16 critical path** relies on: delivering account-state notices (suspend / ban / restore) and giving flagged users a dependable notice + appeal/dispute channel within the review window.

## Why this supports the under-16 path
Age-review outcomes are account-state actions — under-13 → account closure, 13–15 → suspension pending parent consent, 16+ mistake → suspension pending dispute — each starting a 15-day clock **from notice**, with an appeal/dispute path for the 13–15 and 16+ tiers. Moderator-initiated DMs from the Moderation account are the practical way to deliver that notice and carry the appeal:

- The account-state notices (**suspend / ban / restore**) are now selectable in the composer, matching the tier outcomes and the restore-on-resolution case.
- Moderators can **initiate** a DM to a flagged user (not just reply), so notice can actually be sent.
- Reliable delivery with surfaced send failures means a notice is dependable rather than assumed.
- Verified recipient resolution + reply-to-appeal keeps the dispute path intact.

## Adds
- Start a new DM from the inbox (not just reply). Recipient resolution accepts the forms moderators see on profiles: `@username.divine.video`, `@username`/bare `username`, `user.divine.video`, canonical `user@domain`, cross-domain nip-05, or pasted npub/hex — nip-05 verified against the domain's `.well-known` (no spoofable display-name lookup); the verified line echoes `@username.divine.video`.
- Template picker over the compose box, reusing existing moderation templates including the account-state notices (suspend / ban / restore) as editable pre-fills; bodies include the content link when "Link video" is set.
- Sending reliability improvements with error handling.
- New/empty threads render "No messages yet — start the conversation" (also fixes the existing "Message Creator →" deep-link for never-messaged creators).

## Notable fix
The relay publish path connected with an options object the Workers runtime rejects; now connects URL-only (matching the other relay paths), with a regression test.

## Tests
- Recipient resolution (all forms incl. divine handles), templates, nip-05 normalization, the empty-thread fix, the send-failure (502) path, and URL-only WebSocket construction at both the relay-discovery and publish sites.
- Send success path is covered at the publish layer (`publishToRelays` → success) and validated end-to-end live (published to 3 relays). A full route-level send integration test hangs the vitest worker in this environment (not a product issue — the path is live-validated), so it's left as the publish-layer assertion.

## Related
- Builds on #150 (account-state templates) — now reflected in the compose picker.
- Supports the under-16 age-review communication path (notice + appeal); see the Trust & Safety under-16 system coordination notes.

## Design / plan
- `docs/superpowers/specs/2026-06-03-moderator-compose-new-dm-design.md`
- `docs/superpowers/plans/2026-06-03-moderator-compose-new-dm.md`
