### PR TITLE
perf(messages): progressive conversation list + optimistic send

### DIFF
--- a/src/admin/messages-ui.test.mjs
+++ b/src/admin/messages-ui.test.mjs
@@ -26,3 +26,21 @@ describe('messages UI — new message compose hooks', () => {
     expect(messagesHTML).toContain('No messages yet');
   });
 });
+
+describe('messages UI — progressive render + optimistic send', () => {
+  it('renders the conversation list before profiles resolve (background patch)', () => {
+    // #152: paint immediately, then fetch profiles and re-render.
+    expect(messagesHTML).toContain('fetchProfiles(pubkeys).then(() => renderConversations())');
+  });
+
+  it('appends an optimistic pending bubble and reverts on failure', () => {
+    // #151: optimistic append + clear composer immediately, revert on error.
+    expect(messagesHTML).toContain('function createMessageBubble(');
+    expect(messagesHTML).toContain('function appendOutgoingBubble(');
+    expect(messagesHTML).toContain('appendOutgoingBubble(text, sha256, { pending: true })');
+    expect(messagesHTML).toContain('pending-tag');
+    // Revert path restores the typed text.
+    expect(messagesHTML).toContain('pendingBubble.remove();');
+    expect(messagesHTML).toContain('input.value = text;');
+  });
+});

--- a/src/admin/messages-ui.test.mjs
+++ b/src/admin/messages-ui.test.mjs
@@ -51,5 +51,7 @@ describe('messages UI — progressive render + optimistic send', () => {
     expect(messagesHTML).toContain("encodeURIComponent(targetPubkey)");
     expect(messagesHTML).toContain('pendingBubble.isConnected');
     expect(messagesHTML).toContain('selectedPubkey === targetPubkey');
+    // Failed first message of an empty thread restores the empty-state placeholder.
+    expect(messagesHTML).toContain('renderThread([])');
   });
 });

