### PR TITLE
fix(reports): stop dropping relay reports on the NIP-89 client tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Because the service is report-driven, the queue consumer for the legacy `video-m
 ## Features
 
 - **Human review dashboard** — swipe-review queue, per-category verification (confirm/reject an individual detection), direct-message templates for creator communication, stats, and tunable classifier thresholds. Served behind Cloudflare Access on `moderation.admin.divine.video`.
-- **Report ingestion** — authenticated client reports, inbound public NIP-56 (kind `1984`) reports polled from the relay, and NIP-17 report DMs to the moderation@ inbox. Both Nostr paths are review-only and never auto-escalate, since client tags and reporter pubkeys are self-asserted public signals; report DMs additionally do not count toward the distinct-reporter threshold that the authenticated path escalates on. Only `POST /api/v1/report` can produce an automatic `AGE_RESTRICTED`.
+- **Report ingestion** — authenticated client reports, inbound public NIP-56 (kind `1984`) reports polled from the relay, and NIP-17 report DMs to the moderation@ inbox. Both Nostr paths are review-only and never auto-escalate, since client tags and reporter pubkeys are self-asserted public signals. A relay report is ingested whatever client it came from; the NIP-89 `client` tag only decides whether its reporter counts toward the distinct-reporter threshold the authenticated path escalates on — reports from clients outside `TRUSTED_REPORT_CLIENTS`, like report DMs, do not. Only `POST /api/v1/report` can produce an automatic `AGE_RESTRICTED`.
 - **Content categories** — nudity/NSFW, violence, gore, weapons, recreational drugs, self-harm, hate speech / offensive symbols, AI-generated, and deepfake, plus content-warning labels for alcohol, tobacco, medical, and gambling.
 - **AI-generation & provenance signals** (surfaced to moderators as review context, not auto-enforcement):
   - `divine-ai-detector` for per-signal detection, with vendor fallback to Hive and Reality Defender.
@@ -76,7 +76,7 @@ Bindings, routes, feature flags, and non-secret vars live in `wrangler.toml`. Hi
 | `TEAM_DOMAIN` | Cloudflare Access team domain for Zero Trust JWT verification. |
 | `RELAY_POLLING_*` | Relay video-event polling (URL, lookback, limit, enable). |
 | `REPORT_POLLING_*` | Inbound NIP-56 report polling (URL, lookback, limit, max pages). |
-| `RELAY_REPORTS_REQUIRE_DIVINE_CLIENT` | Only ingest reports tagged as sent by the Divine client. |
+| `TRUSTED_REPORT_CLIENTS` | Comma-separated NIP-89 `client` tags whose relay reports may drive automatic outcomes. Reports from any other client are still recorded for review, on a non-escalating source. |
 | `CREATOR_DELETE_PIPELINE_ENABLED` | Enable the kind `5` creator-delete cron. |
 | `AI_DETECTOR_BASE_URL` / `AI_DETECTOR_MODE_*` | `divine-ai-detector` endpoint and per-signal cutover mode. |
 | `INQUISITOR_BASE_URL` | `divine-inquisitor` C2PA / ProofMode service. |

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -5211,8 +5211,10 @@ async function runMigration() {
           const pollStats = {
             totalReports: results.totalReports,
             recorded: results.recorded,
+            recordedUntrustedClient: results.recordedUntrustedClient,
             alreadyProcessed: results.alreadyProcessed,
             skipped: results.skipped,
+            skippedByStatus: results.skippedByStatus,
             targetUnavailable: results.targetUnavailable,
             errors: results.errors.length,
             safeCheckpoint: results.safeCheckpoint,

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -3678,7 +3678,7 @@ describe('Report polling cron integration', () => {
       REPORT_POLLING_RELAY_URL: 'wss://reports.example.test',
       REPORT_POLLING_LOOKBACK_HOURS: '24',
       REPORT_POLLING_LIMIT: '100',
-      RELAY_REPORTS_REQUIRE_DIVINE_CLIENT: 'true',
+      TRUSTED_REPORT_CLIENTS: 'diVine,divine-web,divine-mobile',
       BLOSSOM_DB: createDbMock({ moderationWrites }),
       MODERATION_KV: {
         async get(key) {

--- a/src/moderation/report-review.test.mjs
+++ b/src/moderation/report-review.test.mjs
@@ -6,6 +6,7 @@
 
 import { describe, expect, it } from 'vitest';
 import { recordReportForReview } from './report-review.mjs';
+import { NON_ESCALATING_SOURCES } from '../reports.mjs';
 
 const SHA = 'a'.repeat(64);
 const REPORTER = 'b'.repeat(64);
@@ -90,8 +91,9 @@ describe('recordReportForReview', () => {
       aiTelemetryRecorded: false,
     });
     expect(userReportWrites).toHaveLength(1);
-    // The trailing pair is the conflict guard: upgrade the stored source only
-    // when it is 'dm-report' and the incoming one is not.
+    // The row itself, then the conflict guard: upgrade the stored source only
+    // when it is one of the non-escalating sources and the incoming one is not.
+    // The guard binds that list twice — once per IN clause.
     expect(userReportWrites[0].bindings).toEqual([
       SHA,
       REPORTER,
@@ -99,8 +101,8 @@ describe('recordReportForReview', () => {
       'reported from relay',
       '2026-05-13T17:19:42.000Z',
       'relay-report',
-      'dm-report',
-      'dm-report',
+      ...NON_ESCALATING_SOURCES,
+      ...NON_ESCALATING_SOURCES,
     ]);
     expect(userReportWrites[0].sql).toMatch(/ON CONFLICT\(sha256, reporter_pubkey\) DO UPDATE SET source = excluded\.source/i);
     expect(moderationWrites).toHaveLength(1);

--- a/src/nostr/report-poller.mjs
+++ b/src/nostr/report-poller.mjs
@@ -123,9 +123,27 @@ export function extractReportType(reportEvent) {
     || 'other';
 }
 
-export function isDivineClientReport(reportEvent) {
+// Kept in step with divine-relay-manager's TRUSTED_CLIENTS allowlist. The
+// single 'divine' literal this replaced predated divine-web, which tags
+// 'divine-web' and so failed the match for every report it ever sent.
+export const DEFAULT_TRUSTED_REPORT_CLIENTS = Object.freeze(['diVine', 'divine-web', 'divine-mobile']);
+
+export function parseTrustedReportClients(configured) {
+  const raw = typeof configured === 'string' ? configured : '';
+  const parsed = raw.split(',').map((entry) => entry.trim()).filter(Boolean);
+  return (parsed.length ? parsed : DEFAULT_TRUSTED_REPORT_CLIENTS).map((entry) => entry.toLowerCase());
+}
+
+// A trust signal, never an ingestion gate. NIP-89 makes the `client` tag
+// optional and asks clients to let users opt out of it, NIP-56 defines no such
+// tag at all, and nothing signs it -- so its absence says nothing about the
+// report, and its presence proves nothing either. It may narrow what happens
+// automatically; it may not decide what gets seen.
+export function isTrustedClientReport(reportEvent, trustedClients = DEFAULT_TRUSTED_REPORT_CLIENTS) {
   const client = getEventTagValue(reportEvent?.tags || [], 'client');
-  return typeof client === 'string' && client.toLowerCase() === 'divine';
+  if (typeof client !== 'string') return false;
+  const normalized = client.trim().toLowerCase();
+  return trustedClients.some((trusted) => trusted.toLowerCase() === normalized);
 }
 
 export function shouldAcceptReportTarget(targetEvent) {
@@ -308,13 +326,15 @@ export async function pollRelayForReports(env, options = {}) {
   if (env.BLOSSOM_DB?.prepare) {
     await initReportsTable(env.BLOSSOM_DB);
   }
-  const requireDivineClient = env.RELAY_REPORTS_REQUIRE_DIVINE_CLIENT !== 'false';
+  const trustedClients = parseTrustedReportClients(env.TRUSTED_REPORT_CLIENTS);
 
   const results = {
     totalReports: 0,
     recorded: 0,
+    recordedUntrustedClient: 0,
     alreadyProcessed: 0,
     skipped: 0,
+    skippedByStatus: {},
     targetUnavailable: 0,
     errors: [],
     reports: [],
@@ -362,7 +382,7 @@ export async function pollRelayForReports(env, options = {}) {
           try {
             const outcome = await processReportEvent(report, {
               kv: env.MODERATION_KV,
-              requireDivineClient,
+              trustedClients,
               fetchTargetEvent,
               recordReport,
             });
@@ -370,6 +390,9 @@ export async function pollRelayForReports(env, options = {}) {
             results.reports.push(outcome);
             if (outcome.status === 'recorded') {
               results.recorded++;
+              if (outcome.trustedClient === false) {
+                results.recordedUntrustedClient++;
+              }
             } else if (outcome.status === 'already_processed') {
               results.alreadyProcessed++;
             } else if (outcome.status === 'target_unavailable') {
@@ -392,6 +415,10 @@ export async function pollRelayForReports(env, options = {}) {
               }
             } else {
               results.skipped++;
+              // A single `skipped` total is what let a 28.8% terminal drop rate
+              // look like normal operation for months. Keep the breakdown.
+              const status = outcome.status || 'unknown';
+              results.skippedByStatus[status] = (results.skippedByStatus[status] || 0) + 1;
             }
 
             if (
@@ -488,7 +515,7 @@ async function markProcessed(kv, key, payload, expirationTtl) {
 
 export async function processReportEvent(reportEvent, {
   kv,
-  requireDivineClient = true,
+  trustedClients = DEFAULT_TRUSTED_REPORT_CLIENTS,
   fetchTargetEvent,
   recordReport,
 } = {}) {
@@ -518,12 +545,7 @@ export async function processReportEvent(reportEvent, {
     return { status: 'skipped_invalid_reporter_pubkey' };
   }
 
-  if (requireDivineClient && !isDivineClientReport(reportEvent)) {
-    await markProcessed(kv, processedKey, {
-      status: 'skipped_non_divine_client',
-    }, TERMINAL_SKIP_TTL_SECONDS);
-    return { status: 'skipped_non_divine_client' };
-  }
+  const trustedClient = isTrustedClientReport(reportEvent, trustedClients);
 
   const targetEventId = extractReportTargetEventId(reportEvent);
   if (!targetEventId) {
@@ -557,7 +579,10 @@ export async function processReportEvent(reportEvent, {
     reporterPubkey: reportEvent.pubkey,
     reportType,
     reason: reportEvent.content || null,
-    source: 'relay-report',
+    // Untrusted-client reports are reviewed like any other, but land on a
+    // non-escalating source so they cannot contribute to the 2-reporter
+    // AGE_RESTRICTED threshold a later authenticated report would cross.
+    source: trustedClient ? 'relay-report' : 'relay-report-untrusted',
     reportedAt,
     reportEventId,
     targetEventId,
@@ -579,11 +604,13 @@ export async function processReportEvent(reportEvent, {
     sha256,
     reportType,
     targetEventId,
+    trustedClient,
     action: recordResult.action,
   }, RECORDED_TTL_SECONDS);
 
   return {
     status: 'recorded',
+    trustedClient,
     sha256,
     reportType,
     targetEventId,

--- a/src/nostr/report-poller.test.mjs
+++ b/src/nostr/report-poller.test.mjs
@@ -11,7 +11,9 @@ import {
   fetchReportsFromRelay,
   getReportPollingStatus,
   getLastReportPollTimestamp,
-  isDivineClientReport,
+  isTrustedClientReport,
+  parseTrustedReportClients,
+  DEFAULT_TRUSTED_REPORT_CLIENTS,
   pollRelayForReports,
   processReportEvent,
   processedReportKey,
@@ -193,23 +195,33 @@ describe('kind 1984 parsing', () => {
     });
   });
 
-  it('detects reports from the diVine client tag', () => {
-    expect(isDivineClientReport({
-      kind: 1984,
-      tags: [['client', 'diVine']],
-    })).toBe(true);
+  it('trusts every first-party client tag, case-insensitively', () => {
+    for (const client of ['diVine', 'Divine', 'divine-web', 'divine-mobile', 'DIVINE-WEB']) {
+      expect(isTrustedClientReport({ kind: 1984, tags: [['client', client]] })).toBe(true);
+    }
   });
 
-  it('rejects non-diVine client reports when the client tag is absent', () => {
-    expect(isDivineClientReport({
+  it('does not trust third-party or absent client tags', () => {
+    expect(isTrustedClientReport({
       kind: 1984,
       tags: [['client', 'Amethyst']],
     })).toBe(false);
 
-    expect(isDivineClientReport({
+    expect(isTrustedClientReport({
       kind: 1984,
       tags: [],
     })).toBe(false);
+  });
+
+  it('falls back to the default allowlist when TRUSTED_REPORT_CLIENTS is unset or blank', () => {
+    for (const configured of [undefined, '', '   ', ',,']) {
+      expect(parseTrustedReportClients(configured))
+        .toEqual(DEFAULT_TRUSTED_REPORT_CLIENTS.map((entry) => entry.toLowerCase()));
+    }
+  });
+
+  it('parses a configured allowlist, trimming and lowercasing entries', () => {
+    expect(parseTrustedReportClients(' diVine , Nostria ')).toEqual(['divine', 'nostria']);
   });
 
   it('accepts only video target events with a media sha', () => {
@@ -250,7 +262,7 @@ describe('processReportEvent', () => {
       content: 'Reason: aiGenerated',
     }, {
       kv,
-      requireDivineClient: true,
+      trustedClients: DEFAULT_TRUSTED_REPORT_CLIENTS,
       fetchTargetEvent: async (eventId) => (eventId === TARGET_EVENT_ID ? TARGET : null),
       recordReport: async (payload) => {
         recorded.push(payload);
@@ -300,7 +312,7 @@ describe('processReportEvent', () => {
       content: 'Needs review',
     }, {
       kv,
-      requireDivineClient: true,
+      trustedClients: DEFAULT_TRUSTED_REPORT_CLIENTS,
       fetchTargetEvent: async () => TARGET,
       recordReport: async () => ({
         success: true,
@@ -334,7 +346,7 @@ describe('processReportEvent', () => {
       tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'diVine']],
     }, {
       kv,
-      requireDivineClient: true,
+      trustedClients: DEFAULT_TRUSTED_REPORT_CLIENTS,
       fetchTargetEvent: async () => {
         calls.fetchTargetEvent++;
         return TARGET;
@@ -350,7 +362,60 @@ describe('processReportEvent', () => {
     expect(kv.puts).toHaveLength(0);
   });
 
-  it('skips non-diVine client reports when configured', async () => {
+  // divine-mobile#6592: turning off NIP-89 client attribution stripped the
+  // `client` tag, and this path then dropped the report terminally for 90 days.
+  it('records a report with no client tag, on a non-escalating source', async () => {
+    const kv = createKv();
+    const recorded = [];
+
+    const result = await processReportEvent({
+      id: REPORT_EVENT_ID,
+      kind: 1984,
+      pubkey: REPORTER,
+      tags: [['e', TARGET_EVENT_ID, 'nudity']],
+    }, {
+      kv,
+      trustedClients: DEFAULT_TRUSTED_REPORT_CLIENTS,
+      fetchTargetEvent: async () => TARGET,
+      recordReport: async (payload) => {
+        recorded.push(payload);
+        return { action: 'REVIEW', distinctReporterCount: 1 };
+      },
+    });
+
+    expect(result.status).toBe('recorded');
+    expect(result.trustedClient).toBe(false);
+    expect(recorded).toHaveLength(1);
+    expect(recorded[0].source).toBe('relay-report-untrusted');
+  });
+
+  // The active loss this fix ends: divine-web tags 'divine-web', which the old
+  // `=== 'divine'` literal rejected, so every web report was dropped.
+  it('records a divine-web report as trusted', async () => {
+    const kv = createKv();
+    const recorded = [];
+
+    const result = await processReportEvent({
+      id: REPORT_EVENT_ID,
+      kind: 1984,
+      pubkey: REPORTER,
+      tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'divine-web']],
+    }, {
+      kv,
+      trustedClients: DEFAULT_TRUSTED_REPORT_CLIENTS,
+      fetchTargetEvent: async () => TARGET,
+      recordReport: async (payload) => {
+        recorded.push(payload);
+        return { action: 'REVIEW', distinctReporterCount: 1 };
+      },
+    });
+
+    expect(result.status).toBe('recorded');
+    expect(result.trustedClient).toBe(true);
+    expect(recorded[0].source).toBe('relay-report');
+  });
+
+  it('records a third-party client report for review, but never as escalation-eligible', async () => {
     const kv = createKv();
     const recorded = [];
 
@@ -361,7 +426,7 @@ describe('processReportEvent', () => {
       tags: [['e', TARGET_EVENT_ID, 'spam'], ['client', 'Amethyst']],
     }, {
       kv,
-      requireDivineClient: true,
+      trustedClients: DEFAULT_TRUSTED_REPORT_CLIENTS,
       fetchTargetEvent: async () => TARGET,
       recordReport: async (payload) => {
         recorded.push(payload);
@@ -369,13 +434,12 @@ describe('processReportEvent', () => {
       },
     });
 
-    expect(result.status).toBe('skipped_non_divine_client');
-    expect(recorded).toHaveLength(0);
-    expect(kv.puts).toHaveLength(1);
-    expect(kv.puts[0].key).toBe(processedReportKey(REPORT_EVENT_ID));
-    expect(kv.puts[0].options).toEqual({ expirationTtl: 60 * 60 * 24 * 90 });
+    expect(result.status).toBe('recorded');
+    expect(recorded[0].source).toBe('relay-report-untrusted');
+    expect(kv.puts[0].options).toEqual({ expirationTtl: 60 * 60 * 24 * 180 });
     expect(JSON.parse(kv.store.get(processedReportKey(REPORT_EVENT_ID)))).toMatchObject({
-      status: 'skipped_non_divine_client',
+      status: 'recorded',
+      trustedClient: false,
     });
   });
 
@@ -391,7 +455,7 @@ describe('processReportEvent', () => {
       content: '',
     }, {
       kv,
-      requireDivineClient: true,
+      trustedClients: DEFAULT_TRUSTED_REPORT_CLIENTS,
       fetchTargetEvent: async () => {
         calls.fetchTargetEvent++;
         return TARGET;
@@ -425,7 +489,7 @@ describe('processReportEvent', () => {
       content: '',
     }, {
       kv,
-      requireDivineClient: true,
+      trustedClients: DEFAULT_TRUSTED_REPORT_CLIENTS,
       fetchTargetEvent: async () => {
         calls.fetchTargetEvent++;
         return TARGET;
@@ -457,7 +521,7 @@ describe('processReportEvent', () => {
       tags: [['e', TARGET_EVENT_ID, 'nudity'], ['client', 'diVine']],
     }, {
       kv,
-      requireDivineClient: true,
+      trustedClients: DEFAULT_TRUSTED_REPORT_CLIENTS,
       fetchTargetEvent: async () => null,
       recordReport: async (payload) => {
         recorded.push(payload);
@@ -642,7 +706,7 @@ describe('report polling', () => {
       const result = await pollRelayForReports({
         BLOSSOM_DB: db,
         MODERATION_KV: kv,
-        RELAY_REPORTS_REQUIRE_DIVINE_CLIENT: 'true',
+        TRUSTED_REPORT_CLIENTS: 'diVine,divine-web,divine-mobile',
       }, {
         since: 1778680000,
         limit: 50,
@@ -720,7 +784,7 @@ describe('report polling', () => {
       const result = await pollRelayForReports({
         BLOSSOM_DB: {},
         MODERATION_KV: kv,
-        RELAY_REPORTS_REQUIRE_DIVINE_CLIENT: 'true',
+        TRUSTED_REPORT_CLIENTS: 'diVine,divine-web,divine-mobile',
       }, {
         since: 1778680000,
         limit: 4,
@@ -753,7 +817,7 @@ describe('report polling', () => {
       const result = await pollRelayForReports({
         BLOSSOM_DB: {},
         MODERATION_KV: kv,
-        RELAY_REPORTS_REQUIRE_DIVINE_CLIENT: 'true',
+        TRUSTED_REPORT_CLIENTS: 'diVine,divine-web,divine-mobile',
       }, {
         since: 1778680000,
         limit: 10,
@@ -825,7 +889,7 @@ describe('report polling', () => {
       const result = await pollRelayForReports({
         BLOSSOM_DB: {},
         MODERATION_KV: kv,
-        RELAY_REPORTS_REQUIRE_DIVINE_CLIENT: 'true',
+        TRUSTED_REPORT_CLIENTS: 'diVine,divine-web,divine-mobile',
       }, {
         since: 1778680000,
         limit: 2,
@@ -903,7 +967,7 @@ describe('report polling', () => {
       const result = await pollRelayForReports({
         BLOSSOM_DB: {},
         MODERATION_KV: kv,
-        RELAY_REPORTS_REQUIRE_DIVINE_CLIENT: 'true',
+        TRUSTED_REPORT_CLIENTS: 'diVine,divine-web,divine-mobile',
       }, {
         since: 1778680000,
         limit: 3,
@@ -981,7 +1045,7 @@ describe('report polling', () => {
       const result = await pollRelayForReports({
         BLOSSOM_DB: {},
         MODERATION_KV: kv,
-        RELAY_REPORTS_REQUIRE_DIVINE_CLIENT: 'true',
+        TRUSTED_REPORT_CLIENTS: 'diVine,divine-web,divine-mobile',
       }, {
         since: 1778680000,
         limit: 2,
@@ -1057,7 +1121,7 @@ describe('report polling', () => {
       const result = await pollRelayForReports({
         BLOSSOM_DB: {},
         MODERATION_KV: kv,
-        RELAY_REPORTS_REQUIRE_DIVINE_CLIENT: 'true',
+        TRUSTED_REPORT_CLIENTS: 'diVine,divine-web,divine-mobile',
       }, {
         since: 1778680000,
         limit: 2,
@@ -1154,7 +1218,7 @@ describe('report polling', () => {
       const result = await pollRelayForReports({
         BLOSSOM_DB: {},
         MODERATION_KV: kv,
-        RELAY_REPORTS_REQUIRE_DIVINE_CLIENT: 'true',
+        TRUSTED_REPORT_CLIENTS: 'diVine,divine-web,divine-mobile',
       }, {
         since: 1778680000,
         limit: 2,
@@ -1196,7 +1260,7 @@ describe('report polling', () => {
       const result = await pollRelayForReports({
         BLOSSOM_DB: {},
         MODERATION_KV: kv,
-        RELAY_REPORTS_REQUIRE_DIVINE_CLIENT: 'true',
+        TRUSTED_REPORT_CLIENTS: 'diVine,divine-web,divine-mobile',
       }, {
         since: 1778680000,
         until: 1778692781,

--- a/src/reports.mjs
+++ b/src/reports.mjs
@@ -37,14 +37,6 @@ export async function initReportsTable(db) {
   }
 }
 
-// The one report source whose reporter identity is not established well enough
-// to count toward an automatic moderation outcome. A `dm-report` reporter is
-// whatever key reached the moderation inbox over NIP-17: nothing signs for the
-// reported sha256, nothing proves the key belongs to a distinct person, and
-// minting fresh keys is free. Such a report is still recorded and still shown
-// to a human -- it just cannot be one of the two "distinct reporters" that
-// auto age-restriction counts, or a single actor could supply both halves of
-// the threshold the authenticated path relies on.
 /**
  * Whether this reporter already has a row for this sha256.
  *

--- a/src/reports.mjs
+++ b/src/reports.mjs
@@ -65,7 +65,14 @@ export async function findReportByReporter(db, sha256, reporterPubkey) {
   ).bind(sha256, reporterPubkey).first();
 }
 
-const NON_ESCALATING_SOURCE = 'dm-report';
+// Sources whose reporters may never drive an automatic outcome, and so are
+// excluded from escalationReporterCount. A report DM is the least verified
+// path; an untrusted-client relay report carries an unauthenticated, optional
+// NIP-89 `client` tag that anyone can forge, so neither may supply part of the
+// AGE_RESTRICTED threshold. Both are still recorded for human review.
+export const NON_ESCALATING_SOURCES = Object.freeze(['dm-report', 'relay-report-untrusted']);
+
+const nonEscalatingPlaceholders = NON_ESCALATING_SOURCES.map(() => '?').join(', ');
 
 /**
  * Insert a report and return two reporter counts, so callers can apply
@@ -105,17 +112,17 @@ export async function addReport(db, { sha256, reporter_pubkey, report_type, reas
   //
   // So upgrade on conflict, in one direction only: once a reporter has been
   // seen through a path that may drive an automatic outcome, that sticks. A
-  // later report DM never downgrades a reporter the HTTP or relay path
-  // already established. Everything else about the row stays first-write-wins
-  // -- `report_type`, `reason` and `created_at` keep the report of record as
-  // it was first filed.
+  // later report DM or untrusted-client relay report never downgrades a
+  // reporter the HTTP or trusted relay path already established. Everything
+  // else about the row stays first-write-wins -- `report_type`, `reason` and
+  // `created_at` keep the report of record as it was first filed.
   await db.prepare(`
     INSERT OR IGNORE INTO user_reports (sha256, reporter_pubkey, report_type, reason, created_at, source)
     VALUES (?, ?, ?, ?, COALESCE(?, CURRENT_TIMESTAMP), ?)
     ON CONFLICT(sha256, reporter_pubkey) DO UPDATE SET source = excluded.source
