### PR TITLE
feat(classification): wire divine-ai-detector enrichment, off by default

### DIFF
--- a/src/classification/ai-detector-enrichment.mjs
+++ b/src/classification/ai-detector-enrichment.mjs
@@ -1,0 +1,128 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Enrichment path that calls divine-ai-detector and writes its verdicts to ClickHouse
+// ABOUTME: Gated off by default; produces review evidence, never enforcement actions
+
+import { detectSignals } from '../moderation/ai-detector-client.mjs';
+import { writeModerationLabels } from '../moderation/label-writer.mjs';
+
+/**
+ * nsfw model classes -> classifier categories understood by
+ * classifierCategoryToLabels(). `neutral` and `drawings` never map: they are
+ * the model's negative classes and must not produce a label.
+ */
+const NSFW_CLASS_TO_CATEGORY = {
+  porn: 'porn',
+  sexy: 'sexual',
+  hentai: 'sexual',
+};
+
+export const AI_DETECTOR_SOURCE = {
+  sourceId: 'divine-ai-detector',
+  sourceOwner: 'divine',
+  sourceType: 'machine-labeler',
+  transport: 'ai-detector-enrichment',
+  operation: 'apply',
+};
+
+/**
+ * Is the enrichment path switched on?
+ *
+ * Defaults to off. Merging this must not change behaviour: turning it on is a
+ * deliberate act, because proactive classification was deliberately retired in
+ * the May 2026 pivot to report-driven review.
+ *
+ * @param {Object} env
+ * @returns {boolean}
+ */
+export function isEnrichmentEnabled(env = {}) {
+  return env.AI_DETECTOR_ENRICHMENT_ENABLED === 'true'
+    && !!(env.AI_DETECTOR_BASE_URL || env.SCENE_CLASSIFICATION_BASE_URL);
+}
+
+/**
+ * Convert a `/detect` nsfw envelope into the score map writeModerationLabels
+ * expects.
+ *
+ * Only a `detected` envelope yields a score. `absent` means the model ran and
+ * found nothing; `skipped` means it never ran; `error` means it failed. None of
+ * those are evidence of anything and must not be written — an absent result
+ * that became a zero-scored label would be indistinguishable downstream from a
+ * model that was never configured.
+ *
+ * @param {Object} envelope - one signal envelope from detectSignals()
+ * @returns {Object} category -> confidence, possibly empty
+ */
+export function nsfwEnvelopeToScores(envelope) {
+  if (!envelope || envelope.state !== 'detected') return {};
+  const category = NSFW_CLASS_TO_CATEGORY[envelope.class];
+  if (!category) return {};
+  const confidence = typeof envelope.confidence === 'number' ? envelope.confidence : 0;
+  if (!(confidence > 0)) return {};
+  return { [category]: confidence };
+}
+
+/**
+ * Run divine-ai-detector over one video and write any verdicts to ClickHouse.
+ *
+ * Never throws: enrichment is best-effort and must not fail the caller's
+ * classification. Returns a small summary for logging.
+ *
+ * @param {string} sha256
+ * @param {string} videoUrl
+ * @param {Object} env
+ * @param {Object} [opts]
+ * @param {Function} [opts.detect] - injectable detectSignals, for tests
+ * @param {Function} [opts.writeLabels] - injectable writer, for tests
+ * @returns {Promise<{skipped: boolean, reason?: string, labelsWritten: number, signals?: Object}>}
+ */
+export async function enrichWithAiDetector(sha256, videoUrl, env = {}, opts = {}) {
+  if (!isEnrichmentEnabled(env)) {
+    return { skipped: true, reason: 'AI_DETECTOR_ENRICHMENT_ENABLED is not true', labelsWritten: 0 };
+  }
+  if (!videoUrl) {
+    return { skipped: true, reason: 'no video URL', labelsWritten: 0 };
+  }
+
+  const detect = opts.detect || detectSignals;
+  const writeLabels = opts.writeLabels || writeModerationLabels;
+
+  let response;
+  try {
+    response = await detect({ url: videoUrl, sha256, signals: ['nsfw'] }, env);
+  } catch (error) {
+    console.warn(`[AI-DETECTOR] detect failed for ${sha256}: ${error.message}`);
+    return { skipped: true, reason: `detect failed: ${error.message}`, labelsWritten: 0 };
+  }
+
+  const nsfw = response?.signals?.nsfw;
+  const scores = nsfwEnvelopeToScores(nsfw);
+  const states = { nsfw: nsfw?.state || 'missing' };
+
+  if (Object.keys(scores).length === 0) {
+    console.log(`[AI-DETECTOR] ${sha256}: nsfw=${states.nsfw}, no labels`);
+    return { skipped: false, labelsWritten: 0, signals: states };
+  }
+
+  // action stays empty: this is review evidence, not an enforcement decision.
+  const classification = {
+    action: '',
+    provider: 'divine-ai-detector',
+    scores,
+  };
+
+  try {
+    await writeLabels(sha256, classification, env, AI_DETECTOR_SOURCE);
+  } catch (error) {
+    console.warn(`[AI-DETECTOR] label write failed for ${sha256}: ${error.message}`);
+    return { skipped: false, labelsWritten: 0, signals: states };
+  }
+
+  const written = Object.keys(scores).length;
+  console.log(
+    `[AI-DETECTOR] ${sha256}: nsfw=${nsfw.class} ${nsfw.confidence?.toFixed?.(3)} `
+    + `(${nsfw.frames_flagged}/${nsfw.total_frames} frames) -> ${written} label(s)`
+  );
+  return { skipped: false, labelsWritten: written, signals: states };
+}

