### PR TITLE
docs: rewrite README to reflect current state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,378 +1,124 @@
-# Divine Video Moderation Service
+# Divine Moderation Service
 
-Content moderation service for Divine 6-second videos using Sightengine API and Nostr-based human review workflow. It helps keep the feed human-made — detecting AI-generated content to uphold the "No slop. All human." policy.
+The Trust & Safety worker behind [Divine](https://divine.video). It runs the human-in-the-loop review pipeline for uploaded 6-second videos — ingesting reports, giving moderators a dashboard to triage them, and pushing decisions back out to the relay, CDN, and Nostr. Divine's promise is [no slop, all human](https://github.com/divinevideo/brand-guidelines), and this service is where a person makes the final call on borderline content.
+
+It is a single [Cloudflare Worker](https://developers.cloudflare.com/workers/) (`divine-moderation-service`) serving two custom domains:
+
+- `moderation-api.divine.video` — public and service-to-service API routes.
+- `moderation.admin.divine.video` — the moderator dashboard, behind Cloudflare Access.
+
+## How moderation works today
+
+The service runs in **reactive mode** (`REACTIVE_MODERATION_ONLY = "true"`). Rather than machine-scanning every upload, it acts on signals that something needs a human look:
+
+1. **Reports come in** — from authenticated Divine clients (`POST /api/v1/report`) and from public NIP-56 (kind `1984`) report events polled off `relay.divine.video`. Each report is written to D1 as a review row.
+2. **A moderator triages** — the admin dashboard presents a swipe-review queue of untriaged content, with video playback, uploader context, and any available provenance/AI signals.
+3. **A decision is applied** — the moderator picks an action, and the worker fans it out: it records the decision, publishes Nostr labels/reports, notifies the relay (ban/unban/delete via the relay-admin service binding) and Blossom (blob delete), and hands labels to the ATProto labeler webhook.
+
+Moderation actions are `SAFE`, `REVIEW`, `QUARANTINE`, `AGE_RESTRICTED`, `PERMANENT_BAN`, and `DELETE`.
+
+Because the service is report-driven, the queue consumer for the legacy `video-moderation-queue` currently **acknowledges and skips** every message. The automated multi-provider classifier pipeline still lives in the codebase (`src/moderation/`) and can be re-enabled, but it is not on the upload path in production.
 
 ## Features
 
-- **Automated Analysis**: Uses Sightengine to analyze video content for NSFW and violence
-- **Queue-Based**: Non-blocking moderation via Cloudflare Queues
-- **Three-Tier Classification**:
-  - **SAFE**: Low risk content, approved automatically
-  - **REVIEW**: Borderline content flagged for human review
-  - **QUARANTINE**: High risk content, blocked immediately
-- **AI-Generated Content Detection**: Identifies AI-generated videos to maintain authentic content policy
-- **Late Transcript Reprocessing**: Tracks `202 Pending` transcript runs and reprocesses them on cron when transcripts are ready
-- **Nostr Integration**: Publishes and ingests NIP-56 (kind 1984) report events for human moderation
-- **Cost Optimized**: ~$0.003 per 6-second video
-- **Full Test Coverage**: 40 tests covering all components
+- **Human review dashboard** — swipe-review queue, per-category verification (confirm/reject an individual detection), direct-message templates for creator communication, stats, and tunable classifier thresholds. Served behind Cloudflare Access on `moderation.admin.divine.video`.
+- **Report ingestion** — authenticated client reports plus inbound public NIP-56 (kind `1984`) reports polled from the relay. Relay-originated reports are review-only and never auto-escalate, since client tags and reporter pubkeys are self-asserted public signals.
+- **Content categories** — nudity/NSFW, violence, gore, weapons, recreational drugs, self-harm, hate speech / offensive symbols, AI-generated, and deepfake, plus content-warning labels for alcohol, tobacco, medical, and gambling.
+- **AI-generation & provenance signals** (surfaced to moderators as review context, not auto-enforcement):
+  - `divine-ai-detector` for per-signal detection, with vendor fallback to Hive and Reality Defender.
+  - `divine-inquisitor` for C2PA / ProofMode verification (`inquisitor.divine.video`).
+  - **Video Seal** — interprets the neural-watermark payload extracted upstream; `0x01` is reserved for trusted Divine attestations.
+- **Creator-delete pipeline** — honors Nostr kind `5` deletion requests from creators, removing their own content from Blossom.
+- **Downstream publishing** — NIP-56 reports to Faro and the content relay, NIP-32 (kind `1985`) label events for human-verified labels, and a moderation@ NIP-17 DM inbox.
 
 ## Architecture
 
-```
-Video Upload (Main Service)
-  ↓
-Cloudflare Queue
-  ↓
-Moderation Worker
-  ├─> Sightengine API (3-4 frames analyzed)
-  ├─> Detection (NSFW, Violence, AI-Generated)
-  ├─> Classification (SAFE/REVIEW/QUARANTINE)
-  ├─> KV Storage (results + quarantine flags)
-  └─> Nostr Events (human review reports)
-```
+Everything runs inside one Worker (`src/index.mjs`), which exports three handlers:
 
-## Quick Start
+- **`fetch`** — the HTTP API and admin dashboard.
+- **`queue`** — the `video-moderation-queue` consumer (ack-and-skip under reactive mode).
+- **`scheduled`** — cron work. The every-minute trigger runs the creator-delete pipeline and the lookup-column backfill; the every-5-minute trigger polls the relay for new video events and for inbound reports.
 
-### Prerequisites
+Storage and integrations, all bound in `wrangler.toml`:
 
-- Cloudflare Workers account
-- [Sightengine API account](https://sightengine.com)
-- Nostr private key for signing events
-- Cloudflare Access service token for relay.divine.video
-- Access to faro.nos.social relay
+- **D1** (`BLOSSOM_DB`, database `blossom-webhook-events`) — moderation results, reports, review rows, uploader enforcement, AI-detection events. Schema lives in `migrations/`.
+- **KV** (`MODERATION_KV`) — poller checkpoints, cached lookups, and operational markers.
+- **Queue** (`video-moderation-queue`) — producer + consumer bindings retained for the legacy pipeline.
+- **Service binding** (`RELAY_ADMIN` → `divine-relay-admin-api-prod`) — worker-to-worker ban/unban/delete-event RPCs, authorized with a shared key from Secrets Store. Bypasses the public edge and Cloudflare Access; falls back to the public HTTPS + CF Access path when the binding is absent.
 
-### Installation
+### Where it fits in Divine Trust & Safety
+
+Reports and creator-delete requests flow in from the Divine clients and the relay. Moderators act in this service. Decisions flow back out to the relay (`divine-relay-manager` / Funnelcake), the Blossom CDN, Nostr (labels and reports), and the ATProto labeler — so a single human decision is reflected everywhere the content is served.
+
+## Getting started
+
+Requires Node.js 22 and a Cloudflare account with access to the `divine.video` zone.
 
 ```bash
-# Install dependencies
-npm install
-
-# Create KV namespace
-wrangler kv:namespace create MODERATION_KV
-
-# Create queue
-wrangler queues create video-moderation-queue
-
-# Set secrets
-wrangler secret put SERVICE_API_TOKEN         # Bearer token for moderation-api.divine.video
-wrangler secret put CF_ACCESS_CLIENT_ID        # Cloudflare Access service token ID
-wrangler secret put CF_ACCESS_CLIENT_SECRET    # Cloudflare Access service token secret
-wrangler secret put SIGHTENGINE_API_USER
-wrangler secret put SIGHTENGINE_API_SECRET
-wrangler secret put NOSTR_PRIVATE_KEY
-wrangler secret put FARO_RELAY_URL
-
-# Update wrangler.toml with your KV namespace ID
-
-# Deploy
-wrangler deploy
+npm install        # install dependencies
+npm run dev        # run the Worker locally with Wrangler
+npm test           # run the Vitest suite
+npm run lint       # custom repo lint pass
+npm run tail       # tail production logs
 ```
 
-Production hostnames:
-- `https://moderation-api.divine.video` for public and service-facing API routes
-- `https://moderation.admin.divine.video` for the admin dashboard behind Cloudflare Access
+Tests are written with Vitest on `@cloudflare/vitest-pool-workers`. Every source module has a colocated `*.test.mjs`.
 
-### Configuration
+## Configuration
 
-Edit `wrangler.toml`:
+Bindings, routes, feature flags, and non-secret vars live in `wrangler.toml`. Highlights:
 
-```toml
-[vars]
-CDN_DOMAIN = "cdn.divine.video"  # Your CDN domain
+| Var | Purpose |
+|-----|---------|
+| `REACTIVE_MODERATION_ONLY` | `"true"` — queue consumer ack-skips; moderation is report-driven. |
+| `MODERATION_ENABLED` | Master enable flag. |
+| `CDN_DOMAIN` | Blossom CDN host for video access (`media.divine.video`). |
+| `TEAM_DOMAIN` | Cloudflare Access team domain for Zero Trust JWT verification. |
+| `RELAY_POLLING_*` | Relay video-event polling (URL, lookback, limit, enable). |
+| `REPORT_POLLING_*` | Inbound NIP-56 report polling (URL, lookback, limit, max pages). |
+| `RELAY_REPORTS_REQUIRE_DIVINE_CLIENT` | Only ingest reports tagged as sent by the Divine client. |
+| `CREATOR_DELETE_PIPELINE_ENABLED` | Enable the kind `5` creator-delete cron. |
+| `AI_DETECTOR_BASE_URL` / `AI_DETECTOR_MODE_*` | `divine-ai-detector` endpoint and per-signal cutover mode. |
+| `INQUISITOR_BASE_URL` | `divine-inquisitor` C2PA / ProofMode service. |
+| `FUNNELCAKE_ADMIN_URL` / `FUNNELCAKE_LOOKUP_URL` | Relay admin (writes) and video-lookup (reads) hosts. |
+| `*_THRESHOLD_HIGH` / `*_THRESHOLD_MEDIUM` | Legacy classifier thresholds, retained for provider/classifier tests. |
 
-# Adjust thresholds as needed (0.0 - 1.0)
-NSFW_THRESHOLD_HIGH = "0.8"           # Auto-quarantine threshold
-NSFW_THRESHOLD_MEDIUM = "0.6"         # Human review threshold
-VIOLENCE_THRESHOLD_HIGH = "0.8"
-VIOLENCE_THRESHOLD_MEDIUM = "0.6"
-AI_GENERATED_THRESHOLD_HIGH = "0.8"   # Auto-quarantine AI content
-AI_GENERATED_THRESHOLD_MEDIUM = "0.6" # Flag AI content for review
-TRANSCRIPT_REPROCESS_BATCH_SIZE = "20" # Pending transcript rows to reprocess each cron tick
-TRANSCRIPT_REPROCESS_MAX_AGE_DAYS = "7" # Abandon transcript pending rows older than this many days
-LABEL_WRITE_DEDUPE_ENABLED = "true"    # Set "false" to bypass ClickHouse pre-insert dedupe checks
+Secrets are set with `wrangler secret put <NAME>`. The ones the service reads (see the header of `wrangler.toml` for the full list):
 
-[[kv_namespaces]]
-binding = "MODERATION_KV"
-id = "your_kv_namespace_id"  # From kv:namespace create command
-```
+- `SERVICE_API_TOKEN` — bearer token for authenticated `moderation-api.divine.video` requests.
+- `POLICY_AUD` — Zero Trust application audience tag for the admin app.
+- `CF_ACCESS_CLIENT_ID` / `CF_ACCESS_CLIENT_SECRET` — Cloudflare Access service token for the relay.
+- `NOSTR_PRIVATE_KEY` — signs NIP-56 report events.
+- `MODERATOR_NSEC` / `NOSTR_RELAY_URL` — signs and publishes NIP-32 human-moderator label events.
+- `ADMIN_PASSWORD_HASH` — SHA-256 of the admin dashboard password (`generate-admin-hash.mjs`).
+- `ATPROTO_LABELER_WEBHOOK_URL` / `ATPROTO_LABELER_TOKEN` — the divine-labeler webhook and its bearer token.
+- `REALITY_DEFENDER_API_KEY` — secondary AI verification.
+- `SIGHTENGINE_API_USER` / `SIGHTENGINE_API_SECRET` — optional, for the legacy classifier fallback.
 
-## Integration
+`RELAY_ADMIN_API_KEY` is **not** a per-worker secret — it is bound from Secrets Store (`MODERATION_TO_RELAY_ADMIN_KEY`) and sent as the `X-Admin-Key` header on relay-admin calls. Hive secrets are intentionally unused by the upload and classification paths; do not set them without a reviewed Hive integration.
 
-### Sending Videos for Moderation
+## Deployment
 
-From your main service, send messages to the queue after successful upload:
+CI is defined in `.github/workflows/ci.yml`. On every pull request it runs lint and the test suite; on push to `main` it also deploys the Worker via `cloudflare/wrangler-action` using `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` repository secrets. `semantic_pr.yml` enforces Conventional Commit PR titles.
 
-```javascript
-await env.MODERATION_QUEUE.send({
-  sha256: videoHash,
-  r2Key: `videos/${videoHash}.mp4`,
-  uploadedBy: userPubkey,  // optional (must be 64 hex chars if provided)
-  uploadedAt: Date.now(),
-  metadata: {  // optional
-    fileSize: 128000,
-    contentType: 'video/mp4',
-    duration: 6
-  }
-});
-```
-
-### Checking Moderation Results
-
-```javascript
-// Check if video is quarantined
-const quarantine = await env.MODERATION_KV.get(`quarantine:${sha256}`);
-
-if (quarantine) {
-  return new Response('Content unavailable', { status: 451 });
-}
-
-// Get full moderation result
-const result = await env.MODERATION_KV.get(`moderation:${sha256}`);
-```
-
-## Development
-
-### Running Tests
+To deploy manually:
 
 ```bash
-# Run all tests
-npm test
-
-# Run specific test file
-npm test src/moderation/pipeline.test.mjs
-
-# Watch mode
-npm run test:watch
+npm run deploy     # wrangler deploy
 ```
 
-### Local Development
+Binding the Secrets Store secret requires the deploy token to have account **Secrets Store: Write** permission — see the note in `wrangler.toml`.
 
-```bash
-# Start dev server
-npm run dev
+## Further reading
 
-# Tail production logs
-wrangler tail
-```
-
-## Testing Strategy
-
-This project follows TDD (Test-Driven Development):
-
-1. **Schema Validation** (`src/schemas/queue-message.test.mjs`)
-   - Queue message structure validation
-   - Input sanitization
-
-2. **Sightengine Integration** (`src/moderation/sightengine.test.mjs`)
-   - API calls and error handling
-   - Score extraction from frames
-   - Flagged frame detection
-
-3. **Classification Logic** (`src/moderation/classifier.test.mjs`)
-   - Threshold-based severity classification
-   - Configurable thresholds
-   - Primary concern identification
-
-4. **Nostr Publishing** (`src/nostr/publisher.test.mjs`)
-   - NIP-56 event creation
-   - Event signing
-   - Relay publishing
-
-5. **Pipeline Integration** (`src/moderation/pipeline.test.mjs`)
-   - End-to-end flow
-   - Error handling
-   - Result aggregation
-
-## Project Structure
-
-```
-src/
-├── index.mjs                    # Queue consumer entry point
-├── schemas/
-│   ├── queue-message.mjs        # Message validation
-│   └── queue-message.test.mjs
-├── moderation/
-│   ├── sightengine.mjs          # Sightengine API client
-│   ├── sightengine.test.mjs
-│   ├── classifier.mjs           # Severity classification
-│   ├── classifier.test.mjs
-│   ├── pipeline.mjs             # Full moderation pipeline
-│   └── pipeline.test.mjs
-└── nostr/
-    ├── publisher.mjs            # Nostr event publishing
-    └── publisher.test.mjs
-```
-
-## Moderation Flow
-
-### 1. Analysis
-- Sightengine extracts 3-4 evenly-distributed frames from 6-second video
-- Analyzes each frame for:
-  - Nudity (raw, partial nudity)
-  - Violence (physical violence, weapons, gore)
-  - AI-generated content
-- Returns scores (0.0 - 1.0) for each category per frame
-
-### 2. Classification
-- Calculate max score across all frames
-- Compare against thresholds:
-  - `< MEDIUM`: SAFE
-  - `>= MEDIUM && < HIGH`: REVIEW
-  - `>= HIGH`: QUARANTINE
-
-### 3. Action
-- **SAFE**: Store result, no further action
-- **REVIEW**: Store result + publish Nostr event to faro.nos.social
-- **QUARANTINE**: Store quarantine flag + publish Nostr event + block access
-
-### 4. Storage
-- `moderation:{sha256}`: Complete result with scores and metadata
-- `quarantine:{sha256}`: Present only if video is quarantined
-- `failed:{sha256}`: Logged on errors for debugging
-
-## Nostr Events
-
-Published as NIP-56 (kind 1984) reporting events:
-
-```json
-{
-  "kind": 1984,
-  "tags": [
-    ["L", "MOD"],              // Namespace: Moderation
-    ["l", "NS", "MOD"],        // Label: NS=NSFW, VI=Violence, AI=AI-Generated
-    ["p", "video_sha256"],     // Reported content
-    ["r", "video_cdn_url"]     // Reference URL
-  ],
-  "content": "{\"reason\":\"High nudity detected\",\"scores\":{\"nudity\":0.81,\"violence\":0.001,\"ai_generated\":0.01}}"
-}
-```
-
-### Inbound relay reports
-
-The Worker also ingests public NIP-56 reports from Nostr. On the five-minute cron,
-the report poller reads kind `1984` events from `REPORT_POLLING_RELAY_URL`
-(`wss://relay.divine.video` in production). By default, accepted inbound reports
-must come from the Divine client: `RELAY_REPORTS_REQUIRE_DIVINE_CLIENT=true`
-requires a `client` tag value of `divine`.
-
-Accepted reports are resolved through their target `e` tag. The poller fetches
-that target event, extracts the reported media SHA, and records the same
-`user_reports` and `moderation_results` review rows used by authenticated
-`POST /api/v1/report` submissions. Relay-originated reports are review-only:
-they do not auto-escalate to `AGE_RESTRICTED` because relay client tags and
-reporter pubkeys are public, self-asserted signals.
-
-Operational KV keys:
-
-- `report-poller:last-poll`: checkpoint timestamp for the next bounded relay query
-- `report-poller:last-run`: summary of the most recent report polling cron run
-- `report-poller:last-error`: most recent report polling cron error
-- `report-poller:processed:<event_id>`: idempotence marker for a processed or terminally skipped report event
-
-Checkpointing is conservative. The Worker advances `report-poller:last-poll`
-only to safe terminal report timestamps. Retryable failures do not advance the
-checkpoint. Saturated relay pages record a `resumeUntil` boundary in
-`report-poller:last-run`, so the next cron can continue paging older reports
-without pretending the whole window is safely checkpointed.
-
-## Cost Breakdown
-
-For 1,000 videos per day (6 seconds each):
-
-| Service | Cost |
-|---------|------|
-| Sightengine (3 frames/video) | $3.00/day |
-| Cloudflare Workers | Free (included) |
-| Cloudflare Queue | Free (< 1M ops) |
-| Cloudflare KV | Free (< 10M reads) |
-| **Total** | **~$3.00/day** |
-
-## Monitoring
-
-```bash
-# View queue metrics
-wrangler queues list
-
-# Tail worker logs
-wrangler tail divine-moderation-service
-
-# Check failed moderations
-wrangler kv:key list --namespace-id=YOUR_KV_ID --prefix="failed:"
-
-# View specific result
-wrangler kv:key get --namespace-id=YOUR_KV_ID "moderation:abc123..."
-```
-
-## Troubleshooting
-
-### Moderation label dedupe verification
-- Canonical dedupe key:
-  - `sha256`, `label`, `source_id`, `source_owner`, `source_type`, `transport`, `operation`, `review_state`, `action`
-- Writer logs include per-call counters:
-  - `[LABELS] attempted=... deduped=... inserted=...`
-- Query duplicate keys for a specific content hash:
-
-```sql
-SELECT
-  sha256,
-  label,
-  source_id,
-  source_owner,
-  source_type,
-  transport,
-  operation,
-  review_state,
-  action,
-  count() AS rows_per_key
-FROM moderation_labels
-WHERE sha256 = '...'
-GROUP BY
-  sha256, label, source_id, source_owner, source_type, transport, operation, review_state, action
-HAVING rows_per_key > 1;
-```
-
-### Videos stuck in pending
-- Check queue has consumer: `wrangler queues list`
-- Verify worker is deployed: `wrangler deployments list`
-- Check logs: `wrangler tail`
-
-### High false positive rate
-- Adjust `NSFW_THRESHOLD_HIGH` and `VIOLENCE_THRESHOLD_HIGH` upward
-- Review flagged videos in faro.nos.social
-- Iterate on thresholds based on human review feedback
-
-### Sightengine API errors
-- Verify credentials are set correctly
-- Check API quota and rate limits
-- Ensure videos are publicly accessible at CDN URL
-
-## Known Issues
-
-- **Nostr Event Publishing**: Kind 1984 events currently blocked by relay3.openvine.co
-  - Core moderation continues to work
-  - Quarantine and KV storage unaffected
-  - Human review notifications temporarily unavailable
-
-## Future Enhancements
-
-- [ ] Configure relay to accept kind 1984 events for human review workflow
-- [ ] Add hash-based checking against known bad content databases
-- [ ] Integrate CSAM detection (PhotoDNA/NCMEC) when approved
-- [ ] Add audio analysis for harmful audio content
-- [ ] Implement feedback loop from human review to improve thresholds
-- [ ] Add metrics dashboard for moderation statistics
-- [ ] Support for longer videos with adaptive frame sampling
+- `CONTENT_MODERATION.md` — moderation strategy and the Video Seal provenance model.
+- `AGENTS.md` — repository guidelines and contribution guardrails.
+- `CDN_INTEGRATION.md`, `CLOUDFLARE_ACCESS_SETUP.md`, `ADMIN_SETUP.md` — integration and setup detail.
+- `CHANGELOG.md` — notable changes.
 
 ## License
 
-This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
-
-## Contributing
-
-1. Follow TDD: write tests first
-2. Run `npm test` before committing
-3. Keep test coverage at 100%
-4. Follow existing code style
+Mozilla Public License 2.0. See `LICENSE`.
 
 ---
 


### PR DESCRIPTION
## Summary

Rewrites `README.md` to match the current state of the worker. The prior README described the original proactive, Sightengine-scans-every-upload design; the service has since pivoted to reactive, report-driven human moderation, and the doc had drifted (stale `src/moderation/` layout, obsolete cost/test counts, a resolved "relay3.openvine.co blocks kind 1984" known-issue).

## What changed (all verified against the repo)

- **Moderation model** — documents reactive mode (`REACTIVE_MODERATION_ONLY = "true"`): the `video-moderation-queue` consumer ack-and-skips every message, and moderation is driven by client reports plus inbound NIP-56 (kind `1984`) polling with a human triaging in the admin dashboard. Notes the automated multi-provider classifier still lives in `src/moderation/` but is off the upload path.
- **Actions** — lists the real action set: `SAFE`, `REVIEW`, `QUARANTINE`, `AGE_RESTRICTED`, `PERMANENT_BAN`, `DELETE`.
- **Architecture** — the three worker handlers (`fetch`, `queue`, `scheduled`), the actual crons (every-minute creator-delete + backfill; every-5-minute relay + report polling), and real bindings from `wrangler.toml`: `BLOSSOM_DB` (D1), `MODERATION_KV` (KV), `video-moderation-queue`, and the `RELAY_ADMIN` service binding to `divine-relay-admin-api-prod`.
- **Signals** — `divine-ai-detector` (Hive / Reality Defender fallback), `divine-inquisitor` C2PA/ProofMode, and Video Seal, described as review context rather than auto-enforcement, matching the code.
- **Getting started / Configuration / Deployment** — real npm scripts, the `wrangler.toml` vars/secrets, and the `.github/workflows/ci.yml` lint → test → deploy-on-push flow.
- Aligns prose to the Divine brand guidelines.

## Validation

Doc-only change. No code touched; content cross-checked against `wrangler.toml`, `src/index.mjs` (handlers, routes, queue consumer), `.github/workflows/ci.yml`, `CHANGELOG.md`, and `package.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)