### PR TITLE
perf(messages): one-pass conversation list + indexed thread lookup

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -3471,7 +3471,11 @@ async function runMigration() {
 
       const pubkey = url.pathname.split('/')[4];
       const { getConversationByPubkey } = await import('./nostr/dm-store.mjs');
-      const messages = await getConversationByPubkey(env.BLOSSOM_DB, pubkey);
+      const { getModeratorPubkey } = await import('./nostr/dm-reader.mjs');
+      // Pass moderatorPubkey so the lookup derives the deterministic
+      // conversation_id (indexed) instead of the unindexed sender/recipient OR scan.
+      const moderatorPubkey = env.NOSTR_PRIVATE_KEY ? getModeratorPubkey(env) : undefined;
+      const messages = await getConversationByPubkey(env.BLOSSOM_DB, pubkey, moderatorPubkey);
       if (!messages) {
         // Never-messaged recipient: return an empty thread (200) so the compose UI
         // can render for new conversations instead of showing a load error.

--- a/src/nostr/dm-store.mjs
+++ b/src/nostr/dm-store.mjs
@@ -121,10 +121,16 @@ export async function getConversationByPubkey(db, pubkey, moderatorPubkey) {
   }
 
   // Fallback (no moderator pubkey available, e.g. no signing key configured):
-  // find any conversation this pubkey participates in via the OR query.
+  // find the most recently updated conversation this pubkey participates in
+  // via the OR query. This keeps the legacy behavior available while making
+  // the "first conversation" choice deterministic.
   const rows = await db.prepare(`
-    SELECT DISTINCT conversation_id FROM dm_log
+    SELECT conversation_id
+    FROM dm_log
     WHERE sender_pubkey = ? OR recipient_pubkey = ?
+    GROUP BY conversation_id
+    ORDER BY MAX(id) DESC
+    LIMIT 1
   `).bind(pubkey, pubkey).all();
 
   if (!rows.results || rows.results.length === 0) return null;

--- a/src/nostr/dm-store.mjs
+++ b/src/nostr/dm-store.mjs
@@ -45,15 +45,25 @@ export async function logDm(db, { conversationId, sha256, direction, senderPubke
 }
 
 export async function getConversations(db, { limit = 20, offset = 0, moderatorPubkey } = {}) {
-  // An earlier revision of this query put MAX()/COUNT() in the outer SELECT
-  // without a GROUP BY, which SQLite collapses into a single aggregated row
-  // across the whole filtered set. That made every multi-conversation inbox
-  // render as exactly one sidebar item regardless of how many conversations
-  // actually existed. The subquery already picks the latest id per
-  // conversation, so we select those rows directly and compute
-  // message_count per conversation via a correlated subquery (bounded by
-  // LIMIT).
+  // One grouped pass computes both the latest row id AND the per-conversation
+  // message_count in the same scan, then we join back for the latest row's
+  // columns. This replaces the earlier shape (a per-returned-row correlated
+  // `(SELECT COUNT(*) ...)` subquery on top of a separate MAX(id) GROUP BY),
+  // which did the grouped scan AND an extra index lookup per row.
+  //
+  // No extra index is needed: `id` is INTEGER PRIMARY KEY (the rowid), so the
+  // existing idx_dm_conversation on (conversation_id) is physically
+  // (conversation_id, id) and already covers MAX(id)/COUNT(*) GROUP BY. The
+  // final ORDER BY runs over the reduced one-row-per-conversation set (bounded
+  // by the moderation account's conversation count), so it doesn't warrant its
+  // own created_at index. id DESC is a deterministic tiebreaker for rows that
+  // share a (1-second-resolution) created_at, so pagination is stable.
   const rows = await db.prepare(`
+    WITH latest AS (
+      SELECT conversation_id, MAX(id) AS max_id, COUNT(*) AS message_count
+      FROM dm_log
+      GROUP BY conversation_id
+    )
     SELECT
       dl.conversation_id,
       dl.created_at as last_message_at,
@@ -63,12 +73,10 @@ export async function getConversations(db, { limit = 20, offset = 0, moderatorPu
       dl.content as last_message,
       dl.sha256 as last_sha256,
       dl.message_type as last_message_type,
-      (SELECT COUNT(*) FROM dm_log WHERE conversation_id = dl.conversation_id) as message_count
-    FROM dm_log dl
-    WHERE dl.id IN (
-      SELECT MAX(id) FROM dm_log GROUP BY conversation_id
-    )
-    ORDER BY last_message_at DESC
+      latest.message_count
+    FROM latest
+    JOIN dm_log dl ON dl.id = latest.max_id
+    ORDER BY last_message_at DESC, dl.id DESC
     LIMIT ? OFFSET ?
   `).bind(limit, offset).all();
   const results = rows.results || [];
@@ -97,8 +105,19 @@ export async function getConversation(db, conversationId) {
   return rows.results || [];
 }
 
-export async function getConversationByPubkey(db, pubkey) {
-  // Find conversations where this pubkey is a participant
+export async function getConversationByPubkey(db, pubkey, moderatorPubkey) {
+  // Fast path: the conversation id is deterministic, so when we know the
+  // moderator pubkey we derive it directly and hit the indexed conversation_id
+  // column — no scan. (The old `sender_pubkey = ? OR recipient_pubkey = ?` form
+  // can't use an index on both sides: sender_pubkey is unindexed.)
+  if (moderatorPubkey) {
+    const conversationId = computeConversationId(moderatorPubkey, pubkey);
+    const messages = await getConversation(db, conversationId);
+    return messages.length ? messages : null;
+  }
+
+  // Fallback (no moderator pubkey available, e.g. no signing key configured):
+  // find any conversation this pubkey participates in via the OR query.
   const rows = await db.prepare(`
     SELECT DISTINCT conversation_id FROM dm_log
     WHERE sender_pubkey = ? OR recipient_pubkey = ?

--- a/src/nostr/dm-store.mjs
+++ b/src/nostr/dm-store.mjs
@@ -100,7 +100,7 @@ export async function getConversation(db, conversationId) {
   const rows = await db.prepare(`
     SELECT * FROM dm_log
     WHERE conversation_id = ?
-    ORDER BY created_at ASC
+    ORDER BY created_at ASC, id ASC
   `).bind(conversationId).all();
   return rows.results || [];
 }

--- a/src/nostr/dm-store.mjs
+++ b/src/nostr/dm-store.mjs
@@ -97,6 +97,10 @@ export async function getConversations(db, { limit = 20, offset = 0, moderatorPu
 }
 
 export async function getConversation(db, conversationId) {
+  // id ASC is a load-bearing tiebreaker: created_at is CURRENT_TIMESTAMP at
+  // 1-second resolution, so messages sent in the same second tie on created_at
+  // alone and would render in an undefined order. id is the AUTOINCREMENT rowid
+  // (insertion order), so it gives a stable chronological thread.
   const rows = await db.prepare(`
     SELECT * FROM dm_log
     WHERE conversation_id = ?

--- a/src/nostr/dm-store.test.mjs
+++ b/src/nostr/dm-store.test.mjs
@@ -506,3 +506,45 @@ describe('DM Store - getConversationByPubkey', () => {
     expect(result).toBeNull();
   });
 });
+
+describe('DM Store - getConversationByPubkey against real D1', () => {
+  const db = env.BLOSSOM_DB;
+  const MODERATOR = 'f'.repeat(64);
+  const CREATOR = ('a'.repeat(63) + '1').slice(0, 64);
+
+  beforeEach(async () => {
+    await initDmLogTable(db);
+    await db.prepare('DELETE FROM dm_log').run();
+  });
+
+  it('resolves the thread via the deterministic conversation id (moderator-aware fast path)', async () => {
+    const conversationId = computeConversationId(MODERATOR, CREATOR);
+    await logDm(db, {
+      conversationId,
+      direction: 'incoming',
+      senderPubkey: CREATOR,
+      recipientPubkey: MODERATOR,
+      content: 'hi from creator',
+      nostrEventId: 'evt-1',
+    });
+    await logDm(db, {
+      conversationId,
+      direction: 'outgoing',
+      senderPubkey: MODERATOR,
+      recipientPubkey: CREATOR,
+      content: 'moderator reply',
+      nostrEventId: 'evt-2',
+    });
+
+    // Look up by the creator pubkey with the moderator known — must resolve the
+    // same conversation without touching sender_pubkey (the unindexed OR path).
+    const messages = await getConversationByPubkey(db, CREATOR, MODERATOR);
+    expect(messages).not.toBeNull();
+    expect(messages.map((m) => m.content)).toEqual(['hi from creator', 'moderator reply']);
+  });
+
+  it('returns null for a participant with no conversation (fast path)', async () => {
+    const messages = await getConversationByPubkey(db, 'd'.repeat(64), MODERATOR);
+    expect(messages).toBeNull();
+  });
+});

--- a/src/nostr/dm-store.test.mjs
+++ b/src/nostr/dm-store.test.mjs
@@ -448,7 +448,11 @@ describe('DM Store - getConversations against real D1', () => {
         content,
         nostrEventId: eventId,
       });
-      // Stagger so created_at orders deterministically.
+      // Small gap between inserts. Note created_at is CURRENT_TIMESTAMP at
+      // 1-second resolution, so these rows usually share a last_message_at;
+      // deterministic ordering comes from the `dl.id DESC` tiebreaker in the
+      // query, not from this stagger. The assertions below only check page
+      // sizes, which hold regardless of intra-second tie order.
       await new Promise(r => setTimeout(r, 15));
     }
 

--- a/src/nostr/dm-store.test.mjs
+++ b/src/nostr/dm-store.test.mjs
@@ -515,6 +515,7 @@ describe('DM Store - getConversationByPubkey against real D1', () => {
   const db = env.BLOSSOM_DB;
   const MODERATOR = 'f'.repeat(64);
   const CREATOR = ('a'.repeat(63) + '1').slice(0, 64);
+  const OTHER = ('b'.repeat(63) + '1').slice(0, 64);
 
   beforeEach(async () => {
     await initDmLogTable(db);
@@ -550,5 +551,32 @@ describe('DM Store - getConversationByPubkey against real D1', () => {
   it('returns null for a participant with no conversation (fast path)', async () => {
     const messages = await getConversationByPubkey(db, 'd'.repeat(64), MODERATOR);
     expect(messages).toBeNull();
+  });
+
+  it('uses the most recently updated matching conversation in the legacy fallback', async () => {
+    const olderConversationId = computeConversationId(CREATOR, OTHER);
+    const newerConversationId = computeConversationId(MODERATOR, CREATOR);
+
+    await logDm(db, {
+      conversationId: olderConversationId,
+      direction: 'incoming',
+      senderPubkey: CREATOR,
+      recipientPubkey: OTHER,
+      content: 'older unrelated conversation',
+      nostrEventId: 'evt-fallback-older',
+    });
+    await logDm(db, {
+      conversationId: newerConversationId,
+      direction: 'incoming',
+      senderPubkey: CREATOR,
+      recipientPubkey: MODERATOR,
+      content: 'newer moderator conversation',
+      nostrEventId: 'evt-fallback-newer',
+    });
+
+    const messages = await getConversationByPubkey(db, CREATOR);
+
+    expect(messages).not.toBeNull();
+    expect(messages.map((m) => m.content)).toEqual(['newer moderator conversation']);
   });
 });


### PR DESCRIPTION
Backend query optimization for the admin messages inbox — the first of the messages-perf PRs (do-no-harm, backend-only). Closes #154 and #155.

## #154 — conversation list: one grouped pass instead of per-row correlated COUNT
`getConversations` previously ran a per-returned-row correlated `(SELECT COUNT(*) … WHERE conversation_id = dl.conversation_id)` on top of a separate `WHERE id IN (SELECT MAX(id) … GROUP BY conversation_id)`. Rewritten to a single CTE that computes the latest row id **and** the message_count per conversation in one grouped scan, then joins back for the latest row's columns:

```sql
WITH latest AS (
  SELECT conversation_id, MAX(id) AS max_id, COUNT(*) AS message_count
  FROM dm_log GROUP BY conversation_id
)
SELECT … latest.message_count
FROM latest JOIN dm_log dl ON dl.id = latest.max_id
ORDER BY last_message_at DESC, dl.id DESC
LIMIT ? OFFSET ?
```

**No new index** (contra the issue's suggestion): `id` is `INTEGER PRIMARY KEY` (the rowid), so the existing `idx_dm_conversation` on `(conversation_id)` is physically `(conversation_id, id)` and already covers `MAX(id)`/`COUNT(*) GROUP BY conversation_id`. The final `ORDER BY` runs over the reduced one-row-per-conversation set (bounded by the moderation account's conversation count), so it doesn't warrant a `created_at` index either. Adding `(conversation_id, id)` would be a duplicate index — pure write/storage waste. Added an `id DESC` tiebreaker so pagination is deterministic when rows share a (1-second-resolution) `created_at`.

## #155 — thread lookup: deterministic id instead of unindexed OR scan
`getConversationByPubkey` filtered `WHERE sender_pubkey = ? OR recipient_pubkey = ?` — `sender_pubkey` is unindexed, so the OR forces a scan. The conversation id is deterministic, so the function now derives it via `computeConversationId(moderatorPubkey, pubkey)` and hits the indexed `conversation_id` column directly. Falls back to the OR query when no moderator pubkey is available (no signing key configured). The `/admin/api/messages/{pubkey}` caller passes the moderator pubkey (same `getModeratorPubkey(env)` it already uses for the list).

## PR organization (no stacking)
First of three messages-perf PRs, sliced by concern to avoid 3 PRs editing the same file:
- **This (A)** — `dm-store.mjs` query optimization (#154 + #155). Backend only.
- **B** — `messages.html` progressive list render + optimistic send (#152 + #151).
- **C** — thread pagination (#153), which spans both files; lands after A + B (depends on B's append-only render), rebased — not stacked.

## Validation
- Full suite green (1300), lint clean. The existing real-D1 `getConversations` suite validates the rewrite (per-conversation `message_count` correctness, correct `last_message` per conversation, limit/offset, empty). New real-D1 tests cover the `getConversationByPubkey` fast path (resolves the right thread via the deterministic id; null when the participant has no conversation).