-      WHERE user_reports.source = ?
+      WHERE user_reports.source IN (${nonEscalatingPlaceholders})
         AND excluded.source IS NOT NULL
-        AND excluded.source <> ?
+        AND excluded.source NOT IN (${nonEscalatingPlaceholders})
   `).bind(
     sha256,
     reporter_pubkey,
@@ -123,19 +130,19 @@ export async function addReport(db, { sha256, reporter_pubkey, report_type, reas
     reason ?? null,
     created_at ?? null,
     source ?? null,
-    NON_ESCALATING_SOURCE,
-    NON_ESCALATING_SOURCE,
+    ...NON_ESCALATING_SOURCES,
+    ...NON_ESCALATING_SOURCES,
   ).run();
 
   const row = await db.prepare(`
     SELECT
       COUNT(DISTINCT reporter_pubkey) AS cnt,
       COUNT(DISTINCT CASE
-        WHEN source IS NULL OR source <> ? THEN reporter_pubkey
+        WHEN source IS NULL OR source NOT IN (${nonEscalatingPlaceholders}) THEN reporter_pubkey
       END) AS escalation_cnt
     FROM user_reports
     WHERE sha256 = ?
-  `).bind(NON_ESCALATING_SOURCE, sha256).first();
+  `).bind(...NON_ESCALATING_SOURCES, sha256).first();
 
   return {
     distinctReporterCount: row?.cnt ?? 0,

--- a/src/reports.test.mjs
+++ b/src/reports.test.mjs
@@ -143,6 +143,61 @@ describe('reports', () => {
       expect(third).toMatchObject({ distinctReporterCount: 3, escalationReporterCount: 2 });
     });
 
+    // divine-mobile#6592: an untrusted-client relay report is reviewable, but
+    // its `client` tag is unsigned and user-suppressible, so it may not supply
+    // half the 2-reporter AGE_RESTRICTED threshold for a later real report.
+    it('counts a relay-report-untrusted reporter for display but not for escalation', async () => {
+      const first = await addReport(db, {
+        sha256: SHA256,
+        reporter_pubkey: REPORTER1,
+        report_type: 'nudity',
+        source: 'relay-report-untrusted',
+      });
+      expect(first).toMatchObject({ distinctReporterCount: 1, escalationReporterCount: 0 });
+
+      const second = await addReport(db, {
+        sha256: SHA256,
+        reporter_pubkey: REPORTER2,
+        report_type: 'nudity',
+        source: 'user-report',
+      });
+      expect(second).toMatchObject({ distinctReporterCount: 2, escalationReporterCount: 1 });
+    });
+
+    it('upgrades a relay-report-untrusted reporter who later reports through a trusted path', async () => {
+      await addReport(db, {
+        sha256: SHA256,
+        reporter_pubkey: REPORTER1,
+        report_type: 'nudity',
+        source: 'relay-report-untrusted',
+      });
+
+      const afterTrusted = await addReport(db, {
+        sha256: SHA256,
+        reporter_pubkey: REPORTER1,
+        report_type: 'nudity',
+        source: 'relay-report',
+      });
+      expect(afterTrusted).toMatchObject({ distinctReporterCount: 1, escalationReporterCount: 1 });
+    });
+
+    it('never downgrades an escalation-eligible reporter to relay-report-untrusted', async () => {
+      await addReport(db, {
+        sha256: SHA256,
+        reporter_pubkey: REPORTER1,
+        report_type: 'nudity',
+        source: 'user-report',
+      });
+
+      const afterUntrusted = await addReport(db, {
+        sha256: SHA256,
+        reporter_pubkey: REPORTER1,
+        report_type: 'nudity',
+        source: 'relay-report-untrusted',
+      });
+      expect(afterUntrusted).toMatchObject({ distinctReporterCount: 1, escalationReporterCount: 1 });
+    });
+
     it('counts rows written before the source column toward escalation', async () => {
       // insertReport() writes no source, exactly like every row that predates
       // the column. Those came from the HTTP or relay paths, so they keep

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -202,7 +202,7 @@ REPORT_POLLING_RELAY_URL = "wss://relay.divine.video" # Relay to poll for kind 1
 REPORT_POLLING_LOOKBACK_HOURS = "24"              # How far back to look for reports on first run
 REPORT_POLLING_LIMIT = "100"                      # Max reports to fetch per poll
 REPORT_POLLING_MAX_PAGES = "5"                    # Max bounded pages to drain per report poll
-RELAY_REPORTS_REQUIRE_DIVINE_CLIENT = "true"      # Only ingest reports tagged as sent by diVine
+TRUSTED_REPORT_CLIENTS = "diVine,divine-web,divine-mobile" # NIP-89 client tags whose reports may drive automatic outcomes; others are still reviewed
 
 # Funnelcake admin URL — destination for notifyRelay() NIP-98 add/remove
 # webhooks against /api/moderation/quarantine. Empty string = relay-side


### PR DESCRIPTION
## Problem

The report poller required a `client` tag lowercasing to exactly `divine`, and terminally skipped anything else with a 90-day TTL. Two things were being lost, silently at both ends:

- **divine-web reports are 100% dropped.** It tags `divine-web`, which fails `=== 'divine'`. Sampling the 500 most recent kind-1984 events off `relay.divine.video` (the exact relay the poller reads), **144 (28.8%) from 55 distinct reporters** were being discarded — including 8 first-party divine-web reports carrying `NS-underageUser`, `NS-harassment`, and `NS-violence`. `divine-relay-manager`'s `TRUSTED_CLIENTS` allowlist already includes `divine-web`, so the value is intentional and this matcher is the one that drifted.
- **A divine-mobile user who turns off client attribution loses every subsequent report** — divinevideo/divine-mobile#6592. NIP-89 makes the tag optional and explicitly asks clients to let users opt out of it; NIP-56 defines no `client` tag at all. Every report dropped this way was spec-conformant.

Neither end could see it: the user gets the normal confirmation, and the six skip reasons were summed into one `skipped` counter.

## Approach

The tag is unsigned and forgeable from four public string literals in `nip89_client_tag.dart`, so it was never an authorization signal. This demotes it to a trust signal:

- Every valid, video-targeted kind-1984 is **recorded for review**, whatever client sent it.
- An **untrusted-client** report lands on the `relay-report-untrusted` source, so its reporter is excluded from `escalationReporterCount` and cannot supply half the 2-reporter `AGE_RESTRICTED` threshold a later authenticated report would cross. This reuses the boundary that already keeps report DMs review-only rather than inventing a second one.
- `RELAY_REPORTS_REQUIRE_DIVINE_CLIENT` → `TRUSTED_REPORT_CLIENTS`, a configurable case-insensitive allowlist defaulting to relay-manager's `diVine,divine-web,divine-mobile`.
- The single `skipped` counter splits into a per-status breakdown, persisted to KV instead of discarded.

**No report gains automatic power.** Relay reports already never auto-escalated on their own (`allowAutoAgeRestrict` defaults to `source === 'user-report'`); the only thing the client tag ever changed was escalation-counting, which this preserves.

## Blast radius

This changes production report ingestion the moment it merges — deploy is automatic on push to `main`.

Volume: E1 implies roughly **+40%** into the review queue (144 newly recorded against 356 that pass today). The untrusted source is recorded rather than dropped, so it is available to query in D1 on `user_reports.source` — but that is a SQL-level fact only. There is **no** queue-level filter or sort for it today, and the swipe queue does not even display it: `/admin/api/videos` selects `ADMIN_VIDEO_COLUMNS` off `moderation_results` and filters on `action` / `moderated_at`, and that column list excludes `raw_response`. A "hide untrusted by default" switch is a follow-up, not something this PR delivers. **This is the trust-and-safety capacity call and is yours to make** — happy to hold the merge until you've sized it.

Not addressed here: the ~144 reports already tombstoned in KV under the old 90-day skip are still readable and could be re-driven. Leaving them is a choice; say the word and I'll write the backfill.

## Testing

- `npm test` — 1593 passed / 84 files
- `npm run lint` — clean
- New regression tests: a report with **no** client tag reaches `recordReportForReview` (fails on today's `main`); `divine-web` records as trusted; a third-party client records as untrusted; `relay-report-untrusted` counts for display but not escalation, upgrades to escalation-eligible when the same reporter later reports through a trusted path, and never downgrades one that already was.

Refs divinevideo/divine-mobile#6592