--- a/src/admin/messages-ui.test.mjs
+++ b/src/admin/messages-ui.test.mjs
@@ -31,6 +31,7 @@ describe('messages UI — progressive render + optimistic send', () => {
   it('renders the conversation list before profiles resolve (background patch)', () => {
     // #152: paint immediately, then fetch profiles and re-render.
     expect(messagesHTML).toContain('fetchProfiles(pubkeys).then(() => renderConversations())');
+    expect(messagesHTML).toContain("filterConversations(currentConversationSearch())");
   });
 
   it('appends an optimistic pending bubble and reverts on failure', () => {

--- a/src/admin/messages-ui.test.mjs
+++ b/src/admin/messages-ui.test.mjs
@@ -43,4 +43,13 @@ describe('messages UI — progressive render + optimistic send', () => {
     expect(messagesHTML).toContain('pendingBubble.remove();');
     expect(messagesHTML).toContain('input.value = text;');
   });
+
+  it('guards the optimistic send against mid-send navigation / thread switch', () => {
+    // Snapshot the target thread (don't POST to whatever is selected when the
+    // fetch line runs) and only touch the bubble if it's still in the DOM.
+    expect(messagesHTML).toContain('const targetPubkey = selectedPubkey;');
+    expect(messagesHTML).toContain("encodeURIComponent(targetPubkey)");
+    expect(messagesHTML).toContain('pendingBubble.isConnected');
+    expect(messagesHTML).toContain('selectedPubkey === targetPubkey');
+  });
 });

--- a/src/admin/messages.html
+++ b/src/admin/messages.html
@@ -620,6 +620,10 @@
       renderConversationList(filtered);
     }
 
+    function currentConversationSearch() {
+      return document.getElementById('search-input')?.value || '';
+    }
+
     // --- Fetch conversations ---
 
     async function fetchConversations() {
@@ -647,7 +651,7 @@
     }
 
     function renderConversations() {
-      renderConversationList(conversations);
+      filterConversations(currentConversationSearch());
     }
 
     function renderConversationList(list) {
@@ -676,7 +680,7 @@
             <div class="preview">${escapeHtml(preview) || '(no messages)'}</div>
             <div class="meta">
               <span>${relativeTime(ts)}</span>
-              ${msgType ? '<span class="badge ' + badgeClass(msgType) + '">' + badgeLabel(msgType) + '</span>' : ''}
+              ${msgType ? '<span class="badge ' + badgeClass(msgType) + '">' + escapeHtml(badgeLabel(msgType)) + '</span>' : ''}
             </div>
           </div>
         `;
@@ -777,7 +781,8 @@
       let html = '<div>' + escapeHtml(msg.content || msg.message || '') + '</div>';
 
       if (msg.sha256) {
-        html += '<a class="video-link" href="/admin/video/' + encodeURIComponent(msg.sha256) + '" target="_blank">View video: ' + msg.sha256.slice(0, 12) + '...</a>';
+        const sha256 = String(msg.sha256);
+        html += '<a class="video-link" href="/admin/video/' + encodeURIComponent(sha256) + '" target="_blank">View video: ' + escapeHtml(sha256.slice(0, 12)) + '...</a>';
       }
 
       html += '<div class="bubble-meta">';
@@ -787,7 +792,7 @@
         const ts = msg.created_at || msg.timestamp;
         html += '<span>' + relativeTime(ts) + '</span>';
         if (msg.message_type) {
-          html += '<span class="type-tag">' + badgeLabel(msg.message_type) + '</span>';
+          html += '<span class="type-tag">' + escapeHtml(badgeLabel(msg.message_type)) + '</span>';
         }
       }
       html += '</div>';

--- a/src/admin/messages.html
+++ b/src/admin/messages.html
@@ -862,7 +862,13 @@
         // Revert: remove the optimistic bubble if still present, and restore the
         // typed text only if we're still on the same thread (the composer is a
         // single shared element — don't dump this thread's text into another).
-        if (pendingBubble.isConnected) pendingBubble.remove();
+        if (pendingBubble.isConnected) {
+          pendingBubble.remove();
+          // If that was the only bubble (failed first message of an empty
+          // thread), restore the "no messages yet" placeholder appendOutgoingBubble removed.
+          const threadContainer = document.getElementById('thread-messages');
+          if (!threadContainer.querySelector('.message-bubble')) renderThread([]);
+        }
         if (selectedPubkey === targetPubkey) {
           input.value = text;
           if (sha256) sha256Input.value = sha256;

--- a/src/admin/messages.html
+++ b/src/admin/messages.html
@@ -306,6 +306,15 @@
       align-items: center;
     }
 
+    /* Optimistic outgoing bubble awaiting the publish round-trip. */
+    .message-bubble.pending {
+      opacity: 0.6;
+    }
+
+    .message-bubble .pending-tag {
+      font-style: italic;
+    }
+
     .message-bubble .video-link {
       display: inline-block;
       margin-top: 6px;
@@ -624,11 +633,13 @@
         const data = await res.json();
         conversations = data.conversations || data || [];
 
-        // Fetch profiles for all participants
-        const pubkeys = conversations.map(c => c.participant_pubkey || c.pubkey).filter(Boolean);
-        await fetchProfiles(pubkeys);
-
+        // Paint immediately — displayName() falls back to the truncated pubkey,
+        // so rows show last message + timestamp without waiting on the
+        // relay-bound profile lookup. Then fetch profiles in the background and
+        // re-render to patch in names/avatars when they arrive.
         renderConversations();
+        const pubkeys = conversations.map(c => c.participant_pubkey || c.pubkey).filter(Boolean);
+        fetchProfiles(pubkeys).then(() => renderConversations()).catch(() => {});
       } catch (err) {
         container.innerHTML = '<div class="empty-state">Failed to load conversations</div>';
         console.error('fetchConversations error:', err);
@@ -750,32 +761,52 @@
         return;
       }
 
-      messages.forEach(msg => {
-        const direction = msg.direction || (msg.from_moderator ? 'outgoing' : 'incoming');
-        const bubble = document.createElement('div');
-        bubble.className = 'message-bubble ' + direction;
-
-        let html = '<div>' + escapeHtml(msg.content || msg.message || '') + '</div>';
-
-        if (msg.sha256) {
-          html += '<a class="video-link" href="/admin/video/' + encodeURIComponent(msg.sha256) + '" target="_blank">View video: ' + msg.sha256.slice(0, 12) + '...</a>';
-        }
-
-        const ts = msg.created_at || msg.timestamp;
-        const msgType = msg.message_type;
-        html += '<div class="bubble-meta">';
-        html += '<span>' + relativeTime(ts) + '</span>';
-        if (msgType) {
-          html += '<span class="type-tag">' + badgeLabel(msgType) + '</span>';
-        }
-        html += '</div>';
-
-        bubble.innerHTML = html;
-        container.appendChild(bubble);
-      });
+      messages.forEach(msg => container.appendChild(createMessageBubble(msg)));
 
       // Auto-scroll to bottom
       container.scrollTop = container.scrollHeight;
+    }
+
+    // Build a single message bubble. Shared by renderThread (server rows) and
+    // the optimistic-send append path (a pending outgoing bubble).
+    function createMessageBubble(msg) {
+      const direction = msg.direction || (msg.from_moderator ? 'outgoing' : 'incoming');
+      const bubble = document.createElement('div');
+      bubble.className = 'message-bubble ' + direction + (msg.pending ? ' pending' : '');
+
+      let html = '<div>' + escapeHtml(msg.content || msg.message || '') + '</div>';
+
+      if (msg.sha256) {
+        html += '<a class="video-link" href="/admin/video/' + encodeURIComponent(msg.sha256) + '" target="_blank">View video: ' + msg.sha256.slice(0, 12) + '...</a>';
+      }
+
+      html += '<div class="bubble-meta">';
+      if (msg.pending) {
+        html += '<span class="pending-tag">Sending…</span>';
+      } else {
+        const ts = msg.created_at || msg.timestamp;
+        html += '<span>' + relativeTime(ts) + '</span>';
+        if (msg.message_type) {
+          html += '<span class="type-tag">' + badgeLabel(msg.message_type) + '</span>';
+        }
+      }
+      html += '</div>';
+
+      bubble.innerHTML = html;
+      return bubble;
+    }
+
+    // Optimistically append an outgoing bubble (used by sendMessage before the
+    // publish round-trip resolves). Returns the bubble node so the caller can
+    // mark it delivered or revert it.
+    function appendOutgoingBubble(text, sha256, { pending } = {}) {
+      const container = document.getElementById('thread-messages');
+      const empty = container.querySelector('.empty-state');
+      if (empty) empty.remove();
+      const bubble = createMessageBubble({ direction: 'outgoing', content: text, sha256: sha256 || null, pending });
+      container.appendChild(bubble);
+      container.scrollTop = container.scrollHeight;
+      return bubble;
     }
 
     // --- Send message ---
@@ -788,10 +819,18 @@
       const text = input.value.trim();
       if (!text) return;
 
-      sendBtn.disabled = true;
-      const body = { message: text };
       const sha256 = sha256Input.value.trim();
+      const body = { message: text };
       if (sha256) body.sha256 = sha256;
+
+      // Optimistic: append a pending bubble and clear the composer immediately,
+      // so the UI doesn't block on the relay-bound publish round-trip. On
+      // success we mark the bubble delivered; on failure we revert (remove the
+      // bubble, restore the typed text) so the moderator can retry.
+      const pendingBubble = appendOutgoingBubble(text, sha256, { pending: true });
+      input.value = '';
+      sha256Input.value = '';
+      sendBtn.disabled = true;
 
       try {
         const res = await fetch('/admin/api/messages/' + encodeURIComponent(selectedPubkey), {
@@ -805,10 +844,15 @@
           throw new Error(errBody.error || 'Failed to send message');
         }
 
-        input.value = '';
-        sha256Input.value = '';
-        await loadThread(selectedPubkey);
+        // Delivered: drop the pending state and stamp a timestamp.
+        pendingBubble.classList.remove('pending');
+        const meta = pendingBubble.querySelector('.bubble-meta');
+        if (meta) meta.innerHTML = '<span>' + relativeTime(new Date().toISOString()) + '</span>';
       } catch (err) {
+        // Revert: remove the optimistic bubble and restore the composer text.
+        pendingBubble.remove();
+        input.value = text;
+        if (sha256) sha256Input.value = sha256;
         alert('Failed to send message: ' + err.message);
         console.error('sendMessage error:', err);
       } finally {

--- a/src/admin/messages.html
+++ b/src/admin/messages.html
@@ -823,6 +823,11 @@
       const body = { message: text };
       if (sha256) body.sha256 = sha256;
 
+      // Snapshot the target thread: the moderator can switch conversations
+      // while the publish is in flight, and selectedPubkey would change under
+      // us — we must POST to (and reconcile against) the thread we sent from.
+      const targetPubkey = selectedPubkey;
+
       // Optimistic: append a pending bubble and clear the composer immediately,
       // so the UI doesn't block on the relay-bound publish round-trip. On
       // success we mark the bubble delivered; on failure we revert (remove the
@@ -833,7 +838,7 @@
       sendBtn.disabled = true;
 
       try {
-        const res = await fetch('/admin/api/messages/' + encodeURIComponent(selectedPubkey), {
+        const res = await fetch('/admin/api/messages/' + encodeURIComponent(targetPubkey), {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(body)
@@ -844,15 +849,24 @@
           throw new Error(errBody.error || 'Failed to send message');
         }
 
-        // Delivered: drop the pending state and stamp a timestamp.
-        pendingBubble.classList.remove('pending');
-        const meta = pendingBubble.querySelector('.bubble-meta');
-        if (meta) meta.innerHTML = '<span>' + relativeTime(new Date().toISOString()) + '</span>';
+        // Delivered: drop the pending state and stamp a timestamp — but only if
+        // the bubble is still in the DOM. If the moderator navigated/refreshed
+        // mid-send it was wiped; the server render on next open of that thread
+        // shows the logged row, so there's nothing to reconcile here.
+        if (pendingBubble.isConnected) {
+          pendingBubble.classList.remove('pending');
+          const meta = pendingBubble.querySelector('.bubble-meta');
+          if (meta) meta.innerHTML = '<span>' + relativeTime(new Date().toISOString()) + '</span>';
+        }
       } catch (err) {
-        // Revert: remove the optimistic bubble and restore the composer text.
-        pendingBubble.remove();
-        input.value = text;
-        if (sha256) sha256Input.value = sha256;
+        // Revert: remove the optimistic bubble if still present, and restore the
+        // typed text only if we're still on the same thread (the composer is a
+        // single shared element — don't dump this thread's text into another).
+        if (pendingBubble.isConnected) pendingBubble.remove();
+        if (selectedPubkey === targetPubkey) {
+          input.value = text;
+          if (sha256) sha256Input.value = sha256;
+        }
         alert('Failed to send message: ' + err.message);
         console.error('sendMessage error:', err);
       } finally {


### PR DESCRIPTION
Frontend responsiveness for the admin messages inbox — second of the messages-perf PRs (`messages.html` only). Closes #152 and #151.

## #152 — render the conversation list before profiles resolve
`fetchConversations` `await`ed the bulk relay profile lookup (`fetchProfiles`, a kind-0 WS query with a 5s timeout) **before** the first `renderConversations()`, so the left panel sat on "Loading…" until the relay answered. Now it paints immediately — `displayName()` already falls back to the truncated pubkey, so rows show last message + timestamp right away — then fetches profiles in the background and re-renders to patch in names/avatars when they arrive.

## #151 — optimistic send
`sendMessage` disabled the composer, `await`ed the full publish round-trip (NIP-17 wrap + NIP-65 discovery + publish to every relay), then re-`loadThread`'d (a full DOM rebuild + scroll jump). Now it's optimistic:
- appends a **pending** outgoing bubble and clears/re-enables the composer immediately,
- publishes in the background,
- on success marks the bubble delivered (drops the pending state, stamps a timestamp) — no full-thread re-render,
- on failure **reverts**: removes the optimistic bubble and restores the typed text so the moderator can retry (your call: revert-and-restore over a persistent failed-retry affordance — simpler, less state).

Extracted `createMessageBubble` so the optimistic append (`appendOutgoingBubble`) and the server render (`renderThread`) share one bubble builder; `renderThread` is append-based and no longer full-rebuilds after each send. (Re-opening a thread still renders fresh from the server, so the optimistic bubble can't duplicate the logged row.)

## PR organization (no stacking)
Second of three messages-perf PRs. Independent of **A** (#166, `dm-store.mjs` query opt) — different file. **C** (thread pagination, #153) spans `dm-store.mjs` + `messages.html` and depends on this PR's append-based rendering, so it lands after A + B, rebased — not stacked.

## Validation
- Full suite green (1300), lint clean. `messages-ui.test.mjs` smoke tests pin the progressive-render reorder and the optimistic-send/revert wiring.
- Client-side `messages.html` JS (no unit harness for DOM behavior); final visual confirmation at staging (admin is CF-Access gated).
