### PR TITLE
fix(moderation): route relay-admin actions through a service binding + shared Secrets Store key (#170)

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -766,6 +766,14 @@ function relayRpcForAction(payload) {
   }
 }
 
+// Resolve a secret that may be either a plain string (wrangler secret / [vars])
+// or a Cloudflare Secrets Store binding (async .get()). Mirrors the relay-admin
+// worker's resolveSecret so the shared key works regardless of how it is bound.
+async function resolveSecret(binding) {
+  if (!binding) return null;
+  return typeof binding === 'string' ? binding : await binding.get();
+}
+
 async function callRelayAdminAction(env, payload) {
   const rpcBody = relayRpcForAction(payload);
   const url = `${getRelayAdminUrl(env)}/api/relay-rpc`;
@@ -780,7 +788,11 @@ async function callRelayAdminAction(env, payload) {
   const binding = env.RELAY_ADMIN;
   const viaBinding = !!binding;
 
-  if (viaBinding && !env.RELAY_ADMIN_API_KEY) {
+  // RELAY_ADMIN_API_KEY is a Secrets Store binding in prod (async .get()); also
+  // accept a plain string for local dev / tests.
+  const adminKey = await resolveSecret(env.RELAY_ADMIN_API_KEY);
+
+  if (viaBinding && !adminKey) {
     console.warn('[RELAY-ADMIN] RELAY_ADMIN service binding is present but RELAY_ADMIN_API_KEY is not set — the relay-admin worker will reject the call as unauthorized.');
   } else if (!viaBinding && !(env.CF_ACCESS_CLIENT_ID && env.CF_ACCESS_CLIENT_SECRET)) {
     console.warn('[RELAY-ADMIN] No RELAY_ADMIN service binding and no CF_ACCESS_CLIENT_ID/CF_ACCESS_CLIENT_SECRET — relay-admin API calls will be blocked. See project memory cf_access_relay_admin_secrets.md.');
@@ -794,7 +806,7 @@ async function callRelayAdminAction(env, payload) {
   const init = {
     method: 'POST',
     headers: viaBinding
-      ? { 'Content-Type': 'application/json', 'X-Admin-Key': env.RELAY_ADMIN_API_KEY || '' }
+      ? { 'Content-Type': 'application/json', 'X-Admin-Key': adminKey || '' }
       : getRelayAdminHeaders(env),
     body: JSON.stringify(rpcBody),
     redirect: 'manual',

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -767,45 +767,62 @@ function relayRpcForAction(payload) {
 }
 
 async function callRelayAdminAction(env, payload) {
-  const hasCfAccessSecrets = !!(env.CF_ACCESS_CLIENT_ID && env.CF_ACCESS_CLIENT_SECRET);
-  if (!hasCfAccessSecrets) {
-    console.warn('[RELAY-ADMIN] CF_ACCESS_CLIENT_ID/CF_ACCESS_CLIENT_SECRET not configured on this worker — calls to the relay-admin API will be blocked by Cloudflare Access. See project memory cf_access_relay_admin_secrets.md.');
-  }
-
   const rpcBody = relayRpcForAction(payload);
   const url = `${getRelayAdminUrl(env)}/api/relay-rpc`;
+
+  // Prefer the worker-to-worker service binding when configured: it bypasses the
+  // public CF edge and CF Access (the source of the deprecated-endpoint 522 and
+  // the per-card Ban User 502, issue #170) and avoids relay-admin cold starts.
+  // The relay-admin worker authorizes server-to-server callers via the X-Admin-Key
+  // header (divine-relay-manager worker/src/index.ts). When the binding is absent
+  // (local dev, or as a safety net) we fall back to the public-edge HTTPS + CF
+  // Access path. With the binding the URL host is ignored; only the path matters.
+  const binding = env.RELAY_ADMIN;
+  const viaBinding = !!binding;
+
+  if (viaBinding && !env.RELAY_ADMIN_API_KEY) {
+    console.warn('[RELAY-ADMIN] RELAY_ADMIN service binding is present but RELAY_ADMIN_API_KEY is not set — the relay-admin worker will reject the call as unauthorized.');
+  } else if (!viaBinding && !(env.CF_ACCESS_CLIENT_ID && env.CF_ACCESS_CLIENT_SECRET)) {
+    console.warn('[RELAY-ADMIN] No RELAY_ADMIN service binding and no CF_ACCESS_CLIENT_ID/CF_ACCESS_CLIENT_SECRET — relay-admin API calls will be blocked. See project memory cf_access_relay_admin_secrets.md.');
+  }
 
   // Bound the call so a dead/slow relay-admin endpoint fails fast instead of
   // hanging the request (and the moderator's UI) for the full CF edge timeout.
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), RELAY_ADMIN_TIMEOUT_MS);
 
+  const init = {
+    method: 'POST',
+    headers: viaBinding
+      ? { 'Content-Type': 'application/json', 'X-Admin-Key': env.RELAY_ADMIN_API_KEY || '' }
+      : getRelayAdminHeaders(env),
+    body: JSON.stringify(rpcBody),
+    redirect: 'manual',
+    signal: controller.signal
+  };
+
   let response;
   try {
-    response = await fetch(url, {
-      method: 'POST',
-      headers: getRelayAdminHeaders(env),
-      body: JSON.stringify(rpcBody),
-      redirect: 'manual',
-      signal: controller.signal
-    });
+    response = viaBinding ? await binding.fetch(url, init) : await fetch(url, init);
   } catch (err) {
     if (err?.name === 'AbortError') {
-      throw new Error(`Relay admin call timed out after ${RELAY_ADMIN_TIMEOUT_MS / 1000}s (${url})`);
+      const transport = viaBinding ? ', via service binding' : '';
+      throw new Error(`Relay admin call timed out after ${RELAY_ADMIN_TIMEOUT_MS / 1000}s (${url}${transport})`);
     }
     throw err;
   } finally {
     clearTimeout(timeoutId);
   }
 
-  // Detect Cloudflare Access bouncing the request to the login page.
-  // The relay-admin API host is behind CF Access; without a valid service token,
-  // any call returns a 302 to <team>.cloudflareaccess.com. Surface a self-
-  // documenting error instead of a generic "HTTP 302".
-  if (response.status === 302) {
+  // Detect Cloudflare Access bouncing the request to the login page. Only the
+  // public-edge fallback goes through Access; the service binding skips it, so
+  // this check is irrelevant there. Without a valid service token the host
+  // returns a 302 to <team>.cloudflareaccess.com. Surface a self-documenting
+  // error instead of a generic "HTTP 302".
+  if (!viaBinding && response.status === 302) {
     const location = response.headers.get('location') || '';
     if (/cloudflareaccess\.com/i.test(location)) {
-      const hint = hasCfAccessSecrets
+      const hint = (env.CF_ACCESS_CLIENT_ID && env.CF_ACCESS_CLIENT_SECRET)
         ? 'service token may be invalid, expired, or not authorized for this Access application'
         : 'CF_ACCESS_CLIENT_ID/CF_ACCESS_CLIENT_SECRET secrets are not set on this worker';
       throw new Error(`Relay admin call blocked by Cloudflare Access (${hint}). See project memory cf_access_relay_admin_secrets.md.`);

--- a/src/uploader-enforcement.test.mjs
+++ b/src/uploader-enforcement.test.mjs
@@ -207,6 +207,57 @@ describe('admin uploader enforcement routes', () => {
     }
   });
 
+  it('routes relay bans through the RELAY_ADMIN service binding with X-Admin-Key when configured', async () => {
+    const originalFetch = globalThis.fetch;
+    // Prove the public-edge fetch is NOT used when the binding is present.
+    globalThis.fetch = async () => {
+      throw new Error('public-edge fetch should not be called when RELAY_ADMIN binding is configured');
+    };
+    const bindingCalls = [];
+    const RELAY_ADMIN = {
+      fetch: async (input, init) => {
+        bindingCalls.push({ input: String(input), init });
+        return new Response(JSON.stringify({ success: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }
+    };
+
+    try {
+      const db = createDbMock();
+      const response = await worker.fetch(
+        new Request(`https://moderation.admin.divine.video/admin/api/uploader/${PUBKEY}/enforcement`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Cf-Access-Authenticated-User-Email': 'mod@divine.video'
+          },
+          body: JSON.stringify({ relayBanned: true, reason: 'Escalated by trust and safety' })
+        }),
+        createEnv({
+          BLOSSOM_DB: db,
+          RELAY_ADMIN,
+          RELAY_ADMIN_API_KEY: 'super-secret-admin-key',
+          // CF Access secrets intentionally omitted: the binding path must not need them.
+          RELAY_ADMIN_URL: 'https://relay.admin.divine.video'
+        })
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toMatchObject({ success: true, pubkey: PUBKEY });
+      expect(bindingCalls).toHaveLength(1);
+      expect(bindingCalls[0].input).toBe('https://relay.admin.divine.video/api/relay-rpc');
+      expect(bindingCalls[0].init.headers['X-Admin-Key']).toBe('super-secret-admin-key');
+      expect(bindingCalls[0].init.headers['CF-Access-Client-Id']).toBeUndefined();
+      const banBody = JSON.parse(bindingCalls[0].init.body);
+      expect(banBody.method).toBe('banpubkey');
+      expect(banBody.params[0]).toBe(PUBKEY);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it('removes the relay ban via unbanpubkey when relayBanned is cleared', async () => {
     const originalFetch = globalThis.fetch;
     const fetchCalls = [];

--- a/src/uploader-enforcement.test.mjs
+++ b/src/uploader-enforcement.test.mjs
@@ -207,7 +207,7 @@ describe('admin uploader enforcement routes', () => {
     }
   });
 
-  it('routes relay bans through the RELAY_ADMIN service binding with X-Admin-Key when configured', async () => {
+  it('routes relay bans through the RELAY_ADMIN service binding with X-Admin-Key resolved from a Secrets Store binding', async () => {
     const originalFetch = globalThis.fetch;
     // Prove the public-edge fetch is NOT used when the binding is present.
     globalThis.fetch = async () => {
@@ -238,7 +238,8 @@ describe('admin uploader enforcement routes', () => {
         createEnv({
           BLOSSOM_DB: db,
           RELAY_ADMIN,
-          RELAY_ADMIN_API_KEY: 'super-secret-admin-key',
+          // Secrets Store binding shape (async .get()), as in prod.
+          RELAY_ADMIN_API_KEY: { get: async () => 'super-secret-admin-key' },
           // CF Access secrets intentionally omitted: the binding path must not need them.
           RELAY_ADMIN_URL: 'https://relay.admin.divine.video'
         })
@@ -253,6 +254,49 @@ describe('admin uploader enforcement routes', () => {
       const banBody = JSON.parse(bindingCalls[0].init.body);
       expect(banBody.method).toBe('banpubkey');
       expect(banBody.params[0]).toBe(PUBKEY);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('accepts a plain-string RELAY_ADMIN_API_KEY for the binding path (local dev / fallback)', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () => {
+      throw new Error('public-edge fetch should not be called when RELAY_ADMIN binding is configured');
+    };
+    const bindingCalls = [];
+    const RELAY_ADMIN = {
+      fetch: async (input, init) => {
+        bindingCalls.push({ input: String(input), init });
+        return new Response(JSON.stringify({ success: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }
+    };
+
+    try {
+      const db = createDbMock();
+      const response = await worker.fetch(
+        new Request(`https://moderation.admin.divine.video/admin/api/uploader/${PUBKEY}/enforcement`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Cf-Access-Authenticated-User-Email': 'mod@divine.video'
+          },
+          body: JSON.stringify({ relayBanned: true, reason: 'Escalated by trust and safety' })
+        }),
+        createEnv({
+          BLOSSOM_DB: db,
+          RELAY_ADMIN,
+          RELAY_ADMIN_API_KEY: 'plain-string-key',
+          RELAY_ADMIN_URL: 'https://relay.admin.divine.video'
+        })
+      );
+
+      expect(response.status).toBe(200);
+      expect(bindingCalls).toHaveLength(1);
+      expect(bindingCalls[0].init.headers['X-Admin-Key']).toBe('plain-string-key');
     } finally {
       globalThis.fetch = originalFetch;
     }
@@ -336,6 +380,45 @@ describe('admin uploader enforcement routes', () => {
       expect(response.status).toBe(502);
       const body = await response.json();
       expect(String(body.error || '')).toMatch(/timed out/i);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('fails fast with a timeout error when the relay-admin SERVICE BINDING call aborts', async () => {
+    const originalFetch = globalThis.fetch;
+    // The binding path must not touch the public-edge fetch.
+    globalThis.fetch = async () => {
+      throw new Error('public-edge fetch should not be called when RELAY_ADMIN binding is configured');
+    };
+    const RELAY_ADMIN = {
+      fetch: async () => {
+        throw Object.assign(new Error('The operation was aborted'), { name: 'AbortError' });
+      }
+    };
+
+    try {
+      const response = await worker.fetch(
+        new Request(`https://moderation.admin.divine.video/admin/api/uploader/${PUBKEY}/enforcement`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Cf-Access-Authenticated-User-Email': 'mod@divine.video'
+          },
+          body: JSON.stringify({ relayBanned: true, reason: 'Escalated by trust and safety' })
+        }),
+        createEnv({
+          BLOSSOM_DB: createDbMock(),
+          RELAY_ADMIN,
+          RELAY_ADMIN_API_KEY: { get: async () => 'super-secret-admin-key' },
+          RELAY_ADMIN_URL: 'https://relay.admin.divine.video'
+        })
+      );
+
+      expect(response.status).toBe(502);
+      const body = await response.json();
+      expect(String(body.error || '')).toMatch(/timed out/i);
+      expect(String(body.error || '')).toMatch(/via service binding/i);
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -25,6 +25,18 @@ export default defineWorkersConfig({
       workers: {
         singleWorker: true,
         wrangler: { configPath: './wrangler.toml' },
+        miniflare: {
+          // The RELAY_ADMIN service binding (divine-relay-admin-api-prod) is not
+          // available in the test sandbox; provide a stub so the Workers runtime
+          // can start. Tests that exercise the binding inject their own mock
+          // RELAY_ADMIN via the env passed to worker.fetch, which takes precedence.
+          serviceBindings: {
+            RELAY_ADMIN: () => new Response(JSON.stringify({ success: true }), {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' }
+            }),
+          },
+        },
       },
     },
     coverage: {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -45,12 +45,20 @@ max_retries = 3
 # edge and CF Access (the source of the deprecated /api/moderate 522 and the
 # per-card Ban User 502, issue #170) and avoids relay-admin cold starts. The
 # relay-admin worker authorizes server-to-server callers via the X-Admin-Key
-# header (divine-relay-manager worker/src/index.ts), so set RELAY_ADMIN_API_KEY
-# (secret) to relay-admin's ADMIN_API_KEY. When the binding is absent the code
-# falls back to the public-edge HTTPS + CF Access path.
+# header (divine-relay-manager worker/src/index.ts). When the binding is absent
+# the code falls back to the public-edge HTTPS + CF Access path.
 [[services]]
 binding = "RELAY_ADMIN"
 service = "divine-relay-admin-api-prod"
+
+# Shared X-Admin-Key sent on the RELAY_ADMIN binding calls. Secrets Store secret
+# (MODERATION_TO_RELAY_ADMIN_KEY), the same secret divine-relay-manager binds as
+# MOD_RELAY_ADMIN_KEY, so both sides reference one value (#170). Resolved in code
+# via .get(); a plain string is also accepted for local dev.
+[[secrets_store_secrets]]
+binding = "RELAY_ADMIN_API_KEY"
+store_id = "ef490704b12a4feb91c7feb51229c364"
+secret_name = "MODERATION_TO_RELAY_ADMIN_KEY"
 
 # Environment variables
 [vars]
@@ -180,9 +188,8 @@ crons = ["* * * * *", "*/5 * * * *"]
 # (divine-relay-admin-api-prod worker, has NOSTR_NSEC binding). Override to
 # api-relay-staging.divine.video or relay.admin.divine.video only when needed.
 # Only used for the public-edge fallback; the RELAY_ADMIN service binding is preferred.
-# RELAY_ADMIN_API_KEY - shared admin key for the RELAY_ADMIN service binding; must equal
-# the relay-admin worker's ADMIN_API_KEY. Sent as the X-Admin-Key header so the call
-# authenticates without CF Access. Required when the RELAY_ADMIN binding is configured.
+# RELAY_ADMIN_API_KEY is NOT a per-worker secret — it is the Secrets Store binding
+# defined above (secret MODERATION_TO_RELAY_ADMIN_KEY), sent as the X-Admin-Key header.
 # REALITY_DEFENDER_API_KEY - Reality Defender API key for secondary AI verification (api.prd.realitydefender.xyz)
 # ADMIN_PASSWORD_HASH - SHA-256 hash of admin dashboard password
 # ATPROTO_LABELER_WEBHOOK_URL - URL of the divine-labeler webhook endpoint (https://labels.divine.video/webhook/moderation-result)

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -55,6 +55,11 @@ service = "divine-relay-admin-api-prod"
 # (MODERATION_TO_RELAY_ADMIN_KEY), the same secret divine-relay-manager binds as
 # MOD_RELAY_ADMIN_KEY, so both sides reference one value (#170). Resolved in code
 # via .get(); a plain string is also accepted for local dev.
+#
+# DEPLOY NOTE: binding a Secrets Store secret requires the deploy token
+# (CLOUDFLARE_API_TOKEN in CI) to have account "Secrets Store: Write" (Edit)
+# permission, not just Read — otherwise wrangler deploy fails with code 10021.
+# The CI token is the account token "divine-moderation-service-ci-deploy".
 [[secrets_store_secrets]]
 binding = "RELAY_ADMIN_API_KEY"
 store_id = "ef490704b12a4feb91c7feb51229c364"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -40,6 +40,18 @@ max_batch_size = 10
 max_batch_timeout = 30
 max_retries = 3
 
+# Service binding to the relay-admin worker (divine-relay-admin-api-prod) for
+# ban/unban/delete-event RPCs. Worker-to-worker, so it bypasses the public CF
+# edge and CF Access (the source of the deprecated /api/moderate 522 and the
+# per-card Ban User 502, issue #170) and avoids relay-admin cold starts. The
+# relay-admin worker authorizes server-to-server callers via the X-Admin-Key
+# header (divine-relay-manager worker/src/index.ts), so set RELAY_ADMIN_API_KEY
+# (secret) to relay-admin's ADMIN_API_KEY. When the binding is absent the code
+# falls back to the public-edge HTTPS + CF Access path.
+[[services]]
+binding = "RELAY_ADMIN"
+service = "divine-relay-admin-api-prod"
+
 # Environment variables
 [vars]
 MODERATION_ENABLED = "true"
@@ -167,6 +179,10 @@ crons = ["* * * * *", "*/5 * * * *"]
 # RELAY_ADMIN_URL - relay-admin API host. Default in src/index.mjs is api-relay-prod.divine.video
 # (divine-relay-admin-api-prod worker, has NOSTR_NSEC binding). Override to
 # api-relay-staging.divine.video or relay.admin.divine.video only when needed.
+# Only used for the public-edge fallback; the RELAY_ADMIN service binding is preferred.
+# RELAY_ADMIN_API_KEY - shared admin key for the RELAY_ADMIN service binding; must equal
+# the relay-admin worker's ADMIN_API_KEY. Sent as the X-Admin-Key header so the call
+# authenticates without CF Access. Required when the RELAY_ADMIN binding is configured.
 # REALITY_DEFENDER_API_KEY - Reality Defender API key for secondary AI verification (api.prd.realitydefender.xyz)
 # ADMIN_PASSWORD_HASH - SHA-256 hash of admin dashboard password
 # ATPROTO_LABELER_WEBHOOK_URL - URL of the divine-labeler webhook endpoint (https://labels.divine.video/webhook/moderation-result)


### PR DESCRIPTION
## Why

The per-card **Ban User** action calls the relay-admin worker's `/api/relay-rpc` over the public host `api-relay-prod.divine.video`, which returns **HTTP 522** (the CF edge can't reach the worker — reproduced live: toast `Relay admin error: HTTP 522`, log `[ENFORCE] Relay admin action failed: ... HTTP 522`). #156 did not resolve this; same edge-routing class as the old `/api/moderate` 522.

## What

Prefer a Cloudflare **service binding** (`RELAY_ADMIN` -> `divine-relay-admin-api-prod`) that invokes the worker by name — no edge, no DNS, no CF Access — authenticating with an `X-Admin-Key` header.

- The key is a **shared Cloudflare Secrets Store secret** (`MODERATION_TO_RELAY_ADMIN_KEY`, store `ef490704…`), bound here as `RELAY_ADMIN_API_KEY` and on the relay side as `MOD_RELAY_ADMIN_KEY` — one value, no duplication. Resolved in code via `.get()` (a plain string is also accepted for local dev).
- Falls back to the existing public-edge HTTPS + CF Access path when the binding is absent. The 15s fail-fast timeout and the failure behavior (caught -> HTTP 502 with the relay error, no enforcement persisted) are unchanged.

The relay-manager side that accepts this key: **divinevideo/divine-relay-manager#104** (must land + deploy first).

## Verified

- Reproduced the 522 live, then confirmed the fix targets the right layer (the 522 is the edge, not the relay worker — `handleRelayRpc` only ever returns 200/400).
- Independent code review: addressed (added binding-path timeout coverage); no outstanding issues.
- Lint clean; full suite **1311 tests pass**, including Secrets Store `.get()`, plain-string, binding-vs-fallback, and binding-timeout coverage.

## Deploy preconditions / order

1. `divine-relay-manager#104` deployed (so the relay worker accepts the key).
2. moderation-service's CI deploy token needs **Secrets Store read** to bind the secret (this worker has never used the store before — verify before merge).
3. Then merge this (CI auto-deploys to prod). Verify with a throwaway ban -> success.

## Follow-up once proven (scoped, not in this PR)

After the binding is proven in prod, a follow-up can collapse `callRelayAdminAction` to binding-only and delete the now-dead `getRelayAdminHeaders`. Note: the CF Access secrets themselves stay (also used by `src/nostr/publisher.mjs`), and relay-manager's `ADMIN_API_KEY` / CF Access stay (other callers + the admin UI). Keeping the fallback as a documented break-glass path is also a reasonable choice for a moderation-critical action.

Relates to #170.
