### PR TITLE
fix(dm): classify report DMs from the NIP-32 label and decode the full label vocabulary

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It is a single [Cloudflare Worker](https://developers.cloudflare.com/workers/) (
 
 The service runs in **reactive mode** (`REACTIVE_MODERATION_ONLY = "true"`). Rather than machine-scanning every upload, it acts on signals that something needs a human look:
 
-1. **Reports come in** — from authenticated Divine clients (`POST /api/v1/report`) and from public NIP-56 (kind `1984`) report events polled off `relay.divine.video`. Each report is written to D1 as a review row.
+1. **Reports come in** — from authenticated Divine clients (`POST /api/v1/report`), from public NIP-56 (kind `1984`) report events polled off `relay.divine.video`, and from NIP-17 report DMs sent to the moderation@ inbox. Each report is written to D1 as a review row.
 2. **A moderator triages** — the admin dashboard presents a swipe-review queue of untriaged content, with video playback, uploader context, and any available provenance/AI signals.
 3. **A decision is applied** — the moderator picks an action, and the worker fans it out: it records the decision, publishes Nostr labels/reports, notifies the relay (ban/unban/delete via the relay-admin service binding) and Blossom (blob delete), and hands labels to the ATProto labeler webhook.
 
@@ -22,7 +22,7 @@ Because the service is report-driven, the queue consumer for the legacy `video-m
 ## Features
 
 - **Human review dashboard** — swipe-review queue, per-category verification (confirm/reject an individual detection), direct-message templates for creator communication, stats, and tunable classifier thresholds. Served behind Cloudflare Access on `moderation.admin.divine.video`.
-- **Report ingestion** — authenticated client reports plus inbound public NIP-56 (kind `1984`) reports polled from the relay. Relay-originated reports are review-only and never auto-escalate, since client tags and reporter pubkeys are self-asserted public signals.
+- **Report ingestion** — authenticated client reports, inbound public NIP-56 (kind `1984`) reports polled from the relay, and NIP-17 report DMs to the moderation@ inbox. Both Nostr paths are review-only and never auto-escalate, since client tags and reporter pubkeys are self-asserted public signals; report DMs additionally do not count toward the distinct-reporter threshold that the authenticated path escalates on. Only `POST /api/v1/report` can produce an automatic `AGE_RESTRICTED`.
 - **Content categories** — nudity/NSFW, violence, gore, weapons, recreational drugs, self-harm, hate speech / offensive symbols, AI-generated, and deepfake, plus content-warning labels for alcohol, tobacco, medical, and gambling.
 - **AI-generation & provenance signals** (surfaced to moderators as review context, not auto-enforcement):
   - `divine-ai-detector` for per-signal detection, with vendor fallback to Hive and Reality Defender.

--- a/migrations/012-dm-read-state.sql
+++ b/migrations/012-dm-read-state.sql
@@ -1,0 +1,23 @@
+-- Per-conversation read marker for the admin Messages UI's unread badge.
+--
+-- A separate one-row-per-conversation table (rather than a `read_at` column
+-- on `dm_log` itself) because "read" is a conversation-level concept, not a
+-- per-message one -- there is nothing sensible for an individual message row
+-- to mean by "this one message is read" independent of the rest of its
+-- thread. `getConversations` (dm-store.mjs) LEFT JOINs this table by
+-- conversation_id; a missing row means "never marked read", which combined
+-- with any existing incoming message correctly reads as unread.
+--
+-- `read_at` is always written via SQL `CURRENT_TIMESTAMP` (see
+-- markConversationRead in dm-store.mjs), matching `dm_log.created_at`'s own
+-- generation mechanism exactly. Both columns therefore share the same
+-- SQLite CURRENT_TIMESTAMP text format ("YYYY-MM-DD HH:MM:SS", UTC, no
+-- timezone marker) and remain safely comparable with a plain `>` -- mixing
+-- that format with a client-generated ISO-8601 string (which sorts
+-- differently under a lexicographic TEXT comparison because of the 'T'/'Z'
+-- characters) would silently make "unread" permanently stick at whatever it
+-- was the first time a conversation was marked read.
+CREATE TABLE IF NOT EXISTS dm_conversation_read_state (
+  conversation_id TEXT PRIMARY KEY,
+  read_at TEXT NOT NULL
+);

--- a/src/admin/dashboard.html
+++ b/src/admin/dashboard.html
@@ -5485,7 +5485,7 @@
         if (res.ok) {
           const data = await res.json();
           const convs = data.conversations || data || [];
-          const unread = convs.filter(c => c.unread || c.has_unread).length;
+          const unread = convs.filter(c => c.unread).length;
           if (unread > 0) {
             const badge = document.getElementById('unread-badge');
             if (badge) {

--- a/src/admin/messages.html
+++ b/src/admin/messages.html
@@ -667,7 +667,7 @@
         const preview = (conv.latest_message || conv.preview || '').slice(0, 80);
         const ts = conv.last_message_at || conv.updated_at || conv.created_at;
         const msgType = conv.message_type || conv.latest_message_type || '';
-        const unread = conv.unread || conv.has_unread || false;
+        const unread = Boolean(conv.unread);
         const isActive = pubkey === selectedPubkey;
 
         return `
@@ -698,6 +698,17 @@
 
     async function selectConversation(pubkey, opts = {}) {
       selectedPubkey = pubkey;
+
+      // Optimistically clear the unread dot for this row, then tell the
+      // backend so it stays clear on the next fetchConversations() poll.
+      // Fire-and-forget: a failed mark-read shouldn't block opening the
+      // thread, it just means the dot may reappear next refresh.
+      const conv = conversations.find(c => (c.participant_pubkey || c.pubkey) === pubkey);
+      if (conv && conv.unread) {
+        conv.unread = false;
+      }
+      fetch('/admin/api/messages/' + encodeURIComponent(pubkey) + '/read', { method: 'POST' }).catch(() => {});
+
       renderConversations();
 
       // Dismiss the New Message recipient bar unless we just resolved from it

--- a/src/admin/messages.html
+++ b/src/admin/messages.html
@@ -706,8 +706,8 @@
       const conv = conversations.find(c => (c.participant_pubkey || c.pubkey) === pubkey);
       if (conv && conv.unread) {
         conv.unread = false;
+        fetch('/admin/api/messages/' + encodeURIComponent(pubkey) + '/read', { method: 'POST' }).catch(() => {});
       }
-      fetch('/admin/api/messages/' + encodeURIComponent(pubkey) + '/read', { method: 'POST' }).catch(() => {});
 
       renderConversations();
 

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -3822,6 +3822,23 @@ async function runMigration() {
       return new Response(JSON.stringify({ success: true, relaysPublished: result.relaysPublished }), { headers: { 'Content-Type': 'application/json' } });
     }
 
+    // Admin API: Mark a DM conversation read (clears the unread badge/dot)
+    if (url.pathname.startsWith('/admin/api/messages/') && url.pathname.endsWith('/read') && request.method === 'POST') {
+      const authError = await requireAuth(request, env);
+      if (authError) return authError;
+
+      const pubkey = url.pathname.split('/')[4];
+      const { computeConversationId, markConversationRead } = await import('./nostr/dm-store.mjs');
+      const { getModeratorPubkey } = await import('./nostr/dm-reader.mjs');
+      const moderatorPubkey = env.NOSTR_PRIVATE_KEY ? getModeratorPubkey(env) : undefined;
+      if (!moderatorPubkey) {
+        return new Response(JSON.stringify({ error: 'Moderator signing key not configured' }), { status: 500, headers: { 'Content-Type': 'application/json' } });
+      }
+      const conversationId = computeConversationId(moderatorPubkey, pubkey);
+      await markConversationRead(env.BLOSSOM_DB, conversationId);
+      return new Response(JSON.stringify({ success: true }), { headers: { 'Content-Type': 'application/json' } });
+    }
+
     // Admin API: Resolve a recipient (hex / npub / verified nip-05) to a hex pubkey.
     // Display-name lookup is intentionally NOT supported — see
     // docs/superpowers/specs/2026-06-03-moderator-compose-new-dm-design.md (Non-goals).

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -4224,8 +4224,8 @@ async function runMigration() {
 
         console.log(`[API] Recorded ${result.action} from user report for ${sha256} (type=${report_type}, distinctReporters=${result.distinctReporterCount})`);
 
-        // `escalate` is the action that was actually recorded for this sha256,
-        // not a separate prediction. It used to be addReport's own count-based
+        // `escalate` is this report's recorded-action decision, not a separate
+        // prediction. It used to be addReport's own count-based
         // guess, which could read AGE_RESTRICTED while the row written a line
         // earlier said REVIEW -- the two ran on different inputs (any reporter
         // vs escalation-eligible ones) and different thresholds (5 vs 2, and

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -3831,7 +3831,11 @@ async function runMigration() {
       const authError = await requireAuth(request, env);
       if (authError) return authError;
 
-      const pubkey = url.pathname.split('/')[4];
+      const parts = url.pathname.split('/');
+      if (parts.length !== 6 || !isValidPubkey(parts[4])) {
+        return new Response(JSON.stringify({ error: 'Valid pubkey (64-char hex) required' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+      }
+      const pubkey = parts[4].toLowerCase();
       const { computeConversationId, markConversationRead, initDmReadStateTable } = await import('./nostr/dm-store.mjs');
       const { getModeratorPubkey } = await import('./nostr/dm-reader.mjs');
       const moderatorPubkey = env.NOSTR_PRIVATE_KEY ? getModeratorPubkey(env) : undefined;

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -3772,8 +3772,12 @@ async function runMigration() {
 
       const limit = parseInt(url.searchParams.get('limit') || '20');
       const offset = parseInt(url.searchParams.get('offset') || '0');
-      const { getConversations } = await import('./nostr/dm-store.mjs');
+      const { getConversations, initDmReadStateTable } = await import('./nostr/dm-store.mjs');
       const { getModeratorPubkey } = await import('./nostr/dm-reader.mjs');
+      // getConversations LEFT JOINs dm_conversation_read_state for the unread
+      // flag. Ensure it here rather than relying on migration 012 having been
+      // applied: the deploy job runs on merge, `d1 migrations apply` does not.
+      await initDmReadStateTable(env.BLOSSOM_DB);
       // Pass moderatorPubkey so rows are augmented with participant_pubkey
       // (the non-moderator side) + latest_message/message_type aliases that
       // the admin messages UI expects. Without this, every conversation
@@ -3828,12 +3832,13 @@ async function runMigration() {
       if (authError) return authError;
 
       const pubkey = url.pathname.split('/')[4];
-      const { computeConversationId, markConversationRead } = await import('./nostr/dm-store.mjs');
+      const { computeConversationId, markConversationRead, initDmReadStateTable } = await import('./nostr/dm-store.mjs');
       const { getModeratorPubkey } = await import('./nostr/dm-reader.mjs');
       const moderatorPubkey = env.NOSTR_PRIVATE_KEY ? getModeratorPubkey(env) : undefined;
       if (!moderatorPubkey) {
         return new Response(JSON.stringify({ error: 'Moderator signing key not configured' }), { status: 500, headers: { 'Content-Type': 'application/json' } });
       }
+      await initDmReadStateTable(env.BLOSSOM_DB);
       const conversationId = computeConversationId(moderatorPubkey, pubkey);
       await markConversationRead(env.BLOSSOM_DB, conversationId);
       return new Response(JSON.stringify({ success: true }), { headers: { 'Content-Type': 'application/json' } });

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -4224,9 +4224,17 @@ async function runMigration() {
 
         console.log(`[API] Recorded ${result.action} from user report for ${sha256} (type=${report_type}, distinctReporters=${result.distinctReporterCount})`);
 
+        // `escalate` is the action that was actually recorded for this sha256,
+        // not a separate prediction. It used to be addReport's own count-based
+        // guess, which could read AGE_RESTRICTED while the row written a line
+        // earlier said REVIEW -- the two ran on different inputs (any reporter
+        // vs escalation-eligible ones) and different thresholds (5 vs 2, and
+        // only NSFW escalates). Sourcing it from the decision makes the
+        // response unable to contradict enforcement. It is no longer null: a
+        // single report reads REVIEW, which is what the service did with it.
         return new Response(JSON.stringify({
           success: true,
-          escalate: result.escalate,
+          escalate: result.action,
           distinctReporterCount: result.distinctReporterCount,
         }), {
           headers: { 'Content-Type': 'application/json' }

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -57,6 +57,9 @@ function createDbMock({
   aiDetectionRecentRows = [],
   moderationWrites = [],
   reporterCount = 1,
+  // Defaults to reporterCount: unless a test says otherwise, every reporter on
+  // the row came from a source allowed to drive an automatic outcome.
+  escalationReporterCount = reporterCount,
   onPrepare = null,
 } = {}) {
   return {
@@ -102,7 +105,7 @@ function createDbMock({
             return aiDetectionStatsRow;
           }
           if (sql.includes('FROM user_reports') && sql.includes('COUNT(DISTINCT reporter_pubkey)')) {
-            return { cnt: reporterCount };
+            return { cnt: reporterCount, escalation_cnt: escalationReporterCount };
           }
           return null;
         },

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -412,6 +412,10 @@ describe('HTTP hostname routing', () => {
     expect(moderationWrites[0].bindings[0]).toBe(SHA256);
     expect(moderationWrites[0].bindings[1]).toBe('REVIEW');
     expect(moderationWrites[0].bindings[2]).toBe('user-report');
+    // The response reports the action that was recorded, not a second guess.
+    const reportBody = await response.json();
+    expect(reportBody).toMatchObject({ success: true, escalate: 'REVIEW', distinctReporterCount: 1 });
+    expect(reportBody.escalate).toBe(moderationWrites[0].bindings[1]);
     expect(aiDetectionEvents).toHaveLength(1);
     expect(aiDetectionEvents[0]).toMatchObject({
       sha256: SHA256,
@@ -460,6 +464,47 @@ describe('HTTP hostname routing', () => {
     expect(bound.bindings[0]).toBe(SHA256);
     expect(bound.bindings[1]).toBe('AGE_RESTRICTED');
     expect(bound.bindings[2]).toBe('user-report');
+    const body = await response.json();
+    expect(body).toMatchObject({ success: true, escalate: 'AGE_RESTRICTED', distinctReporterCount: 2 });
+    expect(body.escalate).toBe(bound.bindings[1]);
+  });
+
+  // The response used to carry addReport's own count-based verdict, which ran
+  // on different inputs and different thresholds than the enforcement gate.
+  // Five reporters on a report type that never auto age-restricts is where the
+  // two disagreed outright: the row said REVIEW, the client was told
+  // AGE_RESTRICTED.
+  it('does not report an escalation the moderation row contradicts', async () => {
+    const moderationWrites = [];
+    const env = createEnv({
+      BLOSSOM_DB: createDbMock({ moderationWrites, reporterCount: 5 }),
+    });
+
+    const response = await worker.fetch(
+      new Request('https://moderation-api.divine.video/api/v1/report', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer test-service-token'
+        },
+        body: JSON.stringify({
+          sha256: SHA256,
+          reporter_pubkey: 'b'.repeat(64),
+          report_type: 'spam',
+          reason: 'flooding the feed'
+        })
+      }),
+      env
+    );
+
+    expect(response.status).toBe(200);
+    expect(moderationWrites).toHaveLength(1);
+    expect(moderationWrites[0].bindings[1]).toBe('REVIEW');
+
+    const body = await response.json();
+    expect(body.escalate).toBe('REVIEW');
+    expect(body.escalate).not.toBe('AGE_RESTRICTED');
+    expect(body.distinctReporterCount).toBe(5);
   });
 
   it('rejects /api/v1/report with malformed sha256', async () => {

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -7686,6 +7686,38 @@ describe('POST /admin/api/messages/{pubkey}/read', () => {
     expect(res.status).toBe(500);
     expect((await res.json()).error).toBeTruthy();
   });
+
+  it('400s malformed read route shapes instead of inserting junk read state', async () => {
+    const prepared = [];
+    const res = await worker.fetch(
+      new Request('https://moderation.admin.divine.video/admin/api/messages/a/b/read', {
+        method: 'POST',
+      }),
+      createEnv({
+        ALLOW_DEV_ACCESS: 'true',
+        NOSTR_PRIVATE_KEY: 'deadbeef'.repeat(8),
+        BLOSSOM_DB: createDbMock({ onPrepare: (sql) => prepared.push(sql) }),
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(prepared.some((sql) => /INSERT INTO dm_conversation_read_state/i.test(sql))).toBe(false);
+  });
+
+  it('400s non-hex read-route pubkeys instead of inserting junk read state', async () => {
+    const prepared = [];
+    const res = await worker.fetch(
+      new Request('https://moderation.admin.divine.video/admin/api/messages/not-a-pubkey/read', {
+        method: 'POST',
+      }),
+      createEnv({
+        ALLOW_DEV_ACCESS: 'true',
+        NOSTR_PRIVATE_KEY: 'deadbeef'.repeat(8),
+        BLOSSOM_DB: createDbMock({ onPrepare: (sql) => prepared.push(sql) }),
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(prepared.some((sql) => /INSERT INTO dm_conversation_read_state/i.test(sql))).toBe(false);
+  });
 });
 
 describe('GET /admin/api/dm-templates', () => {

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -7605,6 +7605,38 @@ describe('POST /admin/api/messages/{pubkey} when the send fails', () => {
   });
 });
 
+describe('POST /admin/api/messages/{pubkey}/read', () => {
+  const HEX = '00000000000000000000000000000000000000000000000000000000000000ab';
+
+  it('marks the conversation read and returns success', async () => {
+    const prepared = [];
+    const res = await worker.fetch(
+      new Request('https://moderation.admin.divine.video/admin/api/messages/' + HEX + '/read', {
+        method: 'POST',
+      }),
+      createEnv({
+        ALLOW_DEV_ACCESS: 'true',
+        NOSTR_PRIVATE_KEY: 'deadbeef'.repeat(8),
+        BLOSSOM_DB: createDbMock({ onPrepare: (sql) => prepared.push(sql) }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true });
+    expect(prepared.some((sql) => sql.includes('dm_conversation_read_state'))).toBe(true);
+  });
+
+  it('500s when no moderator signing key is configured, instead of silently no-op succeeding', async () => {
+    const res = await worker.fetch(
+      new Request('https://moderation.admin.divine.video/admin/api/messages/' + HEX + '/read', {
+        method: 'POST',
+      }),
+      createEnv({ ALLOW_DEV_ACCESS: 'true', NOSTR_PRIVATE_KEY: undefined }),
+    );
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBeTruthy();
+  });
+});
+
 describe('GET /admin/api/dm-templates', () => {
   it('returns the creator-facing templates with rendered bodies', async () => {
     const res = await worker.fetch(

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -7587,6 +7587,32 @@ describe('GET /admin/api/messages/{pubkey} for an unknown pubkey', () => {
   });
 });
 
+describe('GET /admin/api/messages', () => {
+  it('creates dm_conversation_read_state before the unread query joins it', async () => {
+    // Same deploy-ordering guard as the /read route: getConversations LEFT
+    // JOINs this table, so a deploy that lands before migration 012 would
+    // otherwise break the whole conversation list, not just the badge.
+    const prepared = [];
+    const res = await worker.fetch(
+      new Request('https://moderation.admin.divine.video/admin/api/messages'),
+      createEnv({
+        ALLOW_DEV_ACCESS: 'true',
+        NOSTR_PRIVATE_KEY: 'deadbeef'.repeat(8),
+        BLOSSOM_DB: createDbMock({ onPrepare: (sql) => prepared.push(sql) }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    const createIndex = prepared.findIndex((sql) =>
+      /CREATE TABLE IF NOT EXISTS\s+dm_conversation_read_state/i.test(sql),
+    );
+    const selectIndex = prepared.findIndex((sql) =>
+      /LEFT JOIN dm_conversation_read_state/i.test(sql),
+    );
+    expect(createIndex).toBeGreaterThanOrEqual(0);
+    expect(selectIndex).toBeGreaterThan(createIndex);
+  });
+});
+
 describe('POST /admin/api/messages/{pubkey} when the send fails', () => {
   it('returns 502 with a reason instead of a silent success', async () => {
     const HEX = '00000000000000000000000000000000000000000000000000000000000000ab';
@@ -7623,6 +7649,31 @@ describe('POST /admin/api/messages/{pubkey}/read', () => {
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ success: true });
     expect(prepared.some((sql) => sql.includes('dm_conversation_read_state'))).toBe(true);
+  });
+
+  it('creates dm_conversation_read_state before writing to it', async () => {
+    // The deploy job runs on merge to main; `wrangler d1 migrations apply`
+    // does not. Without this ensure the first request after a deploy would
+    // fail with "no such table" until migration 012 was applied by hand.
+    const prepared = [];
+    await worker.fetch(
+      new Request('https://moderation.admin.divine.video/admin/api/messages/' + HEX + '/read', {
+        method: 'POST',
+      }),
+      createEnv({
+        ALLOW_DEV_ACCESS: 'true',
+        NOSTR_PRIVATE_KEY: 'deadbeef'.repeat(8),
+        BLOSSOM_DB: createDbMock({ onPrepare: (sql) => prepared.push(sql) }),
+      }),
+    );
+    const createIndex = prepared.findIndex((sql) =>
+      /CREATE TABLE IF NOT EXISTS\s+dm_conversation_read_state/i.test(sql),
+    );
+    const insertIndex = prepared.findIndex((sql) =>
+      /INSERT INTO dm_conversation_read_state/i.test(sql),
+    );
+    expect(createIndex).toBeGreaterThanOrEqual(0);
+    expect(insertIndex).toBeGreaterThan(createIndex);
   });
 
   it('500s when no moderator signing key is configured, instead of silently no-op succeeding', async () => {

--- a/src/moderation/report-review.mjs
+++ b/src/moderation/report-review.mjs
@@ -25,10 +25,16 @@ export async function recordReportForReview(db, {
     report_type: reportType,
     reason,
     created_at: reportedAt,
+    source,
   });
 
   const isNsfw = isNsfwReportType(reportType);
-  const action = (allowAutoAgeRestrict && isNsfw && result.distinctReporterCount >= 2) ? 'AGE_RESTRICTED' : 'REVIEW';
+  // Gate on escalationReporterCount, not distinctReporterCount: the two differ
+  // exactly when a source that may not drive automatic outcomes (a report DM)
+  // has also reported this sha256. Counting those would let one actor supply
+  // half the threshold for free, which is the same trust boundary that keeps
+  // the DM path itself REVIEW-only.
+  const action = (allowAutoAgeRestrict && isNsfw && result.escalationReporterCount >= 2) ? 'AGE_RESTRICTED' : 'REVIEW';
   const moderatedAt = reportedAt || new Date().toISOString();
   const categories = isNsfw ? ['adult'] : [];
   let moderationResultRecorded = false;
@@ -74,6 +80,7 @@ export async function recordReportForReview(db, {
         reportType,
         reportedBy: reporterPubkey,
         distinctReporterCount: result.distinctReporterCount,
+        escalationReporterCount: result.escalationReporterCount,
         reason,
         reportEventId,
         targetEventId,

--- a/src/moderation/report-review.test.mjs
+++ b/src/moderation/report-review.test.mjs
@@ -90,6 +90,8 @@ describe('recordReportForReview', () => {
       aiTelemetryRecorded: false,
     });
     expect(userReportWrites).toHaveLength(1);
+    // The trailing pair is the conflict guard: upgrade the stored source only
+    // when it is 'dm-report' and the incoming one is not.
     expect(userReportWrites[0].bindings).toEqual([
       SHA,
       REPORTER,
@@ -97,7 +99,10 @@ describe('recordReportForReview', () => {
       'reported from relay',
       '2026-05-13T17:19:42.000Z',
       'relay-report',
+      'dm-report',
+      'dm-report',
     ]);
+    expect(userReportWrites[0].sql).toMatch(/ON CONFLICT\(sha256, reporter_pubkey\) DO UPDATE SET source = excluded\.source/i);
     expect(moderationWrites).toHaveLength(1);
     expect(moderationWrites[0].sql).toMatch(/uploaded_by = CASE/i);
     expect(moderationWrites[0].sql).toMatch(/moderation_results\.uploaded_by IS NULL/i);

--- a/src/moderation/report-review.test.mjs
+++ b/src/moderation/report-review.test.mjs
@@ -12,6 +12,9 @@ const REPORTER = 'b'.repeat(64);
 
 function createDbMock({
   reporterCount = 1,
+  // Defaults to reporterCount: unless a test says otherwise, every reporter on
+  // the row is one whose source may drive an automatic outcome.
+  escalationReporterCount = reporterCount,
   moderationWrites = [],
   userReportWrites = [],
   aiDetectionEvents = [],
@@ -53,7 +56,7 @@ function createDbMock({
         },
         async first() {
           if (/COUNT\(DISTINCT reporter_pubkey\)/i.test(sql)) {
-            return { cnt: reporterCount };
+            return { cnt: reporterCount, escalation_cnt: escalationReporterCount };
           }
           return null;
         },
@@ -93,6 +96,7 @@ describe('recordReportForReview', () => {
       'violence',
       'reported from relay',
       '2026-05-13T17:19:42.000Z',
+      'relay-report',
     ]);
     expect(moderationWrites).toHaveLength(1);
     expect(moderationWrites[0].sql).toMatch(/uploaded_by = CASE/i);
@@ -127,6 +131,30 @@ describe('recordReportForReview', () => {
     expect(moderationWrites).toHaveLength(1);
     expect(moderationWrites[0].bindings[1]).toBe('AGE_RESTRICTED');
     expect(JSON.parse(moderationWrites[0].bindings[4])).toEqual(['adult']);
+  });
+
+  it('does not let a DM-sourced reporter complete the authenticated threshold', async () => {
+    const moderationWrites = [];
+    // Two distinct reporters on the row, but only one of them came from a
+    // source allowed to drive an automatic outcome -- the other is a report DM.
+    const db = createDbMock({ moderationWrites, reporterCount: 2, escalationReporterCount: 1 });
+
+    const result = await recordReportForReview(db, {
+      sha256: SHA,
+      reporterPubkey: REPORTER,
+      reportType: 'nudity',
+      source: 'user-report',
+    });
+
+    expect(result.action).toBe('REVIEW');
+    expect(result.distinctReporterCount).toBe(2);
+    expect(result.escalationReporterCount).toBe(1);
+    expect(moderationWrites[0].bindings[1]).toBe('REVIEW');
+    // Both counts are recorded so a moderator can see why it did not escalate.
+    expect(JSON.parse(moderationWrites[0].bindings[5])).toMatchObject({
+      distinctReporterCount: 2,
+      escalationReporterCount: 1,
+    });
   });
 
   it('keeps relay-origin NSFW reports in REVIEW even with multiple distinct reporters', async () => {

--- a/src/nostr/dm-reader.mjs
+++ b/src/nostr/dm-reader.mjs
@@ -51,6 +51,12 @@ export function resolveReportedAt(createdAt, nowMs = Date.now()) {
   return new Date(isUsable ? createdAt * 1000 : nowMs).toISOString();
 }
 
+async function findModerationResultBySha(db, sha256) {
+  return db.prepare(
+    'SELECT sha256 FROM moderation_results WHERE sha256 = ?'
+  ).bind(sha256).first();
+}
+
 /**
  * Derive the moderator's hex pubkey from NOSTR_PRIVATE_KEY (hex)
  * @param {Object} env - Environment with NOSTR_PRIVATE_KEY
@@ -277,15 +283,18 @@ export async function processRumor(rumor, giftWrapId, moderatorPubkey, env) {
   // is what the relay path (`'relay-report'`) already takes. Only the
   // authenticated HTTP report API still auto-escalates.
   //
-  // On a re-poll, skip only once this reporter's row for this sha256 exists.
+  // On a re-poll, skip only once this reporter's row and the review row both
+  // exist for this sha256.
   // recordReportForReview is not idempotent for a report whose timestamp fell
   // back to receipt time: moderated_at moves and the AI telemetry event_key
   // (report:<sha>:<type>:<createdAt>) changes, so INSERT OR IGNORE stops
-  // deduping it. Keying the skip on the report row rather than the dm_log row
-  // suppresses that without also suppressing the retry a failed write needs.
+  // deduping it. Keying the skip on the completed report+review pair, rather
+  // than the dm_log row alone or user_reports alone, suppresses that without
+  // also suppressing the retry a partial failed write needs.
   if (relatedSha256 && env.BLOSSOM_DB && !isOutgoing) {
     const alreadyRecorded = alreadyLogged
-      && await findReportByReporter(env.BLOSSOM_DB, relatedSha256, senderPubkey);
+      && await findReportByReporter(env.BLOSSOM_DB, relatedSha256, senderPubkey)
+      && await findModerationResultBySha(env.BLOSSOM_DB, relatedSha256);
     if (!alreadyRecorded) {
       try {
         await recordReportForReview(env.BLOSSOM_DB, {

--- a/src/nostr/dm-reader.mjs
+++ b/src/nostr/dm-reader.mjs
@@ -208,6 +208,14 @@ export async function processRumor(rumor, giftWrapId, moderatorPubkey, env) {
   // present. Skip for outgoing self-copies: the reporter is the
   // counterparty, not the moderator (who is echoing their own sent
   // message).
+  // No allowAutoAgeRestrict override: a report DM is the least verified
+  // report we accept. The sender is any key that can reach the moderation
+  // inbox, the sha256 is client-supplied, and unlike the relay poller this
+  // path does not fetch the target event, require a Divine client, or pass
+  // the processed-key gate. So it records the report and leaves the call to
+  // a human -- `source: 'dm-report'` takes the REVIEW-only default, which
+  // is what the relay path (`'relay-report'`) already takes. Only the
+  // authenticated HTTP report API still auto-escalates.
   if (relatedSha256 && env.BLOSSOM_DB && !isOutgoing) {
     try {
       await recordReportForReview(env.BLOSSOM_DB, {
@@ -217,7 +225,6 @@ export async function processRumor(rumor, giftWrapId, moderatorPubkey, env) {
         reason: content,
         source: 'dm-report',
         reportedAt: new Date(createdAt * 1000).toISOString(),
-        allowAutoAgeRestrict: true,
       });
     } catch (reportErr) {
       console.warn(`[DM-READER] Failed to record report for review:`, reportErr.message);

--- a/src/nostr/dm-reader.mjs
+++ b/src/nostr/dm-reader.mjs
@@ -7,15 +7,15 @@
 import { getPublicKey } from 'nostr-tools/pure';
 import { hexToBytes } from '@noble/hashes/utils';
 import { unwrapEvent } from 'nostr-tools/nip17';
-import { computeConversationId, logDm } from './dm-store.mjs';
+import { computeConversationId, findDmByNostrEventId, logDm } from './dm-store.mjs';
 import { recordReportForReview } from '../moderation/report-review.mjs';
 import { extractReportType } from './report-poller.mjs';
 import { initReportsTable } from '../reports.mjs';
 import { isValidSha256 } from '../validation.mjs';
 
-// How far back a first sync looks for gift wraps. Also the floor for a
-// report's self-reported timestamp: nothing this reader ingests can honestly
-// be older than the oldest thing it fetches.
+// How far back a first sync looks for gift wraps. Also the plausibility floor
+// for a report's self-reported timestamp: older values are still ingested, but
+// are stamped with receipt time so they surface in the current review queue.
 const INBOX_FIRST_RUN_LOOKBACK_SECONDS = 7 * 86400;
 
 // Tolerance for a reporting client whose clock runs a little fast.
@@ -218,6 +218,15 @@ export async function processRumor(rumor, giftWrapId, moderatorPubkey, env) {
   // Compute conversation ID against the non-moderator side so inbound
   // and outbound messages in the same thread share a conversation_id.
   const conversationId = computeConversationId(moderatorPubkey, counterpartyPubkey);
+
+  // syncInbox deliberately overlaps two days of gift wraps on every tick for
+  // NIP-17 timestamp randomization. If this gift wrap already reached dm_log,
+  // stop before report ingestion so repeated polls cannot re-bump review rows
+  // or emit fresh AI-report telemetry. Keep logDm's own check too as a final
+  // write-side guard.
+  if (env.BLOSSOM_DB && await findDmByNostrEventId(env.BLOSSOM_DB, giftWrapId)) {
+    return 'skipped';
+  }
 
   // Structured report data travels as NIP-17 tags on the rumor, not as
   // JSON-encoded content -- content stays plain human-readable text

--- a/src/nostr/dm-reader.mjs
+++ b/src/nostr/dm-reader.mjs
@@ -10,6 +10,7 @@ import { unwrapEvent } from 'nostr-tools/nip17';
 import { computeConversationId, logDm } from './dm-store.mjs';
 import { recordReportForReview } from '../moderation/report-review.mjs';
 import { extractReportType } from './report-poller.mjs';
+import { initReportsTable } from '../reports.mjs';
 import { isValidSha256 } from '../validation.mjs';
 
 /**
@@ -39,6 +40,15 @@ export async function syncInbox(env) {
 
   const privateKey = hexToBytes(env.NOSTR_PRIVATE_KEY);
   const moderatorPubkey = getPublicKey(privateKey);
+
+  // The fetch handler ensures the reports schema on every request, but this
+  // runs from the cron trigger too, which never touches it. Without this, the
+  // first tick after a deploy could reach a user_reports table that has no
+  // `source` column yet and drop every report it decrypted -- processRumor
+  // catches the write failure and moves on.
+  if (env.BLOSSOM_DB) {
+    await initReportsTable(env.BLOSSOM_DB);
+  }
 
   // Get last sync timestamp from KV
   let lastSync = null;

--- a/src/nostr/dm-reader.mjs
+++ b/src/nostr/dm-reader.mjs
@@ -189,7 +189,10 @@ export async function processRumor(rumor, giftWrapId, moderatorPubkey, env) {
   const rumorTags = Array.isArray(rumor.tags) ? rumor.tags : [];
   const shaTag = rumorTags.find((t) => Array.isArray(t) && t[0] === 'sha256' && t[1]);
   const hasReportTag = rumorTags.some(
-    (t) => Array.isArray(t) && (t[0] === 'report_type' || t[0] === 'l') && t[1]
+    (t) => Array.isArray(t) && (
+      (t[0] === 'report_type' && t[1])
+      || (t[0] === 'l' && t[1] && t[2] === 'social.nos.ontology')
+    )
   );
   const rawSha256 = typeof shaTag?.[1] === 'string' ? shaTag[1].toLowerCase() : null;
   const relatedSha256 = rawSha256 && isValidSha256(rawSha256) ? rawSha256 : null;

--- a/src/nostr/dm-reader.mjs
+++ b/src/nostr/dm-reader.mjs
@@ -171,11 +171,12 @@ export async function processRumor(rumor, giftWrapId, moderatorPubkey, env) {
   // Structured report data travels as NIP-17 tags on the rumor, not as
   // JSON-encoded content -- content stays plain human-readable text
   // (matching NIP-17's "content MUST be plain text" convention) so the
-  // admin Messages UI can keep rendering it as-is. A report DM carries a
-  // ['sha256', <hash>] tag when the reported content has a resolvable
-  // Blossom blob hash (content reports only -- user reports and
-  // DM-message reports have no such hash and never carry this tag,
-  // by design: see divine-mobile#6593 plan's "Non-goals").
+  // admin Messages UI can keep rendering it as-is. Every report DM carries
+  // a ['report_type', <nip-56 type>] tag; only content reports also carry
+  // ['sha256', <hash>], because user reports and DM-message reports have no
+  // resolvable Blossom blob hash (by design: see divine-mobile#6593 plan's
+  // "Non-goals"). So report_type classifies the message, sha256 gates the
+  // user_reports row.
   const rumorTags = Array.isArray(rumor.tags) ? rumor.tags : [];
   const shaTag = rumorTags.find((t) => Array.isArray(t) && t[0] === 'sha256' && t[1]);
   const reportTypeTag = rumorTags.find((t) => Array.isArray(t) && t[0] === 'report_type' && t[1]);
@@ -205,8 +206,13 @@ export async function processRumor(rumor, giftWrapId, moderatorPubkey, env) {
     }
   }
 
-  // Log to dm_log (dedup by nostr_event_id)
-  const messageType = relatedSha256
+  // Log to dm_log (dedup by nostr_event_id). Either machine-readable tag
+  // marks the DM as a report: report_type is present on all three report
+  // variants, sha256 only on content reports. Keying the badge off sha256
+  // alone would render a user report or a DM-message report as an ordinary
+  // reply in the admin Messages UI, which is a display gap rather than the
+  // deliberate user_reports non-goal above.
+  const messageType = (relatedSha256 || reportTypeTag)
     ? 'conversation_report'
     : (isOutgoing ? 'moderator_reply' : 'creator_reply');
   const result = await logDm(env.BLOSSOM_DB, {

--- a/src/nostr/dm-reader.mjs
+++ b/src/nostr/dm-reader.mjs
@@ -10,7 +10,7 @@ import { unwrapEvent } from 'nostr-tools/nip17';
 import { computeConversationId, findDmByNostrEventId, logDm } from './dm-store.mjs';
 import { recordReportForReview } from '../moderation/report-review.mjs';
 import { extractReportType } from './report-poller.mjs';
-import { initReportsTable } from '../reports.mjs';
+import { findReportByReporter, initReportsTable } from '../reports.mjs';
 import { isValidSha256 } from '../validation.mjs';
 
 // How far back a first sync looks for gift wraps. Also the plausibility floor
@@ -220,13 +220,16 @@ export async function processRumor(rumor, giftWrapId, moderatorPubkey, env) {
   const conversationId = computeConversationId(moderatorPubkey, counterpartyPubkey);
 
   // syncInbox deliberately overlaps two days of gift wraps on every tick for
-  // NIP-17 timestamp randomization. If this gift wrap already reached dm_log,
-  // stop before report ingestion so repeated polls cannot re-bump review rows
-  // or emit fresh AI-report telemetry. Keep logDm's own check too as a final
-  // write-side guard.
-  if (env.BLOSSOM_DB && await findDmByNostrEventId(env.BLOSSOM_DB, giftWrapId)) {
-    return 'skipped';
-  }
+  // NIP-17 timestamp randomization, so the same gift wrap is re-processed for
+  // up to two days. Look up whether it already reached dm_log, but don't
+  // return yet: a dm_log row proves the DM was stored, not that its report
+  // was. The report write below warns and continues, and logDm runs either
+  // way, so returning here would make a transient failure permanent -- the
+  // next tick would skip before it ever retried. Each side is deduped against
+  // its own row instead.
+  const alreadyLogged = env.BLOSSOM_DB
+    ? await findDmByNostrEventId(env.BLOSSOM_DB, giftWrapId)
+    : null;
 
   // Structured report data travels as NIP-17 tags on the rumor, not as
   // JSON-encoded content -- content stays plain human-readable text
@@ -273,19 +276,39 @@ export async function processRumor(rumor, giftWrapId, moderatorPubkey, env) {
   // a human -- `source: 'dm-report'` takes the REVIEW-only default, which
   // is what the relay path (`'relay-report'`) already takes. Only the
   // authenticated HTTP report API still auto-escalates.
+  //
+  // On a re-poll, skip only once this reporter's row for this sha256 exists.
+  // recordReportForReview is not idempotent for a report whose timestamp fell
+  // back to receipt time: moderated_at moves and the AI telemetry event_key
+  // (report:<sha>:<type>:<createdAt>) changes, so INSERT OR IGNORE stops
+  // deduping it. Keying the skip on the report row rather than the dm_log row
+  // suppresses that without also suppressing the retry a failed write needs.
   if (relatedSha256 && env.BLOSSOM_DB && !isOutgoing) {
-    try {
-      await recordReportForReview(env.BLOSSOM_DB, {
-        sha256: relatedSha256,
-        reporterPubkey: senderPubkey,
-        reportType,
-        reason: content,
-        source: 'dm-report',
-        reportedAt: resolveReportedAt(createdAt),
-      });
-    } catch (reportErr) {
-      console.warn(`[DM-READER] Failed to record report for review:`, reportErr.message);
+    const alreadyRecorded = alreadyLogged
+      && await findReportByReporter(env.BLOSSOM_DB, relatedSha256, senderPubkey);
+    if (!alreadyRecorded) {
+      try {
+        await recordReportForReview(env.BLOSSOM_DB, {
+          sha256: relatedSha256,
+          reporterPubkey: senderPubkey,
+          reportType,
+          reason: content,
+          source: 'dm-report',
+          reportedAt: resolveReportedAt(createdAt),
+        });
+      } catch (reportErr) {
+        console.warn(`[DM-READER] Failed to record report for review:`, reportErr.message);
+      }
     }
+  }
+
+  // The DM side is settled once dm_log holds this gift wrap. Returning here
+  // rather than letting logDm's own dedup decide keeps the outcome honest:
+  // logDm hands back the *existing* row on a dedup hit, whose truthy .id is
+  // indistinguishable from a fresh insert, so a re-poll used to count as
+  // 'synced'.
+  if (alreadyLogged) {
+    return 'skipped';
   }
 
   // Log to dm_log (dedup by nostr_event_id). Either machine-readable tag

--- a/src/nostr/dm-reader.mjs
+++ b/src/nostr/dm-reader.mjs
@@ -9,6 +9,7 @@ import { hexToBytes } from '@noble/hashes/utils';
 import { unwrapEvent } from 'nostr-tools/nip17';
 import { computeConversationId, logDm } from './dm-store.mjs';
 import { recordReportForReview } from '../moderation/report-review.mjs';
+import { extractReportType } from './report-poller.mjs';
 import { isValidSha256 } from '../validation.mjs';
 
 /**
@@ -173,20 +174,26 @@ export async function processRumor(rumor, giftWrapId, moderatorPubkey, env) {
   // Structured report data travels as NIP-17 tags on the rumor, not as
   // JSON-encoded content -- content stays plain human-readable text
   // (matching NIP-17's "content MUST be plain text" convention) so the
-  // admin Messages UI can keep rendering it as-is. Every report DM carries
-  // a ['report_type', <nip-56 type>] tag; only content reports also carry
-  // ['sha256', <hash>], because user reports and DM-message reports have no
-  // resolvable Blossom blob hash (by design: see divine-mobile#6593 plan's
-  // "Non-goals"). So report_type classifies the message, sha256 gates the
-  // user_reports row.
+  // admin Messages UI can keep rendering it as-is. A report DM carries the
+  // same NIP-32 ['L'/'l', ...] label pair its kind-1984 sibling publishes,
+  // plus a coarse ['report_type', <nip-56 type>] fallback; only content
+  // reports also carry ['sha256', <hash>], because user reports and
+  // DM-message reports have no resolvable Blossom blob hash (by design: see
+  // divine-mobile#6593 plan's "Non-goals"). So the label classifies the
+  // message and sha256 gates the user_reports row.
+  //
+  // extractReportType is the relay poller's resolver, shared deliberately:
+  // both paths write the same (sha256, reporter_pubkey) row under
+  // INSERT OR IGNORE, so if they disagreed on vocabulary whichever ingested
+  // first would pin its answer permanently.
   const rumorTags = Array.isArray(rumor.tags) ? rumor.tags : [];
   const shaTag = rumorTags.find((t) => Array.isArray(t) && t[0] === 'sha256' && t[1]);
-  const reportTypeTag = rumorTags.find((t) => Array.isArray(t) && t[0] === 'report_type' && t[1]);
+  const hasReportTag = rumorTags.some(
+    (t) => Array.isArray(t) && (t[0] === 'report_type' || t[0] === 'l') && t[1]
+  );
   const rawSha256 = typeof shaTag?.[1] === 'string' ? shaTag[1].toLowerCase() : null;
   const relatedSha256 = rawSha256 && isValidSha256(rawSha256) ? rawSha256 : null;
-  const reportType = typeof reportTypeTag?.[1] === 'string' && reportTypeTag[1].trim()
-    ? reportTypeTag[1].trim()
-    : 'dm_report';
+  const reportType = hasReportTag ? extractReportType(rumor) : 'dm_report';
 
   if (rawSha256 && !relatedSha256) {
     console.warn(`[DM-READER] Ignoring invalid sha256 tag on report DM ${giftWrapId}`);
@@ -215,12 +222,12 @@ export async function processRumor(rumor, giftWrapId, moderatorPubkey, env) {
   }
 
   // Log to dm_log (dedup by nostr_event_id). Either machine-readable tag
-  // marks the DM as a report: report_type is present on all three report
-  // variants, sha256 only on content reports. Keying the badge off sha256
-  // alone would render a user report or a DM-message report as an ordinary
-  // reply in the admin Messages UI, which is a display gap rather than the
-  // deliberate user_reports non-goal above.
-  const messageType = (relatedSha256 || reportTypeTag)
+  // marks the DM as a report: the report tags are present on all three
+  // report variants, sha256 only on content reports. Keying the badge off
+  // sha256 alone would render a user report or a DM-message report as an
+  // ordinary reply in the admin Messages UI, which is a display gap rather
+  // than the deliberate user_reports non-goal above.
+  const messageType = (relatedSha256 || hasReportTag)
     ? 'conversation_report'
     : (isOutgoing ? 'moderator_reply' : 'creator_reply');
   const result = await logDm(env.BLOSSOM_DB, {

--- a/src/nostr/dm-reader.mjs
+++ b/src/nostr/dm-reader.mjs
@@ -13,6 +13,44 @@ import { extractReportType } from './report-poller.mjs';
 import { initReportsTable } from '../reports.mjs';
 import { isValidSha256 } from '../validation.mjs';
 
+// How far back a first sync looks for gift wraps. Also the floor for a
+// report's self-reported timestamp: nothing this reader ingests can honestly
+// be older than the oldest thing it fetches.
+const INBOX_FIRST_RUN_LOOKBACK_SECONDS = 7 * 86400;
+
+// Tolerance for a reporting client whose clock runs a little fast.
+const REPORT_CLOCK_SKEW_SECONDS = 5 * 60;
+
+/**
+ * Resolve the timestamp a report DM should be recorded under.
+ *
+ * `rumor.created_at` comes out of the decrypted rumor, so it is written by
+ * whoever sent the DM and constrained by nothing. Two ways that bites:
+ * a missing or non-numeric value makes `new Date(x * 1000).toISOString()`
+ * throw `RangeError`, and because the caller records reports inside a
+ * warn-and-continue block, the whole report would be dropped rather than
+ * mis-stamped; a backdated value lands in `moderation_results.moderated_at`,
+ * which the admin queue sorts on and its `since` filter excludes, hiding the
+ * report from the humans it was escalated to.
+ *
+ * So the rumor's own timestamp is used only where it could plausibly be true,
+ * and receipt time stands in otherwise. Both failure directions round toward
+ * "surfaces now", never toward "surfaces never".
+ *
+ * @param {unknown} createdAt - rumor.created_at, in seconds
+ * @param {number} nowMs - current time in ms, injectable for tests
+ * @returns {string} ISO-8601 timestamp
+ */
+export function resolveReportedAt(createdAt, nowMs = Date.now()) {
+  const nowSeconds = Math.floor(nowMs / 1000);
+  const isUsable = Number.isFinite(createdAt)
+    && createdAt > 0
+    && createdAt <= nowSeconds + REPORT_CLOCK_SKEW_SECONDS
+    && createdAt >= nowSeconds - INBOX_FIRST_RUN_LOOKBACK_SECONDS;
+
+  return new Date(isUsable ? createdAt * 1000 : nowMs).toISOString();
+}
+
 /**
  * Derive the moderator's hex pubkey from NOSTR_PRIVATE_KEY (hex)
  * @param {Object} env - Environment with NOSTR_PRIVATE_KEY
@@ -66,7 +104,7 @@ export async function syncInbox(env) {
     since = lastSync - TWO_DAYS;
   } else {
     // First run: look back 7 days
-    since = Math.floor(Date.now() / 1000) - (7 * 86400);
+    since = Math.floor(Date.now() / 1000) - INBOX_FIRST_RUN_LOOKBACK_SECONDS;
   }
 
   // Fetch gift wrap events from relay
@@ -234,7 +272,7 @@ export async function processRumor(rumor, giftWrapId, moderatorPubkey, env) {
         reportType,
         reason: content,
         source: 'dm-report',
-        reportedAt: new Date(createdAt * 1000).toISOString(),
+        reportedAt: resolveReportedAt(createdAt),
       });
     } catch (reportErr) {
       console.warn(`[DM-READER] Failed to record report for review:`, reportErr.message);

--- a/src/nostr/dm-reader.mjs
+++ b/src/nostr/dm-reader.mjs
@@ -8,6 +8,8 @@ import { getPublicKey } from 'nostr-tools/pure';
 import { hexToBytes } from '@noble/hashes/utils';
 import { unwrapEvent } from 'nostr-tools/nip17';
 import { computeConversationId, logDm } from './dm-store.mjs';
+import { recordReportForReview } from '../moderation/report-review.mjs';
+import { isValidSha256 } from '../validation.mjs';
 
 /**
  * Derive the moderator's hex pubkey from NOSTR_PRIVATE_KEY (hex)
@@ -180,7 +182,15 @@ export async function processRumor(rumor, giftWrapId, moderatorPubkey, env) {
   const rumorTags = Array.isArray(rumor.tags) ? rumor.tags : [];
   const shaTag = rumorTags.find((t) => Array.isArray(t) && t[0] === 'sha256' && t[1]);
   const reportTypeTag = rumorTags.find((t) => Array.isArray(t) && t[0] === 'report_type' && t[1]);
-  const relatedSha256 = shaTag ? shaTag[1] : null;
+  const rawSha256 = typeof shaTag?.[1] === 'string' ? shaTag[1].toLowerCase() : null;
+  const relatedSha256 = rawSha256 && isValidSha256(rawSha256) ? rawSha256 : null;
+  const reportType = typeof reportTypeTag?.[1] === 'string' && reportTypeTag[1].trim()
+    ? reportTypeTag[1].trim()
+    : 'dm_report';
+
+  if (rawSha256 && !relatedSha256) {
+    console.warn(`[DM-READER] Ignoring invalid sha256 tag on report DM ${giftWrapId}`);
+  }
 
   // user_reports.sha256 is NOT NULL (it exists to count distinct
   // reporters per piece of content for escalation policy -- see
@@ -190,19 +200,17 @@ export async function processRumor(rumor, giftWrapId, moderatorPubkey, env) {
   // message).
   if (relatedSha256 && env.BLOSSOM_DB && !isOutgoing) {
     try {
-      await env.BLOSSOM_DB.prepare(`
-        INSERT OR IGNORE INTO user_reports
-        (sha256, reporter_pubkey, report_type, reason, created_at)
-        VALUES (?, ?, ?, ?, ?)
-      `).bind(
-        relatedSha256,
-        senderPubkey,
-        reportTypeTag ? reportTypeTag[1] : 'dm_report',
-        content,
-        new Date(createdAt * 1000).toISOString()
-      ).run();
+      await recordReportForReview(env.BLOSSOM_DB, {
+        sha256: relatedSha256,
+        reporterPubkey: senderPubkey,
+        reportType,
+        reason: content,
+        source: 'dm-report',
+        reportedAt: new Date(createdAt * 1000).toISOString(),
+        allowAutoAgeRestrict: true,
+      });
     } catch (reportErr) {
-      console.warn(`[DM-READER] Failed to insert user_report:`, reportErr.message);
+      console.warn(`[DM-READER] Failed to record report for review:`, reportErr.message);
     }
   }
 

--- a/src/nostr/dm-reader.mjs
+++ b/src/nostr/dm-reader.mjs
@@ -85,98 +85,12 @@ export async function syncInbox(env) {
         continue;
       }
 
-      const senderPubkey = rumor.pubkey;
-      const content = rumor.content;
-      const createdAt = rumor.created_at;
-
-      // NIP-17 gift wraps reach the moderator's inbox in two shapes:
-      //   1. Inbound: someone writes to moderator. rumor.pubkey = them,
-      //      rumor's ['p'] tag = moderator.
-      //   2. Outbound self-copy: moderator writes to someone else, client
-      //      also wraps a copy addressed to moderator so sent messages
-      //      aren't lost. rumor.pubkey = moderator, rumor's ['p'] tag =
-      //      real recipient.
-      // Without handling (2), outgoing replies get stored with
-      // sender = recipient = moderator, which produces a separate
-      // conversation_id (moderator+moderator) and breaks threading.
-      const isOutgoing = senderPubkey === moderatorPubkey;
-      let counterpartyPubkey = null;
-      if (isOutgoing) {
-        // Find the real recipient in rumor tags: first 'p' tag whose value
-        // is not the moderator itself. A valid NIP-17 outgoing rumor must
-        // have one; if it doesn't, the gift wrap is malformed and we can't
-        // thread it correctly. Skip rather than store as a self-conversation
-        // that would later disappear from the admin UI.
-        const pTags = Array.isArray(rumor.tags)
-          ? rumor.tags.filter((t) => Array.isArray(t) && t[0] === 'p' && t[1])
-          : [];
-        const other = pTags.find((t) => t[1] !== moderatorPubkey);
-        if (!other) {
-          console.warn(
-            `[DM-READER] Outgoing rumor has no non-moderator 'p' tag; skipping event ${giftWrap.id}. rumor.tags=${JSON.stringify(rumor.tags || [])}`
-          );
-          errors++;
-          continue;
-        }
-        counterpartyPubkey = other[1];
-      } else {
-        counterpartyPubkey = senderPubkey;
-      }
-
-      const recipientPubkey = isOutgoing ? counterpartyPubkey : moderatorPubkey;
-      const direction = isOutgoing ? 'outgoing' : 'incoming';
-      // Compute conversation ID against the non-moderator side so inbound
-      // and outbound messages in the same thread share a conversation_id.
-      const conversationId = computeConversationId(moderatorPubkey, counterpartyPubkey);
-
-      // Check if this is a structured conversation_report
-      let relatedSha256 = null;
-      try {
-        const parsed = JSON.parse(content);
-        if (parsed && parsed.type === 'conversation_report' && parsed.sha256) {
-          relatedSha256 = parsed.sha256;
-
-          // Also create entry in user_reports table if available.
-          // Skip for outgoing self-copies: the reporter is the counterparty,
-          // not the moderator (who is echoing their own sent message).
-          if (env.BLOSSOM_DB && !isOutgoing) {
-            try {
-              await env.BLOSSOM_DB.prepare(`
-                INSERT OR IGNORE INTO user_reports
-                (sha256, reporter_pubkey, report_type, reason, created_at)
-                VALUES (?, ?, ?, ?, ?)
-              `).bind(
-                parsed.sha256,
-                senderPubkey,
-                parsed.report_type || 'dm_report',
-                parsed.reason || content,
-                new Date(createdAt * 1000).toISOString()
-              ).run();
-            } catch (reportErr) {
-              console.warn(`[DM-READER] Failed to insert user_report:`, reportErr.message);
-            }
-          }
-        }
-      } catch {
-        // Not JSON — regular text message, that's fine
-      }
-
-      // Log to dm_log (dedup by nostr_event_id)
-      const messageType = relatedSha256
-        ? 'conversation_report'
-        : (isOutgoing ? 'moderator_reply' : 'creator_reply');
-      const result = await logDm(env.BLOSSOM_DB, {
-        conversationId,
-        nostrEventId: giftWrap.id,
-        senderPubkey,
-        recipientPubkey,
-        content,
-        direction,
-        messageType,
-        sha256: relatedSha256
-      });
-
-      if (result && result.id) {
+      const outcome = await processRumor(rumor, giftWrap.id, moderatorPubkey, env);
+      if (outcome === null) {
+        // Malformed outgoing self-copy (no resolvable counterparty) --
+        // logged inside processRumor.
+        errors++;
+      } else if (outcome === 'synced') {
         synced++;
       } else {
         skipped++;
@@ -194,6 +108,119 @@ export async function syncInbox(env) {
 
   console.log(`[DM-READER] Sync complete: ${synced} new, ${skipped} deduped, ${errors} errors`);
   return { synced, skipped, errors };
+}
+
+/**
+ * Classify and persist a single already-unwrapped NIP-17 rumor addressed
+ * to (or from) the moderator. Split out from syncInbox's loop so the
+ * classify logic (tag-based report detection, direction handling) is
+ * directly testable against a plain rumor object -- no relay connection
+ * or gift-wrap crypto round-trip required.
+ *
+ * @param {Object} rumor - decrypted kind-14 rumor (unwrapEvent's output)
+ * @param {string} giftWrapId - the outer kind-1059 event id (dm_log dedup key)
+ * @param {string} moderatorPubkey
+ * @param {Object} env - Environment bindings (BLOSSOM_DB)
+ * @returns {Promise<'synced'|'skipped'|null>} null means malformed
+ *   (logged internally) and should count as an error, not synced/skipped.
+ */
+export async function processRumor(rumor, giftWrapId, moderatorPubkey, env) {
+  const senderPubkey = rumor.pubkey;
+  const content = rumor.content;
+  const createdAt = rumor.created_at;
+
+  // NIP-17 gift wraps reach the moderator's inbox in two shapes:
+  //   1. Inbound: someone writes to moderator. rumor.pubkey = them,
+  //      rumor's ['p'] tag = moderator.
+  //   2. Outbound self-copy: moderator writes to someone else, client
+  //      also wraps a copy addressed to moderator so sent messages
+  //      aren't lost. rumor.pubkey = moderator, rumor's ['p'] tag =
+  //      real recipient.
+  // Without handling (2), outgoing replies get stored with
+  // sender = recipient = moderator, which produces a separate
+  // conversation_id (moderator+moderator) and breaks threading.
+  const isOutgoing = senderPubkey === moderatorPubkey;
+  let counterpartyPubkey = null;
+  if (isOutgoing) {
+    // Find the real recipient in rumor tags: first 'p' tag whose value
+    // is not the moderator itself. A valid NIP-17 outgoing rumor must
+    // have one; if it doesn't, the gift wrap is malformed and we can't
+    // thread it correctly. Skip rather than store as a self-conversation
+    // that would later disappear from the admin UI.
+    const pTags = Array.isArray(rumor.tags)
+      ? rumor.tags.filter((t) => Array.isArray(t) && t[0] === 'p' && t[1])
+      : [];
+    const other = pTags.find((t) => t[1] !== moderatorPubkey);
+    if (!other) {
+      console.warn(
+        `[DM-READER] Outgoing rumor has no non-moderator 'p' tag; skipping event ${giftWrapId}. rumor.tags=${JSON.stringify(rumor.tags || [])}`
+      );
+      return null;
+    }
+    counterpartyPubkey = other[1];
+  } else {
+    counterpartyPubkey = senderPubkey;
+  }
+
+  const recipientPubkey = isOutgoing ? counterpartyPubkey : moderatorPubkey;
+  const direction = isOutgoing ? 'outgoing' : 'incoming';
+  // Compute conversation ID against the non-moderator side so inbound
+  // and outbound messages in the same thread share a conversation_id.
+  const conversationId = computeConversationId(moderatorPubkey, counterpartyPubkey);
+
+  // Structured report data travels as NIP-17 tags on the rumor, not as
+  // JSON-encoded content -- content stays plain human-readable text
+  // (matching NIP-17's "content MUST be plain text" convention) so the
+  // admin Messages UI can keep rendering it as-is. A report DM carries a
+  // ['sha256', <hash>] tag when the reported content has a resolvable
+  // Blossom blob hash (content reports only -- user reports and
+  // DM-message reports have no such hash and never carry this tag,
+  // by design: see divine-mobile#6593 plan's "Non-goals").
+  const rumorTags = Array.isArray(rumor.tags) ? rumor.tags : [];
+  const shaTag = rumorTags.find((t) => Array.isArray(t) && t[0] === 'sha256' && t[1]);
+  const reportTypeTag = rumorTags.find((t) => Array.isArray(t) && t[0] === 'report_type' && t[1]);
+  const relatedSha256 = shaTag ? shaTag[1] : null;
+
+  // user_reports.sha256 is NOT NULL (it exists to count distinct
+  // reporters per piece of content for escalation policy -- see
+  // reports.mjs), so this can only ever fire when a sha256 tag is
+  // present. Skip for outgoing self-copies: the reporter is the
+  // counterparty, not the moderator (who is echoing their own sent
+  // message).
+  if (relatedSha256 && env.BLOSSOM_DB && !isOutgoing) {
+    try {
+      await env.BLOSSOM_DB.prepare(`
+        INSERT OR IGNORE INTO user_reports
+        (sha256, reporter_pubkey, report_type, reason, created_at)
+        VALUES (?, ?, ?, ?, ?)
+      `).bind(
+        relatedSha256,
+        senderPubkey,
+        reportTypeTag ? reportTypeTag[1] : 'dm_report',
+        content,
+        new Date(createdAt * 1000).toISOString()
+      ).run();
+    } catch (reportErr) {
+      console.warn(`[DM-READER] Failed to insert user_report:`, reportErr.message);
+    }
+  }
+
+  // Log to dm_log (dedup by nostr_event_id)
+  const messageType = relatedSha256
+    ? 'conversation_report'
+    : (isOutgoing ? 'moderator_reply' : 'creator_reply');
+  const result = await logDm(env.BLOSSOM_DB, {
+    conversationId,
+    nostrEventId: giftWrapId,
+    senderPubkey,
+    recipientPubkey,
+    content,
+    direction,
+    messageType,
+    sha256: relatedSha256
+  });
+
+  return result && result.id ? 'synced' : 'skipped';
 }
 
 /**

--- a/src/nostr/dm-reader.test.mjs
+++ b/src/nostr/dm-reader.test.mjs
@@ -8,7 +8,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { env } from 'cloudflare:test';
 import { generateSecretKey, getPublicKey } from 'nostr-tools/pure';
 import { bytesToHex } from '@noble/hashes/utils';
-import { getModeratorPubkey, processRumor } from './dm-reader.mjs';
+import { getModeratorPubkey, processRumor, resolveReportedAt } from './dm-reader.mjs';
 import { initDmLogTable } from './dm-store.mjs';
 import { initReportsTable } from '../reports.mjs';
 
@@ -81,8 +81,8 @@ describe('DM Reader - processRumor classify logic (real D1)', () => {
     await db.prepare('DELETE FROM moderation_results').run();
   });
 
-  function makeRumor({ pubkey, tags, content }) {
-    return { pubkey, tags, content, created_at: Math.floor(Date.now() / 1000) };
+  function makeRumor({ pubkey, tags, content, created_at = Math.floor(Date.now() / 1000) }) {
+    return { pubkey, tags, content, created_at };
   }
 
   // The DM and the kind-1984 report write the same
@@ -341,5 +341,85 @@ describe('DM Reader - processRumor classify logic (real D1)', () => {
 
     const reportRows = await db.prepare('SELECT * FROM user_reports').all();
     expect(reportRows.results).toHaveLength(1);
+  });
+
+  // rumor.created_at is written by the sender and validated by nothing. Before
+  // resolveReportedAt, a missing one threw RangeError out of
+  // `new Date(undefined * 1000).toISOString()` inside the warn-and-continue
+  // block, so the report vanished entirely -- the worst outcome available for
+  // a moderation report.
+  it('records a report whose rumor carries no created_at instead of dropping it', async () => {
+    // Built literally rather than through makeRumor, whose default parameter
+    // would substitute a valid timestamp and hide the case under test.
+    const rumor = {
+      pubkey: REPORTER,
+      tags: [['p', MODERATOR], ['sha256', SHA256], ['report_type', 'nudity']],
+      content: 'Content Report',
+    };
+    expect(rumor.created_at).toBeUndefined();
+
+    const outcome = await processRumor(rumor, 'evt-no-created-at', MODERATOR, { BLOSSOM_DB: db });
+    expect(outcome).toBe('synced');
+
+    const report = await db.prepare('SELECT * FROM user_reports').first();
+    expect(report).toBeTruthy();
+    expect(report.sha256).toBe(SHA256);
+
+    const moderation = await db.prepare('SELECT * FROM moderation_results').first();
+    expect(moderation.action).toBe('REVIEW');
+    // Stamped with receipt time, so it lands at the top of the queue rather
+    // than nowhere.
+    expect(Date.parse(moderation.moderated_at)).toBeGreaterThan(Date.now() - 60_000);
+  });
+
+  it('does not let a backdated rumor bury its report at the bottom of the review queue', async () => {
+    const rumor = makeRumor({
+      pubkey: REPORTER,
+      tags: [['p', MODERATOR], ['sha256', SHA256], ['report_type', 'nudity']],
+      content: 'Content Report',
+      created_at: 1600000000, // 2020
+    });
+
+    await processRumor(rumor, 'evt-backdated', MODERATOR, { BLOSSOM_DB: db });
+
+    const moderation = await db.prepare('SELECT * FROM moderation_results').first();
+    expect(Date.parse(moderation.moderated_at)).toBeGreaterThan(Date.now() - 60_000);
+  });
+});
+
+describe('DM Reader - resolveReportedAt', () => {
+  const NOW_MS = Date.parse('2026-08-09T12:00:00.000Z');
+  const NOW_SECONDS = Math.floor(NOW_MS / 1000);
+
+  it('keeps a plausible timestamp exactly as sent', () => {
+    const tenMinutesAgo = NOW_SECONDS - 600;
+    expect(resolveReportedAt(tenMinutesAgo, NOW_MS)).toBe(new Date(tenMinutesAgo * 1000).toISOString());
+  });
+
+  it('keeps a timestamp at the far edge of the reader\'s own lookback', () => {
+    const sixDaysAgo = NOW_SECONDS - (6 * 86400);
+    expect(resolveReportedAt(sixDaysAgo, NOW_MS)).toBe(new Date(sixDaysAgo * 1000).toISOString());
+  });
+
+  it('falls back to receipt time for missing, non-numeric, or nonsense values', () => {
+    const now = new Date(NOW_MS).toISOString();
+    expect(resolveReportedAt(undefined, NOW_MS)).toBe(now);
+    expect(resolveReportedAt(null, NOW_MS)).toBe(now);
+    expect(resolveReportedAt('1600000000', NOW_MS)).toBe(now); // string, not a number
+    expect(resolveReportedAt(NaN, NOW_MS)).toBe(now);
+    expect(resolveReportedAt(Infinity, NOW_MS)).toBe(now);
+    expect(resolveReportedAt(0, NOW_MS)).toBe(now);
+    expect(resolveReportedAt(-1, NOW_MS)).toBe(now);
+  });
+
+  it('falls back to receipt time for a backdated or future timestamp', () => {
+    const now = new Date(NOW_MS).toISOString();
+    expect(resolveReportedAt(NOW_SECONDS - (8 * 86400), NOW_MS)).toBe(now);
+    expect(resolveReportedAt(NOW_SECONDS + 3600, NOW_MS)).toBe(now);
+  });
+
+  it('tolerates a client clock that runs slightly fast', () => {
+    const oneMinuteAhead = NOW_SECONDS + 60;
+    expect(resolveReportedAt(oneMinuteAhead, NOW_MS)).toBe(new Date(oneMinuteAhead * 1000).toISOString());
   });
 });

--- a/src/nostr/dm-reader.test.mjs
+++ b/src/nostr/dm-reader.test.mjs
@@ -4,10 +4,13 @@
 // ABOUTME: Tests for DM inbox reader module (dm-reader.mjs)
 // ABOUTME: Verifies pubkey derivation, inbox sync behavior, and error handling
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { env } from 'cloudflare:test';
 import { generateSecretKey, getPublicKey } from 'nostr-tools/pure';
 import { bytesToHex } from '@noble/hashes/utils';
-import { getModeratorPubkey } from './dm-reader.mjs';
+import { getModeratorPubkey, processRumor } from './dm-reader.mjs';
+import { initDmLogTable } from './dm-store.mjs';
+import { initReportsTable } from '../reports.mjs';
 
 // Generate a stable test key in hex format (matching production usage)
 const testSecretKey = generateSecretKey();
@@ -33,5 +36,168 @@ describe('DM Reader - getModeratorPubkey', () => {
     const env = { NOSTR_PRIVATE_KEY: testHex };
     const pubkey = getModeratorPubkey(env);
     expect(pubkey).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+// Regression suite for processRumor -- the classify/persist logic
+// syncInbox delegates to per gift-wrap. Prior to divine-mobile#6593, this
+// logic (deciding whether an incoming DM becomes a user_reports row) had
+// zero test coverage anywhere in this repo. These tests pin the tag-based
+// contract that replaced the never-produced JSON-content-based one (see
+// the issue and its linked plan for the full cross-repo investigation).
+//
+// processRumor operates on an already-decrypted rumor object, so these
+// tests construct that object directly -- no relay connection or NIP-17
+// gift-wrap crypto round-trip needed to exercise the classify logic
+// itself (that round-trip is exercised by production traffic and by
+// nostr-tools' own test suite, not re-proven here).
+describe('DM Reader - processRumor classify logic (real D1)', () => {
+  const db = env.BLOSSOM_DB;
+  const MODERATOR = ('f'.repeat(63) + '1').slice(0, 64);
+  const REPORTER = ('a'.repeat(63) + '1').slice(0, 64);
+  const RECIPIENT = ('b'.repeat(63) + '1').slice(0, 64);
+  const SHA256 = ('c'.repeat(63) + '1').slice(0, 64);
+
+  beforeEach(async () => {
+    await initDmLogTable(db);
+    await initReportsTable(db);
+    await db.prepare('DELETE FROM dm_log').run();
+    await db.prepare('DELETE FROM user_reports').run();
+  });
+
+  function makeRumor({ pubkey, tags, content }) {
+    return { pubkey, tags, content, created_at: Math.floor(Date.now() / 1000) };
+  }
+
+  it('a rumor carrying [sha256, x] and [report_type, y] tags creates a user_reports row with those values', async () => {
+    const proseContent = 'Content Report\nReason: Spam or Unwanted Content\nEvent: ' + 'e'.repeat(64);
+    const rumor = makeRumor({
+      pubkey: REPORTER,
+      tags: [['p', MODERATOR], ['sha256', SHA256], ['report_type', 'spam']],
+      content: proseContent,
+    });
+
+    const outcome = await processRumor(rumor, 'evt-1', MODERATOR, { BLOSSOM_DB: db });
+
+    expect(outcome).toBe('synced');
+    const dmRow = await db.prepare('SELECT * FROM dm_log').first();
+    expect(dmRow.message_type).toBe('conversation_report');
+    expect(dmRow.sha256).toBe(SHA256);
+    expect(dmRow.content).toBe(proseContent); // content stays the human-readable prose, unchanged
+
+    const reportRow = await db.prepare('SELECT * FROM user_reports').first();
+    expect(reportRow).toBeTruthy();
+    expect(reportRow.sha256).toBe(SHA256);
+    expect(reportRow.reporter_pubkey).toBe(REPORTER);
+    expect(reportRow.report_type).toBe('spam');
+    expect(reportRow.reason).toBe(proseContent);
+  });
+
+  it('a rumor with no sha256 tag (plain prose, e.g. a user report or DM-message report) never creates a user_reports row', async () => {
+    const proseContent = 'User Report\nReason: Impersonation\nUser Pubkey: ' + 'b'.repeat(64);
+    const rumor = makeRumor({
+      pubkey: REPORTER,
+      tags: [['p', MODERATOR], ['report_type', 'impersonation']],
+      content: proseContent,
+    });
+
+    const outcome = await processRumor(rumor, 'evt-2', MODERATOR, { BLOSSOM_DB: db });
+
+    expect(outcome).toBe('synced');
+    const dmRow = await db.prepare('SELECT * FROM dm_log').first();
+    expect(dmRow.message_type).toBe('creator_reply');
+    expect(dmRow.sha256).toBeNull();
+    const reportRows = await db.prepare('SELECT * FROM user_reports').all();
+    expect(reportRows.results).toHaveLength(0);
+  });
+
+  it('a rumor with no tags at all (e.g. an ordinary chat reply) classifies as creator_reply, unchanged from before #6593', async () => {
+    const rumor = makeRumor({
+      pubkey: REPORTER,
+      tags: [['p', MODERATOR]],
+      content: 'hey, following up on my last message',
+    });
+
+    const outcome = await processRumor(rumor, 'evt-3', MODERATOR, { BLOSSOM_DB: db });
+
+    expect(outcome).toBe('synced');
+    const dmRow = await db.prepare('SELECT * FROM dm_log').first();
+    expect(dmRow.message_type).toBe('creator_reply');
+    const reportRows = await db.prepare('SELECT * FROM user_reports').all();
+    expect(reportRows.results).toHaveLength(0);
+  });
+
+  it('an empty-string sha256 tag is treated as absent, not inserted as a blank report', async () => {
+    const rumor = makeRumor({
+      pubkey: REPORTER,
+      tags: [['p', MODERATOR], ['sha256', '']],
+      content: 'Content Report',
+    });
+
+    const outcome = await processRumor(rumor, 'evt-4', MODERATOR, { BLOSSOM_DB: db });
+
+    expect(outcome).toBe('synced');
+    const dmRow = await db.prepare('SELECT * FROM dm_log').first();
+    expect(dmRow.message_type).toBe('creator_reply');
+    const reportRows = await db.prepare('SELECT * FROM user_reports').all();
+    expect(reportRows.results).toHaveLength(0);
+  });
+
+  it('an outgoing self-copy carrying a sha256 tag never creates a user_reports row (reporter is the counterparty, not the moderator)', async () => {
+    // Outgoing self-copy: rumor.pubkey === moderator, with a non-moderator
+    // p tag identifying the real recipient -- the exact shape processRumor
+    // detects via isOutgoing.
+    const rumor = makeRumor({
+      pubkey: MODERATOR,
+      tags: [['p', RECIPIENT], ['sha256', SHA256]],
+      content: 'moderator reply text',
+    });
+
+    const outcome = await processRumor(rumor, 'evt-5', MODERATOR, { BLOSSOM_DB: db });
+
+    expect(outcome).toBe('synced');
+    const dmRow = await db.prepare('SELECT * FROM dm_log').first();
+    expect(dmRow.direction).toBe('outgoing');
+    expect(dmRow.message_type).toBe('conversation_report'); // dm_log still reflects the tag...
+    const reportRows = await db.prepare('SELECT * FROM user_reports').all();
+    expect(reportRows.results).toHaveLength(0); // ...but user_reports is skipped for self-copies
+  });
+
+  it('an outgoing rumor with no resolvable non-moderator p tag returns null (malformed, counted as an error upstream)', async () => {
+    const rumor = makeRumor({
+      pubkey: MODERATOR,
+      tags: [['p', MODERATOR]], // only the moderator itself -- no real recipient
+      content: 'malformed self-copy',
+    });
+
+    const outcome = await processRumor(rumor, 'evt-6', MODERATOR, { BLOSSOM_DB: db });
+
+    expect(outcome).toBeNull();
+    const dmRows = await db.prepare('SELECT * FROM dm_log').all();
+    expect(dmRows.results).toHaveLength(0);
+  });
+
+  it('re-processing the same gift-wrap id does not double-insert a user_reports row', async () => {
+    const rumor = makeRumor({
+      pubkey: REPORTER,
+      tags: [['p', MODERATOR], ['sha256', SHA256]],
+      content: 'Content Report',
+    });
+
+    const first = await processRumor(rumor, 'evt-dedup', MODERATOR, { BLOSSOM_DB: db });
+    expect(first).toBe('synced');
+
+    // logDm's dedup-by-nostr_event_id path returns the *existing* row (a
+    // truthy .id), which processRumor can't tell apart from a fresh
+    // insert -- so a dedup hit is pre-existing, unrelated-to-#6593
+    // behavior that still reports 'synced' here (see the issue's own
+    // note: "skipped is structurally always 0"). What this test actually
+    // pins is the user_reports side: INSERT OR IGNORE against
+    // UNIQUE(sha256, reporter_pubkey) must not create a second row.
+    const second = await processRumor(rumor, 'evt-dedup', MODERATOR, { BLOSSOM_DB: db });
+    expect(second).toBe('synced');
+
+    const reportRows = await db.prepare('SELECT * FROM user_reports').all();
+    expect(reportRows.results).toHaveLength(1);
   });
 });

--- a/src/nostr/dm-reader.test.mjs
+++ b/src/nostr/dm-reader.test.mjs
@@ -345,6 +345,50 @@ describe('DM Reader - processRumor classify logic (real D1)', () => {
     expect(moderation.moderated_at).toBe('2000-01-01T00:00:00.000Z');
   });
 
+  // The other half of that dedup: a report whose write failed is not "already
+  // recorded", and the DM being in dm_log doesn't make it so. The report write
+  // sits in a warn-and-continue block and logDm runs regardless, so gating the
+  // re-poll on the dm_log row alone turns any transient D1 failure into a
+  // permanently dropped report -- counted as 'deduped' in the sync log, so it
+  // reads as handled. Same shape as the RangeError this branch removed.
+  it('retries a report whose write failed, on the next pass over the same gift wrap', async () => {
+    let failReportWrite = true;
+    const flakyDb = {
+      prepare(sql) {
+        if (failReportWrite && sql.includes('INSERT OR IGNORE INTO user_reports')) {
+          throw new Error('D1_ERROR: Network connection lost');
+        }
+        return db.prepare(sql);
+      },
+      batch: (...args) => db.batch(...args),
+      exec: (...args) => db.exec(...args),
+    };
+
+    const rumor = makeRumor({
+      pubkey: REPORTER,
+      tags: [['p', MODERATOR], ['sha256', SHA256], ['report_type', 'nudity']],
+      content: 'Content Report',
+    });
+
+    // First pass: the report write blows up, the DM is still logged.
+    expect(await processRumor(rumor, 'evt-flaky', MODERATOR, { BLOSSOM_DB: flakyDb })).toBe('synced');
+    expect((await db.prepare('SELECT * FROM user_reports').all()).results).toHaveLength(0);
+    expect((await db.prepare('SELECT * FROM dm_log').all()).results).toHaveLength(1);
+
+    // Second pass, inside syncInbox's two-day overlap, D1 healthy again.
+    failReportWrite = false;
+    expect(await processRumor(rumor, 'evt-flaky', MODERATOR, { BLOSSOM_DB: flakyDb })).toBe('skipped');
+
+    const reportRows = await db.prepare('SELECT * FROM user_reports').all();
+    expect(reportRows.results).toHaveLength(1);
+    expect(reportRows.results[0].source).toBe('dm-report');
+    const moderation = await db.prepare('SELECT * FROM moderation_results WHERE sha256 = ?').bind(SHA256).first();
+    expect(moderation.action).toBe('REVIEW');
+
+    // The DM itself is still deduped -- the retry must not double-log it.
+    expect((await db.prepare('SELECT * FROM dm_log').all()).results).toHaveLength(1);
+  });
+
   // rumor.created_at is written by the sender and validated by nothing. Before
   // resolveReportedAt, a missing one threw RangeError out of
   // `new Date(undefined * 1000).toISOString()` inside the warn-and-continue

--- a/src/nostr/dm-reader.test.mjs
+++ b/src/nostr/dm-reader.test.mjs
@@ -126,6 +126,25 @@ describe('DM Reader - processRumor classify logic (real D1)', () => {
     expect(dmRow.message_type).toBe('conversation_report');
   });
 
+  it('does not badge unrelated NIP-32 labels as report DMs', async () => {
+    const rumor = makeRumor({
+      pubkey: REPORTER,
+      tags: [
+        ['p', MODERATOR],
+        ['L', 'com.example.other'],
+        ['l', 'NS-underageUser', 'com.example.other'],
+      ],
+      content: 'Plain creator reply with an unrelated label',
+    });
+
+    expect(await processRumor(rumor, 'evt-unrelated-label', MODERATOR, { BLOSSOM_DB: db })).toBe('synced');
+
+    const dmRow = await db.prepare('SELECT * FROM dm_log').first();
+    expect(dmRow.message_type).toBe('creator_reply');
+    const reportRow = await db.prepare('SELECT * FROM user_reports').first();
+    expect(reportRow).toBeFalsy();
+  });
+
   it('a rumor carrying [sha256, x] and [report_type, y] tags creates a user_reports row with those values', async () => {
     const proseContent = 'Content Report\nReason: Spam or Unwanted Content\nEvent: ' + 'e'.repeat(64);
     const rumor = makeRumor({

--- a/src/nostr/dm-reader.test.mjs
+++ b/src/nostr/dm-reader.test.mjs
@@ -85,6 +85,47 @@ describe('DM Reader - processRumor classify logic (real D1)', () => {
     return { pubkey, tags, content, created_at: Math.floor(Date.now() / 1000) };
   }
 
+  // The DM and the kind-1984 report write the same
+  // (sha256, reporter_pubkey) row under INSERT OR IGNORE, so whichever
+  // ingests first pins report_type forever. Both must therefore resolve the
+  // reason identically -- the NIP-56 report_type alone collapses aiGenerated
+  // to 'other', which would strand the row as a mis-typed report.
+  it('resolves report_type from the NIP-32 label, not the collapsed NIP-56 tag', async () => {
+    const rumor = makeRumor({
+      pubkey: REPORTER,
+      tags: [
+        ['p', MODERATOR],
+        ['L', 'social.nos.ontology'],
+        ['l', 'NS-aiGenerated', 'social.nos.ontology'],
+        ['report_type', 'other'],
+        ['sha256', SHA256],
+      ],
+      content: 'Content Report\nReason: AI-Generated Content\nEvent: ' + 'e'.repeat(64),
+    });
+
+    expect(await processRumor(rumor, 'evt-label', MODERATOR, { BLOSSOM_DB: db })).toBe('synced');
+
+    const reportRow = await db.prepare('SELECT * FROM user_reports').first();
+    expect(reportRow.report_type).toBe('ai_generated');
+  });
+
+  it('badges a report DM that carries only the NIP-32 label', async () => {
+    const rumor = makeRumor({
+      pubkey: REPORTER,
+      tags: [
+        ['p', MODERATOR],
+        ['L', 'social.nos.ontology'],
+        ['l', 'NS-underageUser', 'social.nos.ontology'],
+      ],
+      content: 'User Report\nReason: Underage User\nUser Pubkey: ' + 'f'.repeat(64),
+    });
+
+    expect(await processRumor(rumor, 'evt-label-only', MODERATOR, { BLOSSOM_DB: db })).toBe('synced');
+
+    const dmRow = await db.prepare('SELECT * FROM dm_log').first();
+    expect(dmRow.message_type).toBe('conversation_report');
+  });
+
   it('a rumor carrying [sha256, x] and [report_type, y] tags creates a user_reports row with those values', async () => {
     const proseContent = 'Content Report\nReason: Spam or Unwanted Content\nEvent: ' + 'e'.repeat(64);
     const rumor = makeRumor({

--- a/src/nostr/dm-reader.test.mjs
+++ b/src/nostr/dm-reader.test.mjs
@@ -93,7 +93,11 @@ describe('DM Reader - processRumor classify logic (real D1)', () => {
     expect(reportRow.reason).toBe(proseContent);
   });
 
-  it('a rumor with no sha256 tag (plain prose, e.g. a user report or DM-message report) never creates a user_reports row', async () => {
+  it('a rumor with report_type but no sha256 (a user report or DM-message report) is still badged as a report, without a user_reports row', async () => {
+    // user_reports.sha256 is NOT NULL, so these two report variants can
+    // never become a report row -- but they are still reports, and the
+    // admin Messages UI's badge comes from message_type. Classifying them
+    // as creator_reply would hide them among ordinary chat replies.
     const proseContent = 'User Report\nReason: Impersonation\nUser Pubkey: ' + 'b'.repeat(64);
     const rumor = makeRumor({
       pubkey: REPORTER,
@@ -105,10 +109,24 @@ describe('DM Reader - processRumor classify logic (real D1)', () => {
 
     expect(outcome).toBe('synced');
     const dmRow = await db.prepare('SELECT * FROM dm_log').first();
-    expect(dmRow.message_type).toBe('creator_reply');
+    expect(dmRow.message_type).toBe('conversation_report');
     expect(dmRow.sha256).toBeNull();
     const reportRows = await db.prepare('SELECT * FROM user_reports').all();
     expect(reportRows.results).toHaveLength(0);
+  });
+
+  it('an empty-string report_type tag is treated as absent, so an ordinary reply is not badged as a report', async () => {
+    const rumor = makeRumor({
+      pubkey: REPORTER,
+      tags: [['p', MODERATOR], ['report_type', '']],
+      content: 'just a normal reply',
+    });
+
+    const outcome = await processRumor(rumor, 'evt-2b', MODERATOR, { BLOSSOM_DB: db });
+
+    expect(outcome).toBe('synced');
+    const dmRow = await db.prepare('SELECT * FROM dm_log').first();
+    expect(dmRow.message_type).toBe('creator_reply');
   });
 
   it('a rumor with no tags at all (e.g. an ordinary chat reply) classifies as creator_reply, unchanged from before #6593', async () => {

--- a/src/nostr/dm-reader.test.mjs
+++ b/src/nostr/dm-reader.test.mjs
@@ -61,8 +61,24 @@ describe('DM Reader - processRumor classify logic (real D1)', () => {
   beforeEach(async () => {
     await initDmLogTable(db);
     await initReportsTable(db);
+    await db.prepare(`
+      CREATE TABLE IF NOT EXISTS moderation_results (
+        sha256 TEXT PRIMARY KEY,
+        action TEXT,
+        provider TEXT,
+        scores TEXT,
+        categories TEXT,
+        raw_response TEXT,
+        moderated_at TEXT,
+        reviewed_by TEXT,
+        reviewed_at TEXT,
+        review_notes TEXT,
+        uploaded_by TEXT
+      )
+    `).run();
     await db.prepare('DELETE FROM dm_log').run();
     await db.prepare('DELETE FROM user_reports').run();
+    await db.prepare('DELETE FROM moderation_results').run();
   });
 
   function makeRumor({ pubkey, tags, content }) {
@@ -91,6 +107,54 @@ describe('DM Reader - processRumor classify logic (real D1)', () => {
     expect(reportRow.reporter_pubkey).toBe(REPORTER);
     expect(reportRow.report_type).toBe('spam');
     expect(reportRow.reason).toBe(proseContent);
+
+    const moderationRow = await db.prepare('SELECT * FROM moderation_results WHERE sha256 = ?').bind(SHA256).first();
+    expect(moderationRow).toBeTruthy();
+    expect(moderationRow.action).toBe('REVIEW');
+    expect(moderationRow.provider).toBe('user-report');
+    expect(JSON.parse(moderationRow.raw_response)).toMatchObject({
+      source: 'dm-report',
+      reportType: 'spam',
+      reportedBy: REPORTER,
+      reason: proseContent,
+    });
+  });
+
+  it('normalizes a valid uppercase sha256 tag before recording review state', async () => {
+    const rumor = makeRumor({
+      pubkey: REPORTER,
+      tags: [['p', MODERATOR], ['sha256', SHA256.toUpperCase()], ['report_type', 'spam']],
+      content: 'Content Report',
+    });
+
+    const outcome = await processRumor(rumor, 'evt-upper-sha', MODERATOR, { BLOSSOM_DB: db });
+
+    expect(outcome).toBe('synced');
+    const dmRow = await db.prepare('SELECT * FROM dm_log').first();
+    expect(dmRow.sha256).toBe(SHA256);
+    const reportRow = await db.prepare('SELECT * FROM user_reports').first();
+    expect(reportRow.sha256).toBe(SHA256);
+    const moderationRow = await db.prepare('SELECT action FROM moderation_results WHERE sha256 = ?').bind(SHA256).first();
+    expect(moderationRow.action).toBe('REVIEW');
+  });
+
+  it('does not record user_reports or moderation_results for an invalid sha256 tag', async () => {
+    const rumor = makeRumor({
+      pubkey: REPORTER,
+      tags: [['p', MODERATOR], ['sha256', 'not-a-sha'], ['report_type', 'spam']],
+      content: 'Content Report',
+    });
+
+    const outcome = await processRumor(rumor, 'evt-invalid-sha', MODERATOR, { BLOSSOM_DB: db });
+
+    expect(outcome).toBe('synced');
+    const dmRow = await db.prepare('SELECT * FROM dm_log').first();
+    expect(dmRow.message_type).toBe('conversation_report');
+    expect(dmRow.sha256).toBeNull();
+    const reportRows = await db.prepare('SELECT * FROM user_reports').all();
+    expect(reportRows.results).toHaveLength(0);
+    const moderationRows = await db.prepare('SELECT * FROM moderation_results').all();
+    expect(moderationRows.results).toHaveLength(0);
   });
 
   it('a rumor with report_type but no sha256 (a user report or DM-message report) is still badged as a report, without a user_reports row', async () => {

--- a/src/nostr/dm-reader.test.mjs
+++ b/src/nostr/dm-reader.test.mjs
@@ -389,6 +389,39 @@ describe('DM Reader - processRumor classify logic (real D1)', () => {
     expect((await db.prepare('SELECT * FROM dm_log').all()).results).toHaveLength(1);
   });
 
+  it('retries a report whose review row write failed after the reporter row was stored', async () => {
+    let failReviewWrite = true;
+    const flakyDb = {
+      prepare(sql) {
+        if (failReviewWrite && /INSERT INTO moderation_results/i.test(sql)) {
+          throw new Error('D1_ERROR: Network connection lost');
+        }
+        return db.prepare(sql);
+      },
+      batch: (...args) => db.batch(...args),
+      exec: (...args) => db.exec(...args),
+    };
+
+    const rumor = makeRumor({
+      pubkey: REPORTER,
+      tags: [['p', MODERATOR], ['sha256', SHA256], ['report_type', 'nudity']],
+      content: 'Content Report',
+    });
+
+    expect(await processRumor(rumor, 'evt-flaky-review', MODERATOR, { BLOSSOM_DB: flakyDb })).toBe('synced');
+    expect((await db.prepare('SELECT * FROM user_reports').all()).results).toHaveLength(1);
+    expect(await db.prepare('SELECT * FROM moderation_results WHERE sha256 = ?').bind(SHA256).first()).toBeNull();
+    expect((await db.prepare('SELECT * FROM dm_log').all()).results).toHaveLength(1);
+
+    failReviewWrite = false;
+    expect(await processRumor(rumor, 'evt-flaky-review', MODERATOR, { BLOSSOM_DB: flakyDb })).toBe('skipped');
+
+    expect((await db.prepare('SELECT * FROM user_reports').all()).results).toHaveLength(1);
+    const moderation = await db.prepare('SELECT * FROM moderation_results WHERE sha256 = ?').bind(SHA256).first();
+    expect(moderation.action).toBe('REVIEW');
+    expect((await db.prepare('SELECT * FROM dm_log').all()).results).toHaveLength(1);
+  });
+
   // rumor.created_at is written by the sender and validated by nothing. Before
   // resolveReportedAt, a missing one threw RangeError out of
   // `new Date(undefined * 1000).toISOString()` inside the warn-and-continue

--- a/src/nostr/dm-reader.test.mjs
+++ b/src/nostr/dm-reader.test.mjs
@@ -319,28 +319,30 @@ describe('DM Reader - processRumor classify logic (real D1)', () => {
     expect(dmRows.results).toHaveLength(0);
   });
 
-  it('re-processing the same gift-wrap id does not double-insert a user_reports row', async () => {
-    const rumor = makeRumor({
+  it('re-processing the same gift-wrap id skips before re-recording review state', async () => {
+    const rumor = {
       pubkey: REPORTER,
-      tags: [['p', MODERATOR], ['sha256', SHA256]],
+      tags: [['p', MODERATOR], ['sha256', SHA256], ['report_type', 'nudity']],
       content: 'Content Report',
-    });
+    };
 
     const first = await processRumor(rumor, 'evt-dedup', MODERATOR, { BLOSSOM_DB: db });
     expect(first).toBe('synced');
 
-    // logDm's dedup-by-nostr_event_id path returns the *existing* row (a
-    // truthy .id), which processRumor can't tell apart from a fresh
-    // insert -- so a dedup hit is pre-existing, unrelated-to-#6593
-    // behavior that still reports 'synced' here (see the issue's own
-    // note: "skipped is structurally always 0"). What this test actually
-    // pins is the user_reports side: INSERT OR IGNORE against
-    // UNIQUE(sha256, reporter_pubkey) must not create a second row.
+    await db.prepare('UPDATE moderation_results SET moderated_at = ? WHERE sha256 = ?')
+      .bind('2000-01-01T00:00:00.000Z', SHA256)
+      .run();
+
     const second = await processRumor(rumor, 'evt-dedup', MODERATOR, { BLOSSOM_DB: db });
-    expect(second).toBe('synced');
+    expect(second).toBe('skipped');
 
     const reportRows = await db.prepare('SELECT * FROM user_reports').all();
     expect(reportRows.results).toHaveLength(1);
+    const dmRows = await db.prepare('SELECT * FROM dm_log').all();
+    expect(dmRows.results).toHaveLength(1);
+
+    const moderation = await db.prepare('SELECT * FROM moderation_results WHERE sha256 = ?').bind(SHA256).first();
+    expect(moderation.moderated_at).toBe('2000-01-01T00:00:00.000Z');
   });
 
   // rumor.created_at is written by the sender and validated by nothing. Before

--- a/src/nostr/dm-report-contract.test.mjs
+++ b/src/nostr/dm-report-contract.test.mjs
@@ -195,6 +195,48 @@ describe('divine-mobile#6593 cross-repo contract', () => {
     expect(moderation.action).toBe('REVIEW');
   });
 
+  // The upgrade side of that same boundary. A reporter who DM'd first and then
+  // filed an authenticated report is one genuine reporter, not zero -- but
+  // INSERT OR IGNORE pinned their row to 'dm-report', so they stayed out of the
+  // escalation count for good. Only the trusted paths can drive the upgrade; a
+  // report DM never promotes itself.
+  it('a reporter who DM\'d first counts once they report through the authenticated path', async () => {
+    const { recordReportForReview } = await import('../moderation/report-review.mjs');
+
+    const { rumor } = await roundTrip(
+      mobileReportDmTags({
+        nip32Label: 'NS-sexualContent',
+        nip56Type: 'nudity',
+        sha256: SHA256,
+      }),
+      'Content Report\nReason: Sexual Content\nEvent: ' + 'e'.repeat(64),
+      'gw-nsfw-upgrade',
+    );
+
+    // Same key, same blob, now through POST /api/v1/report.
+    const upgraded = await recordReportForReview(db, {
+      sha256: SHA256,
+      reporterPubkey: rumor.pubkey,
+      reportType: 'nudity',
+      source: 'user-report',
+    });
+
+    expect(upgraded.distinctReporterCount).toBe(1);
+    expect(upgraded.escalationReporterCount).toBe(1);
+    expect(upgraded.action).toBe('REVIEW'); // one reporter is still only one
+
+    // And they now count as one of the two the authenticated path escalates on.
+    const second = await recordReportForReview(db, {
+      sha256: SHA256,
+      reporterPubkey: 'c'.repeat(64),
+      reportType: 'nudity',
+      source: 'user-report',
+    });
+
+    expect(second.escalationReporterCount).toBe(2);
+    expect(second.action).toBe('AGE_RESTRICTED');
+  });
+
   it('a user report (no sha256) is badged but writes no user_reports row', async () => {
     const { outcome } = await roundTrip(
       mobileReportDmTags({

--- a/src/nostr/dm-report-contract.test.mjs
+++ b/src/nostr/dm-report-contract.test.mjs
@@ -1,0 +1,174 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: End-to-end contract test for divine-mobile's moderation report DM
+// ABOUTME: Real NIP-59 gift-wrap round trip into the real processRumor + D1
+//
+// The unit tests elsewhere hand processRumor a plain rumor object. This one
+// starts from the exact tag list divine-mobile builds, gift-wraps it with
+// real NIP-44 crypto and schnorr signing, unwraps it, and asserts on the
+// rows the real classify path writes -- so a change on either side of the
+// producer/consumer contract fails here rather than in production.
+
+import { describe, expect, it, beforeEach } from 'vitest';
+import { env } from 'cloudflare:test';
+import { generateSecretKey, getPublicKey } from 'nostr-tools/pure';
+import { wrapEvent, unwrapEvent } from 'nostr-tools/nip59';
+import { processRumor } from './dm-reader.mjs';
+import { initDmLogTable } from './dm-store.mjs';
+import { initReportsTable } from '../reports.mjs';
+
+const SHA256 = 'b'.repeat(64);
+
+// Byte-for-byte what report_content_dialog.dart's _reportDmTags() produces,
+// after dm_repository.sendMessage -> nip17_message_service.buildRumor
+// prepends the ['p', recipient] tag.
+function mobileReportDmTags({ nip32Label, nip56Type, sha256 }) {
+  return [
+    ['L', 'social.nos.ontology'],
+    ['l', nip32Label, 'social.nos.ontology'],
+    ['report_type', nip56Type],
+    ...(sha256 ? [['sha256', sha256]] : []),
+  ];
+}
+
+describe('divine-mobile#6593 cross-repo contract', () => {
+  let db;
+  let reporterSk;
+  let moderatorSk;
+  let moderatorPubkey;
+
+  beforeEach(async () => {
+    db = env.BLOSSOM_DB;
+    await db.prepare('DROP TABLE IF EXISTS dm_log').run();
+    await db.prepare('DROP TABLE IF EXISTS user_reports').run();
+    await db.prepare('DROP TABLE IF EXISTS moderation_results').run();
+    await initDmLogTable(db);
+    await initReportsTable(db);
+    await db.prepare(`
+      CREATE TABLE IF NOT EXISTS moderation_results (
+        sha256 TEXT PRIMARY KEY, action TEXT, provider TEXT, scores TEXT,
+        categories TEXT, raw_response TEXT, moderated_at TEXT,
+        reviewed_by TEXT, reviewed_at TEXT, review_notes TEXT, uploaded_by TEXT
+      )`).run();
+
+    reporterSk = generateSecretKey();
+    moderatorSk = generateSecretKey();
+    moderatorPubkey = getPublicKey(moderatorSk);
+  });
+
+  // Real crypto: mobile's tags -> kind-14 rumor -> kind-13 seal -> kind-1059
+  // gift wrap -> unwrap -> the backend's real classify path.
+  async function roundTrip(tags, content, giftWrapId) {
+    // The kind-14 rumor divine-mobile builds: nip17_message_service.buildRumor
+    // prepends ['p', recipient], then dm_repository's additionalTags follow.
+    const giftWrap = wrapEvent(
+      {
+        kind: 14,
+        content,
+        tags: [['p', moderatorPubkey], ...tags],
+        created_at: Math.floor(Date.now() / 1000),
+      },
+      reporterSk,
+      moderatorPubkey,
+    );
+    expect(giftWrap.kind).toBe(1059);
+    const rumor = unwrapEvent(giftWrap, moderatorSk);
+    expect(rumor.kind).toBe(14);
+    expect(rumor.pubkey).toBe(getPublicKey(reporterSk));
+    const outcome = await processRumor(rumor, giftWrapId, moderatorPubkey, {
+      BLOSSOM_DB: db,
+    });
+    return { rumor, outcome };
+  }
+
+  it('an aiGenerated content report survives the wire as ai_generated', async () => {
+    const { rumor, outcome } = await roundTrip(
+      mobileReportDmTags({
+        nip32Label: 'NS-aiGenerated',
+        nip56Type: 'other', // what contentFilterReasonToNip56Type collapses to
+        sha256: SHA256,
+      }),
+      'Content Report\nReason: AI-Generated Content\nEvent: ' + 'e'.repeat(64),
+      'gw-ai',
+    );
+
+    // The tags really did survive the gift wrap.
+    expect(rumor.tags).toEqual(
+      expect.arrayContaining([['l', 'NS-aiGenerated', 'social.nos.ontology']]),
+    );
+    expect(outcome).toBe('synced');
+
+    const report = await db.prepare('SELECT * FROM user_reports').first();
+    expect(report.report_type).toBe('ai_generated');
+    expect(report.report_type).not.toBe('other'); // the bug this change fixes
+
+    const dm = await db.prepare('SELECT * FROM dm_log').first();
+    expect(dm.message_type).toBe('conversation_report');
+    expect(dm.content).toContain('Reason: AI-Generated Content'); // prose intact
+  });
+
+  it('a sexualContent report becomes NSFW-escalation eligible', async () => {
+    await roundTrip(
+      mobileReportDmTags({
+        nip32Label: 'NS-sexualContent',
+        nip56Type: 'nudity',
+        sha256: SHA256,
+      }),
+      'Content Report\nReason: Sexual Content\nEvent: ' + 'e'.repeat(64),
+      'gw-nsfw',
+    );
+
+    const report = await db.prepare('SELECT * FROM user_reports').first();
+    expect(report.report_type).toBe('sexual_content');
+    const { isNsfwReportType } = await import('../reports.mjs');
+    expect(isNsfwReportType(report.report_type)).toBe(true);
+  });
+
+  it('a user report (no sha256) is badged but writes no user_reports row', async () => {
+    const { outcome } = await roundTrip(
+      mobileReportDmTags({
+        nip32Label: 'NS-underageUser',
+        nip56Type: 'other',
+        sha256: null,
+      }),
+      'User Report\nReason: Underage User\nUser Pubkey: ' + 'f'.repeat(64),
+      'gw-user',
+    );
+
+    expect(outcome).toBe('synced');
+    const dm = await db.prepare('SELECT * FROM dm_log').first();
+    expect(dm.message_type).toBe('conversation_report');
+    const report = await db.prepare('SELECT * FROM user_reports').first();
+    expect(report).toBeFalsy(); // user_reports.sha256 is NOT NULL — by design
+  });
+
+  it('the DM and the kind-1984 poller agree, so INSERT OR IGNORE cannot mis-pin', async () => {
+    const { extractReportType } = await import('./report-poller.mjs');
+
+    // What the kind-1984 report event looks like (content_reporting_service).
+    const kind1984 = {
+      kind: 1984,
+      tags: [
+        ['e', 'e'.repeat(64), 'other'],
+        ['p', 'f'.repeat(64), 'other'],
+        ['L', 'social.nos.ontology'],
+        ['l', 'NS-aiGenerated', 'social.nos.ontology'],
+      ],
+      content: 'CONTENT REPORT - NIP-56\nReason: aiGenerated\nDetails: x',
+    };
+
+    const { rumor } = await roundTrip(
+      mobileReportDmTags({
+        nip32Label: 'NS-aiGenerated',
+        nip56Type: 'other',
+        sha256: SHA256,
+      }),
+      'Content Report\nReason: AI-Generated Content\nEvent: ' + 'e'.repeat(64),
+      'gw-agree',
+    );
+
+    expect(extractReportType(rumor)).toBe(extractReportType(kind1984));
+    expect(extractReportType(rumor)).toBe('ai_generated');
+  });
+});

--- a/src/nostr/dm-report-contract.test.mjs
+++ b/src/nostr/dm-report-contract.test.mjs
@@ -59,7 +59,7 @@ describe('divine-mobile#6593 cross-repo contract', () => {
 
   // Real crypto: mobile's tags -> kind-14 rumor -> kind-13 seal -> kind-1059
   // gift wrap -> unwrap -> the backend's real classify path.
-  async function roundTrip(tags, content, giftWrapId) {
+  async function roundTrip(tags, content, giftWrapId, sk = reporterSk) {
     // The kind-14 rumor divine-mobile builds: nip17_message_service.buildRumor
     // prepends ['p', recipient], then dm_repository's additionalTags follow.
     const giftWrap = wrapEvent(
@@ -69,13 +69,13 @@ describe('divine-mobile#6593 cross-repo contract', () => {
         tags: [['p', moderatorPubkey], ...tags],
         created_at: Math.floor(Date.now() / 1000),
       },
-      reporterSk,
+      sk,
       moderatorPubkey,
     );
     expect(giftWrap.kind).toBe(1059);
     const rumor = unwrapEvent(giftWrap, moderatorSk);
     expect(rumor.kind).toBe(14);
-    expect(rumor.pubkey).toBe(getPublicKey(reporterSk));
+    expect(rumor.pubkey).toBe(getPublicKey(sk));
     const outcome = await processRumor(rumor, giftWrapId, moderatorPubkey, {
       BLOSSOM_DB: db,
     });
@@ -108,7 +108,7 @@ describe('divine-mobile#6593 cross-repo contract', () => {
     expect(dm.content).toContain('Reason: AI-Generated Content'); // prose intact
   });
 
-  it('a sexualContent report becomes NSFW-escalation eligible', async () => {
+  it('a sexualContent report decodes to the NSFW report type', async () => {
     await roundTrip(
       mobileReportDmTags({
         nip32Label: 'NS-sexualContent',
@@ -123,6 +123,41 @@ describe('divine-mobile#6593 cross-repo contract', () => {
     expect(report.report_type).toBe('sexual_content');
     const { isNsfwReportType } = await import('../reports.mjs');
     expect(isNsfwReportType(report.report_type)).toBe(true);
+  });
+
+  // The trust boundary: a report DM is the least verified report we accept.
+  // Any key that can reach the moderation inbox can send one, the sha256 is
+  // client-supplied, and nothing here fetches the target event, requires a
+  // Divine client, or passes the relay's processed-key gate. Two of them must
+  // therefore still land on a human rather than auto-hiding public content.
+  it('two distinct NSFW report DMs stay REVIEW instead of auto age-restricting', async () => {
+    const secondReporterSk = generateSecretKey();
+    expect(getPublicKey(secondReporterSk)).not.toBe(getPublicKey(reporterSk));
+
+    for (const [i, sk] of [reporterSk, secondReporterSk].entries()) {
+      await roundTrip(
+        mobileReportDmTags({
+          nip32Label: 'NS-sexualContent',
+          nip56Type: 'nudity',
+          sha256: SHA256,
+        }),
+        'Content Report\nReason: Sexual Content\nEvent: ' + 'e'.repeat(64),
+        `gw-nsfw-escalation-${i}`,
+        sk,
+      );
+    }
+
+    // Two distinct reporters really did land — this is the input that would
+    // trip AGE_RESTRICTED if the DM path opted into auto-escalation.
+    const reports = await db.prepare('SELECT * FROM user_reports').all();
+    expect(reports.results).toHaveLength(2);
+    const { isNsfwReportType } = await import('../reports.mjs');
+    expect(isNsfwReportType(reports.results[0].report_type)).toBe(true);
+
+    const moderation = await db.prepare('SELECT * FROM moderation_results').first();
+    expect(moderation.action).toBe('REVIEW');
+    expect(moderation.action).not.toBe('AGE_RESTRICTED');
+    expect(JSON.parse(moderation.raw_response).source).toBe('dm-report');
   });
 
   it('a user report (no sha256) is badged but writes no user_reports row', async () => {

--- a/src/nostr/dm-report-contract.test.mjs
+++ b/src/nostr/dm-report-contract.test.mjs
@@ -160,6 +160,41 @@ describe('divine-mobile#6593 cross-repo contract', () => {
     expect(JSON.parse(moderation.raw_response).source).toBe('dm-report');
   });
 
+  // The same boundary from the other side. Keeping the DM path REVIEW-only
+  // stops a report DM escalating on its own, but the authenticated HTTP route
+  // still auto-escalates on two distinct reporters -- and it counts reporters
+  // per sha256, not per source. A report DM must therefore not be able to
+  // supply one of those two, or a single minted key plus one genuine report
+  // would hide public content.
+  it('a report DM cannot complete the authenticated path\'s two-reporter threshold', async () => {
+    const { recordReportForReview } = await import('../moderation/report-review.mjs');
+
+    await roundTrip(
+      mobileReportDmTags({
+        nip32Label: 'NS-sexualContent',
+        nip56Type: 'nudity',
+        sha256: SHA256,
+      }),
+      'Content Report\nReason: Sexual Content\nEvent: ' + 'e'.repeat(64),
+      'gw-nsfw-mixed',
+    );
+
+    // Now a genuine report for the same blob through POST /api/v1/report.
+    const httpResult = await recordReportForReview(db, {
+      sha256: SHA256,
+      reporterPubkey: 'c'.repeat(64),
+      reportType: 'nudity',
+      source: 'user-report',
+    });
+
+    expect(httpResult.distinctReporterCount).toBe(2);
+    expect(httpResult.escalationReporterCount).toBe(1);
+    expect(httpResult.action).toBe('REVIEW');
+
+    const moderation = await db.prepare('SELECT * FROM moderation_results').first();
+    expect(moderation.action).toBe('REVIEW');
+  });
+
   it('a user report (no sha256) is badged but writes no user_reports row', async () => {
     const { outcome } = await roundTrip(
       mobileReportDmTags({

--- a/src/nostr/dm-report-contract.test.mjs
+++ b/src/nostr/dm-report-contract.test.mjs
@@ -20,7 +20,7 @@ import { initReportsTable } from '../reports.mjs';
 
 const SHA256 = 'b'.repeat(64);
 
-// Byte-for-byte what report_content_dialog.dart's _reportDmTags() produces,
+// Byte-for-byte what ContentReportingService.moderationDmTags() produces,
 // after dm_repository.sendMessage -> nip17_message_service.buildRumor
 // prepends the ['p', recipient] tag.
 function mobileReportDmTags({ nip32Label, nip56Type, sha256 }) {

--- a/src/nostr/dm-store.mjs
+++ b/src/nostr/dm-store.mjs
@@ -126,6 +126,9 @@ export async function getConversations(db, { limit = 20, offset = 0, moderatorPu
       CASE
         WHEN li.latest_incoming_at IS NULL THEN 0
         WHEN rs.read_at IS NULL THEN 1
+        -- Both timestamps use SQLite/D1 CURRENT_TIMESTAMP, which has
+        -- one-second resolution. A message logged in the same second as
+        -- mark-read is treated as read until a later incoming message arrives.
         WHEN li.latest_incoming_at > rs.read_at THEN 1
         ELSE 0
       END AS unread

--- a/src/nostr/dm-store.mjs
+++ b/src/nostr/dm-store.mjs
@@ -27,6 +27,21 @@ export async function initDmLogTable(db) {
   await db.prepare('CREATE INDEX IF NOT EXISTS idx_dm_conversation ON dm_log(conversation_id)').run();
   await db.prepare('CREATE INDEX IF NOT EXISTS idx_dm_recipient ON dm_log(recipient_pubkey)').run();
   await db.prepare('CREATE INDEX IF NOT EXISTS idx_dm_sha256 ON dm_log(sha256)').run();
+  await initDmReadStateTable(db);
+}
+
+/**
+ * Create the per-conversation read-state table if it doesn't exist.
+ *
+ * Callable on its own, not just via initDmLogTable, because CI deploys the
+ * worker on every push to main but never runs `wrangler d1 migrations apply`.
+ * Without an ensure on the DM read paths, merging the migration that adds
+ * this table would still ship a getConversations() that LEFT JOINs a table
+ * production does not have yet, and the admin Messages UI would 500 until
+ * someone applied migration 012 by hand.
+ * @param {D1Database} db
+ */
+export async function initDmReadStateTable(db) {
   await db.prepare(`
     CREATE TABLE IF NOT EXISTS dm_conversation_read_state (
       conversation_id TEXT PRIMARY KEY,

--- a/src/nostr/dm-store.mjs
+++ b/src/nostr/dm-store.mjs
@@ -27,6 +27,12 @@ export async function initDmLogTable(db) {
   await db.prepare('CREATE INDEX IF NOT EXISTS idx_dm_conversation ON dm_log(conversation_id)').run();
   await db.prepare('CREATE INDEX IF NOT EXISTS idx_dm_recipient ON dm_log(recipient_pubkey)').run();
   await db.prepare('CREATE INDEX IF NOT EXISTS idx_dm_sha256 ON dm_log(sha256)').run();
+  await db.prepare(`
+    CREATE TABLE IF NOT EXISTS dm_conversation_read_state (
+      conversation_id TEXT PRIMARY KEY,
+      read_at TEXT NOT NULL
+    )
+  `).run();
 }
 
 export async function logDm(db, { conversationId, sha256, direction, senderPubkey, recipientPubkey, messageType, content, nostrEventId }) {
@@ -42,6 +48,23 @@ export async function logDm(db, { conversationId, sha256, direction, senderPubke
   `).bind(conversationId, sha256 || null, direction, senderPubkey, recipientPubkey, messageType || null, content, nostrEventId || null).run();
 
   return { id: result.meta.last_row_id };
+}
+
+/**
+ * Mark a conversation as read as of now. Monotonic: a concurrent call that
+ * resolves its own CURRENT_TIMESTAMP earlier than the row's current value
+ * (per SQLite/D1's write serialization this shouldn't happen in practice,
+ * but the guard is free) is a no-op rather than moving read_at backwards.
+ * @param {D1Database} db
+ * @param {string} conversationId
+ */
+export async function markConversationRead(db, conversationId) {
+  await db.prepare(`
+    INSERT INTO dm_conversation_read_state (conversation_id, read_at)
+    VALUES (?, CURRENT_TIMESTAMP)
+    ON CONFLICT(conversation_id) DO UPDATE SET read_at = CURRENT_TIMESTAMP
+    WHERE CURRENT_TIMESTAMP > dm_conversation_read_state.read_at
+  `).bind(conversationId).run();
 }
 
 export async function getConversations(db, { limit = 20, offset = 0, moderatorPubkey } = {}) {
@@ -63,6 +86,17 @@ export async function getConversations(db, { limit = 20, offset = 0, moderatorPu
       SELECT conversation_id, MAX(id) AS max_id, COUNT(*) AS message_count
       FROM dm_log
       GROUP BY conversation_id
+    ),
+    latest_incoming AS (
+      -- The most recent INCOMING message per conversation, used for the
+      -- unread computation below. Deliberately separate from the "latest"
+      -- CTE above (which is the most recent message in either direction,
+      -- used for the row's display columns): a moderator's own outgoing
+      -- reply must not mark their own inbox as unread to themselves.
+      SELECT conversation_id, MAX(created_at) AS latest_incoming_at
+      FROM dm_log
+      WHERE direction = 'incoming'
+      GROUP BY conversation_id
     )
     SELECT
       dl.conversation_id,
@@ -73,9 +107,17 @@ export async function getConversations(db, { limit = 20, offset = 0, moderatorPu
       dl.content as last_message,
       dl.sha256 as last_sha256,
       dl.message_type as last_message_type,
-      latest.message_count
+      latest.message_count,
+      CASE
+        WHEN li.latest_incoming_at IS NULL THEN 0
+        WHEN rs.read_at IS NULL THEN 1
+        WHEN li.latest_incoming_at > rs.read_at THEN 1
+        ELSE 0
+      END AS unread
     FROM latest
     JOIN dm_log dl ON dl.id = latest.max_id
+    LEFT JOIN latest_incoming li ON li.conversation_id = latest.conversation_id
+    LEFT JOIN dm_conversation_read_state rs ON rs.conversation_id = latest.conversation_id
     ORDER BY last_message_at DESC, dl.id DESC
     LIMIT ? OFFSET ?
   `).bind(limit, offset).all();

--- a/src/nostr/dm-store.mjs
+++ b/src/nostr/dm-store.mjs
@@ -50,10 +50,15 @@ export async function initDmReadStateTable(db) {
   `).run();
 }
 
+export async function findDmByNostrEventId(db, nostrEventId) {
+  if (!nostrEventId) return null;
+  return db.prepare('SELECT id FROM dm_log WHERE nostr_event_id = ?').bind(nostrEventId).first();
+}
+
 export async function logDm(db, { conversationId, sha256, direction, senderPubkey, recipientPubkey, messageType, content, nostrEventId }) {
   // Dedup by nostr_event_id if provided
   if (nostrEventId) {
-    const existing = await db.prepare('SELECT id FROM dm_log WHERE nostr_event_id = ?').bind(nostrEventId).first();
+    const existing = await findDmByNostrEventId(db, nostrEventId);
     if (existing) return existing;
   }
 

--- a/src/nostr/dm-store.test.mjs
+++ b/src/nostr/dm-store.test.mjs
@@ -6,7 +6,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { env } from 'cloudflare:test';
-import { computeConversationId, logDm, getConversations, getConversation, getConversationByPubkey, initDmLogTable } from './dm-store.mjs';
+import { computeConversationId, logDm, getConversations, getConversation, getConversationByPubkey, initDmLogTable, markConversationRead } from './dm-store.mjs';
 
 /**
  * Create a mock D1 database that tracks calls and stores data in-memory
@@ -578,5 +578,204 @@ describe('DM Store - getConversationByPubkey against real D1', () => {
 
     expect(messages).not.toBeNull();
     expect(messages.map((m) => m.content)).toEqual(['newer moderator conversation']);
+  });
+});
+
+// Regression suite for the unread badge (divine-mobile#6593): prior to this
+// change, admin/dashboard.html and admin/messages.html read `conv.unread` /
+// `conv.has_unread`, fields getConversations() never produced -- the badge
+// was structurally always empty. These tests run against real D1 so the
+// SQL CASE/JOIN logic (and the timestamp-format hazard called out in
+// migrations/012-dm-read-state.sql -- read_at and created_at must both be
+// generated via SQLite CURRENT_TIMESTAMP to stay comparably ordered) is
+// verified for real, not against a hand-rolled mock that could silently
+// drift from actual SQLite semantics.
+describe('DM Store - unread / markConversationRead against real D1', () => {
+  const db = env.BLOSSOM_DB;
+
+  const MODERATOR = 'f'.repeat(64);
+  const CREATOR = ('a'.repeat(63) + '1').slice(0, 64);
+  const OTHER_CREATOR = ('a'.repeat(63) + '2').slice(0, 64);
+
+  beforeEach(async () => {
+    await initDmLogTable(db);
+    await db.prepare('DELETE FROM dm_log').run();
+    await db.prepare('DELETE FROM dm_conversation_read_state').run();
+  });
+
+  async function backdateMessage(nostrEventId, timestamp) {
+    await db.prepare('UPDATE dm_log SET created_at = ? WHERE nostr_event_id = ?').bind(timestamp, nostrEventId).run();
+  }
+
+  async function unreadFor(conversationId) {
+    const conversations = await getConversations(db, { limit: 20, offset: 0 });
+    return conversations.find((c) => c.conversation_id === conversationId).unread;
+  }
+
+  it('a fresh conversation with an incoming message and no read state is unread', async () => {
+    const conversationId = computeConversationId(MODERATOR, CREATOR);
+    await logDm(db, {
+      conversationId,
+      direction: 'incoming',
+      senderPubkey: CREATOR,
+      recipientPubkey: MODERATOR,
+      content: 'hi',
+      nostrEventId: 'evt-1',
+    });
+
+    expect(await unreadFor(conversationId)).toBe(1);
+  });
+
+  it('markConversationRead clears unread for a message sent before the mark', async () => {
+    const conversationId = computeConversationId(MODERATOR, CREATOR);
+    await logDm(db, {
+      conversationId,
+      direction: 'incoming',
+      senderPubkey: CREATOR,
+      recipientPubkey: MODERATOR,
+      content: 'hi',
+      nostrEventId: 'evt-1',
+    });
+    await backdateMessage('evt-1', '2000-01-01 00:00:00');
+
+    await markConversationRead(db, conversationId);
+
+    expect(await unreadFor(conversationId)).toBe(0);
+  });
+
+  it('a new incoming message after markConversationRead flips the conversation unread again', async () => {
+    const conversationId = computeConversationId(MODERATOR, CREATOR);
+    await logDm(db, {
+      conversationId,
+      direction: 'incoming',
+      senderPubkey: CREATOR,
+      recipientPubkey: MODERATOR,
+      content: 'first',
+      nostrEventId: 'evt-1',
+    });
+    await backdateMessage('evt-1', '2000-01-01 00:00:00');
+    await markConversationRead(db, conversationId);
+    expect(await unreadFor(conversationId)).toBe(0);
+
+    // A message that arrives after the mark-read timestamp must flip the
+    // conversation back to unread -- this is the exact comparison this
+    // suite exists to pin: read_at and created_at share the same
+    // CURRENT_TIMESTAMP-generated text format, so `>` compares correctly
+    // regardless of which side is "later" in wall-clock terms.
+    await logDm(db, {
+      conversationId,
+      direction: 'incoming',
+      senderPubkey: CREATOR,
+      recipientPubkey: MODERATOR,
+      content: 'second, after read',
+      nostrEventId: 'evt-2',
+    });
+    await backdateMessage('evt-2', '2099-01-01 00:00:00');
+
+    expect(await unreadFor(conversationId)).toBe(1);
+  });
+
+  it('a conversation with only an outgoing message (moderator sent first) is never unread', async () => {
+    const conversationId = computeConversationId(MODERATOR, CREATOR);
+    await logDm(db, {
+      conversationId,
+      direction: 'outgoing',
+      senderPubkey: MODERATOR,
+      recipientPubkey: CREATOR,
+      messageType: 'moderator_reply',
+      content: 'starting a conversation',
+      nostrEventId: 'evt-1',
+    });
+
+    expect(await unreadFor(conversationId)).toBe(0);
+  });
+
+  it('the moderators own reply after marking read does not flip the conversation back to unread', async () => {
+    const conversationId = computeConversationId(MODERATOR, CREATOR);
+    await logDm(db, {
+      conversationId,
+      direction: 'incoming',
+      senderPubkey: CREATOR,
+      recipientPubkey: MODERATOR,
+      content: 'hi',
+      nostrEventId: 'evt-1',
+    });
+    await backdateMessage('evt-1', '2000-01-01 00:00:00');
+    await markConversationRead(db, conversationId);
+    expect(await unreadFor(conversationId)).toBe(0);
+
+    // Moderator's own reply, timestamped after the mark-read point --
+    // must NOT flip unread, or a moderator would see their own inbox as
+    // unread immediately after replying.
+    await logDm(db, {
+      conversationId,
+      direction: 'outgoing',
+      senderPubkey: MODERATOR,
+      recipientPubkey: CREATOR,
+      messageType: 'moderator_reply',
+      content: 'here is my reply',
+      nostrEventId: 'evt-2',
+    });
+    await backdateMessage('evt-2', '2099-01-01 00:00:00');
+
+    expect(await unreadFor(conversationId)).toBe(0);
+  });
+
+  it('unread state is independent per conversation', async () => {
+    const readConvId = computeConversationId(MODERATOR, CREATOR);
+    const unreadConvId = computeConversationId(MODERATOR, OTHER_CREATOR);
+
+    await logDm(db, {
+      conversationId: readConvId,
+      direction: 'incoming',
+      senderPubkey: CREATOR,
+      recipientPubkey: MODERATOR,
+      content: 'hi from creator',
+      nostrEventId: 'evt-read',
+    });
+    await backdateMessage('evt-read', '2000-01-01 00:00:00');
+    await markConversationRead(db, readConvId);
+
+    await logDm(db, {
+      conversationId: unreadConvId,
+      direction: 'incoming',
+      senderPubkey: OTHER_CREATOR,
+      recipientPubkey: MODERATOR,
+      content: 'hi from other creator',
+      nostrEventId: 'evt-unread',
+    });
+
+    expect(await unreadFor(readConvId)).toBe(0);
+    expect(await unreadFor(unreadConvId)).toBe(1);
+  });
+
+  it('markConversationRead is safe to call on a conversation with no messages', async () => {
+    const conversationId = computeConversationId(MODERATOR, CREATOR);
+    await expect(markConversationRead(db, conversationId)).resolves.not.toThrow();
+  });
+
+  it('markConversationRead does not move read_at backwards on a second call', async () => {
+    const conversationId = computeConversationId(MODERATOR, CREATOR);
+    await logDm(db, {
+      conversationId,
+      direction: 'incoming',
+      senderPubkey: CREATOR,
+      recipientPubkey: MODERATOR,
+      content: 'hi',
+      nostrEventId: 'evt-1',
+    });
+
+    await markConversationRead(db, conversationId);
+    const firstReadAt = (await db.prepare('SELECT read_at FROM dm_conversation_read_state WHERE conversation_id = ?').bind(conversationId).first()).read_at;
+
+    // Simulate an out-of-order retry carrying an earlier read_at than what's
+    // already stored -- the WHERE guard in markConversationRead's upsert
+    // must leave the newer stored value alone rather than regressing it.
+    await db.prepare('UPDATE dm_conversation_read_state SET read_at = ? WHERE conversation_id = ?').bind('2099-01-01 00:00:00', conversationId).run();
+    await markConversationRead(db, conversationId);
+    const secondReadAt = (await db.prepare('SELECT read_at FROM dm_conversation_read_state WHERE conversation_id = ?').bind(conversationId).first()).read_at;
+
+    expect(secondReadAt).toBe('2099-01-01 00:00:00');
+    void firstReadAt; // kept for readability of intent, not asserted directly (CURRENT_TIMESTAMP has 1s resolution)
   });
 });

--- a/src/nostr/dm-store.test.mjs
+++ b/src/nostr/dm-store.test.mjs
@@ -766,7 +766,10 @@ describe('DM Store - unread / markConversationRead against real D1', () => {
     });
 
     await markConversationRead(db, conversationId);
-    const firstReadAt = (await db.prepare('SELECT read_at FROM dm_conversation_read_state WHERE conversation_id = ?').bind(conversationId).first()).read_at;
+    // The exact value isn't asserted (CURRENT_TIMESTAMP has 1s resolution),
+    // only that the first call inserted a row for the upsert to conflict on.
+    const firstRow = await db.prepare('SELECT read_at FROM dm_conversation_read_state WHERE conversation_id = ?').bind(conversationId).first();
+    expect(firstRow.read_at).toBeTruthy();
 
     // Simulate an out-of-order retry carrying an earlier read_at than what's
     // already stored -- the WHERE guard in markConversationRead's upsert
@@ -776,6 +779,5 @@ describe('DM Store - unread / markConversationRead against real D1', () => {
     const secondReadAt = (await db.prepare('SELECT read_at FROM dm_conversation_read_state WHERE conversation_id = ?').bind(conversationId).first()).read_at;
 
     expect(secondReadAt).toBe('2099-01-01 00:00:00');
-    void firstReadAt; // kept for readability of intent, not asserted directly (CURRENT_TIMESTAMP has 1s resolution)
   });
 });

--- a/src/nostr/report-poller.mjs
+++ b/src/nostr/report-poller.mjs
@@ -6,6 +6,7 @@
 
 import { extractMediaShaFromEvent, getEventTagValue } from '../validation.mjs';
 import { recordReportForReview } from '../moderation/report-review.mjs';
+import { initReportsTable } from '../reports.mjs';
 import { fetchNostrEventById } from './relay-client.mjs';
 import { VIDEO_KINDS } from './video-kinds.mjs';
 
@@ -296,6 +297,14 @@ export async function pollRelayForReports(env, options = {}) {
   const fetchReports = injectedFetchReportsFromRelay || fetchReportsFromRelay;
   const fetchTargetEvent = injectedFetchTargetEvent || ((eventId) => fetchNostrEventById(eventId, relays, env));
   const recordReport = injectedRecordReport || ((payload) => recordReportForReview(env.BLOSSOM_DB, payload));
+
+  // Same reason as syncInbox's: this runs from the cron trigger, which never
+  // goes through the fetch handler's schema ensure, so the first tick after a
+  // deploy could otherwise write against a user_reports table missing the
+  // `source` column.
+  if (!injectedRecordReport && env.BLOSSOM_DB) {
+    await initReportsTable(env.BLOSSOM_DB);
+  }
   const requireDivineClient = env.RELAY_REPORTS_REQUIRE_DIVINE_CLIENT !== 'false';
 
   const results = {

--- a/src/nostr/report-poller.mjs
+++ b/src/nostr/report-poller.mjs
@@ -67,6 +67,10 @@ function normalizeReportType(value) {
     return fromLabel;
   }
 
+  if (normalized.startsWith('ns_')) {
+    console.warn(`[REPORT-POLLER] Unmapped social.nos.ontology report label: ${value}`);
+  }
+
   if (
     normalized === 'aigenerated'
     || normalized === 'ai_generated'
@@ -77,6 +81,14 @@ function normalizeReportType(value) {
   }
 
   return normalized;
+}
+
+function isSocialOntologyLabelTag(tag) {
+  return Array.isArray(tag)
+    && tag[0] === 'l'
+    && typeof tag[1] === 'string'
+    && tag[1].trim()
+    && tag[2] === 'social.nos.ontology';
 }
 
 /**
@@ -94,7 +106,7 @@ export function extractReportType(reportEvent) {
   const tags = reportEvent?.tags || [];
   const eMarker = tags.find((tag) => tag[0] === 'e' && tag[2])?.[2];
   const pMarker = tags.find((tag) => tag[0] === 'p' && tag[2])?.[2];
-  const label = tags.find((tag) => tag[0] === 'l' && tag[1])?.[1];
+  const label = tags.find(isSocialOntologyLabelTag)?.[1];
   const reportTypeTag = tags.find((tag) => tag[0] === 'report_type' && tag[1])?.[1];
   const content = typeof reportEvent?.content === 'string' ? reportEvent.content : '';
   const reasonMatch = content.match(/^Reason:\s*([^\n\r]+)/im);

--- a/src/nostr/report-poller.mjs
+++ b/src/nostr/report-poller.mjs
@@ -31,9 +31,12 @@ export function extractReportTargetEventId(reportEvent) {
 // values reach here already lowercased and de-hyphenated, so 'NS-sexualContent'
 // arrives as 'ns_sexualcontent' -- a form that matches nothing in
 // AI_REPORT_TYPES or NSFW_REPORT_TYPES. Resolve each to the canonical type so
-// escalation policy (isNsfwReportType -> AGE_RESTRICTED, isAiReportType -> AI
-// telemetry) actually fires. divine-relay-manager's CATEGORY_LABELS is the
-// same table on the display side.
+// the predicates keyed off it actually fire: isNsfwReportType sets the adult
+// category on the review row, and isAiReportType records AI telemetry. Neither
+// Nostr path auto age-restricts -- relay reports and report DMs are both
+// REVIEW-only -- so what this fixes is the stored type and the signals
+// moderators triage on, not automatic enforcement.
+// divine-relay-manager's CATEGORY_LABELS is the same table on the display side.
 const NOS_ONTOLOGY_LABEL_TYPES = new Map([
   ['ns_spam', 'spam'],
   ['ns_harassment', 'harassment'],

--- a/src/nostr/report-poller.mjs
+++ b/src/nostr/report-poller.mjs
@@ -25,6 +25,33 @@ export function extractReportTargetEventId(reportEvent) {
   return null;
 }
 
+// divine-mobile and divine-web publish report reasons as NIP-32 labels in the
+// social.nos.ontology namespace ('NS-sexualContent', 'NS-csam', ...). Those
+// values reach here already lowercased and de-hyphenated, so 'NS-sexualContent'
+// arrives as 'ns_sexualcontent' -- a form that matches nothing in
+// AI_REPORT_TYPES or NSFW_REPORT_TYPES. Resolve each to the canonical type so
+// escalation policy (isNsfwReportType -> AGE_RESTRICTED, isAiReportType -> AI
+// telemetry) actually fires. divine-relay-manager's CATEGORY_LABELS is the
+// same table on the display side.
+const NOS_ONTOLOGY_LABEL_TYPES = new Map([
+  ['ns_spam', 'spam'],
+  ['ns_harassment', 'harassment'],
+  ['ns_violence', 'violence'],
+  ['ns_sexualcontent', 'sexual_content'],
+  ['ns_sexual_content', 'sexual_content'],
+  ['ns_copyright', 'copyright'],
+  ['ns_falseinformation', 'false_information'],
+  ['ns_false_information', 'false_information'],
+  ['ns_childsafety', 'child_safety'],
+  ['ns_child_safety', 'child_safety'],
+  ['ns_csam', 'csam'],
+  ['ns_underageuser', 'underage_user'],
+  ['ns_underage_user', 'underage_user'],
+  ['ns_aigenerated', 'ai_generated'],
+  ['ns_ai_generated', 'ai_generated'],
+  ['ns_other', 'other'],
+]);
+
 function normalizeReportType(value) {
   if (typeof value !== 'string') {
     return null;
@@ -35,10 +62,14 @@ function normalizeReportType(value) {
     return null;
   }
 
+  const fromLabel = NOS_ONTOLOGY_LABEL_TYPES.get(normalized);
+  if (fromLabel) {
+    return fromLabel;
+  }
+
   if (
     normalized === 'aigenerated'
     || normalized === 'ai_generated'
-    || normalized === 'ns_aigenerated'
     || normalized === 'aigenerated_content'
     || normalized === 'ai_generated_content'
   ) {
@@ -48,15 +79,28 @@ function normalizeReportType(value) {
   return normalized;
 }
 
+/**
+ * Resolve a report's type from the most specific source available.
+ *
+ * Shared by both ingestion paths so they can never disagree: the kind-1984
+ * relay poller reads a signed report event, and the DM reader reads a NIP-17
+ * rumor. The `report_type` arm sits above the content regex because a rumor's
+ * content is localized prose ('Reason: Spam or Unwanted Content'), which would
+ * otherwise normalize into a locale-dependent type. kind-1984 events carry no
+ * `report_type` tag, so that arm is inert for them and their behaviour is
+ * unchanged.
+ */
 export function extractReportType(reportEvent) {
   const tags = reportEvent?.tags || [];
   const eMarker = tags.find((tag) => tag[0] === 'e' && tag[2])?.[2];
   const pMarker = tags.find((tag) => tag[0] === 'p' && tag[2])?.[2];
   const label = tags.find((tag) => tag[0] === 'l' && tag[1])?.[1];
+  const reportTypeTag = tags.find((tag) => tag[0] === 'report_type' && tag[1])?.[1];
   const content = typeof reportEvent?.content === 'string' ? reportEvent.content : '';
   const reasonMatch = content.match(/^Reason:\s*([^\n\r]+)/im);
 
   return normalizeReportType(label)
+    || normalizeReportType(reportTypeTag)
     || normalizeReportType(reasonMatch?.[1])
     || normalizeReportType(eMarker)
     || normalizeReportType(pMarker)

--- a/src/nostr/report-poller.mjs
+++ b/src/nostr/report-poller.mjs
@@ -305,7 +305,7 @@ export async function pollRelayForReports(env, options = {}) {
   // goes through the fetch handler's schema ensure, so the first tick after a
   // deploy could otherwise write against a user_reports table missing the
   // `source` column.
-  if (!injectedRecordReport && env.BLOSSOM_DB) {
+  if (env.BLOSSOM_DB?.prepare) {
     await initReportsTable(env.BLOSSOM_DB);
   }
   const requireDivineClient = env.RELAY_REPORTS_REQUIRE_DIVINE_CLIENT !== 'false';

--- a/src/nostr/report-poller.test.mjs
+++ b/src/nostr/report-poller.test.mjs
@@ -18,6 +18,7 @@ import {
   setLastReportPollTimestamp,
   shouldAcceptReportTarget,
 } from './report-poller.mjs';
+import { isAiReportType, isNsfwReportType } from '../reports.mjs';
 
 const TARGET_EVENT_ID = 'a'.repeat(64);
 const REPORT_EVENT_ID = 'c'.repeat(64);
@@ -89,6 +90,83 @@ describe('kind 1984 parsing', () => {
       ],
       content: 'CONTENT REPORT - NIP-56\nReason: aiGenerated\nDetails: AI-Generated Content',
     })).toBe('ai_generated');
+  });
+
+  // Regression: only the aiGenerated family used to be decoded, so every
+  // other NS- label reached user_reports.report_type still prefixed
+  // ('ns_sexualcontent'), matching nothing in NSFW_REPORT_TYPES -- NSFW auto
+  // age-restriction could never fire from a diVine report. Every existing
+  // fixture used NS-aiGenerated, the one label that happened to work.
+  describe('social.nos.ontology label vocabulary', () => {
+    const divineReport = (label) => ({
+      kind: 1984,
+      tags: [
+        ['e', TARGET_EVENT_ID, 'other'],
+        ['L', 'social.nos.ontology'],
+        ['l', label, 'social.nos.ontology'],
+      ],
+      content: '',
+    });
+
+    it.each([
+      ['NS-spam', 'spam'],
+      ['NS-harassment', 'harassment'],
+      ['NS-violence', 'violence'],
+      ['NS-sexualContent', 'sexual_content'],
+      ['NS-copyright', 'copyright'],
+      ['NS-falseInformation', 'false_information'],
+      ['NS-childSafety', 'child_safety'],
+      ['NS-csam', 'csam'],
+      ['NS-underageUser', 'underage_user'],
+      ['NS-aiGenerated', 'ai_generated'],
+      ['NS-other', 'other'],
+    ])('resolves %s to %s', (label, expected) => {
+      expect(extractReportType(divineReport(label))).toBe(expected);
+    });
+
+    it('makes a sexual-content report eligible for NSFW escalation', () => {
+      expect(isNsfwReportType(extractReportType(divineReport('NS-sexualContent')))).toBe(true);
+    });
+
+    it('makes an AI report eligible for AI detection telemetry', () => {
+      expect(isAiReportType(extractReportType(divineReport('NS-aiGenerated')))).toBe(true);
+    });
+  });
+
+  describe('report_type tag (moderation DM ingestion)', () => {
+    it('prefers the NIP-32 label over the report_type tag', () => {
+      expect(extractReportType({
+        tags: [
+          ['l', 'NS-aiGenerated', 'social.nos.ontology'],
+          ['report_type', 'other'],
+        ],
+        content: '',
+      })).toBe('ai_generated');
+    });
+
+    it('falls back to the report_type tag when no label is present', () => {
+      expect(extractReportType({
+        tags: [['report_type', 'nudity']],
+        content: '',
+      })).toBe('nudity');
+    });
+
+    // A DM's content is localized prose, so letting the Reason: regex
+    // outrank an explicit tag would make report_type locale-dependent.
+    it('outranks a localized Reason line in the content', () => {
+      expect(extractReportType({
+        tags: [['report_type', 'spam']],
+        content: 'Content Report\nReason: Contenu indésirable\nEvent: abc',
+      })).toBe('spam');
+    });
+
+    it('leaves kind-1984 events unchanged (they carry no report_type tag)', () => {
+      expect(extractReportType({
+        kind: 1984,
+        tags: [['e', TARGET_EVENT_ID, 'nudity']],
+        content: '',
+      })).toBe('nudity');
+    });
   });
 
   it('detects reports from the diVine client tag', () => {

--- a/src/nostr/report-poller.test.mjs
+++ b/src/nostr/report-poller.test.mjs
@@ -131,6 +131,30 @@ describe('kind 1984 parsing', () => {
     it('makes an AI report eligible for AI detection telemetry', () => {
       expect(isAiReportType(extractReportType(divineReport('NS-aiGenerated')))).toBe(true);
     });
+
+    it('ignores labels from other NIP-32 namespaces', () => {
+      expect(extractReportType({
+        kind: 1984,
+        tags: [
+          ['e', TARGET_EVENT_ID, 'spam'],
+          ['l', 'NS-aiGenerated', 'com.example.other'],
+        ],
+        content: '',
+      })).toBe('spam');
+    });
+
+    it('warns when an NS label is not mapped to a canonical type', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      try {
+        expect(extractReportType(divineReport('NS-newReason'))).toBe('ns_newreason');
+        expect(warn).toHaveBeenCalledWith(
+          '[REPORT-POLLER] Unmapped social.nos.ontology report label: NS-newReason',
+        );
+      } finally {
+        warn.mockRestore();
+      }
+    });
   });
 
   describe('report_type tag (moderation DM ingestion)', () => {

--- a/src/reports.mjs
+++ b/src/reports.mjs
@@ -17,39 +17,79 @@ export async function initReportsTable(db) {
       report_type TEXT NOT NULL,
       reason TEXT,
       created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+      source TEXT,
       UNIQUE(sha256, reporter_pubkey)
     )
   `).run();
+
+  // CREATE TABLE IF NOT EXISTS cannot add `source` to a table that already
+  // exists, and `user_reports` is created here rather than by a file in
+  // migrations/ -- so for every database that predates this column, the
+  // ALTER below is the only thing that adds it. Same reasoning as
+  // initDmReadStateTable's: CI deploys the worker on every push to main but
+  // never runs `wrangler d1 migrations apply`, so a schema change that only
+  // exists as a migration would ship code referencing a column production
+  // does not have.
+  const columns = await db.prepare('PRAGMA table_info(user_reports)').all();
+  const hasSource = (columns?.results || []).some((column) => column.name === 'source');
+  if (!hasSource) {
+    await db.prepare('ALTER TABLE user_reports ADD COLUMN source TEXT').run();
+  }
 }
 
+// The one report source whose reporter identity is not established well enough
+// to count toward an automatic moderation outcome. A `dm-report` reporter is
+// whatever key reached the moderation inbox over NIP-17: nothing signs for the
+// reported sha256, nothing proves the key belongs to a distinct person, and
+// minting fresh keys is free. Such a report is still recorded and still shown
+// to a human -- it just cannot be one of the two "distinct reporters" that
+// auto age-restriction counts, or a single actor could supply both halves of
+// the threshold the authenticated path relies on.
+const NON_ESCALATING_SOURCE = 'dm-report';
+
 /**
- * Insert a report and return both the legacy escalation level and the distinct
- * reporter count so callers can apply per-report-type policy (e.g. NSFW needs
- * 2 unique reporters before auto AGE_RESTRICTED to defend against single-token
+ * Insert a report and return the legacy escalation level plus two reporter
+ * counts, so callers can apply per-report-type policy (e.g. NSFW needs 2
+ * unique reporters before auto AGE_RESTRICTED to defend against single-token
  * griefing).
+ *
+ * `distinctReporterCount` counts every distinct reporter, whatever the source
+ * -- it is what the admin UI and the HTTP report response report, and its
+ * meaning is unchanged. `escalationReporterCount` counts only the reporters
+ * whose source may drive an automatic outcome; it is the one the
+ * AGE_RESTRICTED gate uses. Rows written before `source` existed are NULL and
+ * count toward both, since the DM path never actually produced a row until
+ * tag-based report classification landed (its predecessor sat behind a
+ * `JSON.parse(content)` branch no client ever triggered).
+ *
  * @param {D1Database} db
- * @param {{sha256: string, reporter_pubkey: string, report_type: string, reason?: string, created_at?: string}} report
- * @returns {Promise<{escalate: 'AGE_RESTRICTED'|'REVIEW'|null, distinctReporterCount: number}>}
+ * @param {{sha256: string, reporter_pubkey: string, report_type: string, reason?: string, created_at?: string, source?: string}} report
+ * @returns {Promise<{escalate: 'AGE_RESTRICTED'|'REVIEW'|null, distinctReporterCount: number, escalationReporterCount: number}>}
  */
-export async function addReport(db, { sha256, reporter_pubkey, report_type, reason, created_at }) {
+export async function addReport(db, { sha256, reporter_pubkey, report_type, reason, created_at, source = null }) {
   await db.prepare(`
-    INSERT OR IGNORE INTO user_reports (sha256, reporter_pubkey, report_type, reason, created_at)
-    VALUES (?, ?, ?, ?, COALESCE(?, CURRENT_TIMESTAMP))
-  `).bind(sha256, reporter_pubkey, report_type, reason ?? null, created_at ?? null).run();
+    INSERT OR IGNORE INTO user_reports (sha256, reporter_pubkey, report_type, reason, created_at, source)
+    VALUES (?, ?, ?, ?, COALESCE(?, CURRENT_TIMESTAMP), ?)
+  `).bind(sha256, reporter_pubkey, report_type, reason ?? null, created_at ?? null, source ?? null).run();
 
   const row = await db.prepare(`
-    SELECT COUNT(DISTINCT reporter_pubkey) AS cnt
+    SELECT
+      COUNT(DISTINCT reporter_pubkey) AS cnt,
+      COUNT(DISTINCT CASE
+        WHEN source IS NULL OR source <> ? THEN reporter_pubkey
+      END) AS escalation_cnt
     FROM user_reports
     WHERE sha256 = ?
-  `).bind(sha256).first();
+  `).bind(NON_ESCALATING_SOURCE, sha256).first();
 
   const count = row?.cnt ?? 0;
+  const escalationCount = row?.escalation_cnt ?? 0;
 
   let escalate = null;
   if (count >= 5) escalate = 'AGE_RESTRICTED';
   else if (count >= 3) escalate = 'REVIEW';
 
-  return { escalate, distinctReporterCount: count };
+  return { escalate, distinctReporterCount: count, escalationReporterCount: escalationCount };
 }
 
 const AI_REPORT_TYPES = new Set([

--- a/src/reports.mjs
+++ b/src/reports.mjs
@@ -67,10 +67,39 @@ const NON_ESCALATING_SOURCE = 'dm-report';
  * @returns {Promise<{escalate: 'AGE_RESTRICTED'|'REVIEW'|null, distinctReporterCount: number, escalationReporterCount: number}>}
  */
 export async function addReport(db, { sha256, reporter_pubkey, report_type, reason, created_at, source = null }) {
+  // One report can reach two ingestion paths: divine-mobile publishes the
+  // kind-1984 and sends the report DM for the same content from the same key,
+  // so both write this same (sha256, reporter_pubkey) row. The two paths were
+  // made to agree on `report_type`, but they cannot agree on `source` -- it
+  // names the path they came in through. Under a plain INSERT OR IGNORE that
+  // left arrival order deciding whether a reporter is escalation-eligible,
+  // and a reporter pinned to 'dm-report' stayed excluded from
+  // escalationReporterCount forever, even after reporting again through the
+  // authenticated route.
+  //
+  // So upgrade on conflict, in one direction only: once a reporter has been
+  // seen through a path that may drive an automatic outcome, that sticks. A
+  // later report DM never downgrades a reporter the HTTP or relay path
+  // already established. Everything else about the row stays first-write-wins
+  // -- `report_type`, `reason` and `created_at` keep the report of record as
+  // it was first filed.
   await db.prepare(`
     INSERT OR IGNORE INTO user_reports (sha256, reporter_pubkey, report_type, reason, created_at, source)
     VALUES (?, ?, ?, ?, COALESCE(?, CURRENT_TIMESTAMP), ?)
-  `).bind(sha256, reporter_pubkey, report_type, reason ?? null, created_at ?? null, source ?? null).run();
+    ON CONFLICT(sha256, reporter_pubkey) DO UPDATE SET source = excluded.source
+      WHERE user_reports.source = ?
+        AND excluded.source IS NOT NULL
+        AND excluded.source <> ?
+  `).bind(
+    sha256,
+    reporter_pubkey,
+    report_type,
+    reason ?? null,
+    created_at ?? null,
+    source ?? null,
+    NON_ESCALATING_SOURCE,
+    NON_ESCALATING_SOURCE,
+  ).run();
 
   const row = await db.prepare(`
     SELECT

--- a/src/reports.mjs
+++ b/src/reports.mjs
@@ -45,6 +45,26 @@ export async function initReportsTable(db) {
 // to a human -- it just cannot be one of the two "distinct reporters" that
 // auto age-restriction counts, or a single actor could supply both halves of
 // the threshold the authenticated path relies on.
+/**
+ * Whether this reporter already has a row for this sha256.
+ *
+ * Used by the DM reader to tell "this report is already ingested" apart from
+ * "this gift wrap is already in dm_log", which are not the same thing: the
+ * report write is wrapped in a warn-and-continue block, so a transient failure
+ * leaves the DM logged and the report missing. Asking about the report row
+ * directly is what keeps that case retryable on the next poll.
+ *
+ * @param {D1Database} db
+ * @param {string} sha256
+ * @param {string} reporterPubkey
+ * @returns {Promise<Object|null>} the matching row, or null
+ */
+export async function findReportByReporter(db, sha256, reporterPubkey) {
+  return db.prepare(
+    'SELECT id FROM user_reports WHERE sha256 = ? AND reporter_pubkey = ?'
+  ).bind(sha256, reporterPubkey).first();
+}
+
 const NON_ESCALATING_SOURCE = 'dm-report';
 
 /**

--- a/src/reports.mjs
+++ b/src/reports.mjs
@@ -48,10 +48,16 @@ export async function initReportsTable(db) {
 const NON_ESCALATING_SOURCE = 'dm-report';
 
 /**
- * Insert a report and return the legacy escalation level plus two reporter
- * counts, so callers can apply per-report-type policy (e.g. NSFW needs 2
- * unique reporters before auto AGE_RESTRICTED to defend against single-token
- * griefing).
+ * Insert a report and return two reporter counts, so callers can apply
+ * per-report-type policy (e.g. NSFW needs 2 unique reporters before auto
+ * AGE_RESTRICTED to defend against single-token griefing).
+ *
+ * Counting is all this does. It used to also return an `escalate` level of its
+ * own, off 3-and-5-reporter thresholds that nothing in the service enforced --
+ * a second opinion with no authority, which `/api/v1/report` then echoed to
+ * clients as though it were the outcome. Whether a report escalates depends on
+ * the report type and the source policy, neither of which is knowable here;
+ * recordReportForReview is the only caller and the only place that knows both.
  *
  * `distinctReporterCount` counts every distinct reporter, whatever the source
  * -- it is what the admin UI and the HTTP report response report, and its
@@ -64,7 +70,7 @@ const NON_ESCALATING_SOURCE = 'dm-report';
  *
  * @param {D1Database} db
  * @param {{sha256: string, reporter_pubkey: string, report_type: string, reason?: string, created_at?: string, source?: string}} report
- * @returns {Promise<{escalate: 'AGE_RESTRICTED'|'REVIEW'|null, distinctReporterCount: number, escalationReporterCount: number}>}
+ * @returns {Promise<{distinctReporterCount: number, escalationReporterCount: number}>}
  */
 export async function addReport(db, { sha256, reporter_pubkey, report_type, reason, created_at, source = null }) {
   // One report can reach two ingestion paths: divine-mobile publishes the
@@ -111,14 +117,10 @@ export async function addReport(db, { sha256, reporter_pubkey, report_type, reas
     WHERE sha256 = ?
   `).bind(NON_ESCALATING_SOURCE, sha256).first();
 
-  const count = row?.cnt ?? 0;
-  const escalationCount = row?.escalation_cnt ?? 0;
-
-  let escalate = null;
-  if (count >= 5) escalate = 'AGE_RESTRICTED';
-  else if (count >= 3) escalate = 'REVIEW';
-
-  return { escalate, distinctReporterCount: count, escalationReporterCount: escalationCount };
+  return {
+    distinctReporterCount: row?.cnt ?? 0,
+    escalationReporterCount: row?.escalation_cnt ?? 0,
+  };
 }
 
 const AI_REPORT_TYPES = new Set([

--- a/src/reports.test.mjs
+++ b/src/reports.test.mjs
@@ -67,7 +67,7 @@ describe('reports', () => {
   });
 
   describe('addReport', () => {
-    it('should add a new report and not escalate', async () => {
+    it('should add a new report and count one distinct reporter', async () => {
       const result = await addReport(db, {
         sha256: SHA256,
         reporter_pubkey: REPORTER1,
@@ -75,7 +75,7 @@ describe('reports', () => {
         reason: 'inappropriate content',
       });
 
-      expect(result).toMatchObject({ escalate: null, distinctReporterCount: 1 });
+      expect(result).toEqual({ distinctReporterCount: 1, escalationReporterCount: 1 });
     });
 
     it('should deduplicate same reporter for same sha256', async () => {
@@ -313,33 +313,25 @@ describe('reports', () => {
     });
   });
 
-  describe('escalation thresholds', () => {
-    it('should escalate to REVIEW at 3 unique reporters', async () => {
-      await addReport(db, { sha256: SHA256, reporter_pubkey: REPORTER1, report_type: 'nudity' });
-      await addReport(db, { sha256: SHA256, reporter_pubkey: REPORTER2, report_type: 'nudity' });
-
-      const result = await addReport(db, {
-        sha256: SHA256,
-        reporter_pubkey: REPORTER3,
-        report_type: 'nudity',
-      });
-
-      expect(result).toMatchObject({ escalate: 'REVIEW', distinctReporterCount: 3 });
-    });
-
-    it('should escalate to AGE_RESTRICTED at 5 unique reporters', async () => {
-      await addReport(db, { sha256: SHA256, reporter_pubkey: REPORTER1, report_type: 'nudity' });
-      await addReport(db, { sha256: SHA256, reporter_pubkey: REPORTER2, report_type: 'nudity' });
-      await addReport(db, { sha256: SHA256, reporter_pubkey: REPORTER3, report_type: 'nudity' });
-      await addReport(db, { sha256: SHA256, reporter_pubkey: REPORTER4, report_type: 'nudity' });
+  describe('reporter counts', () => {
+    // addReport used to own 3-and-5-reporter thresholds of its own. Nothing
+    // enforced them, and `/api/v1/report` echoed the result as though it were
+    // the outcome; the real gate lives in recordReportForReview and runs on
+    // escalationReporterCount. All this owes its caller now is the counts.
+    it('reports both counts as distinct reporters accumulate', async () => {
+      await addReport(db, { sha256: SHA256, reporter_pubkey: REPORTER1, report_type: 'nudity', source: 'dm-report' });
+      await addReport(db, { sha256: SHA256, reporter_pubkey: REPORTER2, report_type: 'nudity', source: 'user-report' });
+      await addReport(db, { sha256: SHA256, reporter_pubkey: REPORTER3, report_type: 'nudity', source: 'relay-report' });
+      await addReport(db, { sha256: SHA256, reporter_pubkey: REPORTER4, report_type: 'nudity', source: 'user-report' });
 
       const result = await addReport(db, {
         sha256: SHA256,
         reporter_pubkey: REPORTER5,
         report_type: 'nudity',
+        source: 'user-report',
       });
 
-      expect(result).toMatchObject({ escalate: 'AGE_RESTRICTED', distinctReporterCount: 5 });
+      expect(result).toEqual({ distinctReporterCount: 5, escalationReporterCount: 4 });
     });
   });
 

--- a/src/reports.test.mjs
+++ b/src/reports.test.mjs
@@ -114,6 +114,55 @@ describe('reports', () => {
       expect(count).toBe(2);
     });
 
+    it('counts a dm-report reporter for display but not for escalation', async () => {
+      const first = await addReport(db, {
+        sha256: SHA256,
+        reporter_pubkey: REPORTER1,
+        report_type: 'nudity',
+        source: 'dm-report',
+      });
+      expect(first).toMatchObject({ distinctReporterCount: 1, escalationReporterCount: 0 });
+
+      // A second, authenticated reporter arrives. Two distinct people have now
+      // reported the blob, but only one of them through a path allowed to
+      // drive an automatic outcome -- so the NSFW threshold of 2 is not met.
+      const second = await addReport(db, {
+        sha256: SHA256,
+        reporter_pubkey: REPORTER2,
+        report_type: 'nudity',
+        source: 'user-report',
+      });
+      expect(second).toMatchObject({ distinctReporterCount: 2, escalationReporterCount: 1 });
+
+      const third = await addReport(db, {
+        sha256: SHA256,
+        reporter_pubkey: REPORTER3,
+        report_type: 'nudity',
+        source: 'user-report',
+      });
+      expect(third).toMatchObject({ distinctReporterCount: 3, escalationReporterCount: 2 });
+    });
+
+    it('counts rows written before the source column toward escalation', async () => {
+      // insertReport() writes no source, exactly like every row that predates
+      // the column. Those came from the HTTP or relay paths, so they keep
+      // counting.
+      await insertReport(db, {
+        sha256: SHA256,
+        reporter_pubkey: REPORTER1,
+        report_type: 'nudity',
+      });
+
+      const result = await addReport(db, {
+        sha256: SHA256,
+        reporter_pubkey: REPORTER2,
+        report_type: 'nudity',
+        source: 'user-report',
+      });
+
+      expect(result).toMatchObject({ distinctReporterCount: 2, escalationReporterCount: 2 });
+    });
+
     it('stores an explicit created_at timestamp when provided', async () => {
       const sha256 = 'a'.repeat(64);
       const reporter = 'b'.repeat(64);

--- a/src/reports.test.mjs
+++ b/src/reports.test.mjs
@@ -163,6 +163,107 @@ describe('reports', () => {
       expect(result).toMatchObject({ distinctReporterCount: 2, escalationReporterCount: 2 });
     });
 
+    it('upgrades a dm-report reporter who later reports through the authenticated path', async () => {
+      const first = await addReport(db, {
+        sha256: SHA256,
+        reporter_pubkey: REPORTER1,
+        report_type: 'nudity',
+        source: 'dm-report',
+      });
+      expect(first).toMatchObject({ distinctReporterCount: 1, escalationReporterCount: 0 });
+
+      // Same person, same blob, now through POST /api/v1/report. Under a plain
+      // INSERT OR IGNORE this row stayed 'dm-report' and the reporter never
+      // counted toward escalation again.
+      const second = await addReport(db, {
+        sha256: SHA256,
+        reporter_pubkey: REPORTER1,
+        report_type: 'nudity',
+        source: 'user-report',
+      });
+      expect(second).toMatchObject({ distinctReporterCount: 1, escalationReporterCount: 1 });
+
+      const row = await db.prepare(
+        'SELECT source FROM user_reports WHERE sha256 = ? AND reporter_pubkey = ?'
+      ).bind(SHA256, REPORTER1).first();
+      expect(row.source).toBe('user-report');
+    });
+
+    it('upgrades a dm-report reporter when the kind-1984 poller ingests the same report', async () => {
+      // divine-mobile sends both channels for one report, so this pair is the
+      // ordinary case rather than an edge one -- it just depends which lands
+      // first.
+      await addReport(db, {
+        sha256: SHA256,
+        reporter_pubkey: REPORTER1,
+        report_type: 'sexual_content',
+        source: 'dm-report',
+      });
+
+      const afterRelay = await addReport(db, {
+        sha256: SHA256,
+        reporter_pubkey: REPORTER1,
+        report_type: 'sexual_content',
+        source: 'relay-report',
+      });
+
+      expect(afterRelay).toMatchObject({ distinctReporterCount: 1, escalationReporterCount: 1 });
+    });
+
+    it('does not let a later report DM downgrade an escalating reporter', async () => {
+      await addReport(db, {
+        sha256: SHA256,
+        reporter_pubkey: REPORTER1,
+        report_type: 'nudity',
+        source: 'user-report',
+      });
+
+      const afterDm = await addReport(db, {
+        sha256: SHA256,
+        reporter_pubkey: REPORTER1,
+        report_type: 'nudity',
+        source: 'dm-report',
+      });
+
+      expect(afterDm).toMatchObject({ distinctReporterCount: 1, escalationReporterCount: 1 });
+
+      const row = await db.prepare(
+        'SELECT source FROM user_reports WHERE sha256 = ? AND reporter_pubkey = ?'
+      ).bind(SHA256, REPORTER1).first();
+      expect(row.source).toBe('user-report');
+    });
+
+    it('upgrades only the source, leaving the report of record as first filed', async () => {
+      const firstFiledAt = '2026-05-13T17:19:42.000Z';
+      await addReport(db, {
+        sha256: SHA256,
+        reporter_pubkey: REPORTER1,
+        report_type: 'ai_generated',
+        reason: 'as the DM described it',
+        created_at: firstFiledAt,
+        source: 'dm-report',
+      });
+
+      await addReport(db, {
+        sha256: SHA256,
+        reporter_pubkey: REPORTER1,
+        report_type: 'spam',
+        reason: 'as the later report described it',
+        created_at: '2026-06-01T00:00:00.000Z',
+        source: 'user-report',
+      });
+
+      const row = await db.prepare(
+        'SELECT report_type, reason, created_at, source FROM user_reports WHERE sha256 = ? AND reporter_pubkey = ?'
+      ).bind(SHA256, REPORTER1).first();
+      expect(row).toMatchObject({
+        report_type: 'ai_generated',
+        reason: 'as the DM described it',
+        created_at: firstFiledAt,
+        source: 'user-report',
+      });
+    });
+
     it('stores an explicit created_at timestamp when provided', async () => {
       const sha256 = 'a'.repeat(64);
       const reporter = 'b'.repeat(64);


### PR DESCRIPTION
Refs divinevideo/divine-mobile#6593 (backend half). Replaces #193, which this supersedes -- it carries #193's six approved commits unchanged, plus the cross-service fix that came out of review on the mobile side.

Companion: divinevideo/divine-mobile#6855. Neither half works alone; they should merge together.

## Carried over from #193 (unchanged, already approved)

- Classify moderation report DMs from NIP-17 tags instead of trying to `JSON.parse` the content -- no client has ever sent that JSON.
- Repair the dead unread badge: real `getConversations` unread computation, a read-state table, and a mark-read endpoint. `dashboard.html` and `messages.html` both read `c.unread || c.has_unread`, which nothing ever set.
- Badge a report DM from `report_type`, not only `sha256`, so user reports and DM-message reports don't render as ordinary replies.
- Record report DMs through the shared review ingestion path.

## New in this PR

### 1. Resolve the DM's report type through the shared resolver

`processRumor` read `['report_type', x]` straight off the rumor while the kind-1984 poller ran `extractReportType`. Both write the same `(sha256, reporter_pubkey)` row under `INSERT OR IGNORE`, so two vocabularies meant whichever path ingested first pinned its answer permanently -- and the DM's NIP-56 value is the lossy one, collapsing `aiGenerated` to `other`.

`processRumor` now calls `extractReportType` on the rumor. `extractReportType` gains a `report_type` arm, placed **above** the `Reason:` content regex: a DM's content is localized prose (`Reason: Contenu indésirable`), so letting the regex outrank an explicit tag would make `report_type` locale-dependent. kind-1984 events carry no `report_type` tag, so that arm is inert for them and their behaviour is byte-identical.

### 2. Decode the full social.nos.ontology label vocabulary

`extractReportType` prefers the NIP-32 `l` label, and divine-mobile sets one on every report. `normalizeReportType` lowercases and maps `-` to `_`, so `NS-sexualContent` arrived as `ns_sexualcontent` -- a value that matches nothing in `NSFW_REPORT_TYPES`. Only the `aiGenerated` family was special-cased.

The fix resolves each `social.nos.ontology` label to its canonical type, mirroring the table `divine-relay-manager` already keeps in `CATEGORY_LABELS`. That corrects stored `report_type`, sets adult categories for sexual-content reports, and lets AI telemetry fire from both ingestion paths.

kind-1984 relay reports still pass `source: 'relay-report'`, so `recordReportForReview` leaves `allowAutoAgeRestrict` false for that path. This PR fixes relay report typing, but it does **not** make the relay path auto age-restrict. Section 4 records the matching decision for the DM path.

The mapping is guarded by tests for all eleven current labels, namespace filtering, and a warning when a future `NS-*` label is not mapped.

Tracked independently in #195.

### 3. Contract test with real crypto

The `processRumor` unit tests hand it a plain rumor object, so nothing covered the step where the tags must survive NIP-44 encryption and seal/gift-wrap serialization. `dm-report-contract.test.mjs` starts from the exact tag list divine-mobile builds, wraps and unwraps with real NIP-59 crypto and schnorr signing, and asserts on the rows the real classify path writes.

### 4. Report DMs are REVIEW-only (policy decision)

Review asked for an explicit call on whether an unauthenticated report DM should be able to auto age-restrict public content from a client-supplied `sha256`. **The decision is no.** `9e517d8` drops the `allowAutoAgeRestrict: true` override, so `source: 'dm-report'` takes the same REVIEW-only default that `'relay-report'` already takes.

The trust boundary this records: a report DM is the least verified report the service accepts. `rumor.pubkey` is whatever key reached the moderation inbox, the `sha256` is client-supplied, and unlike the relay poller this path does not fetch the target event, require a Divine client, or pass the processed-key gate. Auto-escalation is left to the authenticated `/api/v1/report` route, which was already the only path with that authority -- the relay poller has never had it, so this makes the two Nostr paths consistent rather than adding a new restriction.

The DM still writes its `user_reports` row and is still badged `conversation_report` in the admin Messages UI. Two NSFW report DMs surface for review exactly as before; they just no longer hide public content without a human. Pinned by a test rather than a comment -- `dm-report-contract.test.mjs` drives two distinct reporter keys through the real gift-wrap round trip and asserts the result stays `REVIEW`.

### 5. Close the same boundary from the other side

Keeping the DM path REVIEW-only stops a report DM escalating *on its own*, but not as one of two. `addReport` counted `DISTINCT reporter_pubkey` per `sha256` with no source filter, and `POST /api/v1/report` still auto age-restricts at two distinct reporters -- so a minted key sending one report DM plus one genuine authenticated report was enough to hide public content, with the unverified half free.

Nothing produced that shape before this branch: the DM path's predecessor only wrote a `user_reports` row from inside the `JSON.parse(content)` branch looking for `type: 'conversation_report'`, the JSON no client has ever sent. Tag-based classification is what makes DM-sourced rows real, so the threshold fix belongs here.

`user_reports` gains a `source` column. `distinctReporterCount` keeps its meaning (every reporter, any source -- the admin UI and the `/api/v1/report` response both surface it); a new `escalationReporterCount` excludes `dm-report` rows and is what gates `AGE_RESTRICTED`. Both are written into `moderation_results.raw_response` so a moderator can see why something did not escalate. Rows predating the column are NULL and still count, since none of them can be DM-sourced.

The column is added by `initReportsTable` rather than a file in `migrations/`, matching how `user_reports` is created in the first place, with an idempotent `ALTER` for existing databases. `syncInbox` and `pollRelayForReports` call `initReportsTable` too: both run from the cron trigger, which never reaches the fetch handler's schema ensure.

### 6. Stop trusting a report DM's self-reported timestamp

`rumor.created_at` is written by the sender and validated by nothing, and it flowed straight into `new Date(createdAt * 1000).toISOString()`. A missing or non-numeric value threw `RangeError` inside `processRumor`'s warn-and-continue block, discarding the whole report -- no `user_reports` row, no `REVIEW` row, while the DM still landed in `dm_log` and looked handled. A backdated value landed in `moderation_results.moderated_at`, which the admin queue sorts on and its `since` filter drops outright.

`resolveReportedAt` uses the rumor's timestamp only where it could plausibly be true -- no older than the reader's own first-run lookback, no further ahead than a clock-skew allowance -- and falls back to receipt time otherwise, so both failure directions round toward "surfaces now" rather than "surfaces never".

### 7. A reporter's escalation eligibility no longer depends on arrival order

`user_reports` is keyed `UNIQUE(sha256, reporter_pubkey)`, and one report reaches two ingestion paths: divine-mobile publishes the kind-1984 **and** sends the report DM for the same content from the same key. Section 3's contract test already pins that pairing -- its last case asserts the two paths agree on `report_type`. They cannot agree on `source`, which names the path they arrived through, so `INSERT OR IGNORE` left arrival order deciding whether that reporter counted toward `escalationReporterCount` -- permanently, once pinned.

Within one cron tick `pollRelayForReports` runs before `syncInbox`, so the ordinary mobile case pins `relay-report` and counts. The mis-pin needs the DM to land without a successful relay ingest first: a kind-1984 publish that failed while the gift wrap landed, the `RELAY_REPORTS_REQUIRE_DIVINE_CLIENT` gate, poller lookback/pagination, or the dialog's resubmit path.

`addReport` now upgrades `source` on conflict, in one direction only -- `dm-report` to any escalation-eligible source. A later report DM never downgrades a reporter the HTTP or relay path established, so the untrusted channel cannot promote itself; it can only fail to be promoted. `report_type`, `reason` and `created_at` stay first-write-wins, so the report of record is still the one first filed.

This is the one change in this PR that loosens rather than tightens: a genuine reporter who happened to DM first counts again toward the authenticated path's two-reporter threshold.

### 8. The report API stops returning a verdict it did not make

`POST /api/v1/report` returned `escalate` from `addReport`'s own 3-and-5-distinct-reporter thresholds, which nothing in the service enforces. The real decision is made a line later in `recordReportForReview`, on different inputs (escalation-eligible reporters, not every reporter) and different thresholds (2, and only for NSFW types) -- so the two could disagree outright. Five `spam` reports wrote `REVIEW` to `moderation_results` while telling the client `AGE_RESTRICTED`, and section 5's `source` column widened the gap by letting DM rows inflate the count the response used but not the one enforcement used.

Deriving the guess from `escalationReporterCount` would close only the second half, so the computation is deleted instead: `addReport` counts reporters and cannot see report type or source policy, so it was never in a position to have an opinion. `escalate` now carries the decision this report was recorded under -- the same value the moderation row is written from -- which makes contradicting enforcement impossible by construction. (Not a claim about the row's final state: `recordReportForReview`'s `ON CONFLICT` keeps a stronger prior action, so a sha256 already `PERMANENT_BAN` or human-reviewed stays that way.)

| reporters (authenticated path) | recorded action | `escalate` before | after |
|---|---|---|---|
| 1 x nudity | `REVIEW` | `null` | `"REVIEW"` |
| 2 x nudity | `AGE_RESTRICTED` | `null` | `"AGE_RESTRICTED"` |
| 5 x spam | `REVIEW` | `"AGE_RESTRICTED"` | `"REVIEW"` |
| 4 x DM + 1 x nudity | `REVIEW` | `"AGE_RESTRICTED"` | `"REVIEW"` |

Response shape is unchanged. The value is no longer null -- a single report reads `REVIEW`, which is what the service did with it. No caller in any Divine repo reads this endpoint today.

### 9. Each side of a report DM dedupes against its own row

`syncInbox` re-processes the same gift wrap for two days, so `9e9b94d` added a `dm_log` lookup that returns before report ingestion. That gate is keyed on the wrong row. `processRumor` records the report inside a warn-and-continue block and calls `logDm` either way, so a transient D1 error on the `user_reports` insert still logs the gift wrap -- and the next tick then skips before it can retry. The report is gone permanently, counted as `deduped` in the sync log, while the DM sits in the admin Messages UI badged as a report. That is the failure shape section 6 exists to remove, reached by a different route.

A `dm_log` row proves the DM was stored, not that its report was. So each side dedupes against its own row: report ingestion skips once this reporter has both a `user_reports` row and a `moderation_results` review row for this sha256, and the `'skipped'` return happens once the gift wrap is in `dm_log`.

This keeps what the gate was for. `recordReportForReview` is not idempotent for a report whose timestamp fell back to receipt time -- `moderated_at` moves and the AI telemetry `event_key` (`report:<sha>:<type>:<createdAt>`) changes, so its `INSERT OR IGNORE` stops deduping -- and the completed report+review check suppresses exactly that. `9e9b94d`'s regression test, which pins that `moderated_at` is not re-bumped, passes unchanged. The `'skipped'` return also keeps `9e9b94d`'s accounting fix: `logDm` hands back the existing row on a dedup hit, whose truthy `.id` used to read as a fresh insert.

## Test plan

- [x] `npm run lint`
- [x] `npm test` -- 1539/1539 across 83 files
- [x] `npx vitest run src/reports.test.mjs src/index.test.mjs src/moderation/report-review.test.mjs src/nostr/dm-report-contract.test.mjs src/nostr/dm-reader.test.mjs src/nostr/report-poller.test.mjs` -- 293/293
- [x] Each new guard red-checked by reverting it: restoring `allowAutoAgeRestrict: true`, gating on `distinctReporterCount`, inlining the raw `created_at`, dropping the `ON CONFLICT` source upgrade (`expected +0 to be 1`), restoring the old `escalate` field (`expected 'AGE_RESTRICTED' to be 'REVIEW'`), and re-keying section 9's skip on only the `dm_log` row or only the `user_reports` row each turn their tests red.




