### PR TITLE
chore(dm): enable moderation@ kind-10050 DM inbox publish

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -170,11 +170,14 @@ BACKFILL_ROWS_PER_TICK = "200"
 # Creator-delete pipeline feature flag (default off; flip to "true" via `wrangler secret put` or [vars] once ready)
 CREATOR_DELETE_PIPELINE_ENABLED = "true"
 
-# moderation@ NIP-17 DM inbox relay list (kind 10050) publish. Ships dormant; flip
-# to "true" only AFTER divine-funnelcake#536 is live in prod so the relay accepts
-# kind 10050. Optional DM_INBOX_DISCOVERY_RELAYS overrides the default aggregator
-# list (purplepag.es, relay.nostr.band, relay.damus.io).
-DM_INBOX_PUBLISH_ENABLED = "false"
+# moderation@ NIP-17 DM inbox relay list (kind 10050) publish. Enabled 2026-07-13:
+# divine-funnelcake#536 is live (prod relay verified storing kind 10050), so the
+# account now advertises its DM inbox (~daily republish, KV-throttled). Flipping
+# this var requires a worker deploy — CF rejects a secret shadowing a deployed
+# [vars] name, so `wrangler secret put` cannot override it. Optional
+# DM_INBOX_DISCOVERY_RELAYS overrides the default aggregator list
+# (purplepag.es, relay.nostr.band, relay.damus.io).
+DM_INBOX_PUBLISH_ENABLED = "true"
 # Relay used to fetch creator kind 5 delete events and target video events.
 CREATOR_DELETE_RELAY_URL = "wss://relay.divine.video"
 


### PR DESCRIPTION
flips DM_INBOX_PUBLISH_ENABLED to true so moderation@ advertises its NIP-17 DM inbox (kind 10050, ~daily republish, KV-throttled).

the flag's own stated precondition is met: divine-funnelcake#536 is live in prod, verified 2026-07-13 (the prod relay stores kind-10050 events from ordinary users). the dm-reader already polls the inbox unconditionally every cron tick, so this only starts advertising an inbox we already read. the event is replaceable, so this is reversible by publishing a replacement.

also corrects the config comment: cloudflare rejects a secret shadowing a deployed [vars] binding name, so this flag flips via var change + deploy, not `wrangler secret put`.

part of divinevideo/divine-mobile#4946.