### PR TITLE
feat(dm): publish moderation@ kind-10050 DM inbox relay list

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -7,7 +7,7 @@
 import { validateQueueMessage } from './schemas/queue-message.mjs';
 import { moderateVideo, classifyVideoOnly } from './moderation/pipeline.mjs';
 import { applyForceProvider, shouldQueueHiveRecheck } from './moderation/report-trigger.mjs';
-import { publishToFaro, publishToContentRelay, publishLabelEvent } from './nostr/publisher.mjs';
+import { publishToFaro, publishToContentRelay, publishLabelEvent, publishDmInboxRelayList } from './nostr/publisher.mjs';
 import { requireAuth, getAuthenticatedUser } from './admin/auth.mjs';
 import { verifyZeroTrustJWT } from './admin/zerotrust.mjs';
 import { getConfiguredBearerTokens, authenticateApiRequest, apiUnauthorizedResponse, authSourceFromVerification, verifyLegacyBearerAuth } from './auth-api.mjs';
@@ -5053,6 +5053,36 @@ async function runMigration() {
           console.log(`[CRON] DM inbox sync: ${syncResult.synced} new, ${syncResult.skipped} deduped, ${syncResult.errors} errors`);
         } catch (err) {
           console.error('[CRON] DM inbox sync failed:', err);
+        }
+      }
+
+      // Republish moderation@'s NIP-17 DM inbox relay list (kind 10050) ~daily so the
+      // account is reachable over standard NIP-17. Flag-gated so it can ship dormant
+      // until the relay accepts kind 10050 (divine-funnelcake#536); KV-throttled to
+      // avoid republishing this static record every cron tick.
+      if (env.DM_INBOX_PUBLISH_ENABLED === 'true') {
+        try {
+          const lastStr = env.MODERATION_KV
+            ? await env.MODERATION_KV.get('dm-inbox-relay-list:last-published')
+            : null;
+          const last = lastStr ? parseInt(lastStr, 10) : 0;
+          const dayMs = 24 * 60 * 60 * 1000;
+          if (Date.now() - last >= dayMs) {
+            const result = await publishDmInboxRelayList(env);
+            if (result.published) {
+              console.log(`[DM-INBOX] kind 10050 published to ${result.relays.length} relay(s); home relay ${result.homeRelayPublished ? 'accepted' : 'NOT yet (will retry next cron)'}${result.failed?.length ? `, ${result.failed.length} failed` : ''}`);
+              // Only throttle once the home relay (the sole inbox tag, and where we actually read
+              // DMs) accepted it. Discovery-relay success alone must not stop us retrying the relay
+              // that matters — e.g. before divine-funnelcake#536 the home relay rejects kind 10050.
+              if (result.homeRelayPublished && env.MODERATION_KV) {
+                await env.MODERATION_KV.put('dm-inbox-relay-list:last-published', String(Date.now()));
+              }
+            } else {
+              console.log(`[DM-INBOX] Publish skipped/failed: ${result.reason || 'all relays failed'}`);
+            }
+          }
+        } catch (error) {
+          console.error('[DM-INBOX] Republish error:', error.message);
         }
       }
 

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -5065,7 +5065,8 @@ async function runMigration() {
           const lastStr = env.MODERATION_KV
             ? await env.MODERATION_KV.get('dm-inbox-relay-list:last-published')
             : null;
-          const last = lastStr ? parseInt(lastStr, 10) : 0;
+          const parsedLast = lastStr ? parseInt(lastStr, 10) : 0;
+          const last = Number.isFinite(parsedLast) ? parsedLast : 0;
           const dayMs = 24 * 60 * 60 * 1000;
           if (Date.now() - last >= dayMs) {
             const result = await publishDmInboxRelayList(env);
@@ -5082,7 +5083,7 @@ async function runMigration() {
             }
           }
         } catch (error) {
-          console.error('[DM-INBOX] Republish error:', error.message);
+          console.error('[DM-INBOX] Republish error:', error?.message || String(error));
         }
       }
 

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -5,6 +5,19 @@
 // ABOUTME: Verifies public API exposure, admin isolation, and workers.dev disablement
 
 import { describe, expect, it, vi } from 'vitest';
