### PR TITLE
feat(classification): enable divine-ai-detector enrichment

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -125,7 +125,7 @@ AI_DETECTOR_BASE_URL = "https://ai-detector.divine.video"
 # a decision, not a deploy. When true, classifyVideoOnly asks the detector for
 # the nsfw signal and writes any verdict to ClickHouse moderation_labels as
 # review evidence (source_owner divine-ai-detector, no enforcement action).
-AI_DETECTOR_ENRICHMENT_ENABLED = "false"
+AI_DETECTOR_ENRICHMENT_ENABLED = "true"
 
 # DEPRECATED — kept so deployed configs that still set this don't break during
 # cutover. The client reads it as a fallback only when AI_DETECTOR_BASE_URL is


### PR DESCRIPTION
## Summary

Flips `AI_DETECTOR_ENRICHMENT_ENABLED` to `true`. `classifyVideoOnly` now asks the detector for the `nsfw` signal and writes detected verdicts to ClickHouse `moderation_labels` as `source_owner: divine-ai-detector`.

This is the deliberate act the flag in #196 was added for.

## What it does and does not do

**Does:** surfaces adult-content candidates to the moderation team as labels, from a self-hosted model, in the slot Hive used to occupy.

**Does not:** block, hide, age-restrict, or action anything. `action` is always empty. Humans remain the decision-maker.

## Quality, stated plainly

The `nsfw` model measures **75% recall at 0/100 false positives** against 28 known-adult clips and the 100 most recent real uploads (`docs/evaluations/2026-08-03-nsfw-threshold-calibration.md` in the detector repo).

**It misses roughly a quarter of adult content.** This narrows the gap; it does not close it. Reporting and human review stay essential.

The 0/100 false-positive figure is consistent with a true rate up to ~3.6%, so expect occasional wrong labels in the review queue.

## Safety properties

- only `detected` writes a label — `absent`/`skipped`/`error` write nothing
- `neutral` and `drawings` never map
- enrichment failures are swallowed; a detector outage cannot fail classification
- revert is a one-line flag change

## Capacity

Detector runs 2 production replicas, ~5s/video. **5 concurrent requests saturate its 2-CPU limit and restart the pod.** Steady state (~263 uploads/day) is comfortable. A bulk backfill of older videos needs more replicas first — worth doing, but as a separate deliberate step.

## Validation

```
npx vitest run src/classification src/moderation/pipeline.test.mjs
  Test Files  6 passed (6)
  Tests       134 passed (134)
```

Full suite passed on #196 (1484 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)