### PR TITLE
perf(review): cache + cached-host the per-card funnelcake lookup

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -923,6 +923,9 @@ async function enrichAdminLookupVideo(video, env) {
     || (ctx.client == null && ctx.content == null);
 
   if (enriched.sha256 && needsFunnelcake) {
+    // Keyed on sha256 (the stable content hash) even though the fetch below may
+    // resolve via lookupId/eventId — the cached value is the record for that
+    // content hash regardless of which identifier resolved it.
     const cacheKey = `admin:lookup:funnelcake:${enriched.sha256}`;
     let funnelcakeVideo = null;
 

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -895,9 +895,11 @@ async function fetchLookupNostrContext(hash, env) {
 // back and forth over the same handful of cards in a review session — skips the
 // origin round-trip. Short TTL keeps title/author from going meaningfully stale
 // (the underlying api.divine.video response is itself only ~15-60s fresh).
-// Env-overridable so an operator can drop the staleness window during an
-// incident without a redeploy.
-const ADMIN_LOOKUP_CACHE_TTL_DEFAULT_SECONDS = 300;
+// Deliberately a fixed constant, not env-configurable: there's no operational
+// need to tune a 300s cache of non-critical title/author context (moderation
+// decisions key off the sha, not the title), and KV's 60s expirationTtl floor
+// would make a finer knob low-value and easy to misconfigure.
+const ADMIN_LOOKUP_CACHE_TTL_SECONDS = 300;
 
 async function enrichAdminLookupVideo(video, env) {
   if (!video) {
@@ -943,8 +945,7 @@ async function enrichAdminLookupVideo(video, env) {
       // "no context" for the whole TTL. Awaited (the cold path already paid for
       // the HTTP round-trip) so the write isn't dropped when the response returns.
       if (funnelcakeVideo) {
-        const ttl = Number(env.ADMIN_LOOKUP_CACHE_TTL_SECONDS) || ADMIN_LOOKUP_CACHE_TTL_DEFAULT_SECONDS;
-        await env.MODERATION_KV.put(cacheKey, JSON.stringify(funnelcakeVideo), { expirationTtl: ttl }).catch((error) => {
+        await env.MODERATION_KV.put(cacheKey, JSON.stringify(funnelcakeVideo), { expirationTtl: ADMIN_LOOKUP_CACHE_TTL_SECONDS }).catch((error) => {
           console.error(`[ADMIN] Failed to cache relay context for ${enriched.sha256}:`, error.message);
         });
       }

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -318,8 +318,13 @@ function buildAdminNostrMetadata(metadata = {}, extras = {}) {
   };
 }
 
-async function fetchFunnelcakeLookupVideo(identifier) {
-  const response = await fetch(`https://relay.divine.video/api/videos/${encodeURIComponent(identifier)}`, {
+async function fetchFunnelcakeLookupVideo(identifier, env) {
+  // Read through the CDN-cached host (api.divine.video) rather than the
+  // uncached relay backup path, so repeat per-card lookups hit Fastly's
+  // edge cache instead of origin. Env-driven so staging points at its own
+  // funnelcake host; defaults to the canonical production cached host.
+  const host = env?.FUNNELCAKE_LOOKUP_URL || 'https://api.divine.video';
+  const response = await fetch(`${host}/api/videos/${encodeURIComponent(identifier)}`, {
     headers: {
       'Accept': 'application/json'
     }
@@ -885,6 +890,13 @@ async function fetchLookupNostrContext(hash, env) {
   }
 }
 
+// Per-card relay context is fetched on demand for the detail view. Cache the
+// successful funnelcake result for a few minutes so the common case — paging
+// back and forth over the same handful of cards in a review session — skips the
+// origin round-trip. Short TTL keeps title/author from going meaningfully stale
+// (the underlying api.divine.video response is itself only ~15-60s fresh).
+const ADMIN_LOOKUP_CACHE_TTL_SECONDS = 300;
+
 async function enrichAdminLookupVideo(video, env) {
   if (!video) {
     return null;
@@ -907,10 +919,33 @@ async function enrichAdminLookupVideo(video, env) {
     || (ctx.client == null && ctx.content == null);
 
   if (enriched.sha256 && needsFunnelcake) {
-    const funnelcakeVideo = await fetchFunnelcakeLookupVideo(enriched.lookupId || enriched.eventId || enriched.sha256).catch((error) => {
-      console.error(`[ADMIN] Failed to fetch relay context for ${enriched.sha256}:`, error.message);
-      return null;
-    });
+    const cacheKey = `admin:lookup:funnelcake:${enriched.sha256}`;
+    let funnelcakeVideo = null;
+
+    try {
+      const cached = await env.MODERATION_KV.get(cacheKey);
+      if (cached) {
+        funnelcakeVideo = JSON.parse(cached);
+      }
+    } catch (error) {
+      console.error(`[ADMIN] Failed to read cached relay context for ${enriched.sha256}:`, error.message);
+    }
+
+    if (!funnelcakeVideo) {
+      funnelcakeVideo = await fetchFunnelcakeLookupVideo(enriched.lookupId || enriched.eventId || enriched.sha256, env).catch((error) => {
+        console.error(`[ADMIN] Failed to fetch relay context for ${enriched.sha256}:`, error.message);
+        return null;
+      });
+
+      // Cache successful results only — never pin a transient miss/failure as
+      // "no context" for the whole TTL. Awaited (the cold path already paid for
+      // the HTTP round-trip) so the write isn't dropped when the response returns.
+      if (funnelcakeVideo) {
+        await env.MODERATION_KV.put(cacheKey, JSON.stringify(funnelcakeVideo), { expirationTtl: ADMIN_LOOKUP_CACHE_TTL_SECONDS }).catch((error) => {
+          console.error(`[ADMIN] Failed to cache relay context for ${enriched.sha256}:`, error.message);
+        });
+      }
+    }
 
     if (funnelcakeVideo) {
       enriched = mergeLookupMetadata(enriched, funnelcakeVideo);
@@ -1127,7 +1162,7 @@ async function getAdminLookupVideo(identifier, env, options = {}) {
     return null;
   }
 
-  const funnelcakeVideo = await fetchFunnelcakeLookupVideo(identifier);
+  const funnelcakeVideo = await fetchFunnelcakeLookupVideo(identifier, env);
   if (!funnelcakeVideo) {
     return null;
   }
@@ -1700,7 +1735,7 @@ export default {
       try {
         const result = await runBackfill(env, {
           limit: count,
-          fetchLookup: (sha256) => fetchFunnelcakeLookupVideo(sha256),
+          fetchLookup: (sha256) => fetchFunnelcakeLookupVideo(sha256, env),
         });
         return new Response(JSON.stringify(result), { headers: JSON_HEADERS });
       } catch (error) {
@@ -2441,7 +2476,7 @@ export default {
           });
         }
 
-        const funnelcakeVideo = await fetchFunnelcakeLookupVideo(sha256).catch((error) => {
+        const funnelcakeVideo = await fetchFunnelcakeLookupVideo(sha256, env).catch((error) => {
           console.error(`[ADMIN] Failed to fetch relay context for ${sha256}:`, error.message);
           return null;
         });
@@ -4793,7 +4828,7 @@ async function runMigration() {
       // when another run holds the KV mutex.
       try {
         const result = await runBackfill(env, {
-          fetchLookup: (sha256) => fetchFunnelcakeLookupVideo(sha256),
+          fetchLookup: (sha256) => fetchFunnelcakeLookupVideo(sha256, env),
         });
         if (!result.skipped) {
           console.log(`[BACKFILL] picked=${result.picked} updated=${result.updated} missing=${result.missing} errored=${result.errored}`);

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -321,8 +321,8 @@ function buildAdminNostrMetadata(metadata = {}, extras = {}) {
 async function fetchFunnelcakeLookupVideo(identifier, env) {
   // Read through the CDN-cached host (api.divine.video) rather than the
   // uncached relay backup path, so repeat per-card lookups hit Fastly's
-  // edge cache instead of origin. Env-driven so staging points at its own
-  // funnelcake host; defaults to the canonical production cached host.
+  // edge cache instead of origin. Env-overridable so staging can point at
+  // its own funnelcake host; defaults to the canonical production cached host.
   const host = env?.FUNNELCAKE_LOOKUP_URL || 'https://api.divine.video';
   const response = await fetch(`${host}/api/videos/${encodeURIComponent(identifier)}`, {
     headers: {
@@ -895,7 +895,9 @@ async function fetchLookupNostrContext(hash, env) {
 // back and forth over the same handful of cards in a review session — skips the
 // origin round-trip. Short TTL keeps title/author from going meaningfully stale
 // (the underlying api.divine.video response is itself only ~15-60s fresh).
-const ADMIN_LOOKUP_CACHE_TTL_SECONDS = 300;
+// Env-overridable so an operator can drop the staleness window during an
+// incident without a redeploy.
+const ADMIN_LOOKUP_CACHE_TTL_DEFAULT_SECONDS = 300;
 
 async function enrichAdminLookupVideo(video, env) {
   if (!video) {
@@ -941,7 +943,8 @@ async function enrichAdminLookupVideo(video, env) {
       // "no context" for the whole TTL. Awaited (the cold path already paid for
       // the HTTP round-trip) so the write isn't dropped when the response returns.
       if (funnelcakeVideo) {
-        await env.MODERATION_KV.put(cacheKey, JSON.stringify(funnelcakeVideo), { expirationTtl: ADMIN_LOOKUP_CACHE_TTL_SECONDS }).catch((error) => {
+        const ttl = Number(env.ADMIN_LOOKUP_CACHE_TTL_SECONDS) || ADMIN_LOOKUP_CACHE_TTL_DEFAULT_SECONDS;
+        await env.MODERATION_KV.put(cacheKey, JSON.stringify(funnelcakeVideo), { expirationTtl: ttl }).catch((error) => {
           console.error(`[ADMIN] Failed to cache relay context for ${enriched.sha256}:`, error.message);
         });
       }

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -948,9 +948,11 @@ async function enrichAdminLookupVideo(video, env) {
       // "no context" for the whole TTL. Awaited (the cold path already paid for
       // the HTTP round-trip) so the write isn't dropped when the response returns.
       if (funnelcakeVideo) {
-        await env.MODERATION_KV.put(cacheKey, JSON.stringify(funnelcakeVideo), { expirationTtl: ADMIN_LOOKUP_CACHE_TTL_SECONDS }).catch((error) => {
+        try {
+          await env.MODERATION_KV.put(cacheKey, JSON.stringify(funnelcakeVideo), { expirationTtl: ADMIN_LOOKUP_CACHE_TTL_SECONDS });
+        } catch (error) {
           console.error(`[ADMIN] Failed to cache relay context for ${enriched.sha256}:`, error.message);
-        });
+        }
       }
     }
 

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -728,7 +728,7 @@ describe('Admin video lookup', () => {
 
     globalThis.fetch = async (url) => {
       restCalls.push(String(url));
-      if (String(url) === `https://relay.divine.video/api/videos/${SHA256}`) {
+      if (String(url) === `https://api.divine.video/api/videos/${SHA256}`) {
         return new Response(JSON.stringify({
           event: {
             id: 'd'.repeat(64),
@@ -794,7 +794,100 @@ describe('Admin video lookup', () => {
           }
         }
       });
-      expect(restCalls).toEqual([`https://relay.divine.video/api/videos/${SHA256}`]);
+      expect(restCalls).toEqual([`https://api.divine.video/api/videos/${SHA256}`]);
+    } finally {
+      globalThis.fetch = originalFetch;
+      globalThis.WebSocket = originalWebSocket;
+    }
+  });
+
+  it('caches the per-card funnelcake lookup so a repeat view skips the REST call', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalWebSocket = globalThis.WebSocket;
+    const restCalls = [];
+
+    globalThis.WebSocket = class {
+      constructor() {
+        throw new Error('WebSocket should not be used for admin lookup metadata');
+      }
+    };
+
+    globalThis.fetch = async (url) => {
+      restCalls.push(String(url));
+      if (String(url) === `https://api.divine.video/api/videos/${SHA256}`) {
+        return new Response(JSON.stringify({
+          event: {
+            id: 'd'.repeat(64),
+            pubkey: 'b'.repeat(64),
+            created_at: 1700000000,
+            kind: 34236,
+            tags: [
+              ['d', SHA256],
+              ['title', 'REST title'],
+              ['imeta', 'url https://media.divine.video/rest-content.mp4', `x ${SHA256}`]
+            ],
+            content: 'REST description',
+            sig: 'e'.repeat(128)
+          },
+          stats: { author_name: 'REST author' }
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    };
+
+    // Map-backed KV so the first request's cache write is visible to the second.
+    const kvStore = new Map();
+    const kv = {
+      async get(key) { return kvStore.has(key) ? kvStore.get(key) : null; },
+      async put(key, value) { kvStore.set(key, value); },
+      async delete(key) { kvStore.delete(key); },
+      async list() { return { keys: [], list_complete: true, cursor: null }; }
+    };
+
+    const makeEnv = () => createEnv({
+      MODERATION_KV: kv,
+      BLOSSOM_DB: createDbMock({
+        moderationResults: new Map([[SHA256, {
+          sha256: SHA256,
+          action: 'REVIEW',
+          provider: 'hiveai',
+          scores: JSON.stringify({ nudity: 0.4 }),
+          categories: JSON.stringify(['nudity']),
+          moderated_at: '2026-03-07T00:00:00.000Z',
+          reviewed_by: null,
+          reviewed_at: null,
+          uploaded_by: 'b'.repeat(64)
+        }]])
+      })
+    });
+
+    try {
+      const first = await worker.fetch(
+        new Request(`https://moderation.admin.divine.video/admin/api/video/${SHA256}`, {
+          headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
+        }),
+        makeEnv()
+      );
+      expect(first.status).toBe(200);
+      await expect(first.json()).resolves.toMatchObject({
+        video: { sha256: SHA256, nostrContext: { title: 'REST title', author: 'REST author' } }
+      });
+
+      const second = await worker.fetch(
+        new Request(`https://moderation.admin.divine.video/admin/api/video/${SHA256}`, {
+          headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
+        }),
+        makeEnv()
+      );
+      expect(second.status).toBe(200);
+      // Same enriched context on the cached read...
+      await expect(second.json()).resolves.toMatchObject({
+        video: { sha256: SHA256, nostrContext: { title: 'REST title', author: 'REST author' } }
+      });
+
+      // ...and the funnelcake REST endpoint was hit exactly once across both views.
+      const lookupCalls = restCalls.filter((u) => u === `https://api.divine.video/api/videos/${SHA256}`);
+      expect(lookupCalls).toEqual([`https://api.divine.video/api/videos/${SHA256}`]);
     } finally {
       globalThis.fetch = originalFetch;
       globalThis.WebSocket = originalWebSocket;
@@ -927,7 +1020,7 @@ describe('Admin video lookup', () => {
     const mediaSha = 'b'.repeat(64);
     const originalFetch = globalThis.fetch;
     globalThis.fetch = async (url) => {
-      if (String(url) === `https://relay.divine.video/api/videos/${SHA256}`) {
+      if (String(url) === `https://api.divine.video/api/videos/${SHA256}`) {
         return new Response(JSON.stringify({
           event: {
             id: SHA256,
@@ -985,7 +1078,7 @@ describe('Admin video lookup', () => {
     const stableId = 'video-imported-stable-id';
     const originalFetch = globalThis.fetch;
     globalThis.fetch = async (url) => {
-      if (String(url) === `https://relay.divine.video/api/videos/${stableId}`) {
+      if (String(url) === `https://api.divine.video/api/videos/${stableId}`) {
         return new Response(JSON.stringify({
           event: {
             id: SHA256,
@@ -1165,7 +1258,7 @@ describe('Admin nostr context lookup', () => {
 
     globalThis.fetch = async (url) => {
       restCalls.push(String(url));
-      if (String(url) === `https://relay.divine.video/api/videos/${SHA256}`) {
+      if (String(url) === `https://api.divine.video/api/videos/${SHA256}`) {
         return new Response(JSON.stringify({
           event: {
             id: 'd'.repeat(64),
@@ -1224,7 +1317,7 @@ describe('Admin nostr context lookup', () => {
           createdAt: 1700000000
         }
       });
-      expect(restCalls).toEqual([`https://relay.divine.video/api/videos/${SHA256}`]);
+      expect(restCalls).toEqual([`https://api.divine.video/api/videos/${SHA256}`]);
     } finally {
       globalThis.fetch = originalFetch;
       globalThis.WebSocket = originalWebSocket;

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -894,6 +894,84 @@ describe('Admin video lookup', () => {
     }
   });
 
+  it('still returns live funnelcake context when the per-card KV cache write is unavailable', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalWebSocket = globalThis.WebSocket;
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const restCalls = [];
+
+    globalThis.WebSocket = class {
+      constructor() {
+        throw new Error('WebSocket should not be used for admin lookup metadata');
+      }
+    };
+
+    globalThis.fetch = async (url) => {
+      restCalls.push(String(url));
+      if (String(url) === `https://api.divine.video/api/videos/${SHA256}`) {
+        return new Response(JSON.stringify({
+          event: {
+            id: 'd'.repeat(64),
+            pubkey: 'b'.repeat(64),
+            created_at: 1700000000,
+            kind: 34236,
+            tags: [
+              ['d', SHA256],
+              ['title', 'REST title'],
+              ['imeta', 'url https://media.divine.video/rest-content.mp4', `x ${SHA256}`]
+            ],
+            content: 'REST description',
+            sig: 'e'.repeat(128)
+          },
+          stats: { author_name: 'REST author' }
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    };
+
+    try {
+      const response = await worker.fetch(
+        new Request(`https://moderation.admin.divine.video/admin/api/video/${SHA256}`, {
+          headers: { 'Cf-Access-Authenticated-User-Email': 'mod@divine.video' }
+        }),
+        createEnv({
+          MODERATION_KV: {
+            async get() { return null; },
+            async delete() {},
+            async list() { return { keys: [], list_complete: true, cursor: null }; }
+          },
+          BLOSSOM_DB: createDbMock({
+            moderationResults: new Map([[SHA256, {
+              sha256: SHA256,
+              action: 'REVIEW',
+              provider: 'hiveai',
+              scores: JSON.stringify({ nudity: 0.4 }),
+              categories: JSON.stringify(['nudity']),
+              moderated_at: '2026-03-07T00:00:00.000Z',
+              reviewed_by: null,
+              reviewed_at: null,
+              uploaded_by: 'b'.repeat(64)
+            }]])
+          })
+        })
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toMatchObject({
+        video: { sha256: SHA256, nostrContext: { title: 'REST title', author: 'REST author' } }
+      });
+      expect(restCalls).toEqual([`https://api.divine.video/api/videos/${SHA256}`]);
+      expect(consoleError).toHaveBeenCalledWith(
+        `[ADMIN] Failed to cache relay context for ${SHA256}:`,
+        expect.any(String)
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+      globalThis.WebSocket = originalWebSocket;
+      consoleError.mockRestore();
+    }
+  });
+
   it('returns stored relay context fields in the admin video list without per-row fan-out', async () => {
     // Contract change (perf/dashboard-speedup):
     //   /admin/api/videos used to fire one funnelcake REST call per row

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -132,8 +132,8 @@ RELAY_REPORTS_REQUIRE_DIVINE_CLIENT = "true"      # Only ingest reports tagged a
 FUNNELCAKE_ADMIN_URL = "https://relay.divine.video"
 
 # Funnelcake read host for per-card admin video lookups (GET /api/videos/{id}).
-# The CDN-cached path; staging overrides this to its own funnelcake host. The
-# admin/NIP-98 write path above stays on the relay and is unaffected.
+# The CDN-cached path; env-overridable so staging can point at its own funnelcake
+# host. The admin/NIP-98 write path above stays on the relay and is unaffected.
 FUNNELCAKE_LOOKUP_URL = "https://api.divine.video"
 
 # Legacy moderation_results lookup-column backfill (perf/dashboard-speedup).

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -131,6 +131,11 @@ RELAY_REPORTS_REQUIRE_DIVINE_CLIENT = "true"      # Only ingest reports tagged a
 # so the corresponding pubkey must be in funnelcake's ADMIN_PUBKEYS.
 FUNNELCAKE_ADMIN_URL = "https://relay.divine.video"
 
+# Funnelcake read host for per-card admin video lookups (GET /api/videos/{id}).
+# The CDN-cached path; staging overrides this to its own funnelcake host. The
+# admin/NIP-98 write path above stays on the relay and is unaffected.
+FUNNELCAKE_LOOKUP_URL = "https://api.divine.video"
+
 # Legacy moderation_results lookup-column backfill (perf/dashboard-speedup).
 # Off by default; flip to "true" via `wrangler secret put` after the manual
 # trigger /admin/api/backfill/run has been verified on a small batch.


### PR DESCRIPTION
Two latency wins on the per-card `/admin/api/video/{sha}` detail path, the work a moderator does on every card in the Quick Review queue. Both are do-no-harm: same data, just fewer/cheaper round-trips.

## #160 (host half) — read through the cached host
`fetchFunnelcakeLookupVideo` hit `relay.divine.video/api/videos/{id}`, the **uncached** backup path. Switched to the CDN-cached canonical host `api.divine.video` via a new `FUNNELCAKE_LOOKUP_URL` var (defaulted, env-overridable so staging can point elsewhere). Threaded `env` through the function's six callers.

Host check before changing anything (read-only, both hosts, same sample sha):
- Identical response bodies (18605 bytes, same shape).
- `api.divine.video` is genuinely edge-cached: `x-cache: MISS → HIT → HIT`, `x-cache-hits` incrementing.
- Safe TTL: `cache-control: public, max-age=15, stale-while-revalidate=45`, so review context is at most ~15-60s stale.

The NIP-98 admin **write** path (`FUNNELCAKE_ADMIN_URL`) stays on the relay and is untouched. (Note: the old hardcoded relay host was already prod, so staging already cross-read prod for these lookups; this doesn't change that, only makes the read cached.)

## #159 — cache the per-card lookup
`enrichAdminLookupVideo` fired an uncached funnelcake call on **every** detail-view click (`buildAdminVideoFromRow` hardcodes `client`/`content` to null, so `needsFunnelcake` is always true for flagged cards). Paging back and forth over the same handful of cards in a session re-fetched each one from scratch.

Now the successful result is cached in KV keyed by sha (`admin:lookup:funnelcake:{sha}`, 300s TTL). Repeat views skip the HTTP call entirely. Misses and failures are **never** cached, so a transient error can't pin "no context" for the window. The 300s TTL layered over the host's own 15-60s freshness keeps a review session stable without going meaningfully stale.

## Scope / no stacking
- This is the **cached-host half of #160** plus **#159**. The **parallelize half of #160** (the D1+KV `Promise.all` in `getAdminLookupVideo`) is in **#163**, independent — different lines, no overlap.
- Branched off `main`; touches only `fetchFunnelcakeLookupVideo` / `enrichAdminLookupVideo` / wrangler vars. No interaction with #164's untriaged/anti-join path.

## Validation
- Full suite green (1299, +1 for the new cache test), lint clean.
- New test: a second per-card request for the same sha hits the funnelcake REST endpoint exactly once across both views (Map-backed KV) and returns identical enriched context.
- Existing per-card tests updated to the new cached host.

Closes #159. Part of #160 (cached-host half here; parallelize half in #163) — close #160 once both land.
