### PR TITLE
feat(dm): allow pinning outbound DM relays via DM_RELAY_URLS

### DIFF
--- a/src/nostr/dm-sender.mjs
+++ b/src/nostr/dm-sender.mjs
@@ -333,15 +333,56 @@ async function recordRateLimit(recipientPubkey, env) {
 // --- Relay Discovery ---
 
 /**
+ * Parse the `DM_RELAY_URLS` publish-target override.
+ *
+ * Unset (the production default) returns [] and every caller keeps today's
+ * behaviour: discovered relays, DIVINE_RELAY, DEFAULT_RELAYS.
+ *
+ * Set, it pins outbound DMs to exactly these relays. That containment is what
+ * makes it safe to run this Worker outside production with a real signing key:
+ * DIVINE_RELAY and DEFAULT_RELAYS are module constants, so without an override
+ * every DM path publishes to relay.divine.video and to three public relays
+ * regardless of environment.
+ *
+ * A value that parses to nothing is treated as unset rather than as "no
+ * relays": returning [] from discovery would surface downstream as success===0,
+ * an ambiguous send, instead of as the misconfiguration it is.
+ *
+ * @param {Object} env
+ * @returns {string[]} Relay URLs, capped at MAX_RELAYS; [] when not overridden
+ */
+function parseRelayOverride(env) {
+  if (!env || typeof env.DM_RELAY_URLS !== 'string') return [];
+  return env.DM_RELAY_URLS
+    .split(',')
+    .map((r) => r.trim())
+    .filter(Boolean)
+    .slice(0, MAX_RELAYS);
+}
+
+/**
  * Discover relays a user reads from, via kind 10002 (NIP-65 relay list).
  * Checks KV cache first, then queries relay.divine.video.
  * Always includes relay.divine.video. Caps at MAX_RELAYS.
+ *
+ * When `DM_RELAY_URLS` is set it short-circuits all of that and becomes the
+ * exact publish target list. See parseRelayOverride.
  *
  * @param {string} pubkey - Hex pubkey of user
  * @param {Object} env
  * @returns {Promise<string[]>} Relay URLs
  */
 export async function discoverUserRelays(pubkey, env) {
+  // A configured override is the complete target list: no cache read, no
+  // kind-10002 discovery, no implicit DIVINE_RELAY. Both of those would
+  // otherwise reintroduce a production relay, which is the whole thing this
+  // exists to prevent.
+  const override = parseRelayOverride(env);
+  if (override.length > 0) {
+    console.log(`[DM] Using DM_RELAY_URLS override (${override.length} relays)`);
+    return override;
+  }
+
   // Check KV cache
   if (env.MODERATION_KV) {
     try {

--- a/src/nostr/dm-sender.mjs
+++ b/src/nostr/dm-sender.mjs
@@ -8,7 +8,7 @@ import { wrapEvent } from 'nostr-tools/nip17';
 import { hexToBytes } from '@noble/hashes/utils';
 import { getPublicKey } from 'nostr-tools/pure';
 import { logDm, computeConversationId } from './dm-store.mjs';
-import { parseRelayOverride } from './relay-override.mjs';
+import { parseRelayOverride, MAX_RELAYS } from './relay-override.mjs';
 
 // Cache moderator keys per env object to avoid re-decoding
 const keyCache = new WeakMap();
@@ -21,7 +21,6 @@ const DEFAULT_RELAYS = [
 
 const DIVINE_RELAY = 'wss://relay.divine.video';
 
-const MAX_RELAYS = 5;
 const RATE_LIMIT_WINDOW_SEC = 60;
 const RATE_LIMIT_MAX = 5;
 const RATE_LIMIT_TTL_SEC = 120;

--- a/src/nostr/dm-sender.mjs
+++ b/src/nostr/dm-sender.mjs
@@ -344,20 +344,50 @@ async function recordRateLimit(recipientPubkey, env) {
  * every DM path publishes to relay.divine.video and to three public relays
  * regardless of environment.
  *
- * A value that parses to nothing is treated as unset rather than as "no
- * relays": returning [] from discovery would surface downstream as success===0,
- * an ambiguous send, instead of as the misconfiguration it is.
+ * Present but unusable THROWS. Setting this variable is a statement that DMs must
+ * not leave a known list, so falling back to DIVINE_RELAY and DEFAULT_RELAYS on a
+ * bad value does the opposite of what was asked, and does it silently: there is
+ * no log distinguishing a malformed value from an unset one. The case is not
+ * exotic. `vars` in wrangler.toml accepts any JSON, so the natural TOML spelling
+ *
+ *     DM_RELAY_URLS = ["ws://127.0.0.1:4444"]
+ *
+ * deploys cleanly and arrives here as an array, not a string.
+ *
+ * Returning [] instead of throwing is not an option: zero relays reads downstream
+ * as success===0 with no rejections, which sendModeratorMessage reports as a
+ * non-definitive send, and the community-strike sweep then retains its warning
+ * claim and never resends. A misconfiguration would silently swallow warnings.
+ *
+ * Unset remains the production default and is unaffected.
  *
  * @param {Object} env
- * @returns {string[]} Relay URLs, capped at MAX_RELAYS; [] when not overridden
+ * @returns {string[]} Relay URLs, deduped and capped at MAX_RELAYS; [] when unset
+ * @throws {Error} when DM_RELAY_URLS is present but yields no usable relay
  */
 function parseRelayOverride(env) {
-  if (!env || typeof env.DM_RELAY_URLS !== 'string') return [];
-  return env.DM_RELAY_URLS
-    .split(',')
-    .map((r) => r.trim())
-    .filter(Boolean)
-    .slice(0, MAX_RELAYS);
+  const raw = env?.DM_RELAY_URLS;
+  if (raw === undefined || raw === null) return [];
+
+  const parsed =
+    typeof raw === 'string'
+      ? raw.split(',').map((r) => r.trim()).filter(Boolean)
+      : [];
+
+  if (parsed.length === 0) {
+    throw new Error(
+      `DM_RELAY_URLS is set but yields no usable relay (${typeof raw}). ` +
+        'Expected a comma-separated string of relay URLs. Refusing to send: ' +
+        'falling back to the production relays would defeat the containment ' +
+        'this setting exists to provide. Unset it to use production defaults.',
+    );
+  }
+
+  // Dedupe BEFORE the cap. Capping first lets duplicates consume the budget and
+  // silently drop a relay that was actually distinct, while the send path still
+  // counts one success per socket -- so a single-relay delivery reports as
+  // MAX_RELAYS-way redundancy.
+  return [...new Set(parsed)].slice(0, MAX_RELAYS);
 }
 
 /**

--- a/src/nostr/dm-sender.mjs
+++ b/src/nostr/dm-sender.mjs
@@ -8,6 +8,7 @@ import { wrapEvent } from 'nostr-tools/nip17';
 import { hexToBytes } from '@noble/hashes/utils';
 import { getPublicKey } from 'nostr-tools/pure';
 import { logDm, computeConversationId } from './dm-store.mjs';
+import { parseRelayOverride } from './relay-override.mjs';
 
 // Cache moderator keys per env object to avoid re-decoding
 const keyCache = new WeakMap();
@@ -331,64 +332,6 @@ async function recordRateLimit(recipientPubkey, env) {
 }
 
 // --- Relay Discovery ---
-
-/**
- * Parse the `DM_RELAY_URLS` publish-target override.
- *
- * Unset (the production default) returns [] and every caller keeps today's
- * behaviour: discovered relays, DIVINE_RELAY, DEFAULT_RELAYS.
- *
- * Set, it pins outbound DMs to exactly these relays. That containment is what
- * makes it safe to run this Worker outside production with a real signing key:
- * DIVINE_RELAY and DEFAULT_RELAYS are module constants, so without an override
- * every DM path publishes to relay.divine.video and to three public relays
- * regardless of environment.
- *
- * Present but unusable THROWS. Setting this variable is a statement that DMs must
- * not leave a known list, so falling back to DIVINE_RELAY and DEFAULT_RELAYS on a
- * bad value does the opposite of what was asked, and does it silently: there is
- * no log distinguishing a malformed value from an unset one. The case is not
- * exotic. `vars` in wrangler.toml accepts any JSON, so the natural TOML spelling
- *
- *     DM_RELAY_URLS = ["ws://127.0.0.1:4444"]
- *
- * deploys cleanly and arrives here as an array, not a string.
- *
- * Returning [] instead of throwing is not an option: zero relays reads downstream
- * as success===0 with no rejections, which sendModeratorMessage reports as a
- * non-definitive send, and the community-strike sweep then retains its warning
- * claim and never resends. A misconfiguration would silently swallow warnings.
- *
- * Unset remains the production default and is unaffected.
- *
- * @param {Object} env
- * @returns {string[]} Relay URLs, deduped and capped at MAX_RELAYS; [] when unset
- * @throws {Error} when DM_RELAY_URLS is present but yields no usable relay
- */
-function parseRelayOverride(env) {
-  const raw = env?.DM_RELAY_URLS;
-  if (raw === undefined || raw === null) return [];
-
-  const parsed =
-    typeof raw === 'string'
-      ? raw.split(',').map((r) => r.trim()).filter(Boolean)
-      : [];
-
-  if (parsed.length === 0) {
-    throw new Error(
-      `DM_RELAY_URLS is set but yields no usable relay (${typeof raw}). ` +
-        'Expected a comma-separated string of relay URLs. Refusing to send: ' +
-        'falling back to the production relays would defeat the containment ' +
-        'this setting exists to provide. Unset it to use production defaults.',
-    );
-  }
-
-  // Dedupe BEFORE the cap. Capping first lets duplicates consume the budget and
-  // silently drop a relay that was actually distinct, while the send path still
-  // counts one success per socket -- so a single-relay delivery reports as
-  // MAX_RELAYS-way redundancy.
-  return [...new Set(parsed)].slice(0, MAX_RELAYS);
-}
 
 /**
  * Discover relays a user reads from, via kind 10002 (NIP-65 relay list).

--- a/src/nostr/dm-sender.test.mjs
+++ b/src/nostr/dm-sender.test.mjs
@@ -461,6 +461,11 @@ describe('DM Sender - DM_RELAY_URLS override', () => {
   });
 
   describe('set but unusable', () => {
+    // A real x-only pubkey. Crypto in this path is real, not mocked, so a made-up
+    // hex string throws inside wrapEvent long before containment is consulted --
+    // which is exactly how two tests in this block came to assert nothing.
+    const recipient = getPublicKey(generateSecretKey());
+
     // The whole point of this variable is that an operator who sets it has said
     // "do not send outside this list". Quietly falling back to the production
     // defaults honours the opposite of what they asked for, and does it silently:
@@ -512,7 +517,13 @@ describe('DM Sender - DM_RELAY_URLS override', () => {
           DM_RELAY_URLS: ['ws://127.0.0.1:4444'],
         };
 
-        const result = await sendModerationDM('b'.repeat(64), 'hello', env);
+        // Real recipient pubkey and the real 7-arg signature. An earlier version
+        // of this test passed 3 args, so `env` landed in the `action` slot and the
+        // function crashed on an undefined env before reaching any containment
+        // code -- it passed with DM_RELAY_URLS support deleted entirely.
+        const result = await sendModerationDM(
+          recipient, 'c'.repeat(64), 'QUARANTINE', 'reason', env, null,
+        );
 
         expect(result.sent).toBe(false);
         // The point: no socket to any relay, production or otherwise.
@@ -550,13 +561,59 @@ describe('DM Sender - DM_RELAY_URLS override', () => {
           DM_RELAY_URLS: ['ws://127.0.0.1:4444'],
         };
 
+        // A REAL pubkey. With 'b'.repeat(64) the real wrapEvent throws first
+        // ("Cannot find square root"), so the definitive:true being asserted came
+        // from an invalid-pubkey crypto failure rather than from the containment
+        // refusal -- and the mutation this test exists to catch survived.
         const result = await sendCommunityStrikeWarning(
-          'b'.repeat(64), 'warning', 'c'.repeat(64), env, null,
+          recipient, 'warning', 'c'.repeat(64), env, null,
         );
 
         expect(result.sent).toBe(false);
         expect(result.definitive).toBe(true);
+        expect(result.reason).toMatch(/DM_RELAY_URLS/);
         expect(sockets).toEqual([]);
+      } finally {
+        vi.unstubAllGlobals();
+      }
+    });
+
+    it('opens sockets to exactly the override relays on the contained happy path', async () => {
+      // Everything else here pins discoverUserRelays' RETURN VALUE, or pins that
+      // nothing is sent when the override is unusable. Neither sees what
+      // publishToRelays is actually handed once containment succeeds: appending
+      // the production relay to the list at all three call sites passed the full
+      // 1579-test suite. Assert the transport, not the answer.
+      const sockets = [];
+      class SpyWS {
+        constructor(url) {
+          sockets.push(url);
+          this.readyState = 3;
+          this.listeners = {};
+          // Fire 'error' via addEventListener, which is what publishToSingleRelay
+          // actually listens on. A no-op listener leaves it waiting out the full
+          // 5s RELAY_TIMEOUT_MS per relay, which stalls the whole file.
+          setTimeout(() => (this.listeners.error || []).forEach((f) => f()), 0);
+        }
+        addEventListener(evt, fn) {
+          (this.listeners[evt] = this.listeners[evt] || []).push(fn);
+        }
+        close() {}
+        send() {}
+      }
+      vi.stubGlobal('WebSocket', SpyWS);
+      try {
+        const env = {
+          NOSTR_PRIVATE_KEY: 'a'.repeat(64),
+          MODERATION_KV: mockKV,
+          DM_RELAY_URLS: 'ws://127.0.0.1:4444,ws://127.0.0.1:5555',
+        };
+
+        await sendModerationDM(recipient, 'c'.repeat(64), 'QUARANTINE', 'reason', env, null);
+
+        expect([...new Set(sockets)].sort()).toEqual(
+          ['ws://127.0.0.1:4444', 'ws://127.0.0.1:5555'],
+        );
       } finally {
         vi.unstubAllGlobals();
       }

--- a/src/nostr/dm-sender.test.mjs
+++ b/src/nostr/dm-sender.test.mjs
@@ -417,15 +417,85 @@ describe('DM Sender - DM_RELAY_URLS override', () => {
     expect(relays).toHaveLength(5);
   });
 
-  it('falls back to normal discovery when DM_RELAY_URLS is only separators', async () => {
-    // An all-blank value must not yield zero relays; that would be read
-    // downstream as success===0 rather than as a configuration error.
-    mockKV.get.mockResolvedValue(null);
-    const env = { MODERATION_KV: mockKV, DM_RELAY_URLS: ' , , ' };
+  it('dedupes before capping, so a distinct relay is not crowded out', async () => {
+    // Without dedupe the cap consumes the duplicates and drops the one relay
+    // that was actually different, while the send path still reports five
+    // successes -- a single-relay delivery that reads as five-relay redundancy.
+    const env = {
+      MODERATION_KV: mockKV,
+      DM_RELAY_URLS: 'ws://a,ws://a,ws://a,ws://a,ws://a,ws://b',
+    };
 
     const relays = await discoverUserRelays('b'.repeat(64), env);
 
-    expect(relays).toContain('wss://relay.divine.video');
+    expect(relays).toEqual(['ws://a', 'ws://b']);
+  });
+
+  it('does not read the cache or open a discovery socket when the override is set', async () => {
+    // The other override tests assert the resulting list, which stays correct
+    // even if discovery still runs and its result is discarded. That would mean
+    // a "contained" run opening a socket to the production relay on every DM,
+    // invisibly. Assert the calls that must not happen, not just the answer.
+    mockKV.get.mockResolvedValue(null);
+    const sockets = [];
+    class SpyWS {
+      constructor(url) {
+        sockets.push(url);
+        this.readyState = 3;
+      }
+      addEventListener() {}
+      close() {}
+      send() {}
+    }
+    vi.stubGlobal('WebSocket', SpyWS);
+    try {
+      const env = { MODERATION_KV: mockKV, DM_RELAY_URLS: 'ws://127.0.0.1:4444' };
+
+      await discoverUserRelays('b'.repeat(64), env);
+
+      expect(mockKV.get).not.toHaveBeenCalled();
+      expect(sockets).toEqual([]);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  describe('set but unusable', () => {
+    // The whole point of this variable is that an operator who sets it has said
+    // "do not send outside this list". Quietly falling back to the production
+    // defaults honours the opposite of what they asked for, and does it silently:
+    // there is no log distinguishing a bad value from an unset one.
+    //
+    // So a value that is PRESENT and unusable is a configuration error, and it
+    // refuses rather than sends. Unset remains the production default and is
+    // unaffected. Returning an empty list instead is not an option -- it reads
+    // downstream as success===0, an ambiguous send that makes the sweep retain a
+    // warning claim and never resend it.
+    for (const [name, value] of [
+      ['a TOML array, which wrangler accepts in vars', ['ws://127.0.0.1:4444']],
+      ['a number', 4444],
+      ['an object', { url: 'ws://127.0.0.1:4444' }],
+      ['whitespace only', '   '],
+      ['separators only', ' , , '],
+      ['an empty string', ''],
+    ]) {
+      it(`refuses to send when DM_RELAY_URLS is ${name}`, async () => {
+        mockKV.get.mockResolvedValue(null);
+        const env = { MODERATION_KV: mockKV, DM_RELAY_URLS: value };
+
+        await expect(discoverUserRelays('b'.repeat(64), env)).rejects.toThrow(
+          /DM_RELAY_URLS/,
+        );
+      });
+    }
+
+    it('leaves the production default alone when DM_RELAY_URLS is absent', async () => {
+      mockKV.get.mockResolvedValue(null);
+
+      const relays = await discoverUserRelays('b'.repeat(64), { MODERATION_KV: mockKV });
+
+      expect(relays).toContain('wss://relay.divine.video');
+    });
   });
 });
 

--- a/src/nostr/dm-sender.test.mjs
+++ b/src/nostr/dm-sender.test.mjs
@@ -489,6 +489,39 @@ describe('DM Sender - DM_RELAY_URLS override', () => {
       });
     }
 
+    it('sends nothing when the override is unusable, rather than falling back', async () => {
+      // Proving parseRelayOverride throws is not the same as proving no DM is
+      // sent. All three send entry points wrap discovery in a catch-all, so a
+      // try/catch that restored the production list would swallow the refusal
+      // and pass every other test in this file.
+      const sockets = [];
+      class SpyWS {
+        constructor(url) {
+          sockets.push(url);
+          this.readyState = 3;
+        }
+        addEventListener() {}
+        close() {}
+        send() {}
+      }
+      vi.stubGlobal('WebSocket', SpyWS);
+      try {
+        const env = {
+          NOSTR_PRIVATE_KEY: 'a'.repeat(64),
+          MODERATION_KV: mockKV,
+          DM_RELAY_URLS: ['ws://127.0.0.1:4444'],
+        };
+
+        const result = await sendModerationDM('b'.repeat(64), 'hello', env);
+
+        expect(result.sent).toBe(false);
+        // The point: no socket to any relay, production or otherwise.
+        expect(sockets).toEqual([]);
+      } finally {
+        vi.unstubAllGlobals();
+      }
+    });
+
     it('leaves the production default alone when DM_RELAY_URLS is absent', async () => {
       mockKV.get.mockResolvedValue(null);
 

--- a/src/nostr/dm-sender.test.mjs
+++ b/src/nostr/dm-sender.test.mjs
@@ -522,6 +522,46 @@ describe('DM Sender - DM_RELAY_URLS override', () => {
       }
     });
 
+    it('reports an unusable override as a DEFINITIVE non-send, so warnings are not swallowed', async () => {
+      // `definitive` decides what the community-strike sweep does with a failure.
+      // A no-send that is definitive releases the claim; a non-definitive one is
+      // ambiguous, so the sweep RETAINS the claim and never resends. That is the
+      // outcome the throw exists to avoid, reached by a different route than the
+      // empty-list return the parser guards against.
+      //
+      // Nothing pinned this: moving `publishAttempted = true` above the discovery
+      // call turns every misconfigured warning into a permanent silent swallow,
+      // and the whole suite still passed.
+      const sockets = [];
+      class SpyWS {
+        constructor(url) {
+          sockets.push(url);
+          this.readyState = 3;
+        }
+        addEventListener() {}
+        close() {}
+        send() {}
+      }
+      vi.stubGlobal('WebSocket', SpyWS);
+      try {
+        const env = {
+          NOSTR_PRIVATE_KEY: 'a'.repeat(64),
+          MODERATION_KV: mockKV,
+          DM_RELAY_URLS: ['ws://127.0.0.1:4444'],
+        };
+
+        const result = await sendCommunityStrikeWarning(
+          'b'.repeat(64), 'warning', 'c'.repeat(64), env, null,
+        );
+
+        expect(result.sent).toBe(false);
+        expect(result.definitive).toBe(true);
+        expect(sockets).toEqual([]);
+      } finally {
+        vi.unstubAllGlobals();
+      }
+    });
+
     it('leaves the production default alone when DM_RELAY_URLS is absent', async () => {
       mockKV.get.mockResolvedValue(null);
 

--- a/src/nostr/dm-sender.test.mjs
+++ b/src/nostr/dm-sender.test.mjs
@@ -23,6 +23,7 @@ import {
   renderComposeTemplate,
   publishToRelays,
 } from './dm-sender.mjs';
+import { isContained, parseRelayOverride } from './relay-override.mjs';
 import { createMockKV } from '../test/helpers.mjs';
 
 // Generate a stable test key in hex format (matching production usage)
@@ -345,6 +346,31 @@ describe('DM Sender - discoverUserRelays', () => {
   });
 });
 
+// vitest-pool-workers does not reliably honor vi.stubGlobal('WebSocket').
+// Assigning globalThis.WebSocket and using reserved-domain hosts is the
+// pattern the rest of this file already uses: 127.0.0.1 and relay.divine.video
+// construct a real socket and wedge the worker RPC (CI Test on this PR hung
+// for 60s after the contained happy-path test, then died on onTaskUpdate).
+function installRecordingWebSocket() {
+  const sockets = [];
+  const original = globalThis.WebSocket;
+  class FakeWS {
+    constructor(url) {
+      sockets.push(url);
+      this._cbs = {};
+      queueMicrotask(() => this._cbs.error && this._cbs.error());
+    }
+    addEventListener(type, cb) { this._cbs[type] = cb; }
+    send() {}
+    close() {}
+  }
+  globalThis.WebSocket = FakeWS;
+  return {
+    sockets,
+    restore() { globalThis.WebSocket = original; },
+  };
+}
+
 describe('DM Sender - DM_RELAY_URLS override', () => {
   let mockKV;
 
@@ -437,26 +463,16 @@ describe('DM Sender - DM_RELAY_URLS override', () => {
     // a "contained" run opening a socket to the production relay on every DM,
     // invisibly. Assert the calls that must not happen, not just the answer.
     mockKV.get.mockResolvedValue(null);
-    const sockets = [];
-    class SpyWS {
-      constructor(url) {
-        sockets.push(url);
-        this.readyState = 3;
-      }
-      addEventListener() {}
-      close() {}
-      send() {}
-    }
-    vi.stubGlobal('WebSocket', SpyWS);
+    const ws = installRecordingWebSocket();
     try {
       const env = { MODERATION_KV: mockKV, DM_RELAY_URLS: 'ws://127.0.0.1:4444' };
 
       await discoverUserRelays('b'.repeat(64), env);
 
       expect(mockKV.get).not.toHaveBeenCalled();
-      expect(sockets).toEqual([]);
+      expect(ws.sockets).toEqual([]);
     } finally {
-      vi.unstubAllGlobals();
+      ws.restore();
     }
   });
 
@@ -499,17 +515,7 @@ describe('DM Sender - DM_RELAY_URLS override', () => {
       // sent. All three send entry points wrap discovery in a catch-all, so a
       // try/catch that restored the production list would swallow the refusal
       // and pass every other test in this file.
-      const sockets = [];
-      class SpyWS {
-        constructor(url) {
-          sockets.push(url);
-          this.readyState = 3;
-        }
-        addEventListener() {}
-        close() {}
-        send() {}
-      }
-      vi.stubGlobal('WebSocket', SpyWS);
+      const ws = installRecordingWebSocket();
       try {
         const env = {
           NOSTR_PRIVATE_KEY: 'a'.repeat(64),
@@ -527,9 +533,9 @@ describe('DM Sender - DM_RELAY_URLS override', () => {
 
         expect(result.sent).toBe(false);
         // The point: no socket to any relay, production or otherwise.
-        expect(sockets).toEqual([]);
+        expect(ws.sockets).toEqual([]);
       } finally {
-        vi.unstubAllGlobals();
+        ws.restore();
       }
     });
 
@@ -543,17 +549,7 @@ describe('DM Sender - DM_RELAY_URLS override', () => {
       // Nothing pinned this: moving `publishAttempted = true` above the discovery
       // call turns every misconfigured warning into a permanent silent swallow,
       // and the whole suite still passed.
-      const sockets = [];
-      class SpyWS {
-        constructor(url) {
-          sockets.push(url);
-          this.readyState = 3;
-        }
-        addEventListener() {}
-        close() {}
-        send() {}
-      }
-      vi.stubGlobal('WebSocket', SpyWS);
+      const ws = installRecordingWebSocket();
       try {
         const env = {
           NOSTR_PRIVATE_KEY: 'a'.repeat(64),
@@ -572,9 +568,9 @@ describe('DM Sender - DM_RELAY_URLS override', () => {
         expect(result.sent).toBe(false);
         expect(result.definitive).toBe(true);
         expect(result.reason).toMatch(/DM_RELAY_URLS/);
-        expect(sockets).toEqual([]);
+        expect(ws.sockets).toEqual([]);
       } finally {
-        vi.unstubAllGlobals();
+        ws.restore();
       }
     });
 
@@ -584,47 +580,62 @@ describe('DM Sender - DM_RELAY_URLS override', () => {
       // publishToRelays is actually handed once containment succeeds: appending
       // the production relay to the list at all three call sites passed the full
       // 1579-test suite. Assert the transport, not the answer.
-      const sockets = [];
-      class SpyWS {
-        constructor(url) {
-          sockets.push(url);
-          this.readyState = 3;
-          this.listeners = {};
-          // Fire 'error' via addEventListener, which is what publishToSingleRelay
-          // actually listens on. A no-op listener leaves it waiting out the full
-          // 5s RELAY_TIMEOUT_MS per relay, which stalls the whole file.
-          setTimeout(() => (this.listeners.error || []).forEach((f) => f()), 0);
-        }
-        addEventListener(evt, fn) {
-          (this.listeners[evt] = this.listeners[evt] || []).push(fn);
-        }
-        close() {}
-        send() {}
-      }
-      vi.stubGlobal('WebSocket', SpyWS);
+      //
+      // Use reserved-domain hosts. A real constructor against 127.0.0.1 or
+      // relay.divine.video wedges vitest-pool-workers even when the test
+      // intended to fake WebSocket (CI Test on this head: worker onTaskUpdate
+      // timeout after the real sockets logged their errors).
+      const ws = installRecordingWebSocket();
       try {
         const env = {
-          NOSTR_PRIVATE_KEY: 'a'.repeat(64),
+          NOSTR_PRIVATE_KEY: testHex,
           MODERATION_KV: mockKV,
-          DM_RELAY_URLS: 'ws://127.0.0.1:4444,ws://127.0.0.1:5555',
+          DM_RELAY_URLS: 'wss://relay.example.com,wss://other.example.com',
         };
 
         await sendModerationDM(recipient, 'c'.repeat(64), 'QUARANTINE', 'reason', env, null);
 
-        expect([...new Set(sockets)].sort()).toEqual(
-          ['ws://127.0.0.1:4444', 'ws://127.0.0.1:5555'],
+        expect([...new Set(ws.sockets)].sort()).toEqual(
+          ['wss://other.example.com', 'wss://relay.example.com'],
         );
       } finally {
-        vi.unstubAllGlobals();
+        ws.restore();
       }
     });
 
-    it('leaves the production default alone when DM_RELAY_URLS is absent', async () => {
-      mockKV.get.mockResolvedValue(null);
+    it('opens the same override sockets on the community-warning send path', async () => {
+      const ws = installRecordingWebSocket();
+      try {
+        const env = {
+          NOSTR_PRIVATE_KEY: testHex,
+          MODERATION_KV: mockKV,
+          DM_RELAY_URLS: 'wss://relay.example.com,wss://other.example.com',
+        };
+        const fakeWrap = () => ({
+          id: 'e'.repeat(64),
+          kind: 1059,
+          pubkey: 'f'.repeat(64),
+          created_at: 1,
+          tags: [['p', recipient]],
+          content: 'wrapped',
+          sig: '0'.repeat(128),
+        });
 
-      const relays = await discoverUserRelays('b'.repeat(64), { MODERATION_KV: mockKV });
+        await sendCommunityStrikeWarning(
+          recipient, 'warning', 'c'.repeat(64), env, null, { wrap: fakeWrap },
+        );
 
-      expect(relays).toContain('wss://relay.divine.video');
+        expect([...new Set(ws.sockets)].sort()).toEqual(
+          ['wss://other.example.com', 'wss://relay.example.com'],
+        );
+      } finally {
+        ws.restore();
+      }
+    });
+
+    it('treats an absent DM_RELAY_URLS as not contained', () => {
+      expect(isContained({})).toBe(false);
+      expect(parseRelayOverride({})).toEqual([]);
     });
   });
 });

--- a/src/nostr/dm-sender.test.mjs
+++ b/src/nostr/dm-sender.test.mjs
@@ -493,6 +493,8 @@ describe('DM Sender - DM_RELAY_URLS override', () => {
     // downstream as success===0, an ambiguous send that makes the sweep retain a
     // warning claim and never resend it.
     for (const [name, value] of [
+      ['null', null],
+      ['explicit undefined', undefined],
       ['a TOML array, which wrangler accepts in vars', ['ws://127.0.0.1:4444']],
       ['a number', 4444],
       ['an object', { url: 'ws://127.0.0.1:4444' }],
@@ -510,7 +512,10 @@ describe('DM Sender - DM_RELAY_URLS override', () => {
       });
     }
 
-    it('sends nothing when the override is unusable, rather than falling back', async () => {
+    it.each([
+      ['null', null],
+      ['a TOML array', ['ws://127.0.0.1:4444']],
+    ])('sends nothing when the override is %s, rather than falling back', async (_name, value) => {
       // Proving parseRelayOverride throws is not the same as proving no DM is
       // sent. All three send entry points wrap discovery in a catch-all, so a
       // try/catch that restored the production list would swallow the refusal
@@ -520,7 +525,7 @@ describe('DM Sender - DM_RELAY_URLS override', () => {
         const env = {
           NOSTR_PRIVATE_KEY: 'a'.repeat(64),
           MODERATION_KV: mockKV,
-          DM_RELAY_URLS: ['ws://127.0.0.1:4444'],
+          DM_RELAY_URLS: value,
         };
 
         // Real recipient pubkey and the real 7-arg signature. An earlier version

--- a/src/nostr/dm-sender.test.mjs
+++ b/src/nostr/dm-sender.test.mjs
@@ -345,6 +345,90 @@ describe('DM Sender - discoverUserRelays', () => {
   });
 });
 
+describe('DM Sender - DM_RELAY_URLS override', () => {
+  let mockKV;
+
+  beforeEach(() => {
+    mockKV = { get: vi.fn(), put: vi.fn() };
+  });
+
+  it('publishes only to DM_RELAY_URLS when set', async () => {
+    mockKV.get.mockResolvedValue(null);
+    const env = {
+      MODERATION_KV: mockKV,
+      DM_RELAY_URLS: 'ws://127.0.0.1:4444',
+    };
+
+    const relays = await discoverUserRelays('b'.repeat(64), env);
+
+    expect(relays).toEqual(['ws://127.0.0.1:4444']);
+    expect(relays).not.toContain('wss://relay.divine.video');
+  });
+
+  it('ignores the KV relay cache when DM_RELAY_URLS is set', async () => {
+    // Containment must not be defeatable by a cache entry written before the
+    // override was configured.
+    mockKV.get.mockResolvedValue(JSON.stringify(['wss://relay.damus.io']));
+    const env = {
+      MODERATION_KV: mockKV,
+      DM_RELAY_URLS: 'ws://127.0.0.1:4444',
+    };
+
+    const relays = await discoverUserRelays('b'.repeat(64), env);
+
+    expect(relays).toEqual(['ws://127.0.0.1:4444']);
+  });
+
+  it('does not write the override list back into the KV cache', async () => {
+    // Caching it would leak a local/staging relay into a later prod-configured
+    // run of the same worker against the same namespace.
+    mockKV.get.mockResolvedValue(null);
+    const env = {
+      MODERATION_KV: mockKV,
+      DM_RELAY_URLS: 'ws://127.0.0.1:4444',
+    };
+
+    await discoverUserRelays('b'.repeat(64), env);
+
+    expect(mockKV.put).not.toHaveBeenCalled();
+  });
+
+  it('parses a comma-separated list, trimming blanks', async () => {
+    const env = {
+      MODERATION_KV: mockKV,
+      DM_RELAY_URLS: ' ws://127.0.0.1:4444 , ,ws://127.0.0.1:5555 ',
+    };
+
+    const relays = await discoverUserRelays('b'.repeat(64), env);
+
+    expect(relays).toEqual(['ws://127.0.0.1:4444', 'ws://127.0.0.1:5555']);
+  });
+
+  it('still caps the override at MAX_RELAYS', async () => {
+    const env = {
+      MODERATION_KV: mockKV,
+      DM_RELAY_URLS: [
+        'ws://r1', 'ws://r2', 'ws://r3', 'ws://r4', 'ws://r5', 'ws://r6',
+      ].join(','),
+    };
+
+    const relays = await discoverUserRelays('b'.repeat(64), env);
+
+    expect(relays).toHaveLength(5);
+  });
+
+  it('falls back to normal discovery when DM_RELAY_URLS is only separators', async () => {
+    // An all-blank value must not yield zero relays; that would be read
+    // downstream as success===0 rather than as a configuration error.
+    mockKV.get.mockResolvedValue(null);
+    const env = { MODERATION_KV: mockKV, DM_RELAY_URLS: ' , , ' };
+
+    const relays = await discoverUserRelays('b'.repeat(64), env);
+
+    expect(relays).toContain('wss://relay.divine.video');
+  });
+});
+
 describe('DM Sender - Error Handling', () => {
   it('should return failure when NOSTR_PRIVATE_KEY is missing', async () => {
     const env = {};

--- a/src/nostr/publisher.mjs
+++ b/src/nostr/publisher.mjs
@@ -7,6 +7,7 @@
 import { finalizeEvent, generateSecretKey, getPublicKey } from 'nostr-tools/pure';
 import { Relay } from 'nostr-tools/relay';
 import { hexToBytes } from '@noble/hashes/utils';
+import { isContained } from './relay-override.mjs';
 
 /**
  * NIP-32 label mapping for content categories
@@ -432,21 +433,48 @@ export async function publishDmInboxRelayList(env, { connect = Relay.connect } =
     return { published: false, reason: 'No signing key configured' };
   }
 
+  // DM_RELAY_URLS declares a non-production run, and this is the second path that
+  // publishes with the signing key. Announcing widely is right in production and
+  // wrong here: a contained run would tell purplepag.es, relay.nostr.band and
+  // relay.damus.io that moderation@'s DM inbox is a localhost relay, replacing
+  // the real kind-10050 on the relays clients actually consult. Strict NIP-17
+  // clients could then not deliver DMs to the moderation account until it was
+  // republished.
+  //
+  // `isContained` is true whenever the variable is PRESENT, including when its
+  // value is unusable, and it is shared with the DM path on purpose. When the two
+  // parsed it separately they disagreed: a TOML array made the DM path refuse
+  // while this one took the production branch, so the exact misconfiguration the
+  // refusal exists to catch produced the exact harm it exists to prevent.
+  const contained = isContained(env);
+
   // Inbox = where dm-reader actually polls for gift-wrapped DMs. Keep in sync with it.
+  //
+  // Suppressing the discovery relays is not enough to contain this path, because
+  // homeRelay is unconditionally a target and its fallback is the production
+  // relay. A contained run with no explicit home relay would still publish a
+  // freshly-signed REPLACEABLE kind-10050 to relay.divine.video with the real key.
+  // Containment must not depend on remembering a second variable, so with nothing
+  // safe to announce, it does not announce.
+  if (contained && !env.RELAY_POLLING_RELAY_URL) {
+    console.warn(
+      '[DM-INBOX] DM_RELAY_URLS is set but RELAY_POLLING_RELAY_URL is not. ' +
+        'Skipping the kind-10050 announcement rather than publishing to the ' +
+        'production relay from a run declared contained.',
+    );
+    return { published: false, reason: 'Contained run without RELAY_POLLING_RELAY_URL' };
+  }
+
   const homeRelay = env.RELAY_POLLING_RELAY_URL || 'wss://relay.divine.video';
   const inboxRelays = [homeRelay];
 
   // Discovery targets: where we publish the event so clients can resolve it.
-  //
-  // DM_RELAY_URLS contains a non-production run, and this is the second path that
-  // publishes with the signing key. Announcing widely is right in production and
-  // wrong here: a contained run would tell purplepag.es, relay.nostr.band and
-  // relay.damus.io that moderation@'s DM inbox is a localhost relay, overwriting
-  // the real kind-10050 on the relays clients actually consult. Strict NIP-17
-  // clients would then be unable to deliver DMs to the moderation account until
-  // it was republished. So when the run is contained, the announcement is too.
-  const contained = typeof env.DM_RELAY_URLS === 'string'
-    && env.DM_RELAY_URLS.split(',').map((r) => r.trim()).filter(Boolean).length > 0;
+  if (contained && env.DM_INBOX_DISCOVERY_RELAYS) {
+    console.warn(
+      '[DM-INBOX] Ignoring DM_INBOX_DISCOVERY_RELAYS because DM_RELAY_URLS is set. ' +
+        'A contained run announces only to its own home relay.',
+    );
+  }
   const discoveryRelays = contained
     ? []
     : env.DM_INBOX_DISCOVERY_RELAYS

--- a/src/nostr/publisher.mjs
+++ b/src/nostr/publisher.mjs
@@ -471,19 +471,33 @@ export async function publishDmInboxRelayList(env, { connect = Relay.connect } =
     // empty allowlist. Caught rather than propagated because this function has
     // never thrown and its callers do not expect it to.
     let allowed = [];
+    let parseError = null;
     try {
       allowed = parseRelayOverride(env);
-    } catch {
+    } catch (err) {
+      // Keep the message. Discarding it left the operator with the skip warning
+      // below telling them to fix RELAY_POLLING_RELAY_URL when that variable was
+      // already correct and the real fault was an unparseable list -- advice that
+      // could not work, for a problem it did not name.
+      parseError = err.message;
       allowed = [];
     }
     if (!allowed.includes(homeRelay)) {
       console.warn(
-        `[DM-INBOX] Skipping the kind-10050 announcement: this run is contained by ` +
-          `DM_RELAY_URLS but its inbox relay (${homeRelay}) is not in that list, so ` +
-          `announcing would publish outside the containment. Set ` +
-          `RELAY_POLLING_RELAY_URL to one of the DM_RELAY_URLS relays.`,
+        parseError
+          ? `[DM-INBOX] Skipping the kind-10050 announcement: DM_RELAY_URLS is set ` +
+            `but unusable, so nothing is allowed. ${parseError}`
+          : `[DM-INBOX] Skipping the kind-10050 announcement: this run is contained ` +
+            `by DM_RELAY_URLS but its inbox relay (${homeRelay}) is not in that list, ` +
+            `so announcing would publish outside the containment. Set ` +
+            `RELAY_POLLING_RELAY_URL to one of the DM_RELAY_URLS relays.`,
       );
-      return { published: false, reason: 'Contained run: home relay is not in DM_RELAY_URLS' };
+      return {
+        published: false,
+        reason: parseError
+          ? 'Contained run: DM_RELAY_URLS is unusable'
+          : 'Contained run: home relay is not in DM_RELAY_URLS',
+      };
     }
   }
   const inboxRelays = [homeRelay];

--- a/src/nostr/publisher.mjs
+++ b/src/nostr/publisher.mjs
@@ -437,9 +437,21 @@ export async function publishDmInboxRelayList(env, { connect = Relay.connect } =
   const inboxRelays = [homeRelay];
 
   // Discovery targets: where we publish the event so clients can resolve it.
-  const discoveryRelays = env.DM_INBOX_DISCOVERY_RELAYS
-    ? env.DM_INBOX_DISCOVERY_RELAYS.split(',').map((r) => r.trim()).filter(Boolean)
-    : ['wss://purplepag.es', 'wss://relay.nostr.band', 'wss://relay.damus.io'];
+  //
+  // DM_RELAY_URLS contains a non-production run, and this is the second path that
+  // publishes with the signing key. Announcing widely is right in production and
+  // wrong here: a contained run would tell purplepag.es, relay.nostr.band and
+  // relay.damus.io that moderation@'s DM inbox is a localhost relay, overwriting
+  // the real kind-10050 on the relays clients actually consult. Strict NIP-17
+  // clients would then be unable to deliver DMs to the moderation account until
+  // it was republished. So when the run is contained, the announcement is too.
+  const contained = typeof env.DM_RELAY_URLS === 'string'
+    && env.DM_RELAY_URLS.split(',').map((r) => r.trim()).filter(Boolean).length > 0;
+  const discoveryRelays = contained
+    ? []
+    : env.DM_INBOX_DISCOVERY_RELAYS
+      ? env.DM_INBOX_DISCOVERY_RELAYS.split(',').map((r) => r.trim()).filter(Boolean)
+      : ['wss://purplepag.es', 'wss://relay.nostr.band', 'wss://relay.damus.io'];
   const targets = [...new Set([homeRelay, ...discoveryRelays])];
 
   const event = createDmInboxRelayListEvent(inboxRelays, env.NOSTR_PRIVATE_KEY);

--- a/src/nostr/publisher.mjs
+++ b/src/nostr/publisher.mjs
@@ -7,7 +7,7 @@
 import { finalizeEvent, generateSecretKey, getPublicKey } from 'nostr-tools/pure';
 import { Relay } from 'nostr-tools/relay';
 import { hexToBytes } from '@noble/hashes/utils';
-import { isContained } from './relay-override.mjs';
+import { isContained, parseRelayOverride } from './relay-override.mjs';
 
 /**
  * NIP-32 label mapping for content categories
@@ -456,16 +456,36 @@ export async function publishDmInboxRelayList(env, { connect = Relay.connect } =
   // freshly-signed REPLACEABLE kind-10050 to relay.divine.video with the real key.
   // Containment must not depend on remembering a second variable, so with nothing
   // safe to announce, it does not announce.
-  if (contained && !env.RELAY_POLLING_RELAY_URL) {
-    console.warn(
-      '[DM-INBOX] DM_RELAY_URLS is set but RELAY_POLLING_RELAY_URL is not. ' +
-        'Skipping the kind-10050 announcement rather than publishing to the ' +
-        'production relay from a run declared contained.',
-    );
-    return { published: false, reason: 'Contained run without RELAY_POLLING_RELAY_URL' };
-  }
-
   const homeRelay = env.RELAY_POLLING_RELAY_URL || 'wss://relay.divine.video';
+
+  if (contained) {
+    // Check the TARGET, not which variables happen to be defined. The previous
+    // version asked whether RELAY_POLLING_RELAY_URL was UNSET -- but wrangler.toml
+    // sets it to wss://relay.divine.video in the single shared [vars] block, so it
+    // is set in every deploy and every `wrangler dev`. The guard never fired in any
+    // configuration this repo ships, and a run declared contained published a
+    // freshly-signed, replaceable kind-10050 to the production relay with the real
+    // key.
+    //
+    // A parse failure means nothing is allowed, which is the same answer as an
+    // empty allowlist. Caught rather than propagated because this function has
+    // never thrown and its callers do not expect it to.
+    let allowed = [];
+    try {
+      allowed = parseRelayOverride(env);
+    } catch {
+      allowed = [];
+    }
+    if (!allowed.includes(homeRelay)) {
+      console.warn(
+        `[DM-INBOX] Skipping the kind-10050 announcement: this run is contained by ` +
+          `DM_RELAY_URLS but its inbox relay (${homeRelay}) is not in that list, so ` +
+          `announcing would publish outside the containment. Set ` +
+          `RELAY_POLLING_RELAY_URL to one of the DM_RELAY_URLS relays.`,
+      );
+      return { published: false, reason: 'Contained run: home relay is not in DM_RELAY_URLS' };
+    }
+  }
   const inboxRelays = [homeRelay];
 
   // Discovery targets: where we publish the event so clients can resolve it.

--- a/src/nostr/publisher.test.mjs
+++ b/src/nostr/publisher.test.mjs
@@ -443,6 +443,45 @@ describe('DM inbox relay list (kind 10050)', () => {
     expect(inboxRelays).toEqual(['wss://relay.divine.video']);
   });
 
+  it('does not announce to public relays when DM_RELAY_URLS contains the run', async () => {
+    // DM_RELAY_URLS says "this run must not reach outside these relays". This is
+    // the second path that publishes with the signing key, and its discovery
+    // fallback is three public relays plus the production one.
+    //
+    // Uncontained, a local run announces "moderation@'s DM inbox is
+    // ws://127.0.0.1:4444" to purplepag.es, relay.nostr.band and relay.damus.io,
+    // overwriting the real kind-10050 there. Strict NIP-17 clients then cannot
+    // deliver DMs to the moderation account until it is republished.
+    const { connect } = createConnect();
+    const env = {
+      NOSTR_PRIVATE_KEY: 'a'.repeat(64),
+      RELAY_POLLING_RELAY_URL: 'ws://127.0.0.1:4444',
+      DM_RELAY_URLS: 'ws://127.0.0.1:4444',
+    };
+
+    await publishDmInboxRelayList(env, { connect });
+
+    const targets = connect.mock.calls.map((c) => c[0]);
+    expect(targets).toEqual(['ws://127.0.0.1:4444']);
+    expect(targets).not.toContain('wss://purplepag.es');
+    expect(targets).not.toContain('wss://relay.divine.video');
+  });
+
+  it('still announces to the public discovery relays in production', async () => {
+    // The pair to the above: unset DM_RELAY_URLS is production, where announcing
+    // widely is the entire point of a kind-10050.
+    const { connect } = createConnect();
+    const env = {
+      NOSTR_PRIVATE_KEY: 'a'.repeat(64),
+      RELAY_POLLING_RELAY_URL: 'wss://relay.divine.video',
+    };
+
+    await publishDmInboxRelayList(env, { connect });
+
+    const targets = connect.mock.calls.map((c) => c[0]);
+    expect(targets).toContain('wss://purplepag.es');
+  });
+
   it('returns {published:false} when no signing key is configured', async () => {
     const result = await publishDmInboxRelayList({});
     expect(result.published).toBe(false);

--- a/src/nostr/publisher.test.mjs
+++ b/src/nostr/publisher.test.mjs
@@ -443,6 +443,55 @@ describe('DM inbox relay list (kind 10050)', () => {
     expect(inboxRelays).toEqual(['wss://relay.divine.video']);
   });
 
+  it.each([
+    ['a TOML array, which wrangler accepts in vars', ['ws://127.0.0.1:4444']],
+    ['a number', 4444],
+    ['whitespace only', '   '],
+    ['separators only', ' , , '],
+    ['an empty string', ''],
+  ])('treats a present-but-unusable DM_RELAY_URLS as contained: %s', async (_name, value) => {
+    // The DM path refuses to send on these values. If this path disagreed and
+    // took the production branch, the exact misconfiguration the refusal exists
+    // to catch would announce moderation@'s DM inbox to purplepag.es,
+    // relay.nostr.band and relay.damus.io, overwriting the real record there.
+    //
+    // Present-and-unparseable means refuse, never "carry on as production".
+    const { connect } = createConnect();
+    const env = {
+      NOSTR_PRIVATE_KEY: 'a'.repeat(64),
+      RELAY_POLLING_RELAY_URL: 'ws://127.0.0.1:4444',
+      DM_RELAY_URLS: value,
+    };
+
+    await publishDmInboxRelayList(env, { connect });
+
+    const targets = connect.mock.calls.map((c) => c[0]);
+    expect(targets).not.toContain('wss://purplepag.es');
+    expect(targets).not.toContain('wss://relay.nostr.band');
+    expect(targets).not.toContain('wss://relay.damus.io');
+  });
+
+  it('refuses to announce at all when contained without an explicit home relay', async () => {
+    // homeRelay falls back to the production relay and is unconditionally a
+    // target, so suppressing the discovery relays alone does not contain this
+    // path: a run declared contained still publishes a freshly-signed,
+    // REPLACEABLE kind-10050 to relay.divine.video with the real key.
+    //
+    // Containment must not depend on remembering a second, undocumented variable.
+    // With no explicit home relay there is nothing safe to announce, so it skips.
+    const { connect } = createConnect();
+    const env = {
+      NOSTR_PRIVATE_KEY: 'a'.repeat(64),
+      DM_RELAY_URLS: 'ws://127.0.0.1:4444',
+    };
+
+    const result = await publishDmInboxRelayList(env, { connect });
+
+    expect(connect).not.toHaveBeenCalled();
+    expect(result.published).toBe(false);
+    expect(result.reason).toMatch(/RELAY_POLLING_RELAY_URL/);
+  });
+
   it('does not announce to public relays when DM_RELAY_URLS contains the run', async () => {
     // DM_RELAY_URLS says "this run must not reach outside these relays". This is
     // the second path that publishes with the signing key, and its discovery

--- a/src/nostr/publisher.test.mjs
+++ b/src/nostr/publisher.test.mjs
@@ -444,6 +444,8 @@ describe('DM inbox relay list (kind 10050)', () => {
   });
 
   it.each([
+    ['null', null],
+    ['explicit undefined', undefined],
     ['a TOML array, which wrangler accepts in vars', ['ws://127.0.0.1:4444']],
     ['a number', 4444],
     ['whitespace only', '   '],

--- a/src/nostr/publisher.test.mjs
+++ b/src/nostr/publisher.test.mjs
@@ -465,10 +465,49 @@ describe('DM inbox relay list (kind 10050)', () => {
 
     await publishDmInboxRelayList(env, { connect });
 
-    const targets = connect.mock.calls.map((c) => c[0]);
-    expect(targets).not.toContain('wss://purplepag.es');
-    expect(targets).not.toContain('wss://relay.nostr.band');
-    expect(targets).not.toContain('wss://relay.damus.io');
+    // An unusable override means nothing is allowed, so nothing is announced.
+    // Asserting only that the aggregators are absent is what hid a home relay
+    // pointing at production.
+    expect(connect).not.toHaveBeenCalled();
+  });
+
+  it('refuses when the home relay is not in the override, even though it is set', async () => {
+    // The guard used to ask whether RELAY_POLLING_RELAY_URL was UNSET. wrangler.toml
+    // sets it to wss://relay.divine.video in the single shared [vars] block, so it
+    // is set in every deploy and every `wrangler dev` -- the guard never fired in
+    // any configuration this repo ships, and a contained run published a signed,
+    // replaceable kind-10050 to the production relay.
+    //
+    // Containment is a property of the TARGET, not of which variables happen to be
+    // defined. This fixture is deliberately the one no other test here uses: a home
+    // relay that is NOT the override value.
+    const { connect } = createConnect();
+    const env = {
+      NOSTR_PRIVATE_KEY: 'a'.repeat(64),
+      RELAY_POLLING_RELAY_URL: 'wss://relay.divine.video',
+      DM_RELAY_URLS: 'ws://127.0.0.1:4444',
+    };
+
+    const result = await publishDmInboxRelayList(env, { connect });
+
+    expect(connect).not.toHaveBeenCalled();
+    expect(result.published).toBe(false);
+  });
+
+  it('announces when the home relay IS in the override', async () => {
+    // The pair: a genuinely contained run still gets its announcement, to its own
+    // relay only. Without this the guard could be satisfied by refusing always.
+    const { connect } = createConnect();
+    const env = {
+      NOSTR_PRIVATE_KEY: 'a'.repeat(64),
+      RELAY_POLLING_RELAY_URL: 'ws://127.0.0.1:4444',
+      DM_RELAY_URLS: 'ws://127.0.0.1:4444,ws://127.0.0.1:5555',
+    };
+
+    const result = await publishDmInboxRelayList(env, { connect });
+
+    expect(connect.mock.calls.map((c) => c[0])).toEqual(['ws://127.0.0.1:4444']);
+    expect(result.published).toBe(true);
   });
 
   it('refuses to announce at all when contained without an explicit home relay', async () => {
@@ -489,7 +528,7 @@ describe('DM inbox relay list (kind 10050)', () => {
 
     expect(connect).not.toHaveBeenCalled();
     expect(result.published).toBe(false);
-    expect(result.reason).toMatch(/RELAY_POLLING_RELAY_URL/);
+    expect(result.reason).toMatch(/DM_RELAY_URLS/);
   });
 
   it('does not announce to public relays when DM_RELAY_URLS contains the run', async () => {

--- a/src/nostr/relay-override.mjs
+++ b/src/nostr/relay-override.mjs
@@ -1,0 +1,76 @@
+/**
+ * `DM_RELAY_URLS` — the containment switch for outbound Nostr writes.
+ *
+ * Every path that signs with NOSTR_PRIVATE_KEY has to agree on what this
+ * variable means, which is why it lives here rather than in the module that
+ * happened to need it first. When dm-sender.mjs and publisher.mjs each parsed it
+ * their own way, a TOML array made the DM path refuse to send while the kind-10050
+ * path announced to three public aggregators — the exact harm, triggered by the
+ * exact misconfiguration the refusal existed to catch.
+ */
+
+/** Publishing to more than this many relays is not more delivery, just more sockets. */
+export const MAX_RELAYS = 5;
+
+/**
+ * Is this run declared contained?
+ *
+ * True whenever `DM_RELAY_URLS` is PRESENT, including when its value is unusable.
+ * That is deliberate and is the direction that fails safe: an operator who set
+ * the variable has said outbound writes must not leave a known list, so a value
+ * we cannot parse means refuse, never "carry on as production".
+ *
+ * @param {Object} env
+ * @returns {boolean}
+ */
+export function isContained(env) {
+  const raw = env?.DM_RELAY_URLS;
+  return raw !== undefined && raw !== null;
+}
+
+/**
+ * The exact relay list for a contained run.
+ *
+ * Present but unusable THROWS. Setting this variable is a statement that writes
+ * must not leave a known list, so falling back to the production defaults on a
+ * bad value does the opposite of what was asked, and silently: there is no log
+ * distinguishing a malformed value from an unset one. The case is not exotic —
+ * `vars` in wrangler.toml accepts any JSON, so the natural TOML spelling
+ *
+ *     DM_RELAY_URLS = ["ws://127.0.0.1:4444"]
+ *
+ * deploys cleanly and arrives here as an array, not a string.
+ *
+ * Returning [] instead of throwing is not an option: zero relays reads downstream
+ * as success===0 with no rejections, which sendModeratorMessage reports as a
+ * non-definitive send, and the community-strike sweep then retains its warning
+ * claim and never resends. A misconfiguration would silently swallow warnings.
+ *
+ * @param {Object} env
+ * @returns {string[]} Relay URLs, deduped and capped at MAX_RELAYS; [] when unset
+ * @throws {Error} when DM_RELAY_URLS is present but yields no usable relay
+ */
+export function parseRelayOverride(env) {
+  if (!isContained(env)) return [];
+  const raw = env.DM_RELAY_URLS;
+
+  const parsed =
+    typeof raw === 'string'
+      ? raw.split(',').map((r) => r.trim()).filter(Boolean)
+      : [];
+
+  if (parsed.length === 0) {
+    throw new Error(
+      `DM_RELAY_URLS is set but yields no usable relay (${typeof raw}). ` +
+        'Expected a comma-separated string of relay URLs. Refusing: falling back ' +
+        'to the production relays would defeat the containment this setting ' +
+        'exists to provide. Unset it to use production defaults.',
+    );
+  }
+
+  // Dedupe BEFORE the cap. Capping first lets duplicates consume the budget and
+  // silently drop a relay that was actually distinct, while the send path still
+  // counts one success per socket -- so a single-relay delivery reports as
+  // MAX_RELAYS-way redundancy.
+  return [...new Set(parsed)].slice(0, MAX_RELAYS);
+}

--- a/src/nostr/relay-override.mjs
+++ b/src/nostr/relay-override.mjs
@@ -24,8 +24,7 @@ export const MAX_RELAYS = 5;
  * @returns {boolean}
  */
 export function isContained(env) {
-  const raw = env?.DM_RELAY_URLS;
-  return raw !== undefined && raw !== null;
+  return env != null && Object.prototype.hasOwnProperty.call(env, 'DM_RELAY_URLS');
 }
 
 /**

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -161,17 +161,25 @@ AI_DETECTOR_GATE_WATERMARK_VISIBLE = "0.8"
 # form DM_RELAY_URLS = ["ws://..."] deploys cleanly and arrives as an array;
 # that is refused at send time rather than silently falling back to production.
 #
-# Setting it contains both paths that publish with NOSTR_PRIVATE_KEY: the DM send
-# path, and the kind-10050 inbox announcement.
+# Setting it contains the two paths that PUBLISH NOSTR EVENTS with
+# NOSTR_PRIVATE_KEY: the DM send path, and the kind-10050 inbox announcement.
 #
-# The announcement additionally needs RELAY_POLLING_RELAY_URL, because that is
-# what it announces AS the inbox and its fallback is the production relay. Set
-# DM_RELAY_URLS without it and the announcement is skipped rather than published
-# to production; the log says so.
+# The announcement also needs RELAY_POLLING_RELAY_URL to name one of these relays,
+# because that is what it announces AS the inbox. If it names anything else the
+# announcement is skipped rather than published outside the containment, and the
+# log says which relay was refused. Note this file sets RELAY_POLLING_RELAY_URL to
+# the production relay below, so a contained run must override it.
 #
-# Still not contained: profile-resolver's kind-0 read reaches relay.divine.video.
-# It publishes nothing and contacts no user, so DM containment holds, but a
-# non-production run is not fully offline.
+# NOT contained, and worth knowing before you run this with a real key:
+#
+#   - notifyRelay (src/relay-notifier.mjs) signs a NIP-98 token with the same key
+#     and POSTs to FUNNELCAKE_ADMIN_URL, which this file also points at
+#     relay.divine.video. It fires on ordinary moderation actions, so a QUARANTINE
+#     from a contained run hides a real video on the production relay. Override
+#     FUNNELCAKE_ADMIN_URL too, or leave enforcement alone in a non-prod run.
+#   - The read paths (dm-reader, report-poller, relay-poller, profile-resolver)
+#     read from production by default. They publish nothing and contact no user,
+#     so DM containment holds, but a contained run is not offline.
 
 # Relay Polling Configuration
 RELAY_POLLING_ENABLED = "true"                    # Enable/disable relay polling

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -161,8 +161,10 @@ AI_DETECTOR_GATE_WATERMARK_VISIBLE = "0.8"
 # form DM_RELAY_URLS = ["ws://..."] deploys cleanly and arrives as an array;
 # that is refused at send time rather than silently falling back to production.
 #
-# Setting it contains the two paths that PUBLISH NOSTR EVENTS with
+# Setting it contains two of the five paths that PUBLISH NOSTR EVENTS with
 # NOSTR_PRIVATE_KEY: the DM send path, and the kind-10050 inbox announcement.
+# It is NOT a global containment switch. Read the list below before running this
+# with a real key.
 #
 # The announcement also needs RELAY_POLLING_RELAY_URL to name one of these relays,
 # because that is what it announces AS the inbox. If it names anything else the
@@ -177,6 +179,15 @@ AI_DETECTOR_GATE_WATERMARK_VISIBLE = "0.8"
 #     relay.divine.video. It fires on ordinary moderation actions, so a QUARANTINE
 #     from a contained run hides a real video on the production relay. Override
 #     FUNNELCAKE_ADMIN_URL too, or leave enforcement alone in a non-prod run.
+#   - publishToFaro (kind 1984) -> FARO_RELAY_URL, publishToContentRelay
+#     (kind 1984) -> NOSTR_RELAY_URL, and publishPreparedLabelEvent (kind 1985
+#     content-warning labels) -> NOSTR_RELAY_URL || FARO_RELAY_URL. All three sign
+#     with the same key. Both variables are SECRETS rather than vars, so leaving
+#     them unset is working containment: publishToFaro throws and the other two
+#     return early. That is real but non-obvious, and it breaks the moment someone
+#     copies production secrets into a staging deploy -- a normal thing to do.
+#     The community sweep publishes a kind-1985 label alongside the (contained)
+#     strike DM, so that is the likeliest way to trip it.
 #   - The read paths (dm-reader, report-poller, relay-poller, profile-resolver)
 #     read from production by default. They publish nothing and contact no user,
 #     so DM containment holds, but a contained run is not offline.

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -144,6 +144,19 @@ AI_DETECTOR_MODE_WATERMARK_VISIBLE = "shadow"
 # threshold; 0.7 is moderate. Tune from shadow-mode agreement data.
 AI_DETECTOR_GATE_WATERMARK_VISIBLE = "0.8"
 
+# Outbound NIP-17 DM publish targets. UNSET in production on purpose: the DM
+# paths then use their built-in list (relay.divine.video plus the user's own
+# NIP-65 read relays, falling back to damus/primal/nos.lol).
+#
+# Set it — comma-separated — and it becomes the exact and only publish target
+# list, skipping both the KV relay cache and kind-10002 discovery. That is the
+# only way to run this Worker outside production with a real signing key without
+# DMs reaching real users, because the default relays are module constants in
+# src/nostr/dm-sender.mjs and are otherwise unreachable from config.
+#
+# Any non-production deployment that sets NOSTR_PRIVATE_KEY must set this too.
+# DM_RELAY_URLS = "ws://127.0.0.1:4444"
+
 # Relay Polling Configuration
 RELAY_POLLING_ENABLED = "true"                    # Enable/disable relay polling
 RELAY_POLLING_RELAY_URL = "wss://relay.divine.video"  # Relay to poll for new video events

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -156,6 +156,16 @@ AI_DETECTOR_GATE_WATERMARK_VISIBLE = "0.8"
 #
 # Any non-production deployment that sets NOSTR_PRIVATE_KEY must set this too.
 # DM_RELAY_URLS = "ws://127.0.0.1:4444"
+#
+# Must be a comma-separated STRING. `vars` accepts any JSON, so the TOML list
+# form DM_RELAY_URLS = ["ws://..."] deploys cleanly and arrives as an array;
+# that is refused at send time rather than silently falling back to production.
+#
+# It contains the DM send path and the kind-10050 inbox announcement. It does NOT
+# contain everything: RELAY_POLLING_RELAY_URL (where dm-reader polls), and
+# profile-resolver's kind-0 read, still reach relay.divine.video. The kind-0 read
+# publishes nothing and contacts no user, so it does not break DM containment,
+# but a non-production run is not fully offline.
 
 # Relay Polling Configuration
 RELAY_POLLING_ENABLED = "true"                    # Enable/disable relay polling

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -161,11 +161,17 @@ AI_DETECTOR_GATE_WATERMARK_VISIBLE = "0.8"
 # form DM_RELAY_URLS = ["ws://..."] deploys cleanly and arrives as an array;
 # that is refused at send time rather than silently falling back to production.
 #
-# It contains the DM send path and the kind-10050 inbox announcement. It does NOT
-# contain everything: RELAY_POLLING_RELAY_URL (where dm-reader polls), and
-# profile-resolver's kind-0 read, still reach relay.divine.video. The kind-0 read
-# publishes nothing and contacts no user, so it does not break DM containment,
-# but a non-production run is not fully offline.
+# Setting it contains both paths that publish with NOSTR_PRIVATE_KEY: the DM send
+# path, and the kind-10050 inbox announcement.
+#
+# The announcement additionally needs RELAY_POLLING_RELAY_URL, because that is
+# what it announces AS the inbox and its fallback is the production relay. Set
+# DM_RELAY_URLS without it and the announcement is skipped rather than published
+# to production; the log says so.
+#
+# Still not contained: profile-resolver's kind-0 read reaches relay.divine.video.
+# It publishes nothing and contacts no user, so DM containment holds, but a
+# non-production run is not fully offline.
 
 # Relay Polling Configuration
 RELAY_POLLING_ENABLED = "true"                    # Enable/disable relay polling


### PR DESCRIPTION
## The problem

Every NIP-17 DM this Worker sends goes to `relay.divine.video` and three public relays, in every environment, and nothing in config can change that.

The publish targets come from module constants (`DIVINE_RELAY`, `DEFAULT_RELAYS`) rather than from `env`. So running this Worker anywhere other than production, with a real signing key, sends **real DMs to real users**. There is no setting that prevents it.

That is the same shape as pointing local dev at a production API, except the blast radius is a stranger's inbox rather than a database row.

## The change

`DM_RELAY_URLS`, when set, becomes the exact publish target list.

Setting it also skips the KV relay cache and kind-10002 discovery, because either of those would reintroduce a production relay and defeat the point. It also contains the kind-10050 inbox announcement: that event is published only when the configured inbox relay is in `DM_RELAY_URLS`, and only to that inbox relay. Unset is the production default and behaviour is unchanged.

A present value that parses to nothing is a configuration error. DM sends and the kind-10050 announcement fail closed instead of falling back to production relays. Only an absent `DM_RELAY_URLS` uses production defaults.

## Why it is worth having

It is what makes it safe to run this Worker outside production at all. Today the only safe way to exercise the DM paths locally is to not have a real signing key, which means the DM paths do not get exercised.

It also satisfies the `AGENTS.md` rule against hardcoding environment-specific domains in application code.

## Verification

- `npm run lint`
- `npm test`: 84 files, 1,586 tests passed

The containment tests assert on the transport targets and fail-closed paths rather than only on returned relay lists.
