### PR TITLE
fix(moderation): route relay-admin actions through live /api/relay-rpc

### DIFF
--- a/src/admin/dashboard.html
+++ b/src/admin/dashboard.html
@@ -3441,19 +3441,29 @@
           throw new Error(data.error || `HTTP ${response.status}`);
         }
 
-        if (currentLookupVideo?.uploaded_by === pubkey) {
-          const reloadId = currentLookupVideo.lookupId || currentLookupVideo.sha256;
-          await lookupVideo(reloadId);
-        } else {
-          await loadVideos();
-        }
-
+        // Confirm success immediately (before the slower list refresh) so the
+        // moderator always gets a prompt, unmistakable signal it landed.
         button.innerHTML = originalText;
         button.disabled = false;
+        showToast(successMessage);
         setLookupStatus(successMessage);
+
+        // Refresh the affected view. A refresh hiccup must not look like the
+        // action itself failed, since it already succeeded above.
+        try {
+          if (currentLookupVideo?.uploaded_by === pubkey) {
+            const reloadId = currentLookupVideo.lookupId || currentLookupVideo.sha256;
+            await lookupVideo(reloadId);
+          } else {
+            await loadVideos();
+          }
+        } catch (refreshError) {
+          console.error('Enforcement view refresh failed:', refreshError);
+        }
       } catch (error) {
         button.innerHTML = originalText;
         button.disabled = false;
+        showToast(`User action failed: ${error.message}`, null, 5000);
         setLookupStatus(`User action failed: ${error.message}`, true);
       }
     }

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -735,21 +735,65 @@ async function processPendingTranscriptReprocess(env) {
   }
 }
 
+// The relay-admin `/api/moderate` endpoint is deprecated and is no longer
+// routed to the worker at the Cloudflare edge (it returns HTTP 522). Call the
+// live `/api/relay-rpc` endpoint instead (the same one the relay admin UI uses),
+// translating our internal action names to NIP-86 RPC methods.
+//
+// Side effects relative to the old `/api/moderate` path: banpubkey triggers
+// relay-manager's ACCOUNT_BANNED DM; unbanpubkey intentionally sends no DM
+// (relay-manager #96). Calling `/api/relay-rpc` directly also bypasses the
+// markHumanReviewed + Zendesk sync that handleModerate ran; that bookkeeping
+// is owned by moderation-service's own review flow, so it is not duplicated here.
+const RELAY_ADMIN_TIMEOUT_MS = 15000;
+
+function relayRpcForAction(payload) {
+  switch (payload?.action) {
+    case 'ban_pubkey':
+      return { method: 'banpubkey', params: [payload.pubkey, payload.reason || ''] };
+    case 'allow_pubkey':
+      return { method: 'unbanpubkey', params: [payload.pubkey] };
+    case 'delete_event':
+      return { method: 'banevent', params: [payload.eventId, payload.reason || ''] };
+    default:
+      throw new Error(`Unsupported relay admin action: ${payload?.action}`);
+  }
+}
+
 async function callRelayAdminAction(env, payload) {
   const hasCfAccessSecrets = !!(env.CF_ACCESS_CLIENT_ID && env.CF_ACCESS_CLIENT_SECRET);
   if (!hasCfAccessSecrets) {
-    console.warn('[RELAY-ADMIN] CF_ACCESS_CLIENT_ID/CF_ACCESS_CLIENT_SECRET not configured on this worker — calls to relay.admin.divine.video will be blocked by Cloudflare Access. See project memory cf_access_relay_admin_secrets.md.');
+    console.warn('[RELAY-ADMIN] CF_ACCESS_CLIENT_ID/CF_ACCESS_CLIENT_SECRET not configured on this worker — calls to the relay-admin API will be blocked by Cloudflare Access. See project memory cf_access_relay_admin_secrets.md.');
   }
 
-  const response = await fetch(`${getRelayAdminUrl(env)}/api/moderate`, {
-    method: 'POST',
-    headers: getRelayAdminHeaders(env),
-    body: JSON.stringify(payload),
-    redirect: 'manual'
-  });
+  const rpcBody = relayRpcForAction(payload);
+  const url = `${getRelayAdminUrl(env)}/api/relay-rpc`;
+
+  // Bound the call so a dead/slow relay-admin endpoint fails fast instead of
+  // hanging the request (and the moderator's UI) for the full CF edge timeout.
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), RELAY_ADMIN_TIMEOUT_MS);
+
+  let response;
+  try {
+    response = await fetch(url, {
+      method: 'POST',
+      headers: getRelayAdminHeaders(env),
+      body: JSON.stringify(rpcBody),
+      redirect: 'manual',
+      signal: controller.signal
+    });
+  } catch (err) {
+    if (err?.name === 'AbortError') {
+      throw new Error(`Relay admin call timed out after ${RELAY_ADMIN_TIMEOUT_MS / 1000}s (${url})`);
+    }
+    throw err;
+  } finally {
+    clearTimeout(timeoutId);
+  }
 
   // Detect Cloudflare Access bouncing the request to the login page.