+
+const publisherMocks = vi.hoisted(() => ({
+  publishDmInboxRelayList: vi.fn()
+}));
+
+vi.mock('./nostr/publisher.mjs', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    publishDmInboxRelayList: publisherMocks.publishDmInboxRelayList
+  };
+});
+
 import worker from './index.mjs';
 
 const SHA256 = 'a'.repeat(64);
@@ -552,6 +565,119 @@ describe('HTTP hostname routing', () => {
       action: 'PERMANENT_BAN',
       blocked: true
     });
+  });
+});
+
+describe('scheduled DM inbox relay list publish', () => {
+  function createDmInboxCronEnv({ flag = 'true', lastPublished = null } = {}) {
+    const kvStore = new Map();
+    if (lastPublished !== null) {
+      kvStore.set('dm-inbox-relay-list:last-published', lastPublished);
+    }
+    const puts = [];
+    const env = createEnv({
+      DM_INBOX_PUBLISH_ENABLED: flag,
+      RELAY_POLLING_ENABLED: 'false',
+      MODERATION_KV: {
+        store: kvStore,
+        async get(key) { return kvStore.get(key) ?? null; },
+        async put(key, value) {
+          puts.push({ key, value });
+          kvStore.set(key, value);
+        },
+        async delete(key) { kvStore.delete(key); },
+        async list() { return { keys: [], list_complete: true, cursor: null }; }
+      }
+    });
+    return { env, kvStore, puts };
+  }
+
+  it('does not publish when the feature flag is off', async () => {
+    publisherMocks.publishDmInboxRelayList.mockReset();
+    const { env, puts } = createDmInboxCronEnv({ flag: 'false' });
+
+    await worker.scheduled(
+      { cron: '*/5 * * * *', scheduledTime: Date.now() },
+      env,
+      { waitUntil: () => {} }
+    );
+
+    expect(publisherMocks.publishDmInboxRelayList).not.toHaveBeenCalled();
+    expect(puts).toHaveLength(0);
+  });
+
+  it('advances the throttle when the home relay accepts', async () => {
+    publisherMocks.publishDmInboxRelayList.mockReset();
+    publisherMocks.publishDmInboxRelayList.mockResolvedValue({
+      published: true,
+      homeRelayPublished: true,
+      relays: ['wss://relay.divine.video'],
+      failed: []
+    });
+    const { env, kvStore } = createDmInboxCronEnv();
+
+    await worker.scheduled(
+      { cron: '*/5 * * * *', scheduledTime: Date.now() },
+      env,
+      { waitUntil: () => {} }
+    );
+
+    expect(publisherMocks.publishDmInboxRelayList).toHaveBeenCalledWith(env);
+    expect(Number(kvStore.get('dm-inbox-relay-list:last-published'))).toBeGreaterThan(0);
+  });
+
+  it('does not publish again before the daily throttle expires', async () => {
+    publisherMocks.publishDmInboxRelayList.mockReset();
+    const { env, kvStore } = createDmInboxCronEnv({ lastPublished: String(Date.now()) });
+
+    await worker.scheduled(
+      { cron: '*/5 * * * *', scheduledTime: Date.now() },
+      env,
+      { waitUntil: () => {} }
+    );
+
+    expect(publisherMocks.publishDmInboxRelayList).not.toHaveBeenCalled();
+    expect(kvStore.get('dm-inbox-relay-list:last-published')).toEqual(expect.any(String));
+  });
+
+  it('does not advance the throttle when only discovery relays accept', async () => {
+    publisherMocks.publishDmInboxRelayList.mockReset();
+    publisherMocks.publishDmInboxRelayList.mockResolvedValue({
+      published: true,
+      homeRelayPublished: false,
+      relays: ['wss://purplepag.es'],
+      failed: [{ relay: 'wss://relay.divine.video', reason: 'kind 10050 not in allowed_kinds' }]
+    });
+    const { env, kvStore } = createDmInboxCronEnv();
+
+    await worker.scheduled(
+      { cron: '*/5 * * * *', scheduledTime: Date.now() },
+      env,
+      { waitUntil: () => {} }
+    );
+
+    expect(publisherMocks.publishDmInboxRelayList).toHaveBeenCalledWith(env);
+    expect(kvStore.has('dm-inbox-relay-list:last-published')).toBe(false);
+  });
+
+  it('treats a corrupt throttle timestamp as due instead of getting stuck', async () => {
+    publisherMocks.publishDmInboxRelayList.mockReset();
+    publisherMocks.publishDmInboxRelayList.mockResolvedValue({
+      published: true,
+      homeRelayPublished: true,
+      relays: ['wss://relay.divine.video'],
+      failed: []
+    });
+    const { env, kvStore } = createDmInboxCronEnv({ lastPublished: 'not-a-number' });
+
+    await worker.scheduled(
+      { cron: '*/5 * * * *', scheduledTime: Date.now() },
+      env,
+      { waitUntil: () => {} }
+    );
+
+    expect(publisherMocks.publishDmInboxRelayList).toHaveBeenCalledWith(env);
+    expect(Number(kvStore.get('dm-inbox-relay-list:last-published'))).toBeGreaterThan(0);
   });
 });
 