--- a/src/classification/ai-detector-enrichment.test.mjs
+++ b/src/classification/ai-detector-enrichment.test.mjs
@@ -1,0 +1,126 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  isEnrichmentEnabled,
+  nsfwEnvelopeToScores,
+  enrichWithAiDetector,
+  AI_DETECTOR_SOURCE,
+} from './ai-detector-enrichment.mjs';
+
+const ON = { AI_DETECTOR_ENRICHMENT_ENABLED: 'true', AI_DETECTOR_BASE_URL: 'https://detector' };
+
+describe('isEnrichmentEnabled', () => {
+  it('is off by default so merging cannot change behaviour', () => {
+    expect(isEnrichmentEnabled({})).toBe(false);
+    expect(isEnrichmentEnabled({ AI_DETECTOR_BASE_URL: 'https://detector' })).toBe(false);
+  });
+
+  it('requires both the flag and a base URL', () => {
+    expect(isEnrichmentEnabled({ AI_DETECTOR_ENRICHMENT_ENABLED: 'true' })).toBe(false);
+    expect(isEnrichmentEnabled(ON)).toBe(true);
+  });
+});
+
+describe('nsfwEnvelopeToScores', () => {
+  it('maps flagging classes onto canonical categories', () => {
+    expect(nsfwEnvelopeToScores({ state: 'detected', class: 'porn', confidence: 0.91 }))
+      .toEqual({ porn: 0.91 });
+    expect(nsfwEnvelopeToScores({ state: 'detected', class: 'sexy', confidence: 0.7 }))
+      .toEqual({ sexual: 0.7 });
+    expect(nsfwEnvelopeToScores({ state: 'detected', class: 'hentai', confidence: 0.8 }))
+      .toEqual({ sexual: 0.8 });
+  });
+
+  it('never labels the model\'s negative classes', () => {
+    expect(nsfwEnvelopeToScores({ state: 'detected', class: 'neutral', confidence: 0.99 })).toEqual({});
+    expect(nsfwEnvelopeToScores({ state: 'detected', class: 'drawings', confidence: 0.99 })).toEqual({});
+  });
+
+  it('writes nothing for absent, skipped, error or missing envelopes', () => {
+    for (const state of ['absent', 'skipped', 'error']) {
+      expect(nsfwEnvelopeToScores({ state, class: 'porn', confidence: 0.9 })).toEqual({});
+    }
+    expect(nsfwEnvelopeToScores(null)).toEqual({});
+    expect(nsfwEnvelopeToScores(undefined)).toEqual({});
+  });
+
+  it('ignores a detected envelope with no usable confidence', () => {
+    expect(nsfwEnvelopeToScores({ state: 'detected', class: 'porn', confidence: 0 })).toEqual({});
+    expect(nsfwEnvelopeToScores({ state: 'detected', class: 'porn' })).toEqual({});
+  });
+});
+
+describe('enrichWithAiDetector', () => {
+  it('does nothing when disabled', async () => {
+    const detect = vi.fn();
+    const res = await enrichWithAiDetector('sha', 'https://v/1.mp4', {}, { detect });
+    expect(res.skipped).toBe(true);
+    expect(detect).not.toHaveBeenCalled();
+  });
+
+  it('skips without a video URL', async () => {
+    const detect = vi.fn();
+    const res = await enrichWithAiDetector('sha', '', ON, { detect });
+    expect(res.skipped).toBe(true);
+    expect(detect).not.toHaveBeenCalled();
+  });
+
+  it('requests only the nsfw signal', async () => {
+    const detect = vi.fn().mockResolvedValue({ signals: { nsfw: { state: 'absent' } } });
+    await enrichWithAiDetector('sha', 'https://v/1.mp4', ON, { detect, writeLabels: vi.fn() });
+    expect(detect).toHaveBeenCalledWith(
+      { url: 'https://v/1.mp4', sha256: 'sha', signals: ['nsfw'] },
+      ON
+    );
+  });
+
+  it('writes a label for a detected verdict, attributed to the detector', async () => {
+    const detect = vi.fn().mockResolvedValue({
+      signals: { nsfw: { state: 'detected', class: 'porn', confidence: 0.93, frames_flagged: 5, total_frames: 8 } },
+    });
+    const writeLabels = vi.fn().mockResolvedValue(undefined);
+    const res = await enrichWithAiDetector('sha', 'https://v/1.mp4', ON, { detect, writeLabels });
+
+    expect(res.labelsWritten).toBe(1);
+    const [sha, classification, , source] = writeLabels.mock.calls[0];
+    expect(sha).toBe('sha');
+    expect(classification.scores).toEqual({ porn: 0.93 });
+    expect(source).toEqual(AI_DETECTOR_SOURCE);
+    expect(source.sourceId).toBe('divine-ai-detector');
+  });
+
+  it('never emits an enforcement action', async () => {
+    const detect = vi.fn().mockResolvedValue({
+      signals: { nsfw: { state: 'detected', class: 'porn', confidence: 0.93 } },
+    });
+    const writeLabels = vi.fn().mockResolvedValue(undefined);
+    await enrichWithAiDetector('sha', 'https://v/1.mp4', ON, { detect, writeLabels });
+    expect(writeLabels.mock.calls[0][1].action).toBe('');
+  });
+
+  it('writes nothing when the model found nothing', async () => {
+    const detect = vi.fn().mockResolvedValue({ signals: { nsfw: { state: 'absent' } } });
+    const writeLabels = vi.fn();
+    const res = await enrichWithAiDetector('sha', 'https://v/1.mp4', ON, { detect, writeLabels });
+    expect(res.labelsWritten).toBe(0);
+    expect(writeLabels).not.toHaveBeenCalled();
+  });
+
+  it('survives a detector transport failure', async () => {
+    const detect = vi.fn().mockRejectedValue(new Error('boom'));
+    const res = await enrichWithAiDetector('sha', 'https://v/1.mp4', ON, { detect, writeLabels: vi.fn() });
+    expect(res.skipped).toBe(true);
+    expect(res.reason).toContain('boom');
+  });
+
+  it('survives a ClickHouse write failure without throwing', async () => {
+    const detect = vi.fn().mockResolvedValue({
+      signals: { nsfw: { state: 'detected', class: 'porn', confidence: 0.93 } },
+    });
+    const writeLabels = vi.fn().mockRejectedValue(new Error('clickhouse down'));
+    const res = await enrichWithAiDetector('sha', 'https://v/1.mp4', ON, { detect, writeLabels });
+    expect(res.labelsWritten).toBe(0);
+  });
+});

