### PR TITLE
fix(creator-delete): avoid missing delayed kind-5 events

### DIFF
--- a/src/creator-delete/cron.mjs
+++ b/src/creator-delete/cron.mjs
@@ -11,6 +11,10 @@ const LAST_POLL_KEY = 'creator-delete-cron:last-poll';
 const DEFAULT_LOOKBACK_SECONDS = 3600; // first run
 const POLL_OVERLAP_SECONDS = 300;
 
+function countProcessedTargets(result) {
+  return (result.targets || []).filter(target => !target.skipped).length;
+}
+
 export async function runCreatorDeleteCron(deps) {
   const { db, kv, queryKind5Since, fetchTargetEvent, callBlossomDelete, now = () => Date.now() } = deps;
   const nowMs = now();
@@ -24,16 +28,11 @@ export async function runCreatorDeleteCron(deps) {
   let processed = 0;
   const errors = [];
 
-  // Keep known transient targets on the backoff-controlled retry path below.
-  // Overlapping relay polls may return the same kind 5 every minute.
   const transientRows = await db.prepare(
     `SELECT kind5_id, target_event_id, creator_pubkey, status, retry_count, accepted_at
      FROM creator_deletions
      WHERE status LIKE 'failed:transient:%' AND retry_count < ?`
   ).bind(MAX_RETRY_COUNT).all();
-  const transientKind5Ids = new Set(
-    (transientRows.results || []).map(row => row.kind5_id)
-  );
 
   let querySucceeded = false;
   try {
@@ -41,16 +40,16 @@ export async function runCreatorDeleteCron(deps) {
     querySucceeded = true;
     for (const kind5 of events) {
       try {
-        if (transientKind5Ids.has(kind5.id)) continue;
-
+        const result = await processKind5(kind5, { db, fetchTargetEvent, callBlossomDelete, now, triggerLabel: 'cron' });
+        const processedTargets = countProcessedTargets(result);
+        if (processedTargets === 0) continue;
         const lagSeconds = Math.max(0, Math.floor(now() / 1000) - (kind5.created_at || 0));
         console.log(JSON.stringify({
           event: 'creator_delete.cron.kind5_lag',
           kind5_id: kind5.id,
           lag_seconds: lagSeconds
         }));
-        await processKind5(kind5, { db, fetchTargetEvent, callBlossomDelete, now, triggerLabel: 'cron' });
-        processed++;
+        processed += processedTargets;
       } catch (e) {
         errors.push({ kind5_id: kind5.id, error: e.message });
       }
@@ -59,18 +58,13 @@ export async function runCreatorDeleteCron(deps) {
     errors.push({ stage: 'query', error: e.message });
   }
 
-  // Retry failed:transient rows with exponential backoff:
-  // Only retry rows where enough time has elapsed since accepted_at (30s * 2^retry_count, capped at 300s).
-  const nowSeconds = Math.floor(nowMs / 1000);
+  // Retry failed:transient rows. decideAction enforces the per-target
+  // exponential backoff when processKind5 attempts to reclaim each row.
   for (const row of (transientRows.results || [])) {
-    const backoffSeconds = Math.min(30 * Math.pow(2, row.retry_count), 300);
-    const acceptedSeconds = Math.floor(Date.parse(row.accepted_at) / 1000);
-    if (nowSeconds - acceptedSeconds < backoffSeconds) continue;
-
     try {
       const kind5 = { id: row.kind5_id, pubkey: row.creator_pubkey, tags: [['e', row.target_event_id]] };
-      await processKind5(kind5, { db, fetchTargetEvent, callBlossomDelete, now, triggerLabel: 'cron' });
-      processed++;
+      const result = await processKind5(kind5, { db, fetchTargetEvent, callBlossomDelete, now, triggerLabel: 'cron' });
+      processed += countProcessedTargets(result);
     } catch (e) {
       errors.push({ kind5_id: row.kind5_id, stage: 'retry', error: e.message });
     }
@@ -85,4 +79,4 @@ export async function runCreatorDeleteCron(deps) {
   return { processed, errors };
 }
 
-export { LAST_POLL_KEY };
+export { LAST_POLL_KEY, POLL_OVERLAP_SECONDS };

--- a/src/creator-delete/cron.mjs
+++ b/src/creator-delete/cron.mjs
@@ -9,17 +9,31 @@ import { MAX_RETRY_COUNT } from './d1.mjs';
 
 const LAST_POLL_KEY = 'creator-delete-cron:last-poll';
 const DEFAULT_LOOKBACK_SECONDS = 3600; // first run
+const POLL_OVERLAP_SECONDS = 300;
 
 export async function runCreatorDeleteCron(deps) {
   const { db, kv, queryKind5Since, fetchTargetEvent, callBlossomDelete, now = () => Date.now() } = deps;
   const nowMs = now();
 
   const lastPollRaw = await kv.get(LAST_POLL_KEY);
-  const lastPollMs = lastPollRaw ? Number(lastPollRaw) : nowMs - (DEFAULT_LOOKBACK_SECONDS * 1000);
-  const sinceSeconds = Math.floor(lastPollMs / 1000);
+  const sinceMs = lastPollRaw
+    ? Number(lastPollRaw) - (POLL_OVERLAP_SECONDS * 1000)
+    : nowMs - (DEFAULT_LOOKBACK_SECONDS * 1000);
+  const sinceSeconds = Math.floor(sinceMs / 1000);
 
   let processed = 0;
   const errors = [];
+
+  // Keep known transient targets on the backoff-controlled retry path below.
+  // Overlapping relay polls may return the same kind 5 every minute.
+  const transientRows = await db.prepare(
+    `SELECT kind5_id, target_event_id, creator_pubkey, status, retry_count, accepted_at
+     FROM creator_deletions
+     WHERE status LIKE 'failed:transient:%' AND retry_count < ?`
+  ).bind(MAX_RETRY_COUNT).all();
+  const transientKind5Ids = new Set(
+    (transientRows.results || []).map(row => row.kind5_id)
+  );
 
   let querySucceeded = false;
   try {
@@ -27,13 +41,15 @@ export async function runCreatorDeleteCron(deps) {
     querySucceeded = true;
     for (const kind5 of events) {
       try {
+        if (transientKind5Ids.has(kind5.id)) continue;
+
         const lagSeconds = Math.max(0, Math.floor(now() / 1000) - (kind5.created_at || 0));
         console.log(JSON.stringify({
           event: 'creator_delete.cron.kind5_lag',
           kind5_id: kind5.id,
           lag_seconds: lagSeconds
         }));
-        await processKind5(kind5, { db, fetchTargetEvent, callBlossomDelete, triggerLabel: 'cron' });
+        await processKind5(kind5, { db, fetchTargetEvent, callBlossomDelete, now, triggerLabel: 'cron' });
         processed++;
       } catch (e) {
         errors.push({ kind5_id: kind5.id, error: e.message });
@@ -45,12 +61,6 @@ export async function runCreatorDeleteCron(deps) {
 
   // Retry failed:transient rows with exponential backoff:
   // Only retry rows where enough time has elapsed since accepted_at (30s * 2^retry_count, capped at 300s).
-  const transientRows = await db.prepare(
-    `SELECT kind5_id, target_event_id, creator_pubkey, status, retry_count, accepted_at
-     FROM creator_deletions
-     WHERE status LIKE 'failed:transient:%' AND retry_count < ?`
-  ).bind(MAX_RETRY_COUNT).all();
-
   const nowSeconds = Math.floor(nowMs / 1000);
   for (const row of (transientRows.results || [])) {
     const backoffSeconds = Math.min(30 * Math.pow(2, row.retry_count), 300);
@@ -59,7 +69,7 @@ export async function runCreatorDeleteCron(deps) {
 
     try {
       const kind5 = { id: row.kind5_id, pubkey: row.creator_pubkey, tags: [['e', row.target_event_id]] };
-      await processKind5(kind5, { db, fetchTargetEvent, callBlossomDelete, triggerLabel: 'cron' });
+      await processKind5(kind5, { db, fetchTargetEvent, callBlossomDelete, now, triggerLabel: 'cron' });
       processed++;
     } catch (e) {
       errors.push({ kind5_id: row.kind5_id, stage: 'retry', error: e.message });

--- a/src/creator-delete/cron.test.mjs
+++ b/src/creator-delete/cron.test.mjs
@@ -5,7 +5,7 @@
 // ABOUTME: Uses makeFakeD1/makeFakeKV; seeds transient rows via rows.set() (fake INSERT is 4-arg only).
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { runCreatorDeleteCron } from './cron.mjs';
+import { POLL_OVERLAP_SECONDS, runCreatorDeleteCron } from './cron.mjs';
 import { MAX_RETRY_COUNT } from './d1.mjs';
 import { makeFakeD1, makeFakeKV } from './test-helpers.mjs';
 
@@ -76,7 +76,7 @@ describe('runCreatorDeleteCron', () => {
       secondPoll.processed,
       recoveryPoll.processed,
       replayPoll.processed
-    ]).toEqual([0, 0, 1, 1]);
+    ]).toEqual([0, 0, 1, 0]);
     expect(deps.db.rows.get('delayed-k5:t1')).toMatchObject({
       status: 'success',
       blob_sha256: SHA_C
@@ -85,9 +85,9 @@ describe('runCreatorDeleteCron', () => {
     expect(deps.callBlossomDelete).toHaveBeenCalledTimes(1);
     expect(deps.queryKind5Since.mock.calls.map(([sinceSeconds]) => sinceSeconds)).toEqual([
       1699996400,
-      1699999700,
-      1699999760,
-      1699999820
+      1700000000 - POLL_OVERLAP_SECONDS,
+      1700000060 - POLL_OVERLAP_SECONDS,
+      1700000120 - POLL_OVERLAP_SECONDS
     ]);
   });
 
@@ -137,6 +137,51 @@ describe('runCreatorDeleteCron', () => {
     });
     expect(deps.fetchTargetEvent).toHaveBeenCalledTimes(2);
     expect(deps.callBlossomDelete).toHaveBeenCalledTimes(2);
+  });
+
+  it('processes non-transient sibling targets when another target is still in backoff', async () => {
+    let nowMs = 1700000000000;
+    const kind5 = {
+      id: 'partial-k5',
+      pubkey: 'pub1',
+      created_at: 1699999970,
+      tags: [['e', 't1'], ['e', 't2']]
+    };
+    deps.db.rows.set('partial-k5:t1', {
+      kind5_id: 'partial-k5',
+      target_event_id: 't1',
+      creator_pubkey: 'pub1',
+      status: 'failed:transient:blossom_5xx',
+      accepted_at: new Date(nowMs - 30_000).toISOString(),
+      blob_sha256: null,
+      retry_count: 1,
+      last_error: 'HTTP 503: prior attempt',
+      completed_at: null
+    });
+
+    deps.now = () => nowMs;
+    deps.queryKind5Since.mockResolvedValueOnce([kind5]);
+    deps.fetchTargetEvent.mockResolvedValueOnce({
+      id: 't2',
+      pubkey: 'pub1',
+      tags: [['imeta', `x ${SHA_C}`]]
+    });
+    deps.callBlossomDelete.mockResolvedValueOnce({ success: true, status: 200 });
+
+    const result = await runCreatorDeleteCron(deps);
+
+    expect(result.processed).toBe(1);
+    expect(deps.fetchTargetEvent).toHaveBeenCalledTimes(1);
+    expect(deps.fetchTargetEvent).toHaveBeenCalledWith('t2');
+    expect(deps.callBlossomDelete).toHaveBeenCalledTimes(1);
+    expect(deps.db.rows.get('partial-k5:t1')).toMatchObject({
+      status: 'failed:transient:blossom_5xx',
+      retry_count: 1
+    });
+    expect(deps.db.rows.get('partial-k5:t2')).toMatchObject({
+      status: 'success',
+      blob_sha256: SHA_C
+    });
   });
 
   it('retries failed:transient rows with retry_count below MAX_RETRY_COUNT', async () => {

--- a/src/creator-delete/cron.test.mjs
+++ b/src/creator-delete/cron.test.mjs
@@ -39,6 +39,106 @@ describe('runCreatorDeleteCron', () => {
     expect(Number(lastPoll)).toBe(1700000000000);
   });
 
+  it('recovers a delayed kind 5 within the poll overlap without repeating Blossom DELETE', async () => {
+    let nowMs = 1700000000000;
+    let visible = false;
+    const kind5 = {
+      id: 'delayed-k5',
+      pubkey: 'pub1',
+      created_at: 1699999970,
+      tags: [['e', 't1']]
+    };
+
+    deps.now = () => nowMs;
+    deps.queryKind5Since.mockImplementation(async (sinceSeconds) => (
+      visible && kind5.created_at >= sinceSeconds ? [kind5] : []
+    ));
+    deps.fetchTargetEvent.mockResolvedValue({
+      id: 't1',
+      pubkey: 'pub1',
+      tags: [['imeta', `x ${SHA_C}`]]
+    });
+    deps.callBlossomDelete.mockResolvedValue({ success: true, status: 200 });
+
+    const firstPoll = await runCreatorDeleteCron(deps);
+    nowMs += 60_000;
+    const secondPoll = await runCreatorDeleteCron(deps);
+
+    visible = true;
+    nowMs += 60_000;
+    const recoveryPoll = await runCreatorDeleteCron(deps);
+
+    nowMs += 60_000;
+    const replayPoll = await runCreatorDeleteCron(deps);
+
+    expect([
+      firstPoll.processed,
+      secondPoll.processed,
+      recoveryPoll.processed,
+      replayPoll.processed
+    ]).toEqual([0, 0, 1, 1]);
+    expect(deps.db.rows.get('delayed-k5:t1')).toMatchObject({
+      status: 'success',
+      blob_sha256: SHA_C
+    });
+    expect(deps.fetchTargetEvent).toHaveBeenCalledTimes(1);
+    expect(deps.callBlossomDelete).toHaveBeenCalledTimes(1);
+    expect(deps.queryKind5Since.mock.calls.map(([sinceSeconds]) => sinceSeconds)).toEqual([
+      1699996400,
+      1699999700,
+      1699999760,
+      1699999820
+    ]);
+  });
+
+  it('keeps overlap replays from bypassing transient retry backoff', async () => {
+    let nowMs = 1700000000000;
+    const kind5 = {
+      id: 'retry-k5',
+      pubkey: 'pub1',
+      created_at: 1699999970,
+      tags: [['e', 't1']]
+    };
+
+    deps.now = () => nowMs;
+    deps.queryKind5Since.mockImplementation(async (sinceSeconds) => (
+      kind5.created_at >= sinceSeconds ? [kind5] : []
+    ));
+    deps.fetchTargetEvent.mockResolvedValue({
+      id: 't1',
+      pubkey: 'pub1',
+      tags: [['imeta', `x ${SHA_C}`]]
+    });
+    deps.callBlossomDelete
+      .mockResolvedValueOnce({ success: false, status: 503, error: 'HTTP 503: unavailable' })
+      .mockResolvedValueOnce({ success: true, status: 200 });
+
+    const firstPoll = await runCreatorDeleteCron(deps);
+    expect(firstPoll.processed).toBe(1);
+    expect(deps.db.rows.get('retry-k5:t1')).toMatchObject({
+      status: 'failed:transient:blossom_5xx',
+      retry_count: 1
+    });
+    expect(deps.fetchTargetEvent).toHaveBeenCalledTimes(1);
+    expect(deps.callBlossomDelete).toHaveBeenCalledTimes(1);
+
+    nowMs += 30_000;
+    const earlyReplay = await runCreatorDeleteCron(deps);
+    expect(earlyReplay.processed).toBe(0);
+    expect(deps.fetchTargetEvent).toHaveBeenCalledTimes(1);
+    expect(deps.callBlossomDelete).toHaveBeenCalledTimes(1);
+
+    nowMs += 30_000;
+    const dueRetry = await runCreatorDeleteCron(deps);
+    expect(dueRetry.processed).toBe(1);
+    expect(deps.db.rows.get('retry-k5:t1')).toMatchObject({
+      status: 'success',
+      retry_count: 1
+    });
+    expect(deps.fetchTargetEvent).toHaveBeenCalledTimes(2);
+    expect(deps.callBlossomDelete).toHaveBeenCalledTimes(2);
+  });
+
   it('retries failed:transient rows with retry_count below MAX_RETRY_COUNT', async () => {
     // Seed D1 directly — the fake's INSERT path is tailored to claimRow's
     // 4-arg bind with 'accepted' status literal, so it can't represent a

--- a/src/creator-delete/d1.mjs
+++ b/src/creator-delete/d1.mjs
@@ -5,6 +5,8 @@
 // ABOUTME: claimRow implements INSERT ... ON CONFLICT DO NOTHING then SELECT to read canonical state.
 
 const MAX_RETRY_COUNT = 5;
+const TRANSIENT_RETRY_BASE_MS = 30_000;
+const TRANSIENT_RETRY_MAX_MS = 300_000;
 // Must exceed the sync endpoint's waitUntil work window. A stale accepted row
 // may be re-claimed after this; Blossom DELETE must remain idempotent.
 const IN_PROGRESS_TIMEOUT_MS = 120_000;
@@ -85,10 +87,13 @@ export function decideAction(existing, { now = Date.now() } = {}) {
     return 'proceed';
   }
   if (existing.status.startsWith('failed:transient:')) {
-    if (existing.retry_count < MAX_RETRY_COUNT) return 'proceed';
-    return 'skip_permanent_failure';
+    if (existing.retry_count >= MAX_RETRY_COUNT) return 'skip_permanent_failure';
+    const acceptedMs = Date.parse(existing.accepted_at);
+    const backoffMs = Math.min(TRANSIENT_RETRY_BASE_MS * Math.pow(2, existing.retry_count), TRANSIENT_RETRY_MAX_MS);
+    if (now - acceptedMs < backoffMs) return 'skip_in_progress';
+    return 'proceed';
   }
   return 'proceed';
 }
 
-export { MAX_RETRY_COUNT, IN_PROGRESS_TIMEOUT_MS };
+export { MAX_RETRY_COUNT, IN_PROGRESS_TIMEOUT_MS, TRANSIENT_RETRY_BASE_MS, TRANSIENT_RETRY_MAX_MS };

--- a/src/creator-delete/d1.test.mjs
+++ b/src/creator-delete/d1.test.mjs
@@ -64,8 +64,24 @@ describe('decideAction', () => {
     expect(decideAction(existing, { now })).toBe('proceed');
   });
 
-  it('proceed when failed:transient and retries remain', () => {
-    expect(decideAction({ status: 'failed:transient:blossom_5xx', retry_count: 2 })).toBe('proceed');
+  it('skip_in_progress when failed:transient retry backoff has not elapsed', () => {
+    const now = Date.now();
+    const existing = {
+      status: 'failed:transient:blossom_5xx',
+      retry_count: 2,
+      accepted_at: new Date(now - 119_000).toISOString()
+    };
+    expect(decideAction(existing, { now })).toBe('skip_in_progress');
+  });
+
+  it('proceed when failed:transient retry backoff has elapsed', () => {
+    const now = Date.now();
+    const existing = {
+      status: 'failed:transient:blossom_5xx',
+      retry_count: 2,
+      accepted_at: new Date(now - 120_001).toISOString()
+    };
+    expect(decideAction(existing, { now })).toBe('proceed');
   });
 
   it('skip when failed:transient and retries exhausted', () => {

--- a/src/creator-delete/process.mjs
+++ b/src/creator-delete/process.mjs
@@ -63,15 +63,15 @@ export async function processKind5(kind5, { db, fetchTargetEvent, callBlossomDel
     const action = claim.claimed ? 'proceed' : decideAction(claim.existing, { now: now() });
 
     if (action === 'skip_success') {
-      resultTargets.push({ target_event_id, status: 'success', blob_sha256: claim.existing.blob_sha256 });
+      resultTargets.push({ target_event_id, status: 'success', blob_sha256: claim.existing.blob_sha256, skipped: true });
       continue;
     }
     if (action === 'skip_permanent_failure') {
-      resultTargets.push({ target_event_id, status: claim.existing.status, last_error: claim.existing.last_error });
+      resultTargets.push({ target_event_id, status: claim.existing.status, last_error: claim.existing.last_error, skipped: true });
       continue;
     }
     if (action === 'skip_in_progress') {
-      resultTargets.push({ target_event_id, status: 'in_progress' });
+      resultTargets.push({ target_event_id, status: 'in_progress', skipped: true });
       continue;
     }
 
@@ -87,7 +87,7 @@ export async function processKind5(kind5, { db, fetchTargetEvent, callBlossomDel
       const reclaimed = reclaim.meta.changes === 1 || reclaim.meta.rows_written === 1;
       if (!reclaimed) {
         // Another worker won the re-claim race. Report in_progress and let them finish.
-        resultTargets.push({ target_event_id, status: 'in_progress' });
+        resultTargets.push({ target_event_id, status: 'in_progress', skipped: true });
         continue;
       }
     }

--- a/src/creator-delete/process.test.mjs
+++ b/src/creator-delete/process.test.mjs
@@ -116,6 +116,7 @@ describe('processKind5', () => {
     });
     const result = await processKind5(kind5, { db, fetchTargetEvent, callBlossomDelete });
     expect(result.targets[0].status).toBe('success');
+    expect(result.targets[0].skipped).toBe(true);
     expect(callBlossomDelete).not.toHaveBeenCalled();
     expect(fetchTargetEvent).not.toHaveBeenCalled();
   });

--- a/src/creator-delete/test-helpers.mjs
+++ b/src/creator-delete/test-helpers.mjs
@@ -37,11 +37,28 @@ export function makeFakeD1() {
               rows.set(target_key, { ...existing, accepted_at: newAccepted, status: 'accepted' });
               return { meta: { changes: 1, rows_written: 1 } };
             }
-            // Other UPDATEs: kind5_id and target_event_id are the last two binds.
+            // State-transition UPDATEs: kind5_id and target_event_id are the last two binds.
             const target_key = `${this._binds[this._binds.length - 2]}:${this._binds[this._binds.length - 1]}`;
             const existing = rows.get(target_key);
             if (existing) {
-              rows.set(target_key, { ...existing, _updated: true });
+              if (this._sql.includes("SET status = 'success'")) {
+                const [blob_sha256, completed_at] = this._binds;
+                rows.set(target_key, {
+                  ...existing,
+                  status: 'success',
+                  blob_sha256,
+                  completed_at,
+                  last_error: null
+                });
+              } else {
+                const [status, last_error] = this._binds;
+                rows.set(target_key, {
+                  ...existing,
+                  status,
+                  last_error,
+                  retry_count: existing.retry_count + (this._sql.includes('retry_count = retry_count + 1') ? 1 : 0)
+                });
+              }
               return { meta: { changes: 1 } };
             }
             return { meta: { changes: 0 } };

--- a/src/nostr/relay-client-labels.test.mjs
+++ b/src/nostr/relay-client-labels.test.mjs
@@ -1,11 +1,11 @@
 // This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
 // If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 //
-// ABOUTME: Tests for kind 1985 label fetchers — since-cursor poll filter shape
-// ABOUTME: and per-video #e/#a queries deduped by event id.
+// ABOUTME: Tests for relay-client collect-all fetchers — since-cursor poll filter shape,
+// ABOUTME: strict EOSE handling, and per-video #e/#a queries deduped by event id.
 
 import { describe, it, expect, afterEach } from 'vitest';
-import { fetchLabelEventsSince, fetchLabelEventsForVideo } from './relay-client.mjs';
+import { fetchKind5EventsSince, fetchLabelEventsSince, fetchLabelEventsForVideo } from './relay-client.mjs';
 
 const originalWebSocket = globalThis.WebSocket;
 afterEach(() => { globalThis.WebSocket = originalWebSocket; });
@@ -107,6 +107,15 @@ describe('fetchLabelEventsSince', () => {
     globalThis.WebSocket = makeClosingBeforeEoseWebSocket({ eventsForFilter: () => [label] });
 
     await expect(fetchLabelEventsSince(1_700_000_000)).rejects.toThrow(/EOSE/i);
+  });
+});
+
+describe('fetchKind5EventsSince', () => {
+  it('rejects when the stream closes before EOSE (possible truncation)', async () => {
+    const kind5 = { id: 'f'.repeat(64), kind: 5, tags: [['e', 'target']] };
+    globalThis.WebSocket = makeClosingBeforeEoseWebSocket({ eventsForFilter: () => [kind5] });
+
+    await expect(fetchKind5EventsSince(1_700_000_000)).rejects.toThrow(/EOSE/i);
   });
 });
 

--- a/src/nostr/relay-client.mjs
+++ b/src/nostr/relay-client.mjs
@@ -489,7 +489,7 @@ export function hasStrongOriginalVineEvidence(nostrContext) {
 }
 
 export async function fetchKind5EventsSince(sinceSeconds, relayUrl = 'wss://relay.divine.video', env = {}) {
-  return queryRelay(relayUrl, { kinds: [5], since: sinceSeconds }, env, { collectAll: true });
+  return queryRelay(relayUrl, { kinds: [5], since: sinceSeconds }, env, { collectAll: true, rejectOnPrematureClose: true });
 }
 
 /**


### PR DESCRIPTION
## Summary

Delayed kind-5 deletion events could be missed forever when relay indexing finished after the cron checkpoint advanced.
This change overlaps persisted checkpoint polls by five minutes, treats truncated relay polls as failed polls, and keeps replay safe.
Transient failures stay on the existing exponential-backoff retry path per target, so one transient target does not hide sibling targets from the same kind 5.

## Motivation

The cron queried from the exact last successful poll time.
An event created earlier but indexed later fell behind every later `since` filter.
A bounded overlap covers the observed delay plus cron alignment while keeping replay work bounded.

## Related Issue

- Closes #187

## Validation

The automated cron regressions, full suite, and lint checks pass on the takeover commit.

- [x] `npm run lint` - 179 modules and 4 HTML files
- [x] `npm test` - 81 files and 1,451 tests
- [x] relevant Wrangler or queue-flow validation if applicable - creator-delete cron tests cover delayed visibility, replay idempotency, per-target retry backoff, sibling target processing, and strict relay truncation handling
- [ ] I could not run some validation locally, and I explained why below

## Manual Test Plan / Notes

No live relay or production mutation was needed.
The regression hides an event across two ticks, reveals it after the checkpoint advances, and verifies one Blossom DELETE.
Additional regressions verify overlap replay waits for transient retry backoff, does not inflate processed count for pure replay, still processes non-transient sibling targets, and rejects a kind-5 relay stream that closes before EOSE.
Delays beyond five minutes can still be missed; a stronger bound needs a relay indexing-lag guarantee.

## Visuals / API Examples

There is no visual or externally visible API change.

- [x] No visual change
- [ ] Screenshots, sample payloads, or logs attached if needed

## Public Artifact Review

The public text uses only repository and protocol terms needed to explain the fix.

- [x] Titles, descriptions, branch names, and screenshots avoid partner, customer, brand, campaign, or other sensitive external names unless explicitly approved
