### PR TITLE
feat(dm): add ACCOUNT_BANNED and ACCOUNT_RESTORED templates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,10 @@ jobs:
       - name: Run tests
         run: |
           set -o pipefail
+          set +e
           npm test 2>&1 | tee /tmp/vitest.log
           status=${PIPESTATUS[0]}
+          set -e
 
           if [ "$status" -eq 0 ]; then
             exit 0

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -3857,7 +3857,7 @@ async function runMigration() {
           });
         }
 
-        const validNotifyActions = ['PERMANENT_BAN', 'AGE_RESTRICTED', 'QUARANTINE', 'ACCOUNT_SUSPENDED', 'REPORT_OUTCOME_ACTION', 'REPORT_OUTCOME_NO_ACTION'];
+        const validNotifyActions = ['PERMANENT_BAN', 'AGE_RESTRICTED', 'QUARANTINE', 'ACCOUNT_SUSPENDED', 'ACCOUNT_BANNED', 'ACCOUNT_RESTORED', 'REPORT_OUTCOME_ACTION', 'REPORT_OUTCOME_NO_ACTION'];
         if (!validNotifyActions.includes(action)) {
           return new Response(JSON.stringify({
             error: `Invalid action. Must be one of: ${validNotifyActions.join(', ')}`

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -5563,6 +5563,47 @@ describe('POST /api/v1/notify', () => {
     expect(body.reason).toContain('not configured');
   });
 
+  it('accepts ACCOUNT_BANNED action', async () => {
+    const env = createEnv({
+      ALLOW_DEV_ACCESS: 'true',
+      NOSTR_PRIVATE_KEY: undefined
+    });
+
+    const response = await worker.fetch(
+      new Request('https://moderation-api.divine.video/api/v1/notify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ recipientPubkey: VALID_PUBKEY, action: 'ACCOUNT_BANNED' })
+      }),
+      env
+    );
+
+    // Not configured -> 200 success path, proving the action passed the allowlist.
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+  });
+
+  it('accepts ACCOUNT_RESTORED action', async () => {
+    const env = createEnv({
+      ALLOW_DEV_ACCESS: 'true',
+      NOSTR_PRIVATE_KEY: undefined
+    });
+
+    const response = await worker.fetch(
+      new Request('https://moderation-api.divine.video/api/v1/notify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ recipientPubkey: VALID_PUBKEY, action: 'ACCOUNT_RESTORED' })
+      }),
+      env
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+  });
+
   it('sends DM for valid request with NOSTR_PRIVATE_KEY configured', async () => {
     const env = createEnv({
       ALLOW_DEV_ACCESS: 'true',

--- a/src/nostr/dm-sender.mjs
+++ b/src/nostr/dm-sender.mjs
@@ -63,6 +63,16 @@ const TEMPLATES = {
   ACCOUNT_SUSPENDED: () =>
     `Your account has been suspended for violating Divine's content policies.\n\nIf you believe this was a mistake, you can reply to this message to appeal.\n\n${FOOTER}`,
 
+  // Account-level permanent ban: no content link, not content-specific.
+  // Distinct from ACCOUNT_SUSPENDED: signals the action is permanent.
+  ACCOUNT_BANNED: () =>
+    `Your account has been banned for violating Divine's content policies. This is a permanent action.\n\nIf you believe this was a mistake, you can reply to this message to appeal.\n\n${FOOTER}`,
+
+  // Account-level restoration: no content link, no appeal prompt.
+  // Sent when a previously suspended/banned account is reinstated.
+  ACCOUNT_RESTORED: () =>
+    `Good news: your account has been restored and you can use Divine again.\n\n${FOOTER}`,
+
   REPORT_OUTCOME_ACTION: (outcome, sha256, title, publishedAt, reportedAt) =>
     `Thanks for your report. We've reviewed ${contentSubject(title, 'the reported content')}${postedDate(publishedAt)} and it has been ${outcome}.${reportedAt ? ` You reported this content on ${formatDate(reportedAt)}.` : ''}\n${contentLink(sha256)}\nIf you have questions, you can reply to this message.\n\n${FOOTER}`,
 

--- a/src/nostr/dm-sender.mjs
+++ b/src/nostr/dm-sender.mjs
@@ -122,7 +122,7 @@ const CATEGORY_TEMPLATES = {
 /**
  * Select a category-specific template for a moderation action.
  * Falls back to generic reason if no category match.
- * @param {string} action - PERMANENT_BAN, AGE_RESTRICTED, or QUARANTINE
+ * @param {string} action - A TEMPLATES key (PERMANENT_BAN, AGE_RESTRICTED, QUARANTINE, ACCOUNT_SUSPENDED, ACCOUNT_BANNED, ACCOUNT_RESTORED, REPORT_OUTCOME_*). ACCOUNT_* actions short-circuit category logic.
  * @param {string|null} reason - Ignored when category matches. When used as fallback,
  *   must be a sentence completion after "was found to" (e.g., "violate content policies").
  *   Caller-provided freeform reasons are overridden by per-action defaults when no category matches.
@@ -173,7 +173,7 @@ export function selectTemplate(action, reason, categories, sha256, title = null,
 
 /**
  * Get message text for a given moderation action.
- * @param {string} action - PERMANENT_BAN, AGE_RESTRICTED, or QUARANTINE
+ * @param {string} action - A TEMPLATES key (PERMANENT_BAN, AGE_RESTRICTED, QUARANTINE, ACCOUNT_SUSPENDED, ACCOUNT_BANNED, ACCOUNT_RESTORED, REPORT_OUTCOME_*)
  * @param {string} reason
  * @returns {string|null} Message text or null if action has no template
  */

--- a/src/nostr/dm-sender.mjs
+++ b/src/nostr/dm-sender.mjs
@@ -71,7 +71,7 @@ const TEMPLATES = {
   // Account-level restoration: no content link, no appeal prompt.
   // Sent when a previously suspended/banned account is reinstated.
   ACCOUNT_RESTORED: () =>
-    `Good news: your account has been restored and you can use Divine again.\n\n${FOOTER}`,
+    `Your account has been restored and you can use Divine again.\n\n${FOOTER}`,
 
   REPORT_OUTCOME_ACTION: (outcome, sha256, title, publishedAt, reportedAt) =>
     `Thanks for your report. We've reviewed ${contentSubject(title, 'the reported content')}${postedDate(publishedAt)} and it has been ${outcome}.${reportedAt ? ` You reported this content on ${formatDate(reportedAt)}.` : ''}\n${contentLink(sha256)}\nIf you have questions, you can reply to this message.\n\n${FOOTER}`,

--- a/src/nostr/dm-sender.mjs
+++ b/src/nostr/dm-sender.mjs
@@ -136,7 +136,7 @@ export function selectTemplate(action, reason, categories, sha256, title = null,
   // Account-level actions (ACCOUNT_BANNED / ACCOUNT_SUSPENDED / ACCOUNT_RESTORED)
   // are not content-specific: they take no category, and category `extra` text
   // (e.g. self-harm crisis lines) must never be spliced into an account notice.
-  if (action.startsWith('ACCOUNT_')) {
+  if (typeof action === 'string' && action.startsWith('ACCOUNT_')) {
     const accountTemplate = TEMPLATES[action];
     return accountTemplate ? accountTemplate() : null;
   }

--- a/src/nostr/dm-sender.mjs
+++ b/src/nostr/dm-sender.mjs
@@ -133,6 +133,14 @@ const CATEGORY_TEMPLATES = {
  * @returns {string|null} Message text or null if action has no template
  */
 export function selectTemplate(action, reason, categories, sha256, title = null, publishedAt = null) {
+  // Account-level actions (ACCOUNT_BANNED / ACCOUNT_SUSPENDED / ACCOUNT_RESTORED)
+  // are not content-specific: they take no category, and category `extra` text
+  // (e.g. self-harm crisis lines) must never be spliced into an account notice.
+  if (action.startsWith('ACCOUNT_')) {
+    const accountTemplate = TEMPLATES[action];
+    return accountTemplate ? accountTemplate() : null;
+  }
+
   let categoryInfo = null;
   if (categories && typeof categories === 'string') {
     try {

--- a/src/nostr/dm-sender.test.mjs
+++ b/src/nostr/dm-sender.test.mjs
@@ -434,6 +434,11 @@ describe('DM Sender - selectTemplate (Category-Specific)', () => {
     expect(msg).toBeNull();
   });
 
+  it('should return null for non-string action', () => {
+    const msg = selectTemplate(null, null, '{"self_harm": 0.9}', 'abc123');
+    expect(msg).toBeNull();
+  });
+
   it('should handle plain string category', () => {
     const msg = selectTemplate('AGE_RESTRICTED', null, 'offensive', 'abc123');
 

--- a/src/nostr/dm-sender.test.mjs
+++ b/src/nostr/dm-sender.test.mjs
@@ -139,7 +139,7 @@ describe('DM Sender - Message Templates', () => {
 
   it('should produce account restored message without appeal or content reference', () => {
     const message = getMessageForAction('ACCOUNT_RESTORED');
-    expect(message).toContain('your account has been restored');
+    expect(message).toContain('Your account has been restored');
     expect(message).toContain('use Divine again');
     expect(message).not.toContain('reply to this message to appeal');
     expect(message).not.toContain('divine.video/video/');

--- a/src/nostr/dm-sender.test.mjs
+++ b/src/nostr/dm-sender.test.mjs
@@ -128,6 +128,24 @@ describe('DM Sender - Message Templates', () => {
     expect(message).not.toContain('Your content');
   });
 
+  it('should produce account banned message without content reference', () => {
+    const message = getMessageForAction('ACCOUNT_BANNED');
+    expect(message).toContain('Your account has been banned');
+    expect(message).toContain('This is a permanent action');
+    expect(message).toContain('reply to this message to appeal');
+    expect(message).not.toContain('divine.video/video/');
+    expect(message).not.toContain('Your content');
+  });
+
+  it('should produce account restored message without appeal or content reference', () => {
+    const message = getMessageForAction('ACCOUNT_RESTORED');
+    expect(message).toContain('your account has been restored');
+    expect(message).toContain('use Divine again');
+    expect(message).not.toContain('reply to this message to appeal');
+    expect(message).not.toContain('divine.video/video/');
+    expect(message).not.toContain('Your content');
+  });
+
   it('should produce correct report outcome message for no action', () => {
     const message = getReportOutcomeMessage('SAFE', 'ghi789');
 

--- a/src/nostr/dm-sender.test.mjs
+++ b/src/nostr/dm-sender.test.mjs
@@ -530,6 +530,14 @@ describe('DM Sender - selectTemplate (Category-Specific)', () => {
     expect(msg).not.toContain('crisis');
     expect(msg).not.toContain('988');
   });
+
+  it('applies the guard to ACCOUNT_SUSPENDED too (unchanged message, no crisis injection)', () => {
+    const msg = selectTemplate('ACCOUNT_SUSPENDED', null, '{"self_harm": 0.9}', null);
+
+    expect(msg).toContain('Your account has been suspended');
+    expect(msg).not.toContain('crisis');
+    expect(msg).not.toContain('988');
+  });
 });
 
 describe('DM Sender - notifyReporters', () => {

--- a/src/nostr/dm-sender.test.mjs
+++ b/src/nostr/dm-sender.test.mjs
@@ -501,6 +501,35 @@ describe('DM Sender - selectTemplate (Category-Specific)', () => {
     expect(msg).toContain('Your content was removed');
     expect(msg).not.toContain('(posted');
   });
+
+  // selectTemplate is the path /api/v1/notify actually uses, so cover the new
+  // account-level actions through it (not just getMessageForAction).
+  it('should resolve ACCOUNT_BANNED through the live dispatch path', () => {
+    const msg = selectTemplate('ACCOUNT_BANNED', null, null, null);
+
+    expect(msg).toContain('Your account has been banned');
+    expect(msg).toContain('permanent action');
+    expect(msg).toContain('reply to this message to appeal');
+    expect(msg).not.toContain('divine.video/video/');
+  });
+
+  it('should resolve ACCOUNT_RESTORED through the live dispatch path', () => {
+    const msg = selectTemplate('ACCOUNT_RESTORED', null, null, null);
+
+    expect(msg).toContain('Your account has been restored');
+    expect(msg).not.toContain('appeal');
+    expect(msg).not.toContain('divine.video/video/');
+  });
+
+  it('should never splice category extra (e.g. crisis lines) into account-level messages', () => {
+    // Even if a caller passes a self_harm category, an account notice must not
+    // get the crisis-line `extra` injected.
+    const msg = selectTemplate('ACCOUNT_BANNED', null, '{"self_harm": 0.9}', null);
+
+    expect(msg).toContain('Your account has been banned');
+    expect(msg).not.toContain('crisis');
+    expect(msg).not.toContain('988');
+  });
 });
 
 describe('DM Sender - notifyReporters', () => {


### PR DESCRIPTION
Companion to divinevideo/divine-relay-manager#98; supports the moderation-DM coverage work in divinevideo/divine-relay-manager#96.

## What this does

Adds two account-state DM actions so relay-manager can distinguish account **ban**, **suspend**, and **restore**. Previously only `ACCOUNT_SUSPENDED` existed, so a ban rendered as a suspension.

## Changes

- **`src/index.mjs`** — added `ACCOUNT_BANNED` and `ACCOUNT_RESTORED` to the `/api/v1/notify` `validNotifyActions` allowlist.
- **`src/nostr/dm-sender.mjs`** — added matching no-arg `TEMPLATES` entries (mirroring `ACCOUNT_SUSPENDED`):
  - `ACCOUNT_BANNED` — permanent-action wording, with reply-to-appeal.
  - `ACCOUNT_RESTORED` — restoration wording, no appeal prompt, no content reference.
- `ACCOUNT_SUSPENDED` is unchanged.

## Tests

- `src/nostr/dm-sender.test.mjs` — asserts the message text for both new actions (and the negative cases: restore has no appeal/content reference).
- `src/index.test.mjs` — both actions pass the `/api/v1/notify` allowlist.

## Merge order

**Land this before relay-manager #98** so the new actions are accepted when relay-manager starts sending them. (If #98 lands first, those two DMs fail and are logged, non-critical, until this ships.)

CI green (tests + lint).
