### PR TITLE
perf(review): parallelize the per-card admin video reads

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1039,7 +1039,9 @@ async function getAdminLookupVideo(identifier, env, options = {}) {
   const hash = isValidSha256(identifier) ? identifier.toLowerCase() : null;
   const cdnUrl = `https://${env.CDN_DOMAIN || 'media.divine.video'}/${hash}`;
   if (hash) {
-    // Independent reads — run them in parallel rather than serially.
+    // Independent reads — run them in parallel rather than serially. On a D1
+    // error the KV read still fires (harmless, vs. serial where it wouldn't),
+    // and Promise.all surfaces the first rejection to the caller's try/catch.
     const [moderatedRow, kvModerationRaw] = await Promise.all([
       env.BLOSSOM_DB.prepare(`
         SELECT ${ADMIN_VIDEO_COLUMNS.join(', ')}, review_notes, raw_response, videoseal

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1039,13 +1039,15 @@ async function getAdminLookupVideo(identifier, env, options = {}) {
   const hash = isValidSha256(identifier) ? identifier.toLowerCase() : null;
   const cdnUrl = `https://${env.CDN_DOMAIN || 'media.divine.video'}/${hash}`;
   if (hash) {
-    const moderatedRow = await env.BLOSSOM_DB.prepare(`
-      SELECT ${ADMIN_VIDEO_COLUMNS.join(', ')}, review_notes, raw_response, videoseal
-      FROM moderation_results
-      WHERE sha256 = ?
-    `).bind(hash).first();
-
-    const kvModerationRaw = await env.MODERATION_KV.get(`moderation:${hash}`);
+    // Independent reads — run them in parallel rather than serially.
+    const [moderatedRow, kvModerationRaw] = await Promise.all([
+      env.BLOSSOM_DB.prepare(`
+        SELECT ${ADMIN_VIDEO_COLUMNS.join(', ')}, review_notes, raw_response, videoseal
+        FROM moderation_results
+        WHERE sha256 = ?
+      `).bind(hash).first(),
+      env.MODERATION_KV.get(`moderation:${hash}`),
+    ]);
     const kvModeration = parseMaybeJson(kvModerationRaw, null);
 
     if (moderatedRow || kvModeration) {

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1039,10 +1039,8 @@ async function getAdminLookupVideo(identifier, env, options = {}) {
   const hash = isValidSha256(identifier) ? identifier.toLowerCase() : null;
   const cdnUrl = `https://${env.CDN_DOMAIN || 'media.divine.video'}/${hash}`;
   if (hash) {
-    // Independent reads — run them in parallel rather than serially. Promise.all
-    // surfaces whichever read rejects first to the caller's try/catch (the serial
-    // version always surfaced the D1 error first). A late KV rejection after a D1
-    // failure is unhandled but inert on Workers — the response has already errored.
+    // Independent reads: run them in parallel rather than serially. Promise.all
+    // surfaces whichever read rejects first to the caller's try/catch.
     const [moderatedRow, kvModerationRaw] = await Promise.all([
       env.BLOSSOM_DB.prepare(`
         SELECT ${ADMIN_VIDEO_COLUMNS.join(', ')}, review_notes, raw_response, videoseal

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1039,9 +1039,10 @@ async function getAdminLookupVideo(identifier, env, options = {}) {
   const hash = isValidSha256(identifier) ? identifier.toLowerCase() : null;
   const cdnUrl = `https://${env.CDN_DOMAIN || 'media.divine.video'}/${hash}`;
   if (hash) {
-    // Independent reads — run them in parallel rather than serially. On a D1
-    // error the KV read still fires (harmless, vs. serial where it wouldn't),
-    // and Promise.all surfaces the first rejection to the caller's try/catch.
+    // Independent reads — run them in parallel rather than serially. Promise.all
+    // surfaces whichever read rejects first to the caller's try/catch (the serial
+    // version always surfaced the D1 error first). A late KV rejection after a D1
+    // failure is unhandled but inert on Workers — the response has already errored.
     const [moderatedRow, kvModerationRaw] = await Promise.all([
       env.BLOSSOM_DB.prepare(`
         SELECT ${ADMIN_VIDEO_COLUMNS.join(', ')}, review_notes, raw_response, videoseal


### PR DESCRIPTION
Parallelizes the two independent reads in `getAdminLookupVideo` (the per-card `/admin/api/video` path). It fetched the `moderation_results` D1 row and the `moderation:{sha}` KV value serially, with no data dependency between them, so each card open paid the **sum** of the two latencies. Running them in one `Promise.all` pays the **slower** of the two instead.

## Changes
- `getAdminLookupVideo`: D1 row + KV value now fetched in parallel via `Promise.all`. Pure refactor — same values, same downstream logic.

## Scope / no stacking
- The `/admin/api/untriaged` change that originally shared this branch (cached-only Nostr context + timing log, #157) **moved to #164**, which rewrites that handler around the `moderation_results` anti-join and supersedes it. This PR is now just the independent per-card parallelize. The two PRs touch different code paths and don't stack.
- The cached-host half of #160 (`relay.divine.video` → `api.divine.video`) is intentionally **not** here — it trades freshness for cache and belongs with the per-card caching work (separate PR).

## Validation
- Full suite green (1298), lint clean. No dedicated `getAdminLookupVideo` unit test exists; the change is a behavior-preserving serial→parallel refactor of two independent reads.

Part of #160.
