### PR TITLE
Age Review: correct the blossom action-to-state mapping comment

### DIFF
--- a/src/blossom-client.mjs
+++ b/src/blossom-client.mjs
@@ -8,7 +8,7 @@
 // Its /admin/moderate webhook handler maps actions to states:
 //   SAFE/APPROVE → Active, RESTRICT/QUARANTINE → Restricted (404 to everyone but
 //   the owner), AGE_RESTRICTED → AgeRestricted, PERMANENT_BAN → Banned, DELETE → Deleted.
-// IMPORTANT: AgeRestricted is an adult-GATE, not a withhold — it serves full bytes
+// IMPORTANT: AgeRestricted is an auth-gate, not a withhold — it serves full bytes
 // to ANY signed-in viewer (only anonymous requests get 401). To actually hide
 // content (e.g. age-review restriction) use QUARANTINE → Restricted, which is
 // reversible (back to Active via SAFE/APPROVE).

--- a/src/blossom-client.mjs
+++ b/src/blossom-client.mjs
@@ -4,10 +4,14 @@
 // ABOUTME: Shared Blossom admin client. Called from the moderator-action pipeline and the creator-delete pipeline.
 // ABOUTME: Maps internal action names to Blossom-understood actions and POSTs to BLOSSOM_WEBHOOK_URL with Bearer auth.
 
-// Blossom has five states (Active/Restricted/Pending/Banned/Deleted).
-// Its webhook handler accepts: SAFE→Active, AGE_RESTRICTED→Restricted,
-// PERMANENT_BAN→Banned, RESTRICT→Restricted, DELETE→Deleted.
-// QUARANTINE maps to RESTRICT (owner can view, public gets 404).
+// Blossom states: Active/Restricted/Pending/Banned/Deleted plus AgeRestricted.
+// Its /admin/moderate webhook handler maps actions to states:
+//   SAFE/APPROVE → Active, RESTRICT/QUARANTINE → Restricted (404 to everyone but
+//   the owner), AGE_RESTRICTED → AgeRestricted, PERMANENT_BAN → Banned, DELETE → Deleted.
+// IMPORTANT: AgeRestricted is an adult-GATE, not a withhold — it serves full bytes
+// to ANY signed-in viewer (only anonymous requests get 401). To actually hide
+// content (e.g. age-review restriction) use QUARANTINE → Restricted, which is
+// reversible (back to Active via SAFE/APPROVE).
 // REVIEW is internal only — content stays publicly accessible.
 const BLOSSOM_ACTION_MAP = {
   'SAFE': 'SAFE',


### PR DESCRIPTION
Relates to divinevideo/divine-relay-manager#110 and divinevideo/divine-relay-manager#117.

Documentation only. The comment claimed AGE_RESTRICTED maps to the withhold state; it
actually forwards AGE_RESTRICTED, which the media server maps to the age-gate state
(served to any signed-in viewer). Clarifies that the QUARANTINE -> RESTRICT path is the
reversible owner-only withhold. No code change.