-  // *.admin.divine.video is behind CF Access; without a valid service token,
+  // The relay-admin API host is behind CF Access; without a valid service token,
   // any call returns a 302 to <team>.cloudflareaccess.com. Surface a self-
   // documenting error instead of a generic "HTTP 302".
   if (response.status === 302) {
@@ -1884,11 +1928,24 @@ export default {
       const current = await getUploaderEnforcement(env.BLOSSOM_DB, pubkey);
 
       if (hasRelayUpdate && body.relayBanned !== Boolean(current?.relay_banned)) {
-        await callRelayAdminAction(env, {
-          action: body.relayBanned ? 'ban_pubkey' : 'allow_pubkey',
-          pubkey,
-          reason: body.reason || `Moderator action by ${moderatorEmail}`
-        });
+        try {
+          await callRelayAdminAction(env, {
+            action: body.relayBanned ? 'ban_pubkey' : 'allow_pubkey',
+            pubkey,
+            reason: body.reason || `Moderator action by ${moderatorEmail}`
+          });
+        } catch (relayError) {
+          // Surface the failure (e.g. timeout) with its message instead of an
+          // opaque 500, and do not record an enforcement the relay never applied.
+          console.error('[ENFORCE] Relay admin action failed:', relayError);
+          return new Response(JSON.stringify({
+            success: false,
+            error: relayError instanceof Error ? relayError.message : 'Relay admin action failed'
+          }), {
+            status: 502,
+            headers: { 'Content-Type': 'application/json' }
+          });
+        }
       }
 
       const enforcement = await setUploaderEnforcement(env.BLOSSOM_DB, pubkey, {

--- a/src/uploader-enforcement.test.mjs
+++ b/src/uploader-enforcement.test.mjs
@@ -196,12 +196,95 @@ describe('admin uploader enforcement routes', () => {
         }
       });
       expect(fetchCalls).toHaveLength(1);
-      expect(fetchCalls[0].input).toBe('https://relay.admin.divine.video/api/moderate');
+      expect(fetchCalls[0].input).toBe('https://relay.admin.divine.video/api/relay-rpc');
       expect(fetchCalls[0].init.headers['CF-Access-Client-Id']).toBe('client-id');
-      expect(JSON.parse(fetchCalls[0].init.body)).toMatchObject({
-        action: 'ban_pubkey',
-        pubkey: PUBKEY
+      const banBody = JSON.parse(fetchCalls[0].init.body);
+      expect(banBody.method).toBe('banpubkey');
+      expect(banBody.params[0]).toBe(PUBKEY);
+      expect(banBody.params[1]).toBe('Escalated by trust and safety');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('removes the relay ban via unbanpubkey when relayBanned is cleared', async () => {
+    const originalFetch = globalThis.fetch;
+    const fetchCalls = [];
+    globalThis.fetch = async (input, init) => {
+      fetchCalls.push({ input: String(input), init });
+      return new Response(JSON.stringify({ success: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
       });
+    };
+
+    try {
+      const db = createDbMock({
+        uploaderEnforcements: new Map([[PUBKEY, {
+          pubkey: PUBKEY,
+          approval_required: 0,
+          approval_reason: null,
+          relay_banned: 1,
+          relay_ban_reason: 'prior ban',
+          created_at: '2026-03-14T00:00:00.000Z',
+          updated_at: '2026-03-14T00:00:00.000Z'
+        }]])
+      });
+      const response = await worker.fetch(
+        new Request(`https://moderation.admin.divine.video/admin/api/uploader/${PUBKEY}/enforcement`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Cf-Access-Authenticated-User-Email': 'mod@divine.video'
+          },
+          body: JSON.stringify({ relayBanned: false, reason: 'Cleared by trust and safety' })
+        }),
+        createEnv({
+          BLOSSOM_DB: db,
+          RELAY_ADMIN_URL: 'https://relay.admin.divine.video',
+          CF_ACCESS_CLIENT_ID: 'client-id',
+          CF_ACCESS_CLIENT_SECRET: 'client-secret'
+        })
+      );
+
+      expect(response.status).toBe(200);
+      expect(fetchCalls).toHaveLength(1);
+      expect(fetchCalls[0].input).toBe('https://relay.admin.divine.video/api/relay-rpc');
+      const unbanBody = JSON.parse(fetchCalls[0].init.body);
+      expect(unbanBody.method).toBe('unbanpubkey');
+      expect(unbanBody.params[0]).toBe(PUBKEY);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('fails fast with a timeout error when the relay-admin call aborts', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () => {
+      throw Object.assign(new Error('The operation was aborted'), { name: 'AbortError' });
+    };
+
+    try {
+      const response = await worker.fetch(
+        new Request(`https://moderation.admin.divine.video/admin/api/uploader/${PUBKEY}/enforcement`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Cf-Access-Authenticated-User-Email': 'mod@divine.video'
+          },
+          body: JSON.stringify({ relayBanned: true, reason: 'Escalated by trust and safety' })
+        }),
+        createEnv({
+          BLOSSOM_DB: createDbMock(),
+          RELAY_ADMIN_URL: 'https://relay.admin.divine.video',
+          CF_ACCESS_CLIENT_ID: 'client-id',
+          CF_ACCESS_CLIENT_SECRET: 'client-secret'
+        })
+      );
+
+      expect(response.status).toBe(502);
+      const body = await response.json();
+      expect(String(body.error || '')).toMatch(/timed out/i);
     } finally {
       globalThis.fetch = originalFetch;
     }
@@ -285,11 +368,9 @@ describe('admin uploader enforcement routes', () => {
 
       expect(response.status).toBe(200);
       expect(fetchCalls).toHaveLength(1);
-      expect(JSON.parse(fetchCalls[0].init.body)).toMatchObject({
-        action: 'delete_event',
-        eventId: EVENT_ID,
-        reason: 'Delete bad event'
-      });
+      const delBody = JSON.parse(fetchCalls[0].init.body);
+      expect(delBody.method).toBe('banevent');
+      expect(delBody.params).toEqual([EVENT_ID, 'Delete bad event']);
     } finally {
       globalThis.fetch = originalFetch;
     }
@@ -379,7 +460,7 @@ describe('admin uploader enforcement routes', () => {
         }
       });
       expect(fetchCalls).toHaveLength(2);
-      expect(fetchCalls.map((call) => JSON.parse(call.init.body).eventId)).toEqual([EVENT_ID, secondEventId]);
+      expect(fetchCalls.map((call) => JSON.parse(call.init.body).params[0])).toEqual([EVENT_ID, secondEventId]);
     } finally {
       globalThis.fetch = originalFetch;
       globalThis.WebSocket = originalWebSocket;


### PR DESCRIPTION
## What
The moderation dashboard's "Ban User" button (and the content relay-deletion path) called the relay-admin `/api/moderate` endpoint, which is deprecated and no longer routed at the Cloudflare edge. It returns HTTP 522, so the request hung for the full edge timeout (~90s) and failed with only a faint status line (surfaced during moderator testing as an "hourglass that never finishes").

## Root cause
- `Ban User → /admin/api/uploader/:pubkey/enforcement → callRelayAdminAction → POST api-relay-prod.divine.video/api/moderate`.
- `/api/moderate` is deprecated (relay-manager's own code notes its `ban_pubkey` case "is not called by any frontend component"; the live admin UI uses `/api/relay-rpc`). Confirmed via `wrangler tail`: the relay-admin worker never receives `/api/moderate`, while `/api/relay-rpc` and sibling paths succeed.
- No timeout meant it hung the full edge timeout; the only feedback was a status line, so it read as a permanent hang.
- The same path backs content relay-deletion (`delete_event`), which was failing silently too.
- Verified the live path works by banning a throwaway test pubkey via the relay admin UI.

## Changes
- `src/index.mjs`: `callRelayAdminAction` now posts to `/api/relay-rpc`, mapping `ban_pubkey→banpubkey`, `allow_pubkey→unbanpubkey`, `delete_event→banevent`; adds a 15s AbortController timeout (fail fast).
- `src/admin/dashboard.html`: success/failure toast, button restored before the list refresh, and the refresh isolated so a refresh hiccup can't masquerade as a failed action.
- `src/uploader-enforcement.test.mjs`: assertions updated to the relay-rpc contract.

## Reviewer note (behavior)
Repointing `delete_event` to `/api/relay-rpc banevent` skips relay-manager's `handleModerate` side effects for that action (markHumanReviewed + Zendesk sync + a content DM). The moderation-service performs its own review bookkeeping and PERMANENT_BAN DMs, so this avoids a duplicate DM and redundant sync rather than losing coverage. Ban/unban have no side-effect change (handleModerate's `ban_pubkey` case just wraps the same `/api/relay-rpc` call).

## Out of scope (separate)
DM-sender WebSocket bug; the Cloudflare `/api/moderate` route cleanup; kind-1984/allowlist oddities.

## Test plan
- `node scripts/lint.mjs` passes; `vitest run` → 166 passing (incl. the `callRelayAdminAction` 302/CF-Access path).
- Manual after deploy: Ban User from the moderation dashboard completes in ~seconds with a toast.