--- a/src/nostr/publisher.mjs
+++ b/src/nostr/publisher.mjs
@@ -336,3 +336,98 @@ function createLabelEvent(labelData, privateKeyHex) {
 
   return signedEvent;
 }
+
+/**
+ * Build a signed NIP-17 kind 10050 DM inbox relay list event.
+ *
+ * The `relay` tags advertise where this pubkey receives gift-wrapped (kind 1059)
+ * DMs. They must match where we actually read from (see dm-reader), or senders
+ * will deliver to relays we don't listen on.
+ *
+ * @param {string[]} inboxRelays - Relay URLs where moderation@ receives DMs.
+ * @param {string} privateKeyHex - Signing key (hex).
+ * @returns {Object} Signed kind-10050 event.
+ */
+function createDmInboxRelayListEvent(inboxRelays, privateKeyHex) {
+  const tags = inboxRelays.map((url) => ['relay', url]);
+
+  const unsignedEvent = {
+    kind: 10050,  // NIP-17 DM inbox relay list
+    created_at: Math.floor(Date.now() / 1000),
+    tags,
+    content: ''
+  };
+
+  const secretKey = hexToBytes(privateKeyHex);
+  return finalizeEvent(unsignedEvent, secretKey);
+}
+
+/**
+ * Publish moderation@'s NIP-17 kind 10050 DM inbox relay list.
+ *
+ * Without this, the moderation account has no advertised DM inbox, so a strict
+ * NIP-17 client "shouldn't try" to message it. The `relay` tags point only at
+ * the relay we actually poll for DMs; we additionally push the event to public
+ * aggregators so clients can discover it. Replaceable (kind 10050), so this is
+ * idempotent and safe to republish.
+ *
+ * @param {Object} env - Worker environment (NOSTR_PRIVATE_KEY, relay config).
+ * @param {Object} [mockRelay] - Mock relay for testing.
+ * @returns {Promise<Object>} Publish summary.
+ */
+export async function publishDmInboxRelayList(env, mockRelay = null) {
+  if (!env.NOSTR_PRIVATE_KEY) {
+    console.log('[DM-INBOX] No NOSTR_PRIVATE_KEY configured, skipping DM inbox publish');
+    return { published: false, reason: 'No signing key configured' };
+  }
+
+  // Inbox = where dm-reader actually polls for gift-wrapped DMs. Keep in sync with it.
+  const homeRelay = env.RELAY_POLLING_RELAY_URL || 'wss://relay.divine.video';
+  const inboxRelays = [homeRelay];
+
+  // Discovery targets: where we publish the event so clients can resolve it.
+  const discoveryRelays = env.DM_INBOX_DISCOVERY_RELAYS
+    ? env.DM_INBOX_DISCOVERY_RELAYS.split(',').map((r) => r.trim()).filter(Boolean)
+    : ['wss://purplepag.es', 'wss://relay.nostr.band', 'wss://relay.damus.io'];
+  const targets = [...new Set([homeRelay, ...discoveryRelays])];
+
+  const event = createDmInboxRelayListEvent(inboxRelays, env.NOSTR_PRIVATE_KEY);
+  console.log(`[DM-INBOX] Publishing kind 10050 ${event.id} (inbox: ${inboxRelays.join(', ')}) to ${targets.length} relays`);
+
+  if (mockRelay) {
+    await mockRelay.publish(event);
+    return { published: true, homeRelayPublished: true, eventId: event.id, pubkey: event.pubkey, relays: targets, failed: [] };
+  }
+
+  const published = [];
+  const failed = [];
+  for (const url of targets) {
+    try {
+      // relay.divine.video is a public Nostr relay that does not require CF Access for
+      // protocol traffic (matches the read path in dm-reader.mjs), and CF Access creds
+      // must never be sent to third-party discovery relays — so we send no headers here.
+      const relay = await Relay.connect(url);
+      try {
+        await relay.publish(event);
+        console.log(`[DM-INBOX] Published kind 10050 ${event.id} to ${url}`);
+        published.push(url);
+      } finally {
+        relay.close();
+      }
+    } catch (error) {
+      console.error(`[DM-INBOX] Failed to publish to ${url}:`, error.message);
+      failed.push({ relay: url, reason: error.message });
+    }
+  }
+
+  return {
+    published: published.length > 0,
+    // The home relay is the only inbox tag and where we actually read DMs, so callers
+    // throttle on this rather than on best-effort discovery-relay success.
+    homeRelayPublished: published.includes(homeRelay),
+    eventId: event.id,
+    pubkey: event.pubkey,
+    relays: published,
+    failed
+  };
+}