--- a/src/moderation/pipeline.mjs
+++ b/src/moderation/pipeline.mjs
@@ -7,6 +7,7 @@
 import { classifyText, parseVttText } from './text-classifier.mjs';
 import { interpretVideoSealPayload } from './videoseal.mjs';
 import { fetchNostrEventBySha256, parseVideoEventMetadata, isOriginalVine, hasStrongOriginalVineEvidence } from '../nostr/relay-client.mjs';
+import { enrichWithAiDetector } from '../classification/ai-detector-enrichment.mjs';
 import { extractTopics } from '../classification/topic-extractor.mjs';
 import { verifyC2pa } from './inquisitor-client.mjs';
 import { shouldForceAIDetection } from './ai-detection-policy.mjs';
@@ -222,6 +223,15 @@ export async function classifyVideoOnly(sha256, env, options = {}) {
   }
 
   console.log(`[CLASSIFY-ONLY] Skipping Hive VLM scene classification for ${sha256}; using local transcript topics only`);
+
+  // Self-hosted enrichment via divine-ai-detector. Off unless
+  // AI_DETECTOR_ENRICHMENT_ENABLED=true, so this cannot revive proactive
+  // scanning by accident. Best-effort: never allowed to fail classification.
+  try {
+    await enrichWithAiDetector(sha256, videoUrl, env);
+  } catch (error) {
+    console.warn(`[CLASSIFY-ONLY] ai-detector enrichment error for ${sha256}: ${error.message}`);
+  }
 
   let topicProfile = null;
   try {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -119,7 +119,13 @@ INQUISITOR_BASE_URL = "https://inquisitor.divine.video"
 # (see docs/superpowers/plans/2026-04-17-divine-ai-detector-design.md §API).
 # Empty string = client disabled; every signal resolves to an `error` envelope
 # and callers fall through to vendor (Hive / Reality Defender).
-AI_DETECTOR_BASE_URL = ""
+AI_DETECTOR_BASE_URL = "https://ai-detector.divine.video"
+# Enrichment gate. Off by default: proactive classification was deliberately
+# retired in the May 2026 pivot to report-driven review, so turning this on is
+# a decision, not a deploy. When true, classifyVideoOnly asks the detector for
+# the nsfw signal and writes any verdict to ClickHouse moderation_labels as
+# review evidence (source_owner divine-ai-detector, no enforcement action).
+AI_DETECTOR_ENRICHMENT_ENABLED = "false"
 
 # DEPRECATED — kept so deployed configs that still set this don't break during
 # cutover. The client reads it as a fallback only when AI_DETECTOR_BASE_URL is


### PR DESCRIPTION
## Summary

Actually calls `divine-ai-detector` from `classifyVideoOnly` and writes its verdicts to ClickHouse `moderation_labels`. Gated behind a flag that defaults to **off**, so merging changes nothing.

## The integration was dead code

The client and adapter have been in this repo for months, but nothing invoked them:

- `AiDetectorSceneClassificationProvider` is never instantiated outside its own tests
- `detectSignals()`'s only caller is `logo_detector.mjs`, a backwards-compat shim
- `classifyVideoOnly` hardcodes `Skipping Hive VLM scene classification … using local transcript topics only` and goes straight to VTT topic extraction

So setting `AI_DETECTOR_BASE_URL` alone would have done nothing. This adds the missing call.

## Deliberately conservative

- **`AI_DETECTOR_ENRICHMENT_ENABLED` defaults to `"false"`.** Proactive classification was retired on purpose in the May 2026 pivot to report-driven review. Re-enabling it should be a decision, not a side effect of a deploy.
- **`action` is always empty** — review-queue evidence, never enforcement. The detector's `nsfw` signal measures **75% recall at 0/100 false positives** on real Divine uploads. That is good enough to surface candidates to humans and not good enough to act on content. It still misses ~25% of adult content.
- **Only a `detected` envelope produces a label.** `absent`, `skipped` and `error` write nothing — a zero-scored label would be indistinguishable downstream from a model that was never configured.
- `neutral` and `drawings` are the model's negative classes and never map.
- Best-effort throughout: a detector outage or ClickHouse failure logs and returns, and cannot fail the caller's classification.

## Mapping

Uses the existing vocabulary: `porn → porn`, `sexy → sexual`, `hentai → sexual`. Labels are attributed `source_owner: divine-ai-detector` — the slot Hive occupied.

## Validation

```
npx vitest run
  Test Files  83 passed (83)
  Tests       1484 passed (1484)
```

14 new tests cover the flag defaults, the class mapping, the negative classes, non-`detected` states, and both failure paths.

## Turning it on

Set `AI_DETECTOR_ENRICHMENT_ENABLED=true`. The detector is live in production (2 replicas, verified inference on real videos).

Capacity note: measured ~5s/video, and **5 concurrent requests saturate the detector's 2-CPU limit and restart the pod**. Steady state at ~263 uploads/day is comfortable; a bulk backfill needs more replicas first.

`AI_DETECTOR_BASE_URL` now points at production, which is a no-op while the flag is false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)