### PR TITLE
fix(classification): disable ai-detector enrichment, wrong sink

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -125,7 +125,7 @@ AI_DETECTOR_BASE_URL = "https://ai-detector.divine.video"
 # a decision, not a deploy. When true, classifyVideoOnly asks the detector for
 # the nsfw signal and writes any verdict to ClickHouse moderation_labels as
 # review evidence (source_owner divine-ai-detector, no enforcement action).
-AI_DETECTOR_ENRICHMENT_ENABLED = "true"
+AI_DETECTOR_ENRICHMENT_ENABLED = "false"
 
 # DEPRECATED — kept so deployed configs that still set this don't break during
 # cutover. The client reads it as a fallback only when AI_DETECTOR_BASE_URL is


### PR DESCRIPTION
## Summary

Sets `AI_DETECTOR_ENRICHMENT_ENABLED` back to `false`. This stops `classifyVideoOnly` from calling the detector until its output has a working destination.

## Motivation

The enrichment was enabled in #197 before its ClickHouse sink was deployable:

- This Worker has no `CLICKHOUSE_URL` or `CLICKHOUSE_PASSWORD` binding, so `writeModerationLabels()` returns without writing.
- `label-writer.mjs` targets the `default` database, while `moderation_labels` lives in `nostr`.

With the flag enabled, detector requests and inference still ran before the label writer discarded the result. This rollback stops that unnecessary work. Persisted moderation labels and enforcement outcomes remain unchanged because the enrichment path never reached either destination.

The enrichment module, its 14 tests, and the `classifyVideoOnly` hook remain available for a future rollout with a valid sink.

## Linked Issue

Follow-up rollback to #197; there is no separate issue.

## Validation

- `npm run lint`
- `npm test` (83 files, 1,484 tests)
- GitHub Lint, Test, and semantic pull-request checks

No visual change.