--- a/src/nostr/publisher.mjs
+++ b/src/nostr/publisher.mjs
@@ -372,7 +372,6 @@ function createDmInboxRelayListEvent(inboxRelays, privateKeyHex) {
  * idempotent and safe to republish.
  *
  * @param {Object} env - Worker environment (NOSTR_PRIVATE_KEY, relay config).
- * @param {Object} [mockRelay] - Mock relay for testing the single-publish short-circuit.
  * @param {Object} [opts] - Test seams.
  * @param {(url: string) => Promise<{publish: Function, close: Function}>} [opts.connect]
  *   - Relay connector for the multi-relay path; defaults to the real transport.
@@ -381,7 +380,7 @@ function createDmInboxRelayListEvent(inboxRelays, privateKeyHex) {
  *     module-level mock of the transport does not reliably isolate).
  * @returns {Promise<Object>} Publish summary.
  */
-export async function publishDmInboxRelayList(env, mockRelay = null, { connect = Relay.connect } = {}) {
+export async function publishDmInboxRelayList(env, { connect = Relay.connect } = {}) {
   if (!env.NOSTR_PRIVATE_KEY) {
     console.log('[DM-INBOX] No NOSTR_PRIVATE_KEY configured, skipping DM inbox publish');
     return { published: false, reason: 'No signing key configured' };
@@ -400,11 +399,6 @@ export async function publishDmInboxRelayList(env, mockRelay = null, { connect =
   const event = createDmInboxRelayListEvent(inboxRelays, env.NOSTR_PRIVATE_KEY);
   console.log(`[DM-INBOX] Publishing kind 10050 ${event.id} (inbox: ${inboxRelays.join(', ')}) to ${targets.length} relays`);
 
-  if (mockRelay) {
-    await mockRelay.publish(event);
-    return { published: true, homeRelayPublished: true, eventId: event.id, pubkey: event.pubkey, relays: targets, failed: [] };
-  }
-
   const published = [];
   const failed = [];
   for (const url of targets) {
@@ -421,8 +415,9 @@ export async function publishDmInboxRelayList(env, mockRelay = null, { connect =
         relay.close();
       }
     } catch (error) {
-      console.error(`[DM-INBOX] Failed to publish to ${url}:`, error.message);
-      failed.push({ relay: url, reason: error.message });
+      const reason = error?.message || String(error);
+      console.error(`[DM-INBOX] Failed to publish to ${url}:`, reason);
+      failed.push({ relay: url, reason });
     }
   }
 

--- a/src/nostr/publisher.mjs
+++ b/src/nostr/publisher.mjs
@@ -372,10 +372,16 @@ function createDmInboxRelayListEvent(inboxRelays, privateKeyHex) {
  * idempotent and safe to republish.
  *
  * @param {Object} env - Worker environment (NOSTR_PRIVATE_KEY, relay config).
- * @param {Object} [mockRelay] - Mock relay for testing.
+ * @param {Object} [mockRelay] - Mock relay for testing the single-publish short-circuit.
+ * @param {Object} [opts] - Test seams.
+ * @param {(url: string) => Promise<{publish: Function, close: Function}>} [opts.connect]
+ *   - Relay connector for the multi-relay path; defaults to the real transport.
+ *     Injected in tests so the per-relay success/failure branches are deterministic
+ *     and never touch the network (the pool runs all files in one worker, so a
+ *     module-level mock of the transport does not reliably isolate).
  * @returns {Promise<Object>} Publish summary.
  */
-export async function publishDmInboxRelayList(env, mockRelay = null) {
+export async function publishDmInboxRelayList(env, mockRelay = null, { connect = Relay.connect } = {}) {
   if (!env.NOSTR_PRIVATE_KEY) {
     console.log('[DM-INBOX] No NOSTR_PRIVATE_KEY configured, skipping DM inbox publish');
     return { published: false, reason: 'No signing key configured' };
@@ -406,7 +412,7 @@ export async function publishDmInboxRelayList(env, mockRelay = null) {
       // relay.divine.video is a public Nostr relay that does not require CF Access for
       // protocol traffic (matches the read path in dm-reader.mjs), and CF Access creds
       // must never be sent to third-party discovery relays — so we send no headers here.
-      const relay = await Relay.connect(url);
+      const relay = await connect(url);
       try {
         await relay.publish(event);
         console.log(`[DM-INBOX] Published kind 10050 ${event.id} to ${url}`);

--- a/src/nostr/publisher.test.mjs
+++ b/src/nostr/publisher.test.mjs
@@ -5,7 +5,13 @@
 // ABOUTME: Verifies NIP-56 (kind 1984) reporting events are created correctly
 
 import { describe, it, expect, vi } from 'vitest';
-import { publishToFaro, publishLabelEvent } from './publisher.mjs';
+import { publishToFaro, publishLabelEvent, publishDmInboxRelayList } from './publisher.mjs';
+import { Relay } from 'nostr-tools/relay';
+
+// Mock the relay transport so the real (non-mockRelay) publish path can be exercised.
+// The other tests pass an explicit mockRelay and never reach Relay.connect, so this only
+// affects the throttle-branch test below.
+vi.mock('nostr-tools/relay', () => ({ Relay: { connect: vi.fn() } }));
 
 describe('Nostr Event Publisher', () => {
   it('should create a kind 1984 report event for QUARANTINE', async () => {
@@ -335,5 +341,77 @@ describe('publishLabelEvent (automated source)', () => {
     const metadata = JSON.parse(labelTag[3]);
     expect(metadata.source).toBe('automated');
     expect(metadata.rejected).toBe(true);
+  });
+});
+
+describe('DM inbox relay list (kind 10050)', () => {
+  it('publishes a signed kind-10050 listing only the home relay as inbox', async () => {
+    const mockRelay = { publish: vi.fn().mockResolvedValue(undefined) };
+    const env = {
+      NOSTR_PRIVATE_KEY: 'a'.repeat(64),
+      RELAY_POLLING_RELAY_URL: 'wss://relay.divine.video'
+    };
+
+    const result = await publishDmInboxRelayList(env, mockRelay);
+
+    expect(mockRelay.publish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 10050,
+        content: '',
+        tags: [['relay', 'wss://relay.divine.video']]
+      })
+    );
+
+    const event = mockRelay.publish.mock.calls[0][0];
+    expect(event.id).toEqual(expect.any(String));
+    expect(event.sig).toEqual(expect.any(String));
+    expect(event.pubkey).toEqual(expect.any(String));
+    expect(result.published).toBe(true);
+    expect(result.homeRelayPublished).toBe(true);
+  });
+
+  it('never lists discovery relays as inbox tags', async () => {
+    const mockRelay = { publish: vi.fn().mockResolvedValue(undefined) };
+    const env = {
+      NOSTR_PRIVATE_KEY: 'a'.repeat(64),
+      RELAY_POLLING_RELAY_URL: 'wss://relay.divine.video',
+      DM_INBOX_DISCOVERY_RELAYS: 'wss://purplepag.es,wss://relay.nostr.band'
+    };
+
+    await publishDmInboxRelayList(env, mockRelay);
+
+    const event = mockRelay.publish.mock.calls[0][0];
+    const inboxRelays = event.tags.filter((t) => t[0] === 'relay').map((t) => t[1]);
+    expect(inboxRelays).toEqual(['wss://relay.divine.video']);
+  });
+
+  it('returns {published:false} when no signing key is configured', async () => {
+    const result = await publishDmInboxRelayList({}, null);
+    expect(result.published).toBe(false);
+  });
+
+  it('does not advance the throttle when the home relay rejects but discovery succeeds', async () => {
+    // Real publish path (no mockRelay): home relay rejects (the pre-#536 state), discovery accepts.
+    Relay.connect.mockImplementation((url) => Promise.resolve({
+      publish: url === 'wss://relay.divine.video'
+        ? vi.fn().mockRejectedValue(new Error('kind 10050 not in allowed_kinds'))
+        : vi.fn().mockResolvedValue(undefined),
+      close: vi.fn()
+    }));
+
+    const env = {
+      NOSTR_PRIVATE_KEY: 'a'.repeat(64),
+      RELAY_POLLING_RELAY_URL: 'wss://relay.divine.video',
+      DM_INBOX_DISCOVERY_RELAYS: 'wss://purplepag.es'
+    };
+
+    const result = await publishDmInboxRelayList(env);
+
+    // published is true (discovery succeeded) but homeRelayPublished is false, so the caller
+    // must keep retrying the home relay rather than throttling for 24h.
+    expect(result.published).toBe(true);
+    expect(result.homeRelayPublished).toBe(false);
+    expect(result.relays).toEqual(['wss://purplepag.es']);
+    expect(result.failed.map((f) => f.relay)).toContain('wss://relay.divine.video');
   });
 });

--- a/src/nostr/publisher.test.mjs
+++ b/src/nostr/publisher.test.mjs
@@ -339,16 +339,29 @@ describe('publishLabelEvent (automated source)', () => {
 });
 
 describe('DM inbox relay list (kind 10050)', () => {
+  function createConnect() {
+    const publishes = new Map();
+    const connect = vi.fn(async (url) => {
+      const publish = vi.fn().mockResolvedValue(undefined);
+      const close = vi.fn();
+      publishes.set(url, publish);
+      return { publish, close };
+    });
+    return { connect, publishes };
+  }
+
   it('publishes a signed kind-10050 listing only the home relay as inbox', async () => {
-    const mockRelay = { publish: vi.fn().mockResolvedValue(undefined) };
+    const { connect, publishes } = createConnect();
     const env = {
       NOSTR_PRIVATE_KEY: 'a'.repeat(64),
-      RELAY_POLLING_RELAY_URL: 'wss://relay.divine.video'
+      RELAY_POLLING_RELAY_URL: 'wss://relay.divine.video',
+      DM_INBOX_DISCOVERY_RELAYS: 'wss://relay.divine.video'
     };
 
-    const result = await publishDmInboxRelayList(env, mockRelay);
+    const result = await publishDmInboxRelayList(env, { connect });
 
-    expect(mockRelay.publish).toHaveBeenCalledWith(
+    expect(connect).toHaveBeenCalledWith('wss://relay.divine.video');
+    expect(publishes.get('wss://relay.divine.video')).toHaveBeenCalledWith(
       expect.objectContaining({
         kind: 10050,
         content: '',
@@ -356,31 +369,33 @@ describe('DM inbox relay list (kind 10050)', () => {
       })
     );
 
-    const event = mockRelay.publish.mock.calls[0][0];
+    const event = publishes.get('wss://relay.divine.video').mock.calls[0][0];
     expect(event.id).toEqual(expect.any(String));
     expect(event.sig).toEqual(expect.any(String));
     expect(event.pubkey).toEqual(expect.any(String));
     expect(result.published).toBe(true);
     expect(result.homeRelayPublished).toBe(true);
+    expect(result.relays).toEqual(['wss://relay.divine.video']);
   });
 
   it('never lists discovery relays as inbox tags', async () => {
-    const mockRelay = { publish: vi.fn().mockResolvedValue(undefined) };
+    const { connect, publishes } = createConnect();
     const env = {
       NOSTR_PRIVATE_KEY: 'a'.repeat(64),
       RELAY_POLLING_RELAY_URL: 'wss://relay.divine.video',
       DM_INBOX_DISCOVERY_RELAYS: 'wss://purplepag.es,wss://relay.nostr.band'
     };
 
-    await publishDmInboxRelayList(env, mockRelay);
+    await publishDmInboxRelayList(env, { connect });
 
-    const event = mockRelay.publish.mock.calls[0][0];
+    expect(connect).toHaveBeenCalledTimes(3);
+    const event = publishes.get('wss://purplepag.es').mock.calls[0][0];
     const inboxRelays = event.tags.filter((t) => t[0] === 'relay').map((t) => t[1]);
     expect(inboxRelays).toEqual(['wss://relay.divine.video']);
   });
 
   it('returns {published:false} when no signing key is configured', async () => {
-    const result = await publishDmInboxRelayList({}, null);
+    const result = await publishDmInboxRelayList({});
     expect(result.published).toBe(false);
   });
 
@@ -403,7 +418,7 @@ describe('DM inbox relay list (kind 10050)', () => {
       DM_INBOX_DISCOVERY_RELAYS: 'wss://purplepag.es'
     };
 
-    const result = await publishDmInboxRelayList(env, null, { connect });
+    const result = await publishDmInboxRelayList(env, { connect });
 
     // published is true (discovery succeeded) but homeRelayPublished is false, so the caller
     // must keep retrying the home relay rather than throttling for 24h.

--- a/src/nostr/publisher.test.mjs
+++ b/src/nostr/publisher.test.mjs
@@ -6,12 +6,6 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { publishToFaro, publishLabelEvent, publishDmInboxRelayList } from './publisher.mjs';
-import { Relay } from 'nostr-tools/relay';
-
-// Mock the relay transport so the real (non-mockRelay) publish path can be exercised.
-// The other tests pass an explicit mockRelay and never reach Relay.connect, so this only
-// affects the throttle-branch test below.
-vi.mock('nostr-tools/relay', () => ({ Relay: { connect: vi.fn() } }));
 
 describe('Nostr Event Publisher', () => {
   it('should create a kind 1984 report event for QUARANTINE', async () => {
@@ -391,13 +385,17 @@ describe('DM inbox relay list (kind 10050)', () => {
   });
 
   it('does not advance the throttle when the home relay rejects but discovery succeeds', async () => {
-    // Real publish path (no mockRelay): home relay rejects (the pre-#536 state), discovery accepts.
-    Relay.connect.mockImplementation((url) => Promise.resolve({
+    // Multi-relay path: home relay rejects (the pre-#536 state), discovery accepts.
+    // Inject the connector so per-relay outcomes are deterministic and never hit the
+    // network. A module-level mock of the transport does not reliably isolate under the
+    // single-worker pool, which let this test fall through to the real network (green
+    // locally with egress, red in CI without it).
+    const connect = (url) => Promise.resolve({
       publish: url === 'wss://relay.divine.video'
         ? vi.fn().mockRejectedValue(new Error('kind 10050 not in allowed_kinds'))
         : vi.fn().mockResolvedValue(undefined),
       close: vi.fn()
-    }));
+    });
 
     const env = {
       NOSTR_PRIVATE_KEY: 'a'.repeat(64),
@@ -405,7 +403,7 @@ describe('DM inbox relay list (kind 10050)', () => {
       DM_INBOX_DISCOVERY_RELAYS: 'wss://purplepag.es'
     };
 
-    const result = await publishDmInboxRelayList(env);
+    const result = await publishDmInboxRelayList(env, null, { connect });
 
     // published is true (discovery succeeded) but homeRelayPublished is false, so the caller
     // must keep retrying the home relay rather than throttling for 24h.

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -169,6 +169,12 @@ BACKFILL_ROWS_PER_TICK = "200"
 
 # Creator-delete pipeline feature flag (default off; flip to "true" via `wrangler secret put` or [vars] once ready)
 CREATOR_DELETE_PIPELINE_ENABLED = "true"
+
+# moderation@ NIP-17 DM inbox relay list (kind 10050) publish. Ships dormant; flip
+# to "true" only AFTER divine-funnelcake#536 is live in prod so the relay accepts
+# kind 10050. Optional DM_INBOX_DISCOVERY_RELAYS overrides the default aggregator
+# list (purplepag.es, relay.nostr.band, relay.damus.io).
+DM_INBOX_PUBLISH_ENABLED = "false"
 # Relay used to fetch creator kind 5 delete events and target video events.
 CREATOR_DELETE_RELAY_URL = "wss://relay.divine.video"
 


### PR DESCRIPTION
## Summary

Publishes moderation@'s NIP-17 kind-10050 DM inbox relay list so strict NIP-17 clients can discover where to deliver gift-wrapped DMs for the moderation account.

Closes #174.

## Motivation

The moderation account already reads NIP-17 DMs from the configured home relay, but it did not advertise a kind-10050 DM inbox relay list. Per NIP-17, strict clients may refuse to DM a recipient without an advertised inbox relay list. This is the backend publish slice for the broader moderation DM work; it does not close the broader routing/bridge work in #169 or divinevideo/divine-mobile#4946.

## What Changed

- Added `publishDmInboxRelayList`, which signs a kind-10050 event with the existing `NOSTR_PRIVATE_KEY`.
- Advertises only `RELAY_POLLING_RELAY_URL` as the inbox relay, matching the relay the DM reader actually polls.
- Publishes the replaceable event to the home relay plus discovery relays for findability.
- Sends no Cloudflare Access credentials to relays, including third-party discovery relays.
- Added `DM_INBOX_PUBLISH_ENABLED`, defaulting to `"false"`, so this ships dormant.
- Added KV throttling so the static record publishes roughly daily only after the home relay accepts it.
- Cleaned up the publisher test seam so the tests exercise the real per-relay publish loop via injected `connect`.
- Added scheduled-handler coverage for flag gating, daily throttle, home-accept throttle advancement, home-reject retry behavior, and corrupt throttle timestamps.

## Sequencing / Operational Notes

Do not enable `DM_INBOX_PUBLISH_ENABLED="true"` until the production home relay accepts kind 10050. Before that, the home relay rejection is expected and the throttle intentionally does not advance.

No new required secrets or bindings are introduced. The implementation reuses `NOSTR_PRIVATE_KEY`, `RELAY_POLLING_RELAY_URL`, and `MODERATION_KV`.

## Validation

- `npm run lint`
- `npm test -- src/nostr/publisher.test.mjs src/index.test.mjs` (183 tests)
- `npm test` (74 files, 1320 tests)
