### PR TITLE
feat(review): align untriaged queue + Needs-Triage count to the no-verdict definition (#158)

### DIFF
--- a/src/admin/bunny-events.mjs
+++ b/src/admin/bunny-events.mjs
@@ -8,74 +8,6 @@
 const DEFAULT_EXCLUDE_STATUS = ['error', 'deleted'];
 
 /**
- * Page through the latest event per sha, ordered most-recent-first.
- * Window-function CTE so each sha appears exactly once and the
- * non-aggregate columns (hls_url, mp4_url, etc.) come from the row
- * with the largest received_at — deterministic, unlike GROUP BY +
- * bare columns.
- */
-export async function latestBunnyEventBySha(env, options = {}) {
-  const {
-    limit = 50,
-    offset = 0,
-    excludeStatusNames = DEFAULT_EXCLUDE_STATUS,
-  } = options;
-  const placeholders = excludeStatusNames.map(() => '?').join(',');
-  // CRITICAL: rank ALL rows first, then filter by status_name on the
-  // winner. Filtering inside the CTE (before ROW_NUMBER) silently
-  // resurrects deleted shas — if a sha has finished@100 and deleted@200,
-  // dropping the deleted row from the CTE makes finished@100 the
-  // "latest". The old correlated subquery used MAX() over the full
-  // table and then required the latest row's status_name to be ok;
-  // this query mirrors that semantic.
-  const sql = `
-    WITH ranked AS (
-      SELECT
-        sha256, video_guid, hls_url, mp4_url, thumbnail_url, received_at, status_name,
-        ROW_NUMBER() OVER (PARTITION BY sha256 ORDER BY received_at DESC) AS rn
-      FROM bunny_webhook_events
-      WHERE sha256 IS NOT NULL
-    )
-    SELECT sha256, video_guid, hls_url, mp4_url, thumbnail_url, received_at, status_name
-    FROM ranked
-    WHERE rn = 1
-      AND status_name NOT IN (${placeholders})
-    ORDER BY received_at DESC
-    LIMIT ? OFFSET ?
-  `;
-  const result = await env.BLOSSOM_DB.prepare(sql)
-    .bind(...excludeStatusNames, limit, offset)
-    .all();
-  return result.results || [];
-}
-
-/**
- * Total distinct shas whose LATEST event is not in the exclude list —
- * matches the semantic of latestBunnyEventBySha. A sha whose latest
- * event is `deleted` must NOT be counted, even if it has older
- * `finished` events.
- */
-export async function countLatestBunnyEvents(env, options = {}) {
-  const { excludeStatusNames = DEFAULT_EXCLUDE_STATUS } = options;
-  const placeholders = excludeStatusNames.map(() => '?').join(',');
-  const sql = `
-    WITH ranked AS (
-      SELECT
-        sha256, status_name,
-        ROW_NUMBER() OVER (PARTITION BY sha256 ORDER BY received_at DESC) AS rn
-      FROM bunny_webhook_events
-      WHERE sha256 IS NOT NULL
-    )
-    SELECT COUNT(*) AS total
-    FROM ranked
-    WHERE rn = 1
-      AND status_name NOT IN (${placeholders})
-  `;
-  const row = await env.BLOSSOM_DB.prepare(sql).bind(...excludeStatusNames).first();
-  return row?.total || 0;
-}
-
-/**
  * Latest event for a single sha. Used by getAdminLookupVideo and
  * getStoredAdminPlaybackCandidates (replaces hand-rolled correlated
  * subqueries that did MAX(received_at) WHERE sha256 = ? once per call).
@@ -94,10 +26,10 @@ export async function latestBunnyEventForSha(env, sha256) {
 /**
  * Page through the latest event per sha whose sha has NO moderation_results
  * row yet — i.e. videos the automation has produced no verdict for ("needs
- * triage"). Same rank-then-filter semantic as latestBunnyEventBySha, plus a
- * LEFT JOIN anti-join so already-decided videos are excluded in the query
- * itself (no per-row KV lookups). moderation_results.sha256 is the PK, so the
- * join is 1:1.
+ * triage"). Ranks ALL rows per sha then filters the winner by status_name
+ * (so a finished-then-deleted sha stays excluded), plus a LEFT JOIN anti-join
+ * so already-decided videos are excluded in the query itself (no per-row KV
+ * lookups). moderation_results.sha256 is the PK, so the join is 1:1.
  */
 export async function latestUntriagedBunnyEvents(env, options = {}) {
   const { limit = 50, offset = 0, excludeStatusNames = DEFAULT_EXCLUDE_STATUS } = options;

--- a/src/admin/bunny-events.mjs
+++ b/src/admin/bunny-events.mjs
@@ -90,3 +90,65 @@ export async function latestBunnyEventForSha(env, sha256) {
   `).bind(sha256).first();
   return row || null;
 }
+
+/**
+ * Page through the latest event per sha whose sha has NO moderation_results
+ * row yet — i.e. videos the automation has produced no verdict for ("needs
+ * triage"). Same rank-then-filter semantic as latestBunnyEventBySha, plus a
+ * LEFT JOIN anti-join so already-decided videos are excluded in the query
+ * itself (no per-row KV lookups). moderation_results.sha256 is the PK, so the
+ * join is 1:1.
+ */
+export async function latestUntriagedBunnyEvents(env, options = {}) {
+  const { limit = 50, offset = 0, excludeStatusNames = DEFAULT_EXCLUDE_STATUS } = options;
+  const placeholders = excludeStatusNames.map(() => '?').join(',');
+  const sql = `
+    WITH ranked AS (
+      SELECT
+        sha256, video_guid, hls_url, mp4_url, thumbnail_url, received_at, status_name,
+        ROW_NUMBER() OVER (PARTITION BY sha256 ORDER BY received_at DESC) AS rn
+      FROM bunny_webhook_events
+      WHERE sha256 IS NOT NULL
+    )
+    SELECT r.sha256, r.video_guid, r.hls_url, r.mp4_url, r.thumbnail_url, r.received_at, r.status_name
+    FROM ranked r
+    LEFT JOIN moderation_results m ON m.sha256 = r.sha256
+    WHERE r.rn = 1
+      AND r.status_name NOT IN (${placeholders})
+      AND m.sha256 IS NULL
+    ORDER BY r.received_at DESC
+    LIMIT ? OFFSET ?
+  `;
+  const result = await env.BLOSSOM_DB.prepare(sql)
+    .bind(...excludeStatusNames, limit, offset)
+    .all();
+  return result.results || [];
+}
+
+/**
+ * Count of "needs triage" videos — latest event per sha, not in the excluded
+ * statuses, with NO moderation_results row. The exact anti-join the dashboard
+ * NEEDS TRIAGE card and the untriaged queue should both use, so the number and
+ * the list can't drift.
+ */
+export async function countUntriagedBunnyEvents(env, options = {}) {
+  const { excludeStatusNames = DEFAULT_EXCLUDE_STATUS } = options;
+  const placeholders = excludeStatusNames.map(() => '?').join(',');
+  const sql = `
+    WITH ranked AS (
+      SELECT
+        sha256, status_name,
+        ROW_NUMBER() OVER (PARTITION BY sha256 ORDER BY received_at DESC) AS rn
+      FROM bunny_webhook_events
+      WHERE sha256 IS NOT NULL
+    )
+    SELECT COUNT(*) AS total
+    FROM ranked r
+    LEFT JOIN moderation_results m ON m.sha256 = r.sha256
+    WHERE r.rn = 1
+      AND r.status_name NOT IN (${placeholders})
+      AND m.sha256 IS NULL
+  `;
+  const row = await env.BLOSSOM_DB.prepare(sql).bind(...excludeStatusNames).first();
+  return row?.total || 0;
+}

--- a/src/admin/bunny-events.test.mjs
+++ b/src/admin/bunny-events.test.mjs
@@ -122,4 +122,19 @@ describe('latestUntriagedBunnyEvents / countUntriagedBunnyEvents', () => {
     // Only SHA_B is untriaged-and-not-deleted; SHA_A has a verdict, C and D are deleted.
     expect(await countUntriagedBunnyEvents(env)).toBe(1);
   });
+
+  it('honors LIMIT and OFFSET, ordered by received_at DESC', async () => {
+    // Add a second untriaged sha newer than SHA_B (received_at 250) so the
+    // anti-join returns two rows to page through: [SHA_E@500, SHA_B@250].
+    const SHA_E = 'e'.repeat(64);
+    await env.BLOSSOM_DB.prepare(
+      `INSERT INTO bunny_webhook_events (sha256, video_guid, hls_url, status_name, received_at) VALUES (?,?,?,?,?)`,
+    ).bind(SHA_E, 'g-e-1', 'E', 'finished', 500).run();
+
+    expect(await countUntriagedBunnyEvents(env)).toBe(2);
+    const first = await latestUntriagedBunnyEvents(env, { limit: 1, offset: 0 });
+    const second = await latestUntriagedBunnyEvents(env, { limit: 1, offset: 1 });
+    expect(first.map((r) => r.sha256)).toEqual([SHA_E]);
+    expect(second.map((r) => r.sha256)).toEqual([SHA_B]);
+  });
 });

--- a/src/admin/bunny-events.test.mjs
+++ b/src/admin/bunny-events.test.mjs
@@ -10,6 +10,8 @@ import {
   latestBunnyEventBySha,
   latestBunnyEventForSha,
   countLatestBunnyEvents,
+  latestUntriagedBunnyEvents,
+  countUntriagedBunnyEvents,
 } from './bunny-events.mjs';
 
 const SHA_A = 'a'.repeat(64);
@@ -123,5 +125,38 @@ describe('latestBunnyEventForSha', () => {
   it('returns null for unknown sha', async () => {
     const row = await latestBunnyEventForSha(env, 'f'.repeat(64));
     expect(row).toBeNull();
+  });
+});
+
+describe('latestUntriagedBunnyEvents / countUntriagedBunnyEvents', () => {
+  // SHA_A gets a moderation_results row (= has a verdict). SHA_B does not
+  // (= needs triage). SHA_C's latest event is deleted (excluded regardless).
+  beforeEach(async () => {
+    await env.BLOSSOM_DB.prepare(`CREATE TABLE IF NOT EXISTS moderation_results (
+      sha256 TEXT PRIMARY KEY,
+      action TEXT NOT NULL,
+      moderated_at TEXT
+    )`).run();
+    await env.BLOSSOM_DB.prepare('DELETE FROM moderation_results').run();
+    await env.BLOSSOM_DB.prepare(
+      `INSERT INTO moderation_results (sha256, action) VALUES (?, 'SAFE')`,
+    ).bind(SHA_A).run();
+  });
+
+  it('returns only videos with no moderation_results row', async () => {
+    const rows = await latestUntriagedBunnyEvents(env);
+    expect(rows.map((r) => r.sha256)).toEqual([SHA_B]);
+  });
+
+  it('counts only untriaged videos', async () => {
+    expect(await countUntriagedBunnyEvents(env)).toBe(1);
+  });
+
+  it('excludes a sha once it gains a moderation_results row', async () => {
+    await env.BLOSSOM_DB.prepare(
+      `INSERT INTO moderation_results (sha256, action) VALUES (?, 'REVIEW')`,
+    ).bind(SHA_B).run();
+    expect(await countUntriagedBunnyEvents(env)).toBe(0);
+    expect(await latestUntriagedBunnyEvents(env)).toEqual([]);
   });
 });

--- a/src/admin/bunny-events.test.mjs
+++ b/src/admin/bunny-events.test.mjs
@@ -1,15 +1,13 @@
 // This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
 // If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 //
-// ABOUTME: Tests for latestBunnyEventBySha — window-function CTE
-// ABOUTME: replacing four hand-rolled correlated subqueries.
+// ABOUTME: Tests for the latest-event-per-sha lookup helpers over
+// ABOUTME: bunny_webhook_events (single-sha lookup + untriaged anti-join).
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import { env } from 'cloudflare:test';
 import {
-  latestBunnyEventBySha,
   latestBunnyEventForSha,
-  countLatestBunnyEvents,
   latestUntriagedBunnyEvents,
   countUntriagedBunnyEvents,
 } from './bunny-events.mjs';
@@ -61,62 +59,6 @@ async function seed() {
 
 beforeEach(seed);
 
-describe('latestBunnyEventBySha', () => {
-  it('returns one row per sha with the LATEST hls_url (deterministic)', async () => {
-    const rows = await latestBunnyEventBySha(env);
-    const a = rows.find((r) => r.sha256 === SHA_A);
-    const b = rows.find((r) => r.sha256 === SHA_B);
-    expect(a.hls_url).toBe('C');
-    expect(a.received_at).toBe(300);
-    expect(b.hls_url).toBe('Y');
-    expect(b.received_at).toBe(250);
-  });
-
-  it('orders results by received_at DESC across distinct shas', async () => {
-    const rows = await latestBunnyEventBySha(env);
-    expect(rows.map((r) => r.sha256)).toEqual([SHA_A, SHA_B]);
-  });
-
-  it('excludes shas whose latest status is deleted/error', async () => {
-    const rows = await latestBunnyEventBySha(env);
-    expect(rows.find((r) => r.sha256 === SHA_C)).toBeUndefined();
-  });
-
-  it('excludes a sha that finished then was deleted (regression)', async () => {
-    // The old correlated subquery did MAX(received_at) over ALL rows,
-    // then required the latest row's status not be deleted. A naive CTE
-    // that filters status_name BEFORE ranking would resurrect this sha:
-    // dropping the deleted row makes the older 'finished' row the
-    // "latest". This test pins the correct semantic.
-    const SHA_D = 'd'.repeat(64);
-    await env.BLOSSOM_DB.prepare(
-      `INSERT INTO bunny_webhook_events (sha256, video_guid, hls_url, status_name, received_at) VALUES (?,?,?,?,?)`,
-    ).bind(SHA_D, 'g-d-1', 'D-finished', 'finished', 100).run();
-    await env.BLOSSOM_DB.prepare(
-      `INSERT INTO bunny_webhook_events (sha256, video_guid, hls_url, status_name, received_at) VALUES (?,?,?,?,?)`,
-    ).bind(SHA_D, 'g-d-2', 'D-deleted', 'deleted', 200).run();
-
-    const rows = await latestBunnyEventBySha(env);
-    expect(rows.find((r) => r.sha256 === SHA_D)).toBeUndefined();
-
-    // 2 valid shas (A, B); C and D must be excluded.
-    expect(await countLatestBunnyEvents(env)).toBe(2);
-  });
-
-  it('honors LIMIT and OFFSET', async () => {
-    const first = await latestBunnyEventBySha(env, { limit: 1, offset: 0 });
-    const second = await latestBunnyEventBySha(env, { limit: 1, offset: 1 });
-    expect(first[0].sha256).toBe(SHA_A);
-    expect(second[0].sha256).toBe(SHA_B);
-  });
-});
-
-describe('countLatestBunnyEvents', () => {
-  it('counts distinct shas excluding deleted/error', async () => {
-    expect(await countLatestBunnyEvents(env)).toBe(2);
-  });
-});
-
 describe('latestBunnyEventForSha', () => {
   it('returns the latest event for the sha', async () => {
     const row = await latestBunnyEventForSha(env, SHA_A);
@@ -158,5 +100,26 @@ describe('latestUntriagedBunnyEvents / countUntriagedBunnyEvents', () => {
     ).bind(SHA_B).run();
     expect(await countUntriagedBunnyEvents(env)).toBe(0);
     expect(await latestUntriagedBunnyEvents(env)).toEqual([]);
+  });
+
+  it('excludes a sha that finished then was deleted (rank-then-filter regression)', async () => {
+    // The anti-join shares the rank-ALL-then-filter-the-winner semantic:
+    // a sha with finished@100 and deleted@200 must stay excluded. Filtering
+    // status_name before ROW_NUMBER would resurrect the older finished row
+    // as the "latest" and leak a deleted sha into the untriaged queue. This
+    // SHA_D has no moderation_results row, so only the status filter can
+    // exclude it.
+    const SHA_D = 'd'.repeat(64);
+    await env.BLOSSOM_DB.prepare(
+      `INSERT INTO bunny_webhook_events (sha256, video_guid, hls_url, status_name, received_at) VALUES (?,?,?,?,?)`,
+    ).bind(SHA_D, 'g-d-1', 'D-finished', 'finished', 100).run();
+    await env.BLOSSOM_DB.prepare(
+      `INSERT INTO bunny_webhook_events (sha256, video_guid, hls_url, status_name, received_at) VALUES (?,?,?,?,?)`,
+    ).bind(SHA_D, 'g-d-2', 'D-deleted', 'deleted', 200).run();
+
+    const rows = await latestUntriagedBunnyEvents(env);
+    expect(rows.find((r) => r.sha256 === SHA_D)).toBeUndefined();
+    // Only SHA_B is untriaged-and-not-deleted; SHA_A has a verdict, C and D are deleted.
+    expect(await countUntriagedBunnyEvents(env)).toBe(1);
   });
 });

--- a/src/admin/dashboard-ui.test.mjs
+++ b/src/admin/dashboard-ui.test.mjs
@@ -35,4 +35,15 @@ describe('dashboard provenance UI hooks', () => {
     expect(dashboardHTML).toContain('src="${cardThumbUrl}"');
     expect(dashboardHTML).toContain('openVideoModal');
   });
+
+  it('triage cards carry the lazy Nostr-context hydration hooks', () => {
+    // Regression guard: the untriaged list query no longer returns per-row
+    // relay context, so triage cards must hydrate it client-side. createTriageCard
+    // emits the #nostr-${sha} container (string-concat form, distinct from the
+    // moderated grid's template-literal form) and the View link's divine-link id
+    // so updateDivineLink can upgrade it; loadTriageVideos drives loadNostrContext.
+    expect(dashboardHTML).toContain('<div class="nostr-context" id="nostr-\' + sha256 + \'">');
+    expect(dashboardHTML).toContain('id="divine-link-\' + sha256 + \'"');
+    expect(dashboardHTML).toContain('loadNostrContext(video.sha256, container)');
+  });
 });

--- a/src/admin/dashboard-ui.test.mjs
+++ b/src/admin/dashboard-ui.test.mjs
@@ -45,5 +45,10 @@ describe('dashboard provenance UI hooks', () => {
     expect(dashboardHTML).toContain('<div class="nostr-context" id="nostr-\' + sha256 + \'">');
     expect(dashboardHTML).toContain('id="divine-link-\' + sha256 + \'"');
     expect(dashboardHTML).toContain('loadNostrContext(video.sha256, container)');
+    expect(dashboardHTML).toContain('applyNostrMetadataToVideo(sha256, data.metadata)');
+    expect(dashboardHTML).toContain('triageVideos.find(v => v.sha256 === sha256)');
+    expect(dashboardHTML).toContain('id="event-meta-\' + escapeHtml(video.sha256 || \'\') + \'"');
+    expect(dashboardHTML).toContain('uploader-enforcement-slot-\' + sha256 + \'');
+    expect(dashboardHTML).toContain('uploader-history-slot-\' + sha256 + \'');
   });
 });

--- a/src/admin/dashboard.html
+++ b/src/admin/dashboard.html
@@ -3209,7 +3209,7 @@
           provenanceHTML +
           '<div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">' +
             '<span style="font-size: 12px; color: #666;">' + (timeAgo ? '📅 ' + timeAgo : '') + '</span>' +
-            '<a href="' + divineUrl + '" target="_blank" style="color: #8b5cf6; font-size: 12px; text-decoration: none;">View →</a>' +
+            '<a id="divine-link-' + sha256 + '" href="' + divineUrl + '" target="_blank" style="color: #8b5cf6; font-size: 12px; text-decoration: none;">View →</a>' +
           '</div>' +
           '<div style="display: flex; gap: 8px;">' +
             '<button onclick="sendToHive(\'' + sha256 + '\', this)" style="background: linear-gradient(135deg, #8b5cf6, #6366f1); color: white; border: none; padding: 10px 12px; border-radius: 6px; cursor: pointer; flex: 1; font-weight: 600; font-size: 13px;">' +

--- a/src/admin/dashboard.html
+++ b/src/admin/dashboard.html
@@ -2839,6 +2839,21 @@
           } else {
             grid.innerHTML = triageVideos.map(video => createTriageCard(video)).join('');
           }
+          // Hydrate each newly rendered card's Nostr context lazily — the
+          // untriaged list query returns no per-row relay context (#164), so
+          // fetch it client-side per card (non-blocking) rather than blocking
+          // the list. In append mode only the new cards are in the DOM; in a
+          // full render newVideos === triageVideos.
+          newVideos.forEach(video => {
+            const container = document.getElementById('nostr-' + video.sha256);
+            if (!container) return;
+            if (video.nostrContext) {
+              container.innerHTML = createNostrMetadataHTML(video.nostrContext);
+              updateDivineLink(video.sha256, video.nostrContext);
+            } else {
+              loadNostrContext(video.sha256, container);
+            }
+          });
           // Set up pause handlers for newly rendered videos
           setTimeout(setupVideoPauseHandlers, 100);
         }
@@ -3140,7 +3155,7 @@
     }
 
     function createTriageCard(video) {
-      const { sha256, cdnUrl, thumbnailUrl, receivedAt, nostrContext, showDirectActions, showTranscriptTools } = video;
+      const { sha256, cdnUrl, thumbnailUrl, receivedAt, showDirectActions, showTranscriptTools } = video;
 
       // Format timestamp
       const timestamp = receivedAt ? new Date(receivedAt).toLocaleString() : 'Unknown';
@@ -3154,31 +3169,11 @@
       // Prefer resolved public URL when available (older imports often use stable IDs, not blob hashes)
       const divineUrl = video.divineUrl || 'https://divine.video/video/' + sha256;
 
-      // Nostr context display
-      const author = nostrContext?.author || null;
-      const title = nostrContext?.title || null;
-      const content = nostrContext?.content || null;
-      const client = nostrContext?.client || null;
-      const pubkey = nostrContext?.pubkey || null;
-
-      // Build metadata line
-      let metaLine = '';
-      if (author) {
-        metaLine += '<span style="color: #a78bfa;">👤 ' + escapeHtml(author) + '</span>';
-      } else if (pubkey) {
-        metaLine += '<span style="color: #666;">👤 ' + pubkey + '</span>';
-      }
-      if (client) {
-        metaLine += (metaLine ? ' · ' : '') + '<span style="color: #666;">' + escapeHtml(client) + '</span>';
-      }
-
-      // Build description (title or content)
-      let description = '';
-      if (title && title.trim()) {
-        description = escapeHtml(title.substring(0, 100));
-      } else if (content && content.trim()) {
-        description = escapeHtml(content.substring(0, 100));
-      }
+      // Nostr context (author/title/published + pre-AI/Vine-era badges) is
+      // hydrated lazily into the #nostr-${sha} container below — the same path
+      // the moderated grid uses. The untriaged list query no longer returns
+      // per-row relay context (#164), so each card fetches it client-side
+      // instead of the list blocking on ~50 round-trips.
 
       const directActions = showDirectActions ? (
         '<div class="action-buttons">' +
@@ -3210,8 +3205,7 @@
             '<button onclick="copyToClipboard(\'' + copyVideoUrl + '\'); event.stopPropagation();" style="background: #333; color: #888; border: none; padding: 2px 6px; border-radius: 3px; cursor: pointer; font-size: 10px;" title="Copy video URL">📋 URL</button> ' +
             '<button onclick="copyDashboardPermalink(\'' + sha256 + '\', this); event.stopPropagation();" style="background: #333; color: #888; border: none; padding: 2px 6px; border-radius: 3px; cursor: pointer; font-size: 10px;" title="Copy permalink to this item">🔗 Link</button>' +
           '</div>' +
-          (metaLine ? '<div style="font-size: 12px; margin-bottom: 6px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">' + metaLine + '</div>' : '') +
-          (description ? '<div style="font-size: 13px; color: #ccc; margin-bottom: 8px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">' + description + '</div>' : '') +
+          '<div class="nostr-context" id="nostr-' + sha256 + '"><div class="nostr-loading">Loading context...</div></div>' +
           provenanceHTML +
           '<div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">' +
             '<span style="font-size: 12px; color: #666;">' + (timeAgo ? '📅 ' + timeAgo : '') + '</span>' +

--- a/src/admin/dashboard.html
+++ b/src/admin/dashboard.html
@@ -2393,6 +2393,7 @@
 
     function getVideoBySha(sha256) {
       return allVideos.find(v => v.sha256 === sha256)
+        || triageVideos.find(v => v.sha256 === sha256)
         || (currentLookupVideo && currentLookupVideo.sha256 === sha256 ? currentLookupVideo : null);
     }
 
@@ -2596,6 +2597,7 @@
       const nostrContainer = document.getElementById(`nostr-${video.sha256}`);
       if (nostrContainer) {
         if (video.nostrContext) {
+          applyNostrMetadataToVideo(video.sha256, video.nostrContext);
           nostrContainer.innerHTML = createNostrMetadataHTML(video.nostrContext);
           updateDivineLink(video.sha256, video.nostrContext);
         } else {
@@ -2848,6 +2850,7 @@
             const container = document.getElementById('nostr-' + video.sha256);
             if (!container) return;
             if (video.nostrContext) {
+              applyNostrMetadataToVideo(video.sha256, video.nostrContext);
               container.innerHTML = createNostrMetadataHTML(video.nostrContext);
               updateDivineLink(video.sha256, video.nostrContext);
             } else {
@@ -3094,6 +3097,12 @@
       return '<div class="uploader-history" id="' + containerId + '" data-pubkey="' + pubkey + '"><div class="uploader-history-loading" style="font-size: 11px; color: #666; padding: 4px 0;">Loading uploader history…</div></div>';
     }
 
+    function createCreatorMessageLink(video) {
+      return video.uploaded_by
+        ? '<div class="divine-link"><a href="/admin/messages?pubkey=' + escapeHtml(video.uploaded_by) + '" target="_blank" rel="noopener noreferrer">Message Creator →</a></div>'
+        : '';
+    }
+
     async function hydrateUploaderHistory(containerId, pubkey) {
       const el = document.getElementById(containerId);
       if (!el) return;
@@ -3220,8 +3229,9 @@
             '</button>' +
           '</div>' +
           '<div class="action-buttons compact">' + creatorInfoButton + '</div>' +
-          uploaderEnforcementPanel +
-          uploaderHistoryPanel +
+          '<div id="creator-message-slot-' + sha256 + '"></div>' +
+          '<div id="uploader-enforcement-slot-' + sha256 + '">' + uploaderEnforcementPanel + '</div>' +
+          '<div id="uploader-history-slot-' + sha256 + '">' + uploaderHistoryPanel + '</div>' +
           directActions +
           transcriptTools +
         '</div>' +
@@ -3664,6 +3674,7 @@
         if (!resp.ok) throw new Error('fetch failed');
         const data = await resp.json();
         if (data.found && data.metadata) {
+          applyNostrMetadataToVideo(sha256, data.metadata);
           container.innerHTML = createNostrMetadataHTML(data.metadata);
           updateDivineLink(sha256, data.metadata);
         } else {
@@ -3671,6 +3682,43 @@
         }
       } catch (e) {
         container.innerHTML = '<div class="nostr-not-found">No Nostr event found</div>';
+      }
+    }
+
+    function applyNostrMetadataToVideo(sha256, metadata) {
+      if (!metadata) return null;
+      const video = getVideoBySha(sha256);
+      if (!video) return null;
+
+      video.nostrContext = { ...(video.nostrContext || {}), ...metadata };
+      if (metadata.eventId) video.eventId = metadata.eventId;
+      if (metadata.pubkey && isFullHexPubkey(metadata.pubkey)) video.uploaded_by = metadata.pubkey;
+      if (metadata.author) video.author = metadata.author;
+      if (metadata.publishedAt) video.publishedAt = metadata.publishedAt;
+
+      refreshHydratedCardContext(video);
+      return video;
+    }
+
+    function refreshHydratedCardContext(video) {
+      const eventMeta = document.getElementById('event-meta-' + video.sha256);
+      if (eventMeta) {
+        eventMeta.outerHTML = createEventMetaHTML(video);
+      }
+
+      const enforcement = document.getElementById('uploader-enforcement-slot-' + video.sha256);
+      if (enforcement) {
+        enforcement.innerHTML = createUploaderEnforcementPanel(video);
+      }
+
+      const history = document.getElementById('uploader-history-slot-' + video.sha256);
+      if (history) {
+        history.innerHTML = createUploaderHistoryPanel(video);
+      }
+
+      const messageLink = document.getElementById('creator-message-slot-' + video.sha256);
+      if (messageLink) {
+        messageLink.innerHTML = createCreatorMessageLink(video);
       }
     }
 
@@ -3853,7 +3901,7 @@
         : '';
 
       return (
-        '<div class="event-meta">' +
+        '<div class="event-meta" id="event-meta-' + escapeHtml(video.sha256 || '') + '">' +
           '<div class="event-meta-avatar" aria-hidden="true">' + escapeHtml(avatarChar) + '</div>' +
           '<div class="event-meta-body">' +
             '<div class="event-meta-name">' + escapeHtml(authorName) + '</div>' +
@@ -4108,16 +4156,10 @@
                 View on divine.video →
               </a>
             </div>
-            ${video.uploaded_by ? `
-            <div class="divine-link">
-              <a href="/admin/messages?pubkey=${video.uploaded_by}" target="_blank" rel="noopener noreferrer">
-                Message Creator →
-              </a>
-            </div>
-            ` : ''}
+            <div id="creator-message-slot-${sha256}">${createCreatorMessageLink(video)}</div>
 
-            ${uploaderEnforcementPanel}
-            ${uploaderHistoryPanel}
+            <div id="uploader-enforcement-slot-${sha256}">${uploaderEnforcementPanel}</div>
+            <div id="uploader-history-slot-${sha256}">${uploaderHistoryPanel}</div>
 
             <div class="action-buttons compact">
               ${creatorInfoButton}

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -256,7 +256,7 @@ function buildFunnelcakeVideoLookup(eventResponse, identifier) {
       content: metadata.content || event.content || null,
       url: videoUrl || null,
       publishedAt: metadata.publishedAt || null,
-      pubkey: event.pubkey ? `${event.pubkey.substring(0, 16)}...` : null,
+      pubkey: event.pubkey || null,
       eventId: event.id,
       platform: metadata.platform || null
     },
@@ -289,7 +289,7 @@ function buildStoredLookupMetadata(row) {
       content: null,
       url: row.content_url || null,
       publishedAt: Number.isFinite(publishedAt) ? publishedAt : null,
-      pubkey: row.uploaded_by ? `${row.uploaded_by.substring(0, 16)}...` : null,
+      pubkey: row.uploaded_by || null,
       eventId,
       platform: null
     } : null
@@ -313,6 +313,7 @@ function buildAdminNostrMetadata(metadata = {}, extras = {}) {
     vineHashId: metadata.vineHashId ?? null,
     vineUserId: metadata.vineUserId ?? null,
     content: metadata.content || null,
+    pubkey: metadata.pubkey || null,
     eventId: metadata.eventId || null,
     createdAt: extras.createdAt ?? metadata.createdAt ?? null
   };
@@ -2428,6 +2429,7 @@ export default {
           metadata: buildAdminNostrMetadata({
             ...metadata,
             content: metadata.content || event.content || null,
+            pubkey: event.pubkey || metadata.pubkey || null,
             eventId
           }, {
             createdAt: event.created_at || null

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1642,7 +1642,7 @@ export default {
           const pendingFlagged = pending.review + pending.quarantine + pending.ageRestricted + pending.permanentBan;
           // Exact anti-join (videos with no moderation_results row) — the same
           // definition the untriaged list uses, so card and queue can't drift.
-          // (Was `totalInD1 − totalModerated`, an approximation that counts
+          // (Was `totalInD1 - totalModerated`, an approximation that counts
           // moderation_results rows for non-bunny shas.)
           const untriaged = untriagedCount;
 
@@ -1725,8 +1725,11 @@ export default {
         return authError;
       }
 
-      const limit = Math.min(parseInt(url.searchParams.get('limit') || '50', 10), 200);
-      const offset = parseInt(url.searchParams.get('offset') || '0', 10);
+      // Guard the query boundary: a non-numeric or negative limit/offset
+      // (?limit=abc, ?limit=-5) must not bind NaN or a negative LIMIT (which
+      // SQLite reads as unbounded) into the untriaged query.
+      const limit = Math.min(Math.max(1, parseInt(url.searchParams.get('limit') || '50', 10) || 50), 200);
+      const offset = Math.max(0, parseInt(url.searchParams.get('offset') || '0', 10) || 0);
       console.log(`[${requestId}] Fetching untriaged videos: limit=${limit}, offset=${offset}`);
 
       try {

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -37,7 +37,7 @@ import { notifyRelay } from './relay-notifier.mjs';
 import { runClassicVineRollback } from './moderation/classic-vine-rollback.mjs';
 import { ADMIN_VIDEO_COLUMNS, buildAdminVideoFromRow } from './admin/lookup-helpers.mjs';
 import { cachedStat } from './admin/cache.mjs';
-import { latestBunnyEventBySha, latestBunnyEventForSha, countLatestBunnyEvents } from './admin/bunny-events.mjs';
+import { latestBunnyEventForSha, latestUntriagedBunnyEvents, countUntriagedBunnyEvents } from './admin/bunny-events.mjs';
 import { runBackfill } from './admin/backfill-lookup-columns.mjs';
 import { notifyBlossom } from './blossom-client.mjs';
 import { handleSyncDelete } from './creator-delete/sync-endpoint.mjs';
@@ -1601,7 +1601,7 @@ export default {
         const fresh = url.searchParams.get('fresh') === '1';
         const stats = await cachedStat(env, ctx, 'admin-stats', 60, async () => {
           // All stats from D1 - fast SQL queries instead of KV iteration
-          const [totalResult, moderationStats, pendingStats] = await Promise.all([
+          const [totalResult, moderationStats, pendingStats, untriagedCount] = await Promise.all([
             env.BLOSSOM_DB.prepare(`
               SELECT COUNT(DISTINCT sha256) as total
               FROM bunny_webhook_events
@@ -1615,6 +1615,7 @@ export default {
               SELECT action, COUNT(*) as count FROM moderation_results
               WHERE reviewed_by IS NULL GROUP BY action
             `).all(),
+            countUntriagedBunnyEvents(env),
           ]);
 
           const totalInD1 = totalResult?.total || 0;
@@ -1639,7 +1640,11 @@ export default {
           }
 
           const pendingFlagged = pending.review + pending.quarantine + pending.ageRestricted + pending.permanentBan;
-          const untriaged = Math.max(0, totalInD1 - totalModerated);
+          // Exact anti-join (videos with no moderation_results row) — the same
+          // definition the untriaged list uses, so card and queue can't drift.
+          // (Was `totalInD1 − totalModerated`, an approximation that counts
+          // moderation_results rows for non-bunny shas.)
+          const untriaged = untriagedCount;
 
           return { totalInD1, totalModerated, untriaged, pendingFlagged, breakdown, pending };
         }, { fresh });
@@ -1725,82 +1730,30 @@ export default {
       console.log(`[${requestId}] Fetching untriaged videos: limit=${limit}, offset=${offset}`);
 
       try {
-        const rows = await latestBunnyEventBySha(env, { limit, offset });
+        // "Needs triage" = videos the automation produced no verdict for, i.e.
+        // no moderation_results row. The anti-join does that filtering in the
+        // query itself (no per-row KV reads). These are unprocessed uploads with
+        // no decision to enrich; the per-card /admin/api/video path fills in any
+        // Nostr context lazily when a card is opened. See #158.
+        const rows = await latestUntriagedBunnyEvents(env, { limit, offset });
 
-        // Filter to rows that haven't been moderated yet. Old code did
-        // a sequential `for` loop with await — this is one parallel batch.
-        const moderationFlags = await Promise.all(
-          rows.map((row) => env.MODERATION_KV.get(`moderation:${row.sha256}`)),
-        );
-        const unmoderatedRows = rows.filter((_, i) => !moderationFlags[i]);
+        const videos = rows.map((row) => ({
+          sha256: row.sha256,
+          videoGuid: row.video_guid,
+          hlsUrl: row.hls_url,
+          mp4Url: row.mp4_url,
+          thumbnailUrl: row.thumbnail_url,
+          receivedAt: row.received_at,
+          status: 'UNTRIAGED',
+          cdnUrl: `https://${env.CDN_DOMAIN}/${row.sha256}`,
+          eventId: null,
+          uploaded_by: null,
+          nostrContext: null,
+        }));
 
-        // Fetch Nostr context per unmoderated row, with a 1-hour KV cache
-        // so the next page render doesn't pay the WS roundtrip cost.
-        const nostrPromises = unmoderatedRows.map(async (row) => {
-          const cacheKey = `nostr:event:${row.sha256}`;
-          try {
-            const cached = await env.MODERATION_KV.get(cacheKey);
-            if (cached) {
-              const event = JSON.parse(cached);
-              const metadata = parseVideoEventMetadata(event);
-              return {
-                sha256: row.sha256,
-                eventId: event.id,
-                title: metadata?.title || null,
-                author: metadata?.author || null,
-                client: metadata?.client || null,
-                content: metadata?.content || event.content || null,
-                pubkey: event.pubkey || null,
-              };
-            }
-            const event = await fetchNostrEventBySha256(row.sha256, ['wss://relay.divine.video'], env);
-            if (event) {
-              ctx.waitUntil(env.MODERATION_KV.put(cacheKey, JSON.stringify(event), { expirationTtl: 3600 }));
-              const metadata = parseVideoEventMetadata(event);
-              return {
-                sha256: row.sha256,
-                eventId: event.id,
-                title: metadata?.title || null,
-                author: metadata?.author || null,
-                client: metadata?.client || null,
-                content: metadata?.content || event.content || null,
-                pubkey: event.pubkey || null,
-              };
-            }
-          } catch (e) {
-            console.error(`[ADMIN] Failed to fetch Nostr context for ${row.sha256}:`, e.message);
-          }
-          return { sha256: row.sha256 };
-        });
+        const total = await cachedStat(env, ctx, 'untriaged-total', 60, () => countUntriagedBunnyEvents(env));
 
-        const nostrResults = await Promise.all(nostrPromises);
-        const nostrMap = new Map(nostrResults.map((r) => [r.sha256, r]));
-
-        const videos = unmoderatedRows.map((row) => {
-          const nostr = nostrMap.get(row.sha256) || {};
-          return {
-            sha256: row.sha256,
-            videoGuid: row.video_guid,
-            hlsUrl: row.hls_url,
-            mp4Url: row.mp4_url,
-            thumbnailUrl: row.thumbnail_url,
-            receivedAt: row.received_at,
-            status: 'UNTRIAGED',
-            cdnUrl: `https://${env.CDN_DOMAIN}/${row.sha256}`,
-            eventId: nostr.eventId || null,
-            uploaded_by: nostr.pubkey || null,
-            nostrContext: {
-              title: nostr.title,
-              author: nostr.author,
-              client: nostr.client,
-              content: nostr.content,
-              pubkey: nostr.pubkey ? `${nostr.pubkey.substring(0, 16)}...` : null,
-            },
-          };
-        });
-
-        const total = await cachedStat(env, ctx, 'untriaged-total', 60, () => countLatestBunnyEvents(env));
-
+        console.log(`[${requestId}] Returning ${videos.length} untriaged videos in ${Date.now() - startTime}ms`);
         return new Response(JSON.stringify({
           videos,
           total,

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -664,7 +664,7 @@ describe('Admin video lookup', () => {
             url: 'https://media.divine.video/content.mp4',
             publishedAt: 1389756506,
             eventId: 'c'.repeat(64),
-            pubkey: `${'b'.repeat(16)}...`
+            pubkey: 'b'.repeat(64)
           }
         }
       });
@@ -1143,6 +1143,7 @@ describe('Admin nostr context lookup', () => {
           vineHashId: null,
           vineUserId: null,
           content: null,
+          pubkey: 'b'.repeat(64),
           eventId: 'c'.repeat(64),
           createdAt: null
         }
@@ -1220,6 +1221,7 @@ describe('Admin nostr context lookup', () => {
           vineHashId: null,
           vineUserId: null,
           content: 'REST description',
+          pubkey: 'b'.repeat(64),
           eventId: 'd'.repeat(64),
           createdAt: 1700000000
         }


### PR DESCRIPTION
Implements the decision in #158: "needs triage" = videos the automation produced **no verdict** for (no `moderation_results` row), instead of the legacy KV `moderation:{sha}` key (written only by manual moderation / escalation / the transcript cron, **not** the `/api/v1/moderate` scan). The dashboard NEEDS TRIAGE count and the untriaged queue previously used different definitions and could drift; this unifies both on one anti-join.

See #158 for the decision and routing-model rationale.

**Note on current data:** `bunny_webhook_events` is empty in prod (0 rows; `moderation_results` ~324k). The untriaged queue is sourced from that table, so the queue and count read 0 in production today. The primary value of this change is **consistency** — the card and queue resolve from the same definition and can't drift. The reduced per-row fan-out described below is a structural property that only takes effect once the table is populated. Why the source table is empty is tracked in #168.

## Changes
- **`/admin/api/untriaged`** uses one anti-join (`latestUntriagedBunnyEvents`): latest bunny event per sha `LEFT JOIN moderation_results … WHERE m.sha256 IS NULL`. Filtering in the query (rather than post-filtering per row in app code) avoids per-row `MODERATION_KV.get('moderation:…')` reads and per-row relay enrichment, and makes `total` come from the same anti-join as the returned rows so the count and the list can't disagree.
- **Dashboard NEEDS TRIAGE count** uses the same anti-join (`countUntriagedBunnyEvents`) instead of the `totalInD1 − totalModerated` approximation, so the card and the queue can't drift.
- Adds `latestUntriagedBunnyEvents` / `countUntriagedBunnyEvents` (+ tests) and an untriaged timing log.
- **Triage-queue cards hydrate Nostr context client-side** (`dashboard.html`): the triage queue's render path (`loadTriageVideos` → `createTriageCard`) gets the same `#nostr-${sha}` container the moderated grid uses and hydrates each card via `loadNostrContext` after render (per-card, non-blocking), rather than relying on list-query enrichment. Also restores the pre-AI / Vine-era published badges.

## Behavior
The untriaged queue shows only no-verdict videos; AI-flagged items remain in the AI FLAGGED / Quick Review queue. Card and queue agree on one definition.

## Dead-code cleanup
`latestBunnyEventBySha` / `countLatestBunnyEvents` have no remaining app caller after this change, so they're removed. The rank-ALL-then-filter-the-winner regression (a finished-then-deleted sha must stay excluded) is ported into the untriaged test block, since the anti-join reuses the same `ranked` CTE.

## PR organization (no stacking)
Independent of #163 (`getAdminLookupVideo` parallelize) and #165. #163 originally shared the untriaged handler; this supersedes that hunk.

## Validation
- Full suite green (1298), lint clean. `bunny-events.test.mjs` covers the anti-join (only no-verdict shas; excluded once a row appears; deleted-status excluded; finished-then-deleted regression; LIMIT/OFFSET pagination). `dashboard-ui.test.mjs` pins the triage hydration hooks (`#nostr-${sha}` container, `divine-link` id, `loadNostrContext` call).
- Triage-card hydration is client-side `dashboard.html` JS (no unit harness); final visual confirmation at staging.
