### PR TITLE
feat(moderation): Reality Defender provider and action queue

### DIFF
--- a/BUNNYCDN_FINDINGS.md
+++ b/BUNNYCDN_FINDINGS.md
@@ -1,0 +1,304 @@
+# BunnyCDN Stream API Research Findings
+
+## Summary
+
+I researched BunnyCDN's content moderation features and found their **Automated Content Tagging** system. Here's what I discovered and how our integration works.
+
+## Key Findings
+
+### 1. BunnyCDN Has Automated Content Tagging
+
+**Announced**: January 2025
+**Status**: FREE preview feature
+**Purpose**: Video content moderation and categorization
+
+**How it works**:
+- Machine learning automatically tags videos during transcoding
+- Categories include: adult, sports, people, games, movie + 16 subcategories
+- Designed specifically for content moderation use cases
+- Privacy-focused: Your videos are never used to train the ML models
+
+### 2. API Structure Discovery
+
+After researching documentation and library source code, I found the exact API response format:
+
+**Endpoint**: `GET https://video.bunnycdn.com/library/{libraryId}/videos/{videoId}`
+
+**Authentication**: `AccessKey` header (found in BunnyCDN dashboard)
+
+**Response Structure**:
+```json
+{
+  "videoLibraryId": 12345,
+  "guid": "video-guid-here",
+  "title": "Video Title",
+  "length": 6,
+  "status": 4,
+  "metaTags": [
+    { "property": "contentTag", "value": "adult" },
+    { "property": "contentTag", "value": "people" },
+    { "property": "category", "value": "sports" }
+  ],
+  "dateUploaded": "2025-01-23T12:00:00Z",
+  "encodeProgress": 100,
+  ...
+}
+```
+
+**Critical Discovery**: Content tags are stored in the `metaTags` array with `property` and `value` fields, NOT as a separate `tags` or `contentTags` field.
+
+**Source**: TypeScript definitions from `dan-online/bunnycdn-stream` library on GitHub
+
+### 3. Available Node.js Libraries
+
+Three main libraries for BunnyCDN Stream:
+
+#### bunnycdn-stream (Recommended)
+- **Package**: `bunnycdn-stream` on npm
+- **Author**: dan-online
+- **Stars**: 41 on GitHub
+- **Language**: TypeScript
+- **License**: Apache-2.0
+- **Status**: Actively maintained, last update 6 months ago
+- **Features**: Full Stream API support, TypeScript types
+
+**Installation**:
+```bash
+npm install bunnycdn-stream
+```
+
+**Usage**:
+```javascript
+import BunnyStream from 'bunnycdn-stream';
+
+const stream = new BunnyStream({
+  apiKey: process.env.BUNNY_API_KEY,
+  libraryId: process.env.BUNNY_LIBRARY_ID
+});
+
+// Get video metadata including content tags
+const video = await stream.getVideo('video-guid');
+console.log(video.metaTags);  // [{ property: "contentTag", value: "adult" }]
+```
+
+#### bunnycdn (Alternative)
+- **Package**: `bunnycdn` on npm
+- **Author**: wraith4081
+- **Features**: Storage + Stream operations
+
+#### Direct API (What we're using)
+- Simple fetch() calls
+- No dependencies
+- Full control over requests
+- Works in Cloudflare Workers (our deployment environment)
+
+### 4. How to Enable Content Tagging
+
+**Step 1**: Go to https://panel.bunny.net/stream
+**Step 2**: Select your video library
+**Step 3**: Click "Settings"
+**Step 4**: Find "Encoding" section
+**Step 5**: Enable "Automated Content Tagging"
+**Step 6**: Save settings
+
+**Important**: Only NEW videos uploaded after enabling will have tags. Existing videos need re-transcoding.
+
+### 5. Content Categories
+
+Based on blog post and research, BunnyCDN detects 16+ categories:
+
+**Moderation-relevant**:
+- **adult** → Maps to our `nudity` category
+- (possibly violence, weapons, etc. - needs testing)
+
+**Other categories** (not used for moderation):
+- sports (soccer, tennis, racing, etc.)
+- people
+- games
+- movie
+
+### 6. Our Implementation
+
+I updated the BunnyCDN provider to work with the discovered API structure:
+
+#### src/moderation/providers/bunnycdn/client.mjs
+
+**Key function**: `extractContentTags(metaTags)`
+
+This function:
+1. Receives the `metaTags` array from BunnyCDN API
+2. Filters for entries with content-related properties:
+   - "contentTag"
+   - "contentCategory"
+   - "category"
+   - "tag"
+   - (case-insensitive partial matching)
+3. Extracts the `value` from matching entries
+4. Returns array of tag names: `["adult", "people"]`
+
+**Example**:
+```javascript
+// Input: API response
+{
+  metaTags: [
+    { property: "contentTag", value: "adult" },
+    { property: "contentTag", value: "people" },
+    { property: "customMeta", value: "user-data" }  // ignored
+  ]
+}
+
+// Output: extractContentTags() returns
+["adult", "people"]
+```
+
+#### src/moderation/providers/bunnycdn/normalizer.mjs
+
+Maps BunnyCDN categories to our standard format:
+
+```javascript
+'adult' → 'nudity' (score: 1.0)
+'adult_content' → 'nudity'
+'sexual' → 'nudity'
+'nsfw' → 'nudity'
+'violence' → 'violence'
+'weapons' → 'weapons'
+// etc.
+```
+
+**Note**: BunnyCDN doesn't provide confidence scores, so we use `1.0` for detected categories.
+
+### 7. Video ID Mapping
+
+Our implementation supports multiple ways to identify videos:
+
+1. **Explicit ID**: `metadata.bunnyVideoId`
+2. **SHA256**: `metadata.sha256` (if you use SHA256 as video ID)
+3. **URL parsing**: Extract from `https://cdn.divine.video/{id}.mp4`
+
+**You need to verify**: How Divine's SHA256 maps to BunnyCDN video IDs.
+
+Check your upload code to see if:
+- SHA256 IS the BunnyCDN video ID
+- You store BunnyCDN's generated ID somewhere
+- You need a mapping table
+
+## Next Steps
+
+### 1. Enable Content Tagging
+Enable in your BunnyCDN panel (see Step 4 above)
+
+### 2. Upload a Test Video
+Upload a NEW video to get content tags (existing videos won't have them)
+
+### 3. Run Test Script
+```bash
+BUNNY_API_KEY=xxx BUNNY_LIBRARY_ID=xxx \
+  node scripts/test-bunnycdn-provider.mjs \
+  https://cdn.divine.video/YOUR_VIDEO_SHA256.mp4
+```
+
+This will:
+- Call BunnyCDN API and show raw response
+- Display what `metaTags` properties exist
+- Show detected content tags
+- Compare with Sightengine accuracy
+
+### 4. Verify metaTags Property Name
+The test will reveal the exact property name BunnyCDN uses:
+- Is it "contentTag"?
+- Is it "category"?
+- Something else?
+
+If it's different from our guesses, we'll update `extractContentTags()` to match.
+
+### 5. Test Accuracy
+Test with various videos:
+- Safe content (should NOT flag)
+- Adult content (should flag as "adult")
+- Content Sightengine got wrong
+
+### 6. Switch Provider (if good)
+If BunnyCDN is more accurate than Sightengine:
+
+```bash
+# .env
+PRIMARY_MODERATION_PROVIDER=bunnycdn
+
+# Deploy
+npm run deploy
+```
+
+## Cost Analysis
+
+| Provider | Cost (100K videos/month) | Notes |
+|----------|--------------------------|-------|
+| **BunnyCDN** | $0 (FREE) | Included with Stream hosting during preview |
+| **Sightengine** | $399 | Inaccurate (false positives + false negatives) |
+| **AWS Rekognition** | ~$1,000 | Most accurate, but expensive |
+
+**If BunnyCDN works well**:
+- Save $399/month (or $1,000/month vs AWS)
+- Simpler architecture (one service for hosting + moderation)
+- Already paying for BunnyCDN hosting
+
+## Potential Issues & Solutions
+
+### Issue: "No content tags found"
+**Causes**:
+1. Content tagging not enabled
+2. Video uploaded before feature was enabled
+3. Video still transcoding
+
+**Solution**: Enable feature, upload NEW test video
+
+### Issue: "Could not determine BunnyCDN video ID"
+**Cause**: Video ID mapping unclear
+
+**Solution**: Check upload code to see how Divine videos map to BunnyCDN IDs
+
+### Issue: Wrong metaTags property name
+**Cause**: BunnyCDN uses different property name than we guessed
+
+**Solution**: Test script will show available properties, update `extractContentTags()`
+
+### Issue: BunnyCDN doesn't detect what we need
+**Cause**: Feature might only detect "adult" category for now
+
+**Solution**: Fall back to AWS or Sightengine, email BunnyCDN support
+
+## Documentation Sources
+
+1. **Blog Post**: https://bunny.net/blog/introducing-bunny-stream-video-content-tagging/
+2. **Support Article**: https://support.bunny.net/hc/en-us/articles/4412240806802-Understanding-Bunny-Stream-Content-Tagging
+3. **API Docs**: https://docs.bunny.net/reference/video_getvideo
+4. **TypeScript Types**: https://github.com/dan-online/bunnycdn-stream (exact response structure)
+5. **Video Storage**: https://docs.bunny.net/docs/stream-video-storage-structure
+
+## Questions for BunnyCDN Support (if needed)
+
+If the test reveals issues or limitations:
+
+**Email**: support@bunny.net
+
+**Questions**:
+1. What is the exact property name in metaTags for content tags?
+2. What categories beyond "adult" do you detect?
+3. Do you have violence, weapons, drugs detection?
+4. What's the accuracy compared to AWS Rekognition or Sightengine?
+5. Is CSAM detection available? (Bunny Shield - announced August 2025)
+6. Pricing: Will content tagging remain free after preview?
+
+## Conclusion
+
+BunnyCDN's Automated Content Tagging is a promising option:
+
+✅ **Free** (during preview)
+✅ **Already using BunnyCDN** for hosting
+✅ **Simple integration** (one API call)
+✅ **Privacy-focused** (videos not used for training)
+
+❓ **Unknown accuracy** - needs testing
+❓ **Limited categories?** - might only detect "adult" for now
+❓ **Preview status** - might change/become paid later
+
+**Recommendation**: Test it! If it works well enough for adult content detection, it could save significant money and simplify your architecture.

--- a/BUNNYCDN_QUESTIONS.md
+++ b/BUNNYCDN_QUESTIONS.md
@@ -1,0 +1,172 @@
+# BunnyCDN Content Moderation Questions
+
+## Email Template for BunnyCDN Support
+
+**To**: support@bunny.net
+**Subject**: Video Content Moderation API - Divine.video
+
+---
+
+Hi BunnyCDN Team,
+
+We're currently using Bunny Stream for video hosting on Divine.video (6-second videos, similar to Vine). We're implementing content moderation and would like to know if BunnyCDN offers video content moderation features.
+
+**Our Requirements**:
+- Adult content detection (nudity, sexual content)
+- Violence/gore detection
+- Weapons, drugs, hate symbols detection
+- Ideally: CSAM detection (if available)
+
+**Questions**:
+
+1. **Does BunnyCDN offer automated video content moderation or tagging?**
+   - If yes, what categories can you detect?
+   - What's the API endpoint and authentication method?
+
+2. **Is this feature included in Bunny Stream pricing or is it extra?**
+   - If extra, what's the pricing structure?
+   - Per-video, per-minute, or volume tiers?
+
+3. **What's the accuracy/reliability compared to services like AWS Rekognition or Sightengine?**
+   - Do you have benchmark data?
+   - Can we test it on sample videos?
+
+4. **Do you offer CSAM (child safety) detection?**
+   - Hash matching against known databases?
+   - AI-based novel CSAM detection?
+   - NCMEC reporting integration?
+
+5. **Technical details**:
+   - Request/response format?
+   - Synchronous or asynchronous API?
+   - What video formats are supported?
+   - Any file size or duration limits?
+
+6. **What's the ETA for Bunny Shield's CSAM detection?**
+   - I saw it was announced as "coming soon" in August 2025
+   - Is it available now? If not, when?
+
+**Context**: We're currently evaluating AWS Rekognition and Sightengine, but since we're already using BunnyCDN for hosting, integrating moderation with you would be simpler and potentially more cost-effective.
+
+Looking forward to hearing from you!
+
+Best regards,
+[Your Name]
+Divine.video
+
+---
+
+## What to Do with Their Response
+
+### If BunnyCDN Has Moderation:
+
+1. **Get API Documentation**
+   - Endpoint URLs
+   - Authentication (API keys)
+   - Request/response formats
+   - Available categories
+
+2. **Update the BunnyCDN Provider**
+   - `src/moderation/providers/bunnycdn/client.mjs` - Add actual API calls
+   - `src/moderation/providers/bunnycdn/normalizer.mjs` - Map their categories
+   - `src/moderation/providers/bunnycdn/adapter.mjs` - Update capabilities
+
+3. **Test It**
+   ```bash
+   # .env
+   BUNNY_API_KEY=your-key
+   BUNNY_LIBRARY_ID=your-library
+   PRIMARY_MODERATION_PROVIDER=bunnycdn
+   ```
+
+4. **Compare with AWS/Sightengine**
+   ```javascript
+   const results = await moderateWithMultiple(
+     videoUrl,
+     metadata,
+     env,
+     ['bunnycdn', 'aws-rekognition', 'sightengine']
+   );
+   // See which is most accurate
+   ```
+
+### If BunnyCDN Doesn't Have Moderation:
+
+1. **Use AWS Rekognition**
+   - Most accurate self-serve option
+   - $0.10/min = ~$0.01 per 6-second video
+
+2. **Keep BunnyCDN for Hosting Only**
+   - Videos stay on BunnyCDN
+   - AWS reads from BunnyCDN URLs for moderation
+
+3. **Consider Hybrid Approach**
+   - BunnyCDN: Video hosting + delivery
+   - AWS: Content moderation
+   - Two services, but integrated
+
+### If BunnyCDN CSAM is Coming Soon:
+
+**Ask**:
+- Specific ETA (weeks? months?)
+- Beta access availability
+- Pricing when released
+
+**Decision**:
+- **If < 4 weeks**: Wait for it, use Sightengine temporarily
+- **If > 4 weeks**: Start with AWS, switch to BunnyCDN when ready
+
+---
+
+## Cost Comparison (Estimated)
+
+**Scenario**: 100K videos/month (6 seconds each)
+
+| Provider | Cost Estimate | Notes |
+|----------|---------------|-------|
+| **BunnyCDN** | $0 - $500? | Unknown, possibly included in Stream pricing |
+| **AWS Rekognition** | ~$1,000 | $0.10/min × 10K minutes |
+| **Sightengine** | $399 | Top tier, but inaccurate |
+
+**If BunnyCDN includes moderation**: Huge savings + simplification
+
+---
+
+## Next Steps After Response
+
+1. ✅ Email BunnyCDN (use template above)
+2. ⏰ Wait for response (usually 24-48 hours)
+3. **If YES**:
+   - Get API docs
+   - Implement BunnyCDN provider
+   - Test accuracy
+   - Switch if good
+4. **If NO**:
+   - Implement AWS authentication
+   - Deploy AWS provider
+   - Monitor accuracy
+
+---
+
+## Current Provider Status
+
+| Provider | Status | Action Needed |
+|----------|--------|---------------|
+| **AWS Rekognition** | ⚠️ Code ready, needs auth | Implement AWS SigV4 authentication |
+| **Sightengine** | ✅ Working but inaccurate | Keep as fallback only |
+| **BunnyCDN** | ❓ Unknown capabilities | Email support (see template above) |
+
+---
+
+## I Can Help With
+
+Once you get BunnyCDN's response, I can:
+- Implement their API in the BunnyCDN provider
+- Map their categories to our standard format
+- Test and compare accuracy with AWS
+- Help decide which provider to use
+
+Or if BunnyCDN doesn't have it:
+- Implement AWS SigV4 authentication
+- Get AWS provider working end-to-end
+- Help with AWS setup (S3, IAM, etc.)

--- a/BUNNYCDN_SETUP.md
+++ b/BUNNYCDN_SETUP.md
@@ -1,0 +1,205 @@
+# BunnyCDN Provider Setup Guide
+
+## Quick Start
+
+The BunnyCDN provider uses BunnyCDN Stream's automated content tagging feature to detect adult content, violence, and other categories. Since you're already using BunnyCDN for video hosting, this may be the most cost-effective option.
+
+## Step 1: Enable Content Tagging
+
+1. Go to https://panel.bunny.net/stream
+2. Select your video library
+3. Click "Settings"
+4. Find "Automated Content Tagging" section
+5. Enable content tagging (it's FREE during preview)
+6. Save settings
+
+**Note**: Content tagging only applies to NEW videos uploaded after enabling. Existing videos won't have tags unless you re-transcode them.
+
+## Step 2: Get API Credentials
+
+You should already have these if you're using BunnyCDN:
+
+1. **API Key**:
+   - Go to https://panel.bunny.net/account
+   - Copy your API Key (or generate a new one)
+
+2. **Library ID**:
+   - Go to https://panel.bunny.net/stream
+   - Your library ID is in the URL: `panel.bunny.net/stream/{libraryId}`
+   - Or find it in your library settings
+
+## Step 3: Configure Environment
+
+Add to your `.env` file:
+
+```bash
+# BunnyCDN Configuration
+BUNNY_API_KEY=your-api-key-here
+BUNNY_LIBRARY_ID=your-library-id-here
+
+# Set BunnyCDN as primary provider (optional)
+PRIMARY_MODERATION_PROVIDER=bunnycdn
+```
+
+## Step 4: Test the Provider
+
+Run the test script to verify everything works:
+
+```bash
+BUNNY_API_KEY=xxx BUNNY_LIBRARY_ID=xxx node scripts/test-bunnycdn-provider.mjs
+```
+
+Or test a specific video:
+
+```bash
+BUNNY_API_KEY=xxx BUNNY_LIBRARY_ID=xxx \
+  node scripts/test-bunnycdn-provider.mjs \
+  https://cdn.divine.video/YOUR_VIDEO_SHA256.mp4
+```
+
+The test script will:
+1. Call the BunnyCDN API and show the raw response
+2. Display normalized scores for all categories
+3. Compare with Sightengine (if configured)
+4. Identify any disagreements between providers
+
+## Understanding the Results
+
+### What BunnyCDN Detects
+
+Based on their blog post, BunnyCDN's content tagging detects:
+- **adult** - Adult/sexual content (maps to our `nudity` category)
+- **sports** - Sports content (not used for moderation)
+- **people** - People in video (not used for moderation)
+- **games** - Gaming content (not used for moderation)
+- **movie** - Movie clips (not used for moderation)
+
+**Important**: We primarily care about the "adult" tag for content moderation. Other tags might be useful for discovery/recommendations but don't trigger moderation actions.
+
+### Expected Response Format
+
+The BunnyCDN API returns video metadata including a `metaTags` array:
+
+```json
+{
+  "videoLibraryId": 12345,
+  "guid": "e7e9b99a-ea2a-434a-b200-f6615e7b6abd",
+  "title": "Video Title",
+  "metaTags": [
+    { "property": "contentTag", "value": "adult" },
+    { "property": "contentTag", "value": "people" },
+    { "property": "customMeta", "value": "something" }
+  ],
+  "length": 6,
+  "status": 4,
+  ...
+}
+```
+
+**Key Discovery**: Content tags are stored in the `metaTags` array with property/value structure, NOT as a separate `tags` or `contentTags` field. Our code extracts entries where `property` matches content tag indicators (contentTag, category, tag, etc.)
+
+## Step 5: Compare Accuracy
+
+Test BunnyCDN against Sightengine with various videos:
+
+1. **Safe content** - Should NOT flag
+2. **Adult content** - Should flag as "adult"
+3. **Borderline content** - See which is more accurate
+4. **Videos Sightengine got wrong** - Test known false positives/negatives
+
+Document your findings:
+- False positives (flagged when shouldn't be)
+- False negatives (missed actual violations)
+- Overall accuracy vs Sightengine
+
+## Step 6: Switch Provider (if BunnyCDN is better)
+
+If BunnyCDN is more accurate than Sightengine:
+
+```bash
+# Update .env
+PRIMARY_MODERATION_PROVIDER=bunnycdn
+
+# Redeploy
+npm run deploy
+```
+
+The orchestrator will automatically use BunnyCDN as primary, with Sightengine as fallback.
+
+## Troubleshooting
+
+### "No content tags found" Warning
+
+This means:
+1. Content tagging is not enabled in your library settings, OR
+2. The video was uploaded before content tagging was enabled, OR
+3. The video hasn't finished transcoding yet
+
+**Fix**: Enable content tagging, then upload a NEW test video.
+
+### "Could not determine BunnyCDN video ID"
+
+Our code tries multiple methods to get the video ID:
+1. `metadata.bunnyVideoId` - Explicit video ID
+2. `metadata.sha256` - SHA256 hash (if that's how you store them)
+3. URL parsing - Extract from `cdn.divine.video/{id}.mp4`
+
+**Fix**: Check how your videos are stored in BunnyCDN. You may need to update the `getVideoId()` function in `src/moderation/providers/bunnycdn/client.mjs`.
+
+### BunnyCDN API Returns 404
+
+This means the video ID doesn't exist in your library.
+
+**Fix**: Verify the video is actually in your BunnyCDN library. Check the video ID mapping logic.
+
+### "AccessKey invalid" Error
+
+Your API key is wrong or expired.
+
+**Fix**: Generate a new API key in the BunnyCDN panel.
+
+## Video ID Mapping
+
+**Important**: You need to determine how Divine's video SHA256 maps to BunnyCDN video IDs.
+
+Options:
+1. **SHA256 IS the video ID** - If you upload videos using SHA256 as the ID
+2. **Store bunnyVideoId in metadata** - If BunnyCDN generates IDs, store them in your database
+3. **Maintain a mapping table** - Map SHA256 → BunnyCDN video ID
+
+Check your upload code to see which approach you use.
+
+## Cost Comparison
+
+| Provider | Cost (100K videos/month) | Notes |
+|----------|--------------------------|-------|
+| **BunnyCDN** | $0 (FREE) | Included with Stream hosting during preview |
+| **Sightengine** | $399 | Top tier, but inaccurate |
+| **AWS Rekognition** | ~$1,000 | Most accurate, but expensive |
+
+**If BunnyCDN is accurate enough**: Massive cost savings + simplification (one service for hosting + moderation).
+
+## Next Steps After Testing
+
+### If BunnyCDN Works Well:
+1. Set `PRIMARY_MODERATION_PROVIDER=bunnycdn`
+2. Keep Sightengine as fallback for now
+3. Monitor accuracy over time
+4. Consider removing Sightengine entirely to save $399/month
+
+### If BunnyCDN Doesn't Work Well:
+1. Implement AWS Rekognition authentication (see `AWS_SETUP.md`)
+2. Test AWS accuracy
+3. Switch to AWS as primary
+
+### If BunnyCDN Doesn't Have the Feature Yet:
+1. Email BunnyCDN support (template in `BUNNYCDN_QUESTIONS.md`)
+2. Ask about ETA for content tagging feature
+3. Use AWS or Sightengine in the meantime
+
+## Support
+
+If you have questions about BunnyCDN's content tagging feature:
+- Email: support@bunny.net
+- Docs: https://docs.bunny.net/docs/stream
+- Blog: https://bunny.net/blog/introducing-bunny-stream-video-content-tagging/

--- a/BUNNYCDN_WEBHOOK_INTEGRATION.md
+++ b/BUNNYCDN_WEBHOOK_INTEGRATION.md
@@ -1,0 +1,415 @@
+# BunnyCDN Webhook Integration Report
+
+## Executive Summary
+
+**Problem**: Videos are being uploaded to BunnyCDN and tagged for content, but they're **not appearing in the moderation dashboard** because they're never being sent to the moderation queue.
+
+**Root Cause**: Missing integration between BunnyCDN Stream and the Divine moderation service.
+
+**Solution**: Implement a webhook endpoint that receives notifications from BunnyCDN when videos finish encoding, then queues them for moderation.
+
+---
+
+## What's Happening Now (BROKEN)
+
+```
+User uploads video
+    ↓
+BunnyCDN Stream receives video ✅
+    ↓
+BunnyCDN encodes & tags video ✅
+    ↓
+??? NOTHING HAPPENS ❌
+    ↓
+Moderation queue: EMPTY ❌
+    ↓
+Dashboard: NO VIDEOS ❌
+```
+
+---
+
+## What Should Happen (FIXED)
+
+```
+User uploads video
+    ↓
+BunnyCDN Stream receives video ✅
+    ↓
+BunnyCDN encodes & tags video ✅
+    ↓
+BunnyCDN sends webhook to your endpoint ✅
+    ↓
+Your webhook handler queues video for moderation ✅
+    ↓
+Moderation worker processes video ✅
+    ↓
+Results stored in KV ✅
+    ↓
+Dashboard shows videos ✅
+```
+
+---
+
+## BunnyCDN Webhook Details
+
+### Webhook Configuration
+
+1. Go to https://panel.bunny.net/stream
+2. Select your video library (ID: 515420)
+3. Click "Settings" → "Webhooks"
+4. Set webhook URL to: `https://divine-moderation-service.protestnet.workers.dev/webhook/bunnycdn`
+
+### Webhook Payload
+
+When a video status changes, BunnyCDN sends a POST request:
+
+```json
+{
+  "VideoLibraryId": 515420,
+  "VideoGuid": "657bb740-a71b-4529-a012-528021c31a92",
+  "Status": 3
+}
+```
+
+### Status Codes (Events)
+
+| Status | Event | Action Needed? |
+|--------|-------|----------------|
+| 0 | Queued for encoding | No |
+| 1 | Processing preview | No |
+| 2 | Actively encoding | No |
+| **3** | **Encoding complete** | **YES - Queue for moderation** |
+| 4 | Single resolution finished | Maybe (video is playable) |
+| 5 | Encoding failed | No (log error) |
+| 6 | Pre-signed upload initiated | No |
+| 7 | Pre-signed upload completed | No |
+| 8 | Pre-signed upload failed | No |
+| 9 | Auto captions generated | No |
+| 10 | Auto title/description generated | No |
+
+**Key Event**: Status `3` (Encoding complete) - This is when content tags are finalized and video is ready for moderation.
+
+---
+
+## Required Implementation
+
+### 1. Add Webhook Endpoint to Moderation Service
+
+**File**: `src/index.mjs`
+
+Add this webhook handler:
+
+```javascript
+// In the fetch() handler, add:
+if (url.pathname === '/webhook/bunnycdn' && request.method === 'POST') {
+  return handleBunnyCDNWebhook(request, env);
+}
+
+/**
+ * Handle BunnyCDN webhook for video encoding completion
+ */
+async function handleBunnyCDNWebhook(request, env) {
+  try {
+    const payload = await request.json();
+    const { VideoLibraryId, VideoGuid, Status } = payload;
+
+    console.log(`[WEBHOOK] BunnyCDN event: Library=${VideoLibraryId}, Video=${VideoGuid}, Status=${Status}`);
+
+    // Only process "encoding complete" events
+    if (Status !== 3 && Status !== 4) {
+      console.log(`[WEBHOOK] Ignoring status ${Status} (not encoding complete)`);
+      return new Response(JSON.stringify({ received: true, action: 'ignored' }), {
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+
+    // Fetch video metadata from BunnyCDN to get SHA256
+    const videoMetadata = await fetchBunnyVideoMetadata(VideoGuid, env);
+
+    if (!videoMetadata || !videoMetadata.sha256) {
+      console.error(`[WEBHOOK] Could not determine SHA256 for video ${VideoGuid}`);
+      return new Response(JSON.stringify({
+        error: 'Missing SHA256 in video metadata',
+        videoGuid: VideoGuid
+      }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+
+    const sha256 = videoMetadata.sha256;
+
+    // Check if already moderated (avoid duplicates)
+    const existingResult = await env.MODERATION_KV.get(`moderation:${sha256}`);
+    if (existingResult) {
+      console.log(`[WEBHOOK] Video ${sha256} already moderated, skipping`);
+      return new Response(JSON.stringify({
+        received: true,
+        action: 'already_moderated',
+        sha256
+      }), {
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+
+    // Queue for moderation
+    await env.MODERATION_QUEUE.send({
+      sha256,
+      r2Key: `blobs/${sha256}`, // Blossom format
+      uploadedAt: Date.now(),
+      metadata: {
+        bunnyVideoId: VideoGuid,
+        bunnyLibraryId: VideoLibraryId,
+        source: 'bunnycdn_webhook'
+      }
+    });
+
+    console.log(`[WEBHOOK] Queued ${sha256} for moderation`);
+
+    return new Response(JSON.stringify({
+      received: true,
+      action: 'queued',
+      sha256,
+      videoGuid: VideoGuid
+    }), {
+      headers: { 'Content-Type': 'application/json' }
+    });
+
+  } catch (error) {
+    console.error('[WEBHOOK] Error processing BunnyCDN webhook:', error);
+    return new Response(JSON.stringify({
+      error: error.message
+    }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }
+}
+
+/**
+ * Fetch video metadata from BunnyCDN to extract SHA256
+ */
+async function fetchBunnyVideoMetadata(videoGuid, env) {
+  const response = await fetch(
+    `https://video.bunnycdn.com/library/${env.BUNNY_LIBRARY_ID}/videos/${videoGuid}`,
+    {
+      headers: {
+        'AccessKey': env.BUNNY_API_KEY,
+        'Accept': 'application/json'
+      }
+    }
+  );
+
+  if (!response.ok) {
+    console.error(`[WEBHOOK] BunnyCDN API error: ${response.status} ${response.statusText}`);
+    return null;
+  }
+
+  const video = await response.json();
+
+  // Extract SHA256 from video metadata
+  // You need to determine where SHA256 is stored in BunnyCDN metadata
+  // Options:
+  // 1. In video.title (if you upload with SHA256 as title)
+  // 2. In video.guid (if guid IS the SHA256)
+  // 3. In custom metadata tags
+
+  // For now, assume guid IS the SHA256 (verify this!)
+  return {
+    sha256: video.guid,
+    videoGuid: video.guid,
+    title: video.title,
+    length: video.length
+  };
+}
+```
+
+### 2. Add Required Environment Variables
+
+**File**: `wrangler.toml`
+
+Ensure these are configured:
+
+```toml
+[vars]
+BUNNY_LIBRARY_ID = "515420"  # Your BunnyCDN library ID
+
+# Secrets (set with: wrangler secret put <NAME>)
+# BUNNY_API_KEY - Already configured
+```
+
+---
+
+## Critical Question: SHA256 Mapping
+
+**IMPORTANT**: You need to determine how BunnyCDN video GUIDs map to SHA256 hashes.
+
+### Option 1: GUID IS the SHA256 (Simplest)
+If you upload videos to BunnyCDN using SHA256 as the video ID, then:
+```javascript
+const sha256 = VideoGuid; // Direct mapping
+```
+
+### Option 2: SHA256 in Title
+If you upload with SHA256 in the title:
+```javascript
+const sha256 = video.title; // Assuming title = SHA256
+```
+
+### Option 3: SHA256 in Custom Metadata
+If you store SHA256 in metaTags:
+```javascript
+const sha256Tag = video.metaTags.find(tag =>
+  tag.property === 'sha256' || tag.property === 'hash'
+);
+const sha256 = sha256Tag ? sha256Tag.value : null;
+```
+
+### Option 4: External Mapping Table
+If BunnyCDN generates its own GUIDs, you need a KV mapping:
+```javascript
+// During upload: Store mapping
+await env.MODERATION_KV.put(`bunny-guid:${bunnyGuid}`, sha256);
+
+// During webhook: Retrieve mapping
+const sha256 = await env.MODERATION_KV.get(`bunny-guid:${VideoGuid}`);
+```
+
+**Action Required**: Check your upload service code to determine which option you're using.
+
+---
+
+## Testing the Webhook
+
+### 1. Deploy Updated Service
+
+```bash
+npm run deploy
+```
+
+### 2. Configure Webhook in BunnyCDN
+
+1. Go to https://panel.bunny.net/stream
+2. Select library 515420
+3. Settings → Webhooks
+4. Set URL: `https://divine-moderation-service.protestnet.workers.dev/webhook/bunnycdn`
+5. Save
+
+### 3. Test with New Upload
+
+Upload a test video to BunnyCDN and watch the logs:
+
+```bash
+npx wrangler tail
+```
+
+Expected log sequence:
+```
+[WEBHOOK] BunnyCDN event: Library=515420, Video=xxx, Status=3
+[WEBHOOK] Queued abc123... for moderation
+[MODERATION] Processing batch of 1 videos
+[MODERATION] ✅ COMPLETED abc123... in 650ms - SAFE
+```
+
+### 4. Verify in Dashboard
+
+Visit: https://divine-moderation-service.protestnet.workers.dev/admin/dashboard
+
+You should now see the video with moderation results.
+
+---
+
+## Backfilling Existing Videos
+
+Since 157K videos were uploaded BEFORE webhook integration, use the backfill script:
+
+```bash
+# Test with 10 videos first (dry-run)
+node scripts/backfill-moderation.mjs --max-total 10 --dry-run
+
+# Process all videos (resume-able if interrupted)
+node scripts/backfill-moderation.mjs
+```
+
+This will:
+1. Fetch kind 34236 Nostr events from relay
+2. Extract SHA256 from imeta tags
+3. Queue each video for moderation
+4. Update dashboard as they're processed
+
+**Note**: The backfill script uses Nostr events, not BunnyCDN's API. This works if you publish Nostr events when uploading videos.
+
+---
+
+## Alternative: Pull-Based Integration (If Webhooks Don't Work)
+
+If BunnyCDN webhooks are unavailable or unreliable, implement a scheduled worker:
+
+```javascript
+// In wrangler.toml
+[triggers]
+crons = ["*/5 * * * *"]  // Every 5 minutes
+
+// In src/index.mjs
+export default {
+  async scheduled(event, env, ctx) {
+    // List recent videos from BunnyCDN
+    const response = await fetch(
+      `https://video.bunnycdn.com/library/${env.BUNNY_LIBRARY_ID}/videos?page=1&itemsPerPage=100&orderBy=date`,
+      {
+        headers: { 'AccessKey': env.BUNNY_API_KEY }
+      }
+    );
+
+    const videos = await response.json();
+
+    // Queue unmoderated videos
+    for (const video of videos.items) {
+      const sha256 = determineSha256(video); // Your mapping logic
+      const existingResult = await env.MODERATION_KV.get(`moderation:${sha256}`);
+
+      if (!existingResult) {
+        await env.MODERATION_QUEUE.send({
+          sha256,
+          r2Key: `blobs/${sha256}`,
+          uploadedAt: Date.now(),
+          metadata: { bunnyVideoId: video.guid }
+        });
+      }
+    }
+  }
+}
+```
+
+This approach polls BunnyCDN every 5 minutes for new videos.
+
+---
+
+## Summary
+
+### Immediate Actions
+
+1. **Determine SHA256 mapping**: Check how BunnyCDN video GUIDs map to SHA256 hashes
+2. **Implement webhook endpoint**: Add `/webhook/bunnycdn` handler to `src/index.mjs`
+3. **Configure webhook in BunnyCDN**: Point to your worker URL
+4. **Deploy**: `npm run deploy`
+5. **Test**: Upload new video and verify it appears in dashboard
+6. **Backfill**: Run backfill script to process existing 157K videos
+
+### Long-term
+
+- Monitor webhook reliability
+- Set up alerting if webhooks fail
+- Consider webhook signature verification for security
+- Implement retry logic if moderation queue fails
+
+---
+
+## Questions for You, Rabble
+
+1. **How are you uploading videos to BunnyCDN?** (Direct API, Blossom server, other?)
+2. **What is the mapping between BunnyCDN video GUIDs and SHA256 hashes?** (Are they the same? Stored separately?)
+3. **Do you publish Nostr events when uploading videos?** (If yes, backfill script will work)
+4. **Should we use webhooks or scheduled polling?** (Webhooks are faster, polling is more reliable)
+
+Let me know and I can implement the webhook handler with the correct SHA256 mapping logic.

--- a/CDN_ACTIONS.md
+++ b/CDN_ACTIONS.md
@@ -1,0 +1,377 @@
+# ABOUTME: CDN Integration - Content Actions and Authentication
+# ABOUTME: Explains how to handle moderation actions in the CDN with Nostr auth
+
+## Content Actions
+
+The moderation service returns one of 4 actions:
+
+### 1. SAFE
+- **Meaning**: Content is safe for all audiences
+- **CDN Behavior**: Serve without restrictions
+- **KV Key**: Only in `moderation:{sha256}`
+
+### 2. REVIEW
+- **Meaning**: Flagged for human review, uncertain classification
+- **CDN Behavior**: Serve normally, but log for manual review
+- **KV Key**: Only in `moderation:{sha256}`
+- **Note**: Human moderators can upgrade to AGE_RESTRICTED or PERMANENT_BAN
+
+### 3. AGE_RESTRICTED
+- **Meaning**: Adult content (nudity, violence, gore, drugs, etc.) - requires age verification
+- **CDN Behavior**:
+  - Without auth: Return 403 + error message explaining age verification needed
+  - With valid Nostr auth: Serve content (user takes responsibility)
+- **KV Keys**:
+  - `moderation:{sha256}` → Full result with `action: "AGE_RESTRICTED"`
+  - `age-restricted:{sha256}` → Quick lookup flag
+
+### 4. PERMANENT_BAN
+- **Meaning**: Illegal/dangerous content (self-harm, hate speech, extreme gore)
+- **CDN Behavior**: NEVER serve to anyone except admin dashboard
+- **KV Keys**:
+  - `moderation:{sha256}` → Full result with `action: "PERMANENT_BAN"`
+  - `permanent-ban:{sha256}` → Quick lookup flag
+
+## CDN Implementation
+
+```javascript
+// src/handlers/serve-video.mjs
+export async function serveVideo(request, env) {
+  const url = new URL(request.url);
+  const sha256 = extractSha256(url.pathname);
+
+  // Step 1: Check PERMANENT_BAN (NEVER serve)
+  const permanentBan = await env.MODERATION_KV.get(`permanent-ban:${sha256}`);
+  if (permanentBan) {
+    console.log(`[CDN] BLOCKED permanent ban: ${sha256}`);
+    return new Response('Content unavailable - removed for policy violation', {
+      status: 451,  // Unavailable For Legal Reasons
+      headers: { 'Content-Type': 'text/plain' }
+    });
+  }
+
+  // Step 2: Check AGE_RESTRICTED
+  const ageRestricted = await env.MODERATION_KV.get(`age-restricted:${sha256}`);
+  if (ageRestricted) {
+    // Check for Nostr auth header
+    const authHeader = request.headers.get('Authorization');
+
+    if (!authHeader) {
+      console.log(`[CDN] Age-restricted content requested without auth: ${sha256}`);
+      return new Response(JSON.stringify({
+        error: 'age_restricted',
+        message: 'This content requires age verification via Nostr authentication',
+        sha256,
+        category: JSON.parse(ageRestricted).category
+      }), {
+        status: 403,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+
+    // Verify Nostr auth (NIP-98)
+    const authValid = await verifyNostrAuth(authHeader, request, env);
+
+    if (!authValid) {
+      console.log(`[CDN] Invalid Nostr auth for age-restricted: ${sha256}`);
+      return new Response(JSON.stringify({
+        error: 'invalid_auth',
+        message: 'Invalid Nostr authentication'
+      }), {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+
+    console.log(`[CDN] Serving age-restricted with valid auth: ${sha256}`);
+    // Fall through to serve content
+  }
+
+  // Step 3: Serve from R2
+  const r2Key = `blobs/${sha256}`;  // Blossom format
+  const object = await env.R2_VIDEOS.get(r2Key);
+
+  if (!object) {
+    return new Response('Not found', { status: 404 });
+  }
+
+  return new Response(object.body, {
+    headers: {
+      'Content-Type': object.httpMetadata.contentType || 'video/mp4',
+      'Cache-Control': 'public, max-age=31536000, immutable',
+      'ETag': object.httpEtag,
+      'X-Content-Rating': ageRestricted ? 'age-restricted' : 'safe'
+    }
+  });
+}
+
+/**
+ * Extract SHA256 from URL path
+ */
+function extractSha256(pathname) {
+  // Handle both /blobs/{sha256} and /{sha256}.mp4
+  const match = pathname.match(/([a-f0-9]{64})/i);
+  return match ? match[1].toLowerCase() : null;
+}
+```
+
+## Nostr Authentication (NIP-98)
+
+For age-restricted content, clients must provide Nostr authentication:
+
+### Client-Side (JavaScript)
+
+```javascript
+// User wants to view age-restricted video
+async function fetchAgeRestrictedVideo(sha256, nostrPrivateKey) {
+  const url = `https://cdn.divine.video/blobs/${sha256}`;
+
+  // Create NIP-98 auth event
+  const authEvent = {
+    kind: 27235,  // HTTP Auth
+    created_at: Math.floor(Date.now() / 1000),
+    tags: [
+      ['u', url],
+      ['method', 'GET']
+    ],
+    content: ''
+  };
+
+  // Sign with Nostr private key (using nostr-tools or similar)
+  const signedEvent = await signEvent(authEvent, nostrPrivateKey);
+
+  // Encode as base64
+  const authHeader = `Nostr ${btoa(JSON.stringify(signedEvent))}`;
+
+  // Fetch video with auth
+  const response = await fetch(url, {
+    headers: {
+      'Authorization': authHeader
+    }
+  });
+
+  if (response.status === 403) {
+    const error = await response.json();
+    console.log('Age verification required:', error.category);
+    // Show age verification UI
+  }
+
+  return response;
+}
+```
+
+### Server-Side Verification
+
+```javascript
+// src/utils/nostr-auth.mjs
+import { verifySignature, getEventHash } from 'nostr-tools';
+
+/**
+ * Verify NIP-98 Nostr authentication
+ * @param {string} authHeader - Authorization header value
+ * @param {Request} request - Original request
+ * @param {Object} env - Environment bindings
+ * @returns {Promise<boolean>} True if auth is valid
+ */
+export async function verifyNostrAuth(authHeader, request, env) {
+  try {
+    // Parse "Nostr <base64-event>"
+    if (!authHeader.startsWith('Nostr ')) {
+      return false;
+    }
+
+    const base64Event = authHeader.substring(6);
+    const eventJson = atob(base64Event);
+    const event = JSON.parse(eventJson);
+
+    // Verify event structure
+    if (event.kind !== 27235) {
+      console.log('[AUTH] Invalid kind, expected 27235');
+      return false;
+    }
+
+    // Verify event hash
+    const calculatedId = getEventHash(event);
+    if (calculatedId !== event.id) {
+      console.log('[AUTH] Event hash mismatch');
+      return false;
+    }
+
+    // Verify signature
+    const validSignature = verifySignature(event);
+    if (!validSignature) {
+      console.log('[AUTH] Invalid signature');
+      return false;
+    }
+
+    // Verify URL matches
+    const urlTag = event.tags.find(t => t[0] === 'u');
+    const requestUrl = new URL(request.url);
+    if (!urlTag || urlTag[1] !== requestUrl.href) {
+      console.log('[AUTH] URL mismatch');
+      return false;
+    }
+
+    // Verify method matches
+    const methodTag = event.tags.find(t => t[0] === 'method');
+    if (!methodTag || methodTag[1] !== request.method) {
+      console.log('[AUTH] Method mismatch');
+      return false;
+    }
+
+    // Check timestamp (not older than 60 seconds)
+    const now = Math.floor(Date.now() / 1000);
+    if (Math.abs(now - event.created_at) > 60) {
+      console.log('[AUTH] Event too old or in future');
+      return false;
+    }
+
+    console.log(`[AUTH] Valid auth from pubkey: ${event.pubkey}`);
+    return true;
+
+  } catch (error) {
+    console.error('[AUTH] Verification error:', error);
+    return false;
+  }
+}
+```
+
+## Admin Dashboard Actions
+
+The admin dashboard at `/admin/dashboard` should allow moderators to:
+
+### 1. View All Content
+- See SAFE, REVIEW, AGE_RESTRICTED, and PERMANENT_BAN content
+- Filter by action type
+- Sort by scores
+
+### 2. Change Classifications
+- **REVIEW → SAFE**: Mark as false positive
+- **REVIEW → AGE_RESTRICTED**: Requires age verification
+- **REVIEW → PERMANENT_BAN**: Escalate to removal
+- **AGE_RESTRICTED → SAFE**: Downgrade if misclassified
+- **AGE_RESTRICTED → PERMANENT_BAN**: Escalate to removal
+
+### 3. Take Down Content
+- **Soft Take Down**: Change to AGE_RESTRICTED (still accessible with auth)
+- **Hard Take Down**: Change to PERMANENT_BAN (completely removed)
+
+### Implementation
+
+```javascript
+// Add to src/index.mjs admin API
+
+// POST /admin/api/moderate/{sha256}
+if (url.pathname.startsWith('/admin/api/moderate/') && request.method === 'POST') {
+  const authError = await requireAuth(request, env);
+  if (authError) return authError;
+
+  const sha256 = url.pathname.split('/')[4];
+  const { action, reason } = await request.json();
+
+  // Validate action
+  if (!['SAFE', 'REVIEW', 'AGE_RESTRICTED', 'PERMANENT_BAN'].includes(action)) {
+    return new Response('Invalid action', { status: 400 });
+  }
+
+  // Get existing moderation result
+  const existingData = await env.MODERATION_KV.get(`moderation:${sha256}`);
+  if (!existingData) {
+    return new Response('Not found', { status: 404 });
+  }
+
+  const existing = JSON.parse(existingData);
+
+  // Update moderation result
+  const updated = {
+    ...existing,
+    action,
+    reason: reason || `Manual override by moderator`,
+    manualOverride: true,
+    overriddenBy: 'admin',  // Could get from auth token
+    overriddenAt: Date.now()
+  };
+
+  // Write updated result
+  await env.MODERATION_KV.put(
+    `moderation:${sha256}`,
+    JSON.stringify(updated)
+  );
+
+  // Update action-specific keys
+  await Promise.all([
+    // Clear old keys
+    env.MODERATION_KV.delete(`age-restricted:${sha256}`),
+    env.MODERATION_KV.delete(`permanent-ban:${sha256}`),
+    env.MODERATION_KV.delete(`quarantine:${sha256}`)  // Legacy
+  ]);
+
+  // Set new key based on action
+  if (action === 'AGE_RESTRICTED') {
+    await env.MODERATION_KV.put(
+      `age-restricted:${sha256}`,
+      JSON.stringify({
+        category: updated.category,
+        reason: updated.reason,
+        timestamp: Date.now(),
+        manualOverride: true
+      })
+    );
+  } else if (action === 'PERMANENT_BAN') {
+    await env.MODERATION_KV.put(
+      `permanent-ban:${sha256}`,
+      JSON.stringify({
+        category: updated.category,
+        reason: updated.reason,
+        timestamp: Date.now(),
+        manualOverride: true
+      })
+    );
+  }
+
+  return new Response(JSON.stringify({
+    success: true,
+    sha256,
+    action,
+    message: `Content updated to ${action}`
+  }), {
+    headers: { 'Content-Type': 'application/json' }
+  });
+}
+```
+
+## Summary
+
+### Content Access Rules
+
+| Action | No Auth | With Nostr Auth | Admin |
+|--------|---------|-----------------|-------|
+| SAFE | ✅ Serve | ✅ Serve | ✅ Serve |
+| REVIEW | ✅ Serve | ✅ Serve | ✅ Serve |
+| AGE_RESTRICTED | ❌ 403 | ✅ Serve | ✅ Serve |
+| PERMANENT_BAN | ❌ 451 | ❌ 451 | ✅ Serve (view only) |
+
+### KV Keys Used
+
+- `moderation:{sha256}` - Full moderation result (all actions)
+- `age-restricted:{sha256}` - Quick flag for age-restricted content
+- `permanent-ban:{sha256}` - Quick flag for banned content
+- `quarantine:{sha256}` - **DEPRECATED** (use permanent-ban instead)
+
+### CDN Flow
+
+1. Check `permanent-ban:{sha256}` → If exists, return 451
+2. Check `age-restricted:{sha256}` → If exists:
+   - Check Authorization header
+   - If missing → return 403 with error
+   - If invalid → return 401
+   - If valid → serve content
+3. Serve content from R2
+
+### Next Steps
+
+1. ✅ Update CDN to check `permanent-ban` and `age-restricted` keys
+2. ✅ Implement NIP-98 Nostr auth verification
+3. ✅ Add admin dashboard action buttons
+4. ✅ Test age-restricted flow with Nostr clients
+5. ✅ Update CDN_INTEGRATION.md with correct terminology

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,33 @@
+# Divine Video Moderation Service - Project Notes
+
+## Video Content Location
+
+**CRITICAL**: All videos are hosted on **cdn.divine.video**, NOT r2.divine.video.
+
+## Video URL Resolution
+
+When fetching videos for moderation:
+
+1. **ALWAYS** use the URL from the `imeta` tag in the Nostr event (kind 34236) if available
+2. The `imeta` tag contains the actual video file URL (e.g., `https://cdn.divine.video/{sha256}.mp4`)
+3. The `r` tag contains the ORIGINAL source URL (e.g., vine.co) - DO NOT USE THIS for Sightengine
+4. If no Nostr event exists, fall back to `https://cdn.divine.video/{sha256}.mp4`
+
+## Nostr Event Structure (kind 34236)
+
+```json
+{
+  "tags": [
+    ["imeta", "url https://cdn.divine.video/{sha256}.mp4", "m video/mp4", "x {sha256}", ...],
+    ["r", "https://vine.co/v/{original_id}"],  // Original source - DO NOT USE
+    ...
+  ]
+}
+```
+
+## Important Notes
+
+- Never use the `r` tag URL for video processing - it's the original source (often dead links like vine.co)
+- Always prefer the `imeta` tag URL which points to our CDN
+- The Sightengine API requires publicly accessible video URLs
+- Videos are stored in R2 under `blobs/{sha256}` or `videos/{sha256}.mp4` but accessed via CDN

--- a/DASHBOARD_INTERACTIVE_TODO.md
+++ b/DASHBOARD_INTERACTIVE_TODO.md
@@ -1,0 +1,274 @@
+# ABOUTME: Interactive Dashboard Features - Implementation Guide
+# ABOUTME: What needs to be added to make the dashboard actually useful
+
+## Problem
+
+The dashboard is currently **100% passive** - you can only view videos, you can't DO anything with them.
+
+## Required Interactive Features
+
+### 1. Quick Action Buttons on Each Video Card
+
+Add these 4 buttons at the bottom of each video card:
+
+```html
+<div class="action-buttons">
+  <button class="action-btn approve" onclick="quickAction('${sha256}', 'SAFE')">Approve</button>
+  <button class="action-btn age-restrict" onclick="quickAction('${sha256}', 'AGE_RESTRICTED')">Age-Restrict</button>
+  <button class="action-btn ban" onclick="quickAction('${sha256}', 'PERMANENT_BAN')">Ban</button>
+  <button class="action-btn edit" onclick="openEditModal('${sha256}')">Edit Scores</button>
+</div>
+```
+
+**Location:** Add inside `.video-info` div, after the timestamp
+
+### 2. JavaScript for Quick Actions
+
+```javascript
+// Quick action - change moderation action without modal
+async function quickAction(sha256, action) {
+  if (!confirm(`Are you sure you want to set this video to ${action}?`)) {
+    return;
+  }
+
+  try {
+    const response = await fetch(`/admin/api/moderate/${sha256}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action, reason: `Quick action: ${action}` })
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+
+    const result = await response.json();
+    console.log('Action updated:', result);
+
+    // Reload videos to show updated data
+    await loadVideos(paginationState.currentCursor);
+    alert(`Successfully updated to ${action}`);
+  } catch (error) {
+    console.error('Failed to update action:', error);
+    alert('Failed to update: ' + error.message);
+  }
+}
+```
+
+### 3. Modal for Editing Scores
+
+Add this HTML before the closing `</body>` tag:
+
+```html
+<!-- Edit Scores Modal -->
+<div class="modal" id="edit-modal">
+  <div class="modal-content">
+    <div class="modal-header">
+      <h2>Edit Moderation Scores</h2>
+      <button class="modal-close" onclick="closeEditModal()">&times;</button>
+    </div>
+    <div class="modal-body">
+      <div id="edit-scores-container"></div>
+
+      <div class="form-group">
+        <label>Action</label>
+        <select id="edit-action">
+          <option value="SAFE">Safe</option>
+          <option value="REVIEW">Review</option>
+          <option value="AGE_RESTRICTED">Age-Restricted</option>
+          <option value="PERMANENT_BAN">Permanent Ban</option>
+        </select>
+      </div>
+
+      <div class="form-group">
+        <label>Reason for Override</label>
+        <textarea id="edit-reason" placeholder="Explain why you're overriding the AI classification..."></textarea>
+      </div>
+    </div>
+    <div class="modal-footer">
+      <button class="btn-cancel" onclick="closeEditModal()">Cancel</button>
+      <button class="btn-save" onclick="saveEdits()">Save Changes</button>
+    </div>
+  </div>
+</div>
+```
+
+### 4. JavaScript for Modal
+
+```javascript
+let currentEditingSha256 = null;
+let currentEditingVideo = null;
+
+// Open modal to edit scores
+function openEditModal(sha256) {
+  const video = allVideos.find(v => v.sha256 === sha256);
+  if (!video) return;
+
+  currentEditingSha256 = sha256;
+  currentEditingVideo = video;
+
+  // Build score sliders
+  const categories = ['nudity', 'violence', 'gore', 'offensive', 'weapon', 'self_harm',
+                     'recreational_drug', 'alcohol', 'tobacco', 'ai_generated', 'deepfake',
+                     'medical', 'gambling', 'money', 'destruction', 'military',
+                     'text_profanity', 'qr_unsafe'];
+
+  const slidersHTML = categories.map(cat => {
+    const currentScore = video.scores[cat] || 0;
+    const label = formatCategoryName(cat);
+    return `
+      <div class="score-slider">
+        <label>${label}</label>
+        <input type="range" id="edit-${cat}" min="0" max="100" value="${(currentScore * 100).toFixed(0)}"
+               oninput="updateSliderValue('${cat}', this.value)">
+        <span class="score-slider-value" id="value-${cat}">${(currentScore * 100).toFixed(0)}%</span>
+      </div>
+    `;
+  }).join('');
+
+  document.getElementById('edit-scores-container').innerHTML = slidersHTML;
+  document.getElementById('edit-action').value = video.action;
+  document.getElementById('edit-reason').value = video.manualOverride ? video.reason : '';
+
+  // Show modal
+  document.getElementById('edit-modal').classList.add('show');
+}
+
+function closeEditModal() {
+  document.getElementById('edit-modal').classList.remove('show');
+  currentEditingSha256 = null;
+  currentEditingVideo = null;
+}
+
+function updateSliderValue(category, value) {
+  document.getElementById(`value-${category}`).textContent = value + '%';
+}
+
+async function saveEdits() {
+  if (!currentEditingSha256) return;
+
+  // Get all slider values
+  const categories = ['nudity', 'violence', 'gore', 'offensive', 'weapon', 'self_harm',
+                     'recreational_drug', 'alcohol', 'tobacco', 'ai_generated', 'deepfake',
+                     'medical', 'gambling', 'money', 'destruction', 'military',
+                     'text_profanity', 'qr_unsafe'];
+
+  const newScores = {};
+  categories.forEach(cat => {
+    const slider = document.getElementById(`edit-${cat}`);
+    if (slider) {
+      newScores[cat] = parseInt(slider.value) / 100;
+    }
+  });
+
+  const action = document.getElementById('edit-action').value;
+  const reason = document.getElementById('edit-reason').value || 'Manual score override by moderator';
+
+  try {
+    const response = await fetch(`/admin/api/moderate/${currentEditingSha256}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        action,
+        reason,
+        scores: newScores  // TODO: Add score override support to backend
+      })
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+
+    const result = await response.json();
+    console.log('Scores updated:', result);
+
+    closeEditModal();
+    await loadVideos(paginationState.currentCursor);
+    alert('Successfully updated scores and action');
+  } catch (error) {
+    console.error('Failed to update:', error);
+    alert('Failed to update: ' + error.message);
+  }
+}
+
+// Close modal when clicking outside
+document.addEventListener('click', (e) => {
+  const modal = document.getElementById('edit-modal');
+  if (e.target === modal) {
+    closeEditModal();
+  }
+});
+```
+
+### 5. Show Manual Override Badge
+
+Update the badge HTML to show when content has been manually overridden:
+
+```html
+<div class="video-overlay">
+  <span class="badge ${actionClass}">${action}</span>
+  ${video.manualOverride ? '<span class="override-badge">MANUAL</span>' : ''}
+</div>
+```
+
+### 6. Backend: Add Score Override Support
+
+The current `/admin/api/moderate/{sha256}` endpoint only accepts `action` and `reason`. We need to add support for overriding scores:
+
+```javascript
+// In src/index.mjs, update the moderate endpoint
+const { action, reason, scores } = await request.json();
+
+// If scores provided, override them
+if (scores) {
+  updated.scores = {
+    ...existing.scores,
+    ...scores
+  };
+}
+```
+
+## Implementation Priority
+
+1. **HIGH**: Quick action buttons (Approve, Age-Restrict, Ban)
+2. **HIGH**: Manual override badge
+3. **MEDIUM**: Edit scores modal
+4. **MEDIUM**: Backend score override support
+5. **LOW**: Bulk selection checkboxes
+
+## Expected User Flow
+
+1. **Moderator sees video flagged as REVIEW**
+2. **Clicks "Approve" button** → Video instantly set to SAFE
+3. **OR clicks "Edit Scores"** → Modal opens
+4. **Drags "AI-Generated" slider from 85% down to 10%** (false positive)
+5. **Types reason**: "This is not AI-generated, it's just heavily edited"
+6. **Clicks "Save Changes"** → Video updated with manual override badge
+7. **Dashboard refreshes** → Video shows "MANUAL" badge
+
+## Benefits
+
+- **Fast triage**: Approve/ban videos with 1 click
+- **Override AI mistakes**: Adjust individual scores
+- **Audit trail**: Reasons logged for all manual overrides
+- **Visual feedback**: See which videos have been manually reviewed
+
+## CSS Already Added
+
+All the CSS for these features has been added to the dashboard:
+- `.action-buttons` - Button container
+- `.action-btn` - Button styles with approve/age-restrict/ban/edit variants
+- `.override-badge` - Purple badge for manual overrides
+- `.modal` - Full modal system with header/body/footer
+- `.score-slider` - Range sliders for editing scores
+- `.form-group` - Form styling
+
+## Next Steps
+
+1. Add action buttons HTML to video cards
+2. Add modal HTML before `</body>`
+3. Add JavaScript functions for quick actions and modal
+4. Test quick approve/ban workflow
+5. Test edit scores modal workflow
+6. Add backend score override support
+7. Deploy and use in production

--- a/DEPLOYMENT_BUNNYCDN.md
+++ b/DEPLOYMENT_BUNNYCDN.md
@@ -1,0 +1,118 @@
+# BunnyCDN Migration - Deployment Notes
+
+**Date**: October 23, 2025
+**Status**: ✅ DEPLOYED
+
+## Summary
+
+Switched from Sightengine to BunnyCDN for primary video content moderation.
+
+## Why We Switched
+
+### Problems with Sightengine
+- ❌ **Inaccurate**: Missing actual nudity (scored 0.04 on porn video)
+- ❌ **False categories**: Flagging porn as "alcohol" instead of nudity
+- ❌ **Expensive**: $399/month
+- ❌ **Slow**: ~6,500ms per video
+- ❌ **Accessibility issues**: Can't reliably access our videos
+
+### BunnyCDN Advantages
+- ✅ **Accurate**: Correctly identified nudity with 1.00 score
+- ✅ **FREE**: Included with Stream hosting
+- ✅ **Fast**: ~650ms per video (10x faster)
+- ✅ **Already enabled**: 157K videos already tagged
+- ✅ **Integrated**: No need to download videos for moderation
+
+## Test Results
+
+Tested 11 videos (1 adult, 10 safe):
+- **Agreement**: 100% on classification (flag vs safe)
+- **Accuracy**: BunnyCDN correctly identified nudity, Sightengine missed it
+- **Performance**: BunnyCDN 10x faster
+- **Cost savings**: $399/month → $0/month
+
+## What Changed
+
+### Configuration
+- **wrangler.toml**: Set `PRIMARY_MODERATION_PROVIDER = "bunnycdn"`
+- **Secrets**: Added `BUNNY_API_KEY` and `BUNNY_LIBRARY_ID`
+
+### Code (Already Deployed)
+- ✅ BunnyCDN provider implementation (`src/moderation/providers/bunnycdn/`)
+- ✅ Pluggable provider architecture (`src/moderation/providers/orchestrator.mjs`)
+- ✅ Pipeline integration (`src/moderation/pipeline.mjs`)
+
+### Fallback Strategy
+- Sightengine remains configured as fallback (if BunnyCDN fails)
+- Automatic fallback via orchestrator
+
+## Deployment Steps
+
+1. ✅ Updated `wrangler.toml` with `PRIMARY_MODERATION_PROVIDER = "bunnycdn"`
+2. ✅ Added BunnyCDN secrets:
+   ```bash
+   wrangler secret put BUNNY_API_KEY
+   wrangler secret put BUNNY_LIBRARY_ID
+   ```
+3. ✅ Deployed to production:
+   ```bash
+   npm run deploy
+   ```
+
+## BunnyCDN Configuration
+
+**Library**: 515420
+**Content Tagging**: ENABLED (in BunnyCDN panel)
+**Videos Tagged**: 157,669 videos
+**API Endpoint**: `https://video.bunnycdn.com/library/515420/videos/{videoId}`
+
+## Categories Detected
+
+BunnyCDN's `category` field values:
+- **adult** → Maps to `nudity` (score: 1.0)
+- gaming, animated, anime, movie, animals-cats, other-people, other → Safe content
+- untagged → No detection
+
+## Monitoring
+
+Watch for:
+- BunnyCDN API errors in logs
+- Videos with `category: "untagged"` (no detection)
+- Fallback to Sightengine (indicates BunnyCDN issues)
+
+Check logs:
+```bash
+npx wrangler tail
+```
+
+## Rollback Plan
+
+If issues arise:
+
+```bash
+# Revert to Sightengine
+npx wrangler secret put PRIMARY_MODERATION_PROVIDER
+# Enter: sightengine
+
+# Then redeploy
+npm run deploy
+```
+
+## Cost Impact
+
+**Before**: $399/month (Sightengine)
+**After**: $0/month (BunnyCDN included with hosting)
+**Savings**: $399/month = $4,788/year
+
+## Next Steps
+
+- ✅ Monitor production for 24-48 hours
+- Consider removing Sightengine credentials after confirmed success
+- Update monitoring dashboards to track BunnyCDN usage
+
+## Related Files
+
+- Implementation: `src/moderation/providers/bunnycdn/`
+- Research: `BUNNYCDN_FINDINGS.md`
+- Setup guide: `BUNNYCDN_SETUP.md`
+- Test scripts: `scripts/test-bunnycdn-provider.mjs`, `scripts/compare-providers.mjs`

--- a/DISCOVERY_FEATURES.md
+++ b/DISCOVERY_FEATURES.md
@@ -1,0 +1,429 @@
+# Video Analysis for Discovery & Recommendation
+
+## Overview
+
+While moderating videos, we can extract valuable metadata for discovery algorithms at minimal additional cost. This includes:
+
+1. **Audio fingerprinting** - Detect videos using the same/similar audio (like TikTok's "original audio")
+2. **Content labels** - Tag videos with objects, scenes, activities for search/discovery
+3. **Scene detection** - Break videos into segments for clip-based features
+4. **Visual similarity** - Find related/remix videos
+
+---
+
+## Feature 1: Audio Fingerprinting (Most Requested)
+
+**Use Case**: "Find all videos using this audio" - enables TikTok-style audio reuse discovery
+
+### How It Works
+1. Extract audio fingerprint from each video during moderation
+2. Store fingerprint in database with video metadata
+3. When new video uploaded, check if fingerprint matches existing videos
+4. Tag videos with:
+   - `originalAudio: true` (first video with this audio)
+   - `audioSourceSha256: abc123` (links to original)
+   - `audioRemixCount: 42` (how many videos use this audio)
+
+### Recommended Service: **AcoustID / Chromaprint**
+
+**Why:**
+- Open source, self-hosted (no per-video API costs!)
+- Battle-tested (used by MusicBrainz, millions of tracks)
+- Fast fingerprint generation (< 1 second per video)
+- Robust to quality differences (compression, trimming)
+
+**Implementation:**
+```bash
+# Install Chromaprint
+npm install chromaprint-js
+
+# Or use WASM version for Cloudflare Workers
+```
+
+```javascript
+// Generate fingerprint
+import { Chromaprint } from 'chromaprint-js';
+
+async function generateAudioFingerprint(videoUrl) {
+  // Extract audio from video (ffmpeg or similar)
+  const audioBuffer = await extractAudio(videoUrl);
+
+  // Generate fingerprint
+  const fingerprint = await Chromaprint.fingerprint(audioBuffer);
+
+  return {
+    fingerprint: fingerprint.data,  // Raw fingerprint
+    duration: fingerprint.duration
+  };
+}
+
+// Store in database
+await db.videos.update(sha256, {
+  audioFingerprint: fingerprint.data,
+  audioDuration: fingerprint.duration
+});
+
+// Find matching videos
+const matches = await db.videos.findByAudioFingerprint(fingerprint);
+if (matches.length > 0) {
+  // This audio has been used before!
+  const original = matches[0];  // First upload
+
+  await db.videos.update(sha256, {
+    originalAudio: false,
+    audioSourceSha256: original.sha256,
+    audioSourceNostrId: original.nostrEventId
+  });
+
+  // Update remix count on original
+  await db.videos.increment(original.sha256, 'audioRemixCount');
+}
+```
+
+**Alternative: Commercial API**
+If self-hosting is too complex, use **Emysound API**:
+- REST API for audio fingerprinting
+- Handles video directly
+- Returns match results
+- Paid service (pricing TBD)
+
+---
+
+## Feature 2: Content Labels for Discovery
+
+**Use Case**: Tag videos with what's in them - "beach", "sunset", "dog", "cooking" - enables content-based search and recommendation
+
+### Recommended Service: **Google Video Intelligence API**
+
+**Why:**
+- Best-in-class label detection
+- Three levels: frame, shot, segment
+- Google Knowledge Graph integration
+- Same $0.10/min pricing as moderation
+- Can run in parallel with Hive moderation
+
+**Labels Detected:**
+- **Objects**: dog, cat, car, phone, food, etc.
+- **Scenes**: beach, sunset, city, forest, etc.
+- **Activities**: cooking, dancing, sports, gaming, etc.
+- **Animals**: specific species (golden retriever, not just "dog")
+- **Products**: brands, items
+- **Locations**: landmarks, buildings
+
+**Example Output:**
+```json
+{
+  "labels": [
+    {
+      "description": "Beach",
+      "confidence": 0.95,
+      "segments": [
+        {"start": 0, "end": 10}
+      ]
+    },
+    {
+      "description": "Sunset",
+      "confidence": 0.89,
+      "segments": [
+        {"start": 5, "end": 15}
+      ]
+    },
+    {
+      "description": "Golden Retriever",
+      "confidence": 0.87,
+      "segments": [
+        {"start": 0, "end": 6}
+      ]
+    }
+  ]
+}
+```
+
+**Discovery Use Cases:**
+- Search: "Show me videos with dogs on the beach"
+- Recommendations: "You watched beach videos, here are more"
+- Trending: "What objects/scenes are trending this week?"
+- Auto-tagging: No manual tagging needed
+
+**Implementation:**
+```javascript
+// Run in parallel with moderation
+const [moderationResult, labelsResult] = await Promise.all([
+  moderateWithHive(videoUrl, metadata, env),
+  detectLabelsWithGoogle(videoUrl, metadata, env)
+]);
+
+// Store labels for discovery
+await db.videos.update(sha256, {
+  contentLabels: labelsResult.labels.map(l => ({
+    label: l.description,
+    confidence: l.confidence,
+    category: l.category  // e.g., 'object', 'scene', 'activity'
+  }))
+});
+
+// Enable search
+await searchIndex.index({
+  sha256,
+  labels: labelsResult.labels.map(l => l.description)
+});
+```
+
+---
+
+## Feature 3: Logo Detection (Hive)
+
+**Use Case**: Detect brands/logos in videos - useful for sponsored content, brand safety, trending brands
+
+**Service**: Hive Logo Detection API
+
+**Capabilities:**
+- 11,000+ logos recognized
+- Location/size/clarity of each logo
+- What object the logo is on (clothing, product, sign, etc.)
+
+**Example Output:**
+```json
+{
+  "logos": [
+    {
+      "class": "Nike",
+      "score": 0.95,
+      "location": {"x": 100, "y": 200, "width": 50, "height": 30},
+      "on_object": "shirt",
+      "time": 2.5
+    }
+  ]
+}
+```
+
+**Discovery Use Cases:**
+- Find videos featuring specific brands
+- Brand trend analysis
+- Sponsored content detection
+- User interest inference (likes Nike → recommend athletic content)
+
+---
+
+## Feature 4: Scene/Shot Detection
+
+**Use Case**: Break videos into scenes for clip-based features, auto-highlights, scene search
+
+**Service**: Google Video Intelligence (included in label detection)
+
+**How It Works:**
+- Automatically detects scene changes (shot boundaries)
+- Labels each scene independently
+- Enables scene-level search and navigation
+
+**Example:**
+```json
+{
+  "shots": [
+    {
+      "start": 0,
+      "end": 5.2,
+      "labels": ["Beach", "Sunset"]
+    },
+    {
+      "start": 5.2,
+      "end": 10.8,
+      "labels": ["Dog", "Playing"]
+    }
+  ]
+}
+```
+
+**Discovery Use Cases:**
+- "Jump to the beach scene"
+- Auto-generate highlights (best scenes)
+- Scene-based recommendations
+- Clip extraction for sharing
+
+---
+
+## Recommended Multi-Provider Architecture
+
+### Primary Setup: Hive (Moderation) + Google (Discovery)
+
+```javascript
+async function analyzeVideo(videoUrl, metadata, env) {
+  // Run in parallel for efficiency
+  const [moderation, discovery] = await Promise.all([
+    // Hive: Moderation (nudity, violence, AI-gen)
+    moderateWithHive(videoUrl, metadata, env),
+
+    // Google: Labels, scenes, objects
+    analyzeWithGoogle(videoUrl, metadata, env)
+  ]);
+
+  // Audio fingerprinting (async, can run after)
+  const audioFingerprint = await generateAudioFingerprint(videoUrl);
+  const audioMatches = await findAudioMatches(audioFingerprint);
+
+  return {
+    // Moderation
+    classification: moderation.classification,
+    scores: moderation.scores,
+
+    // Discovery
+    contentLabels: discovery.labels,
+    scenes: discovery.shots,
+    logos: discovery.logos,
+
+    // Audio
+    audioFingerprint: audioFingerprint.data,
+    audioMatches: audioMatches.map(m => ({
+      sha256: m.sha256,
+      similarity: m.score
+    })),
+    originalAudio: audioMatches.length === 0
+  };
+}
+```
+
+### Cost Analysis
+
+For 1000 hours of video per month:
+
+| Service | Purpose | Cost |
+|---------|---------|------|
+| Hive | Moderation | ~$1,500-3,000/mo |
+| Google Video Intelligence | Labels + Scenes | ~$6,000/mo |
+| AcoustID (self-hosted) | Audio fingerprinting | ~$0/mo (compute only) |
+| **Total** | | **~$7,500-9,000/mo** |
+
+**Alternative (cheaper):** Only use Google when needed
+- Moderate all videos with Hive
+- Only run Google labels on videos that pass moderation
+- Reduces Google costs by ~50-70% (filtering out rejected videos)
+
+---
+
+## Implementation Priorities
+
+### Phase 1: Audio Fingerprinting (Highest Value)
+- Unique feature for Divine (like Vine/TikTok)
+- Self-hosted = low ongoing cost
+- Enables viral audio discovery
+- **Timeline: 1-2 weeks**
+
+### Phase 2: Content Labels (Medium Value)
+- Add Google Video Intelligence alongside Hive
+- Store labels in database
+- Build basic search/filter
+- **Timeline: 2-3 weeks**
+
+### Phase 3: Logo Detection (Lower Priority)
+- Add if brand analysis is important
+- Can be done later
+- **Timeline: 1 week (after Phase 2)**
+
+### Phase 4: Advanced Discovery
+- Build recommendation algorithm using labels
+- Trending content by labels/audio
+- User interest profiles
+- **Timeline: Ongoing**
+
+---
+
+## Database Schema Updates
+
+```sql
+-- Add discovery columns to videos table
+ALTER TABLE videos ADD COLUMN audio_fingerprint TEXT;
+ALTER TABLE videos ADD COLUMN audio_duration REAL;
+ALTER TABLE videos ADD COLUMN original_audio BOOLEAN DEFAULT TRUE;
+ALTER TABLE videos ADD COLUMN audio_source_sha256 TEXT;
+ALTER TABLE videos ADD COLUMN audio_remix_count INTEGER DEFAULT 0;
+ALTER TABLE videos ADD COLUMN content_labels JSONB;  -- Array of {label, confidence, category}
+ALTER TABLE videos ADD COLUMN scenes JSONB;  -- Array of {start, end, labels[]}
+ALTER TABLE videos ADD COLUMN detected_logos JSONB;  -- Array of {brand, confidence, location}
+
+-- Indexes for discovery
+CREATE INDEX idx_audio_fingerprint ON videos(audio_fingerprint);
+CREATE INDEX idx_audio_source ON videos(audio_source_sha256);
+CREATE INDEX idx_content_labels ON videos USING GIN(content_labels);
+
+-- Audio matches table (for fuzzy matching)
+CREATE TABLE audio_matches (
+  video1_sha256 TEXT,
+  video2_sha256 TEXT,
+  similarity REAL,
+  PRIMARY KEY (video1_sha256, video2_sha256)
+);
+```
+
+---
+
+## API Endpoints for Discovery
+
+```javascript
+// Find videos with same audio
+GET /api/videos/{sha256}/audio-remixes
+→ Returns videos using same audio
+
+// Search by labels
+GET /api/videos/search?labels=beach,sunset,dog
+→ Returns videos matching labels
+
+// Trending audio
+GET /api/trending/audio?period=24h
+→ Returns most-used audio tracks
+
+// Trending content
+GET /api/trending/labels?period=7d
+→ Returns most popular content types
+
+// Related videos (by labels)
+GET /api/videos/{sha256}/related
+→ Returns videos with similar labels
+```
+
+---
+
+## Example: Audio Reuse Discovery Flow
+
+```
+User uploads video with audio:
+  1. Extract audio fingerprint → "fp_abc123"
+  2. Check database for matching fingerprints
+  3. Match found! → Video X uploaded 2 days ago
+  4. Tag new video:
+     - originalAudio: false
+     - audioSourceSha256: "video_x_sha256"
+  5. Increment remix count on Video X
+  6. Nostr event includes audio source tag:
+     ["audio_source", "video_x_sha256", "wss://relay.openvine.co"]
+
+User browses Video X:
+  - Shows "42 videos use this audio"
+  - Click to see all remixes
+  - Auto-play remix feed
+
+Discovery algorithm:
+  - "Videos with popular audio" trending section
+  - Recommend other videos with same audio
+  - User interest: likes beach + sunset → find more beach/sunset videos
+```
+
+---
+
+## Next Steps
+
+1. **Decision**: Which features are highest priority?
+   - Audio fingerprinting? (my recommendation - unique value)
+   - Content labels?
+   - Both?
+
+2. **Implementation Order**:
+   - Migrate to Hive for moderation first (fix accuracy)
+   - Add audio fingerprinting (unique feature, low cost)
+   - Add Google labels if budget allows (discovery++)
+
+3. **Timeline**:
+   - Week 1-2: Hive migration
+   - Week 3-4: Audio fingerprinting MVP
+   - Week 5+: Content labels (optional)
+
+Want me to start implementing audio fingerprinting? It's the highest ROI feature IMO.

--- a/DIVINE_MODERATION_REQUIREMENTS.md
+++ b/DIVINE_MODERATION_REQUIREMENTS.md
@@ -1,0 +1,644 @@
+# Divine Video Moderation Requirements & Implementation
+
+**Last Updated**: 2025-10-23
+
+## Platform Context
+
+- **Format**: 6-second videos (Vine-style)
+- **Platform**: Nostr-based decentralized video sharing
+- **Value Proposition**: Authentic, human-created content (no AI-generated)
+- **Hosting**: cdn.divine.video (Cloudflare R2)
+
+---
+
+## Content Moderation Requirements
+
+### 1. CSAM (Child Sexual Abuse Material)
+**Action**: **ABSOLUTE BLOCK** + Legal Reporting
+- Zero tolerance policy
+- Must detect both known and novel CSAM
+- Automatic reporting to NCMEC (National Center for Missing & Exploited Children)
+- Cannot be opted into by any user
+- Legal requirement, not platform policy
+
+**Implementation**:
+- Hash matching against known CSAM database
+- AI classifier for novel/unknown CSAM
+- Immediate blocking (never show to users)
+- Automatic reporting workflow
+
+### 2. Adult Content / Pornography
+**Action**: **AGE-GATE with OPT-IN**
+- Adult users (18+) can opt-in to view
+- Minors completely blocked
+- Similar to Twitter/X model
+- Not illegal, just age-restricted
+
+**Implementation**:
+- Detect adult/sexual content (nudity, sexual activity, etc.)
+- Tag video with age restriction flag
+- Only show to users who:
+  1. Are verified 18+
+  2. Have opted into adult content in settings
+- Store user preference in profile
+
+### 3. Other Harmful Content
+**Action**: **FLAG for Human Review**
+- Violence, gore, hate speech, weapons, drugs, etc.
+- Not auto-blocked, but flagged for moderator review
+- Moderators decide: approve, age-gate, or remove
+- Reviewed via faro.nos.social (existing human moderation tool)
+
+**Implementation**:
+- AI detection scores content
+- High scores → flag for human review
+- Moderators review in faro.nos.social
+- Manual decision: approve/gate/block
+
+### 4. AI-Generated Content
+**Action**: **FLAG for Review** (per "no AI content" policy)
+- Brand differentiator for Divine
+- Detected via AI/deepfake models
+- May allow with disclosure vs hard block (TBD)
+- Human review to confirm
+
+**Implementation**:
+- Deepfake + AI-generated detection
+- Flag videos with high AI scores
+- Human verification
+- Possible outcome: block or require "AI-generated" label
+
+---
+
+## Moderation Flow
+
+```
+Video Upload
+    ↓
+[1. CSAM Detection] → MATCH? → BLOCK + NCMEC Report
+    ↓ PASS
+[2. Adult Content Detection] → HIGH SCORE? → Age-gate (opt-in required)
+    ↓ PASS / LOW SCORE
+[3. Harmful Content Detection] → HIGH SCORE? → Flag for human review
+    ↓ PASS / LOW SCORE
+[4. AI-Generated Detection] → HIGH SCORE? → Flag for human review
+    ↓ PASS
+APPROVED - Publish to feed
+```
+
+---
+
+## Recommended Provider: Hive Moderation
+
+### Why Hive is Perfect for Divine
+
+**1. CSAM Detection Suite** (Critical Requirement)
+- Partnership with Thorn (nonprofit child safety org)
+- **57M+ known CSAM hashes** (NCMEC database, regularly updated)
+- **AI classifier** for novel CSAM detection
+- **Video hash matching** with scene-sensitive video hashing (SSVH)
+- **Integrated NCMEC reporting** (manage/review/escalate from one interface)
+- **Privacy-first**: Deletes original media after processing (only keeps embeddings)
+
+**2. Visual Moderation API**
+- Adult content detection (sexual_activity, sexual_display, nudity levels)
+- Violence, gore, weapons, drugs, hate symbols
+- AI-generated + deepfake detection
+- 97% nudity accuracy, 98% AI detection accuracy
+
+**3. Single Platform Benefits**
+- One API for all moderation needs
+- Consistent scoring system
+- Unified billing
+- Battle-tested (Reddit, TikTok, Quora)
+
+### Why NOT AWS Rekognition
+
+AWS documentation explicitly states:
+> "Amazon Rekognition's image and video moderation APIs don't detect whether an image includes illegal content, such as CSAM."
+
+AWS cannot fulfill Divine's legal requirements.
+
+### Why NOT Google Video Intelligence
+
+Google has CSAM tools (CSAI Match, Content Safety API) but:
+- Separate from general moderation API
+- More complex integration (2 different systems)
+- Primarily designed for YouTube-scale platforms
+- Hive is simpler for Divine's use case
+
+---
+
+## Implementation Architecture
+
+### Dual API Approach with Hive
+
+```javascript
+async function moderateVideo(videoUrl, metadata, env) {
+  // Step 1: CSAM Detection (CRITICAL - always first)
+  const csamResult = await hive.detectCSAM(videoUrl);
+
+  if (csamResult.isCSAM) {
+    // IMMEDIATE BLOCK
+    await blockVideo(metadata.sha256, 'CSAM_DETECTED');
+
+    // AUTOMATIC NCMEC REPORTING
+    await reportToNCMEC(csamResult, metadata);
+
+    return {
+      action: 'BLOCKED',
+      reason: 'CSAM',
+      reportId: csamResult.ncmecReportId
+    };
+  }
+
+  // Step 2: General Content Moderation
+  const moderation = await hive.moderateContent(videoUrl, {
+    classes: [
+      'yes_sexual_content',
+      'yes_sexual_activity',
+      'yes_suggestive',
+      'yes_ai_generated',
+      'yes_deepfake',
+      'yes_violence',
+      'yes_gore',
+      'yes_weapon',
+      'yes_drugs',
+      'yes_hate_symbols'
+    ]
+  });
+
+  // Step 3: Classification Logic
+  const classification = classifyContent(moderation);
+
+  return classification;
+}
+
+function classifyContent(moderation) {
+  const scores = extractScores(moderation);
+
+  // Adult content → Age-gate
+  if (scores.sexual_activity > 0.8 || scores.sexual_content > 0.8) {
+    return {
+      action: 'AGE_GATE',
+      reason: 'ADULT_CONTENT',
+      requiresOptIn: true,
+      ageRestriction: 18,
+      scores
+    };
+  }
+
+  // AI-generated → Flag for review
+  if (scores.ai_generated > 0.7 || scores.deepfake > 0.7) {
+    return {
+      action: 'FLAG_FOR_REVIEW',
+      reason: 'AI_GENERATED',
+      flagType: 'POLICY_VIOLATION',
+      scores
+    };
+  }
+
+  // Other harmful content → Flag for review
+  const harmfulScore = Math.max(
+    scores.violence,
+    scores.gore,
+    scores.weapon,
+    scores.drugs,
+    scores.hate_symbols
+  );
+
+  if (harmfulScore > 0.7) {
+    return {
+      action: 'FLAG_FOR_REVIEW',
+      reason: 'HARMFUL_CONTENT',
+      flagType: 'SAFETY',
+      primaryConcern: getPrimaryConcern(scores),
+      scores
+    };
+  }
+
+  // Safe content
+  return {
+    action: 'APPROVED',
+    scores
+  };
+}
+```
+
+### Database Schema
+
+```sql
+CREATE TABLE video_moderation (
+  sha256 TEXT PRIMARY KEY,
+
+  -- CSAM Detection
+  csam_checked BOOLEAN DEFAULT FALSE,
+  csam_detected BOOLEAN DEFAULT FALSE,
+  csam_hash_match BOOLEAN DEFAULT FALSE,
+  csam_classifier_score REAL,
+  ncmec_report_id TEXT,
+
+  -- Content Classification
+  moderation_action TEXT, -- BLOCKED, AGE_GATE, FLAG_FOR_REVIEW, APPROVED
+  moderation_reason TEXT,
+
+  -- Age Gating
+  age_restricted BOOLEAN DEFAULT FALSE,
+  minimum_age INTEGER,
+  requires_opt_in BOOLEAN DEFAULT FALSE,
+
+  -- Flagging
+  flagged_for_review BOOLEAN DEFAULT FALSE,
+  flag_type TEXT, -- POLICY_VIOLATION, SAFETY, etc.
+  flag_reason TEXT,
+  reviewed_by TEXT,
+  reviewed_at TIMESTAMP,
+  review_decision TEXT,
+
+  -- Scores
+  adult_content_score REAL,
+  ai_generated_score REAL,
+  violence_score REAL,
+  harmful_content_score REAL,
+
+  -- Metadata
+  moderation_provider TEXT, -- 'hive'
+  moderated_at TIMESTAMP,
+  raw_result JSONB
+);
+
+-- Indexes
+CREATE INDEX idx_csam_detected ON video_moderation(csam_detected) WHERE csam_detected = TRUE;
+CREATE INDEX idx_flagged ON video_moderation(flagged_for_review) WHERE flagged_for_review = TRUE;
+CREATE INDEX idx_age_restricted ON video_moderation(age_restricted) WHERE age_restricted = TRUE;
+```
+
+### User Preferences (Adult Content Opt-In)
+
+```sql
+CREATE TABLE user_preferences (
+  pubkey TEXT PRIMARY KEY, -- Nostr pubkey
+
+  -- Adult Content Settings
+  adult_content_enabled BOOLEAN DEFAULT FALSE,
+  adult_content_opted_in_at TIMESTAMP,
+  age_verified BOOLEAN DEFAULT FALSE,
+  age_verification_method TEXT, -- 'self_reported', 'id_verified', etc.
+  age_verification_date TIMESTAMP,
+
+  -- Content Filtering
+  show_ai_generated BOOLEAN DEFAULT FALSE,
+  show_flagged_content BOOLEAN DEFAULT FALSE,
+
+  updated_at TIMESTAMP
+);
+```
+
+### Nostr Event Tags
+
+Videos should include moderation tags in Nostr events (kind 34236):
+
+```json
+{
+  "kind": 34236,
+  "tags": [
+    ["imeta", "url https://cdn.divine.video/{sha256}.mp4", ...],
+
+    // Moderation tags
+    ["content-warning", "adult"],  // For age-gated content
+    ["L", "content-warning"],      // Label namespace
+    ["l", "sexual", "content-warning"],  // Specific warning
+
+    // Age restriction
+    ["age-restriction", "18"],
+
+    // AI-generated flag (if allowed with disclosure)
+    ["ai-generated", "true"],
+
+    // Optional: Moderation provider attestation
+    ["moderation", "hive", "2025-10-23T12:00:00Z", "adult-content"]
+  ]
+}
+```
+
+---
+
+## API Integration Details
+
+### Hive CSAM Detection API
+
+```javascript
+// Endpoint
+POST https://api.thehive.ai/api/v2/task/sync
+
+// Headers
+Authorization: Token {HIVE_CSAM_API_KEY}
+Content-Type: application/json
+
+// Request
+{
+  "url": "https://cdn.divine.video/{sha256}.mp4",
+  "detection_type": "csam_combined" // hash + classifier
+}
+
+// Response
+{
+  "status": [{
+    "response": {
+      "output": [{
+        "hash_match": {
+          "is_match": false,
+          "hash_type": "perceptual" // or "cryptographic"
+        },
+        "classifier": {
+          "csam_score": 0.05, // 0-1 probability
+          "is_csam": false    // bool threshold
+        }
+      }]
+    }
+  }]
+}
+
+// If CSAM detected
+{
+  "hash_match": {
+    "is_match": true,
+    "matched_hash": "abc123...",
+    "ncmec_reported": true,
+    "report_id": "ncmec_12345"
+  }
+}
+```
+
+### Hive Visual Moderation API
+
+```javascript
+// Endpoint
+POST https://api.thehive.ai/api/v2/task/sync
+
+// Request
+{
+  "url": "https://cdn.divine.video/{sha256}.mp4",
+  "moderation_classes": [
+    "yes_sexual_content",
+    "yes_sexual_activity",
+    "yes_suggestive",
+    "yes_ai_generated",
+    "yes_deepfake",
+    "yes_violence",
+    "yes_gore",
+    "yes_weapon",
+    "yes_drugs",
+    "yes_hate_symbols",
+    "yes_offensive"
+  ]
+}
+
+// Response
+{
+  "status": [{
+    "response": {
+      "output": [
+        {
+          "time": 2.0, // seconds into video
+          "classes": [
+            {
+              "class": "yes_sexual_content",
+              "score": 0.95
+            },
+            {
+              "class": "yes_ai_generated",
+              "score": 0.12
+            }
+          ]
+        }
+      ]
+    }
+  }]
+}
+```
+
+---
+
+## User Experience Flows
+
+### Flow 1: Age-Gated Adult Content
+
+```
+User browses feed
+  ↓
+Sees blurred thumbnail with "18+ Content" label
+  ↓
+Clicks to view
+  ↓
+IF user.age_verified && user.adult_content_enabled:
+  → Show video
+ELSE IF user.age_verified && !user.adult_content_enabled:
+  → Prompt: "This video contains adult content. Enable in settings?"
+    → [Go to Settings] [Cancel]
+ELSE:
+  → Prompt: "This video is restricted to adults 18+. Verify your age?"
+    → [Verify Age] [Cancel]
+```
+
+### Flow 2: Flagged Content Review
+
+```
+AI flags video for review
+  ↓
+Video hidden from public feed (not published)
+  ↓
+Moderator notified in faro.nos.social
+  ↓
+Moderator reviews video + AI scores
+  ↓
+Decision:
+  → APPROVE: Publish to feed
+  → AGE-GATE: Publish with 18+ restriction
+  → BLOCK: Remove permanently
+  → REQUEST MORE INFO: Contact uploader
+```
+
+### Flow 3: CSAM Detection
+
+```
+Video uploaded
+  ↓
+CSAM detection API called
+  ↓
+MATCH DETECTED
+  ↓
+[AUTOMATIC ACTIONS]
+- Video immediately blocked (never shown)
+- Upload rejected
+- NCMEC report filed automatically
+- Account flagged for investigation
+- Law enforcement notification (if required)
+  ↓
+User sees: "Upload failed. Content violates legal requirements."
+(No specifics given to avoid evasion tactics)
+```
+
+---
+
+## Cost Estimates
+
+### Hive Pricing (Estimated)
+
+**CSAM Detection**:
+- Typically enterprise pricing
+- May be subsidized for safety (some providers offer reduced/free CSAM detection)
+- Contact Hive sales for pricing
+
+**Visual Moderation**:
+- ~$1,500-3,000/month for 1000 hours
+- 6-second videos = ~$0.015-0.03 per video (estimated)
+
+**Total for 100K videos/month**:
+- ~$1,500-3,000 base
+- May increase with volume
+
+**Note**: CSAM detection is often priced separately or subsidized as it's a legal/safety requirement.
+
+---
+
+## Legal & Compliance Considerations
+
+### CSAM Reporting Requirements
+
+**United States (NCMEC)**:
+- Platforms must report CSAM to NCMEC
+- Failure to report is a federal crime
+- Hive's integrated reporting helps compliance
+
+**International**:
+- EU: Report to national hotlines
+- UK: Report to IWF (Internet Watch Foundation)
+- Hive supports international reporting workflows
+
+### Age Verification
+
+**Current Approach** (Minimum Viable):
+- Self-reported age in profile
+- Terms of Service agreement (user attests 18+)
+
+**Future Enhancements**:
+- ID verification (passport, driver's license)
+- Third-party age verification services
+- Credit card verification
+- Compliance with UK Online Safety Act (if serving UK users)
+
+### User Privacy
+
+**CSAM Detection**:
+- Hive deletes original media after processing
+- Only embeddings/hashes retained
+- Privacy-preserving approach
+
+**Moderation Logs**:
+- Store minimal PII
+- Retain for legal compliance period
+- Encrypt sensitive data
+
+---
+
+## Migration Timeline
+
+### Phase 1: CSAM Detection (Week 1-2) - HIGHEST PRIORITY
+1. Sign up for Hive CSAM Detection API
+2. Implement CSAM check in moderation pipeline
+3. Test with NCMEC test dataset (if available)
+4. Configure automatic reporting workflow
+5. Deploy to production (BLOCKING - no videos published without this)
+
+### Phase 2: Adult Content Age-Gating (Week 3-4)
+1. Implement Hive Visual Moderation API
+2. Build age-gating classification logic
+3. Add user preference settings (opt-in/out)
+4. Update Nostr event tags (content-warning)
+5. Implement blurred thumbnail UI
+6. Deploy age verification flow
+
+### Phase 3: Harmful Content Flagging (Week 5-6)
+1. Integrate with faro.nos.social (human review tool)
+2. Build flagging workflow
+3. Moderator dashboard enhancements
+4. Notification system for moderators
+5. Review and appeal process
+
+### Phase 4: AI-Generated Detection (Week 7-8)
+1. Enable AI-generated detection models
+2. Define policy (block vs label)
+3. Implement flagging/labeling logic
+4. User communication about policy
+5. Monitor false positive rate
+
+---
+
+## Testing Strategy
+
+### CSAM Detection Testing
+⚠️ **NEVER use real CSAM for testing**
+
+**Safe Testing Approaches**:
+1. Synthetic test images (if Hive provides)
+2. Hash matching test vectors (non-CSAM hashes)
+3. Adult content that should NOT match CSAM
+4. Borderline content (clothed minors in non-sexual context)
+
+### Adult Content Testing
+- Known adult content (should age-gate)
+- Suggestive but not explicit (borderline cases)
+- Artistic nudity (classical art, medical)
+- False positives (beach photos, etc.)
+
+### Integration Testing
+- Full pipeline: upload → moderation → classification → action
+- User flows: opt-in, age verification, blurred previews
+- Moderator flows: review queue, decisions, appeals
+
+---
+
+## Open Questions
+
+1. **Age verification method?**
+   - Self-reported sufficient for now?
+   - Need robust verification (ID check)?
+   - UK/EU users require stricter verification?
+
+2. **AI-generated policy?**
+   - Hard block or allow with label?
+   - User opt-in to see AI content?
+   - Exceptions for artistic use?
+
+3. **Appeal process?**
+   - How do users appeal moderation decisions?
+   - Who reviews appeals?
+   - Timeline for appeals?
+
+4. **CSAM detection threshold?**
+   - Zero tolerance (any score > 0)?
+   - Use Hive's recommended threshold?
+   - Hash match = instant block?
+
+5. **Human moderator capacity?**
+   - How many moderators?
+   - Response time SLA?
+   - 24/7 coverage needed?
+
+---
+
+## Next Steps
+
+**Immediate**:
+1. Contact Hive sales for CSAM Detection API access
+2. Confirm pricing for CSAM + Visual Moderation
+3. Define AI-generated content policy (block vs label)
+4. Determine age verification approach
+
+**Ready to Implement**:
+- CSAM detection integration (highest priority)
+- Adult content age-gating
+- Hive Visual Moderation API adapter
+
+Want me to start implementing the Hive CSAM + Visual Moderation integration?

--- a/MIGRATION_RECOMMENDATION.md
+++ b/MIGRATION_RECOMMENDATION.md
@@ -1,0 +1,424 @@
+# Migration from Sightengine - Recommendation
+
+## Problem Statement
+
+Sightengine is **mostly wrong** on:
+1. **Nudity detection** - Critical for content moderation
+2. **AI-generated content detection** - Important for authenticity
+
+These are core moderation categories. Accuracy is more important than cost.
+
+---
+
+## Recommended Solution: **Hive Moderation API**
+
+### Why Hive?
+
+**Best-in-class accuracy for your problem areas:**
+- **Nudity detection: 97% accuracy** (vs Sightengine's poor performance)
+- **AI-generated content: 98%+ accuracy** (vs Sightengine's poor performance)
+- **Deepfake video detection** with confidence scoring
+- Error rate **6-12x lower** than major cloud providers (AWS, Google)
+
+**Technical advantages:**
+- Built specifically for content moderation (not general video AI)
+- Fast response times (under 200ms)
+- Multi-modal: images, videos, GIFs, live streams
+- Used in production by Reddit, Quora, TikTok, Chatroulette
+- U.S. Department of Defense invested $2.4M in their tech
+
+**API simplicity:**
+- Synchronous API like Sightengine (easier migration)
+- Similar request/response pattern
+- RESTful design
+
+### Hive API Example
+
+```javascript
+// Hive Visual Moderation API
+POST https://api.thehive.ai/api/v2/task/sync
+
+{
+  "url": "https://cdn.divine.video/abc123.mp4",
+  "moderation_classes": [
+    "yes_sexual_content",
+    "yes_sexual_activity",
+    "yes_suggestive",
+    "yes_deepfake",
+    "yes_ai_generated",
+    "yes_violence",
+    "yes_gore",
+    // ... etc
+  ]
+}
+
+// Response format (simplified)
+{
+  "status": [{
+    "response": {
+      "output": [
+        {
+          "time": 2.5,  // seconds into video
+          "classes": [
+            {
+              "class": "yes_sexual_content",
+              "score": 0.95  // confidence
+            },
+            {
+              "class": "yes_deepfake",
+              "score": 0.02
+            }
+          ]
+        }
+      ]
+    }
+  }]
+}
+```
+
+---
+
+## Alternative/Complementary Solution: Specialized AI Detection
+
+If you want **best-in-class AI detection** as a separate service:
+
+### Option A: **Hive AI Deepfake Detection** (included in their API)
+- Face detection + deepfake classification
+- "yes_deepfake" / "no_deepfake" with confidence
+- Already integrated with nudity/violence detection
+
+### Option B: **Reality Defender** (dedicated AI detection)
+- Multi-model deepfake detection platform
+- Real-time analysis
+- API + web interface
+- Handles video, images, audio, text
+- Could run in parallel with Hive for validation
+
+### Option C: **Sensity AI**
+- 95-98% accuracy
+- Comprehensive (video, images, audio, text)
+- API + cloud-based or on-premise
+- Enterprise-focused
+
+### Option D: **MediaFirewall**
+- Specialized in AI-generated content filtering
+- Detects GAN videos, deepfakes, stylized fabrications
+- SDK/API integration (< 48 hours)
+- Good for detecting fully synthetic videos (not just face swaps)
+
+---
+
+## Recommended Architecture
+
+### Single Provider (Simplest)
+```
+Divine Video → Hive API → Moderation Result
+```
+- Use Hive for everything (nudity, violence, gore, AI detection, deepfakes)
+- Simplest migration
+- Best overall accuracy
+
+### Dual Provider (Belt & Suspenders for AI Detection)
+```
+Divine Video → Hive API → Nudity, Violence, Gore, etc.
+            ↘ Reality Defender / Sensity → AI/Deepfake detection
+```
+- Use Hive for general moderation (97% nudity accuracy)
+- Use specialized service for AI detection (96-98% accuracy)
+- Higher confidence in AI detection results
+- More complex integration, higher cost
+
+### Recommended: **Start with Hive alone**
+- Covers both your problem areas well
+- Simpler migration
+- Can add specialized AI detection later if needed
+
+---
+
+## Migration Plan
+
+### Phase 1: Parallel Testing (Week 1-2)
+1. Sign up for Hive API (free trial available)
+2. Implement Hive adapter using pluggable architecture
+3. Run Sightengine + Hive in parallel on sample videos
+4. Log both results, compare accuracy
+5. **Validate that Hive fixes your nudity/AI detection issues**
+
+### Phase 2: Gradual Rollout (Week 3-4)
+1. Switch to Hive as primary, keep Sightengine as fallback
+2. Monitor accuracy, false positive/negative rates
+3. Gather feedback from any manual review process
+4. Fine-tune confidence thresholds
+
+### Phase 3: Full Cutover (Week 5)
+1. Switch entirely to Hive
+2. Cancel Sightengine subscription
+3. Remove Sightengine code (keep in git history)
+
+### Phase 4: Optional Enhancement (Week 6+)
+1. If AI detection still needs improvement, add Reality Defender or Sensity
+2. Run both Hive + specialized detector, require agreement on AI-generated flags
+3. Reduce false positives/negatives further
+
+---
+
+## Cost Comparison (Estimated)
+
+| Provider | Model | Estimated Cost (1000 hrs/mo) | Notes |
+|----------|-------|------------------------------|-------|
+| Sightengine | Tier-based | ~$399/mo | Cheap but inaccurate for nudity/AI |
+| Hive | Volume-based | $1,000-3,000/mo (est) | Need to contact for pricing |
+| AWS Rekognition | Pay-per-use | ~$6,000/mo | Good but no AI detection |
+| Reality Defender | Enterprise | Unknown | Likely higher, specialized service |
+
+**Key insight:** Hive will likely cost 3-8x more than Sightengine, but if you're getting mostly wrong results on your core categories, the current setup has no value regardless of cost.
+
+---
+
+## Implementation Code Changes
+
+Using the pluggable architecture from `MODERATION_PROVIDER_ARCHITECTURE.md`:
+
+### 1. Create Hive Adapter
+
+```javascript
+// src/moderation/providers/hive/adapter.mjs
+
+import { BaseModerationProvider, STANDARD_CAPABILITIES } from '../base-provider.mjs';
+
+export class HiveProvider extends BaseModerationProvider {
+  constructor() {
+    super('hive', {
+      ...STANDARD_CAPABILITIES,
+      aiGenerated: true,
+      deepfake: true,
+      textOcr: true,
+      liveStream: true
+    });
+  }
+
+  isConfigured(env) {
+    return !!env.HIVE_API_KEY;
+  }
+
+  async moderate(videoUrl, metadata, env, options = {}) {
+    const response = await fetch('https://api.thehive.ai/api/v2/task/sync', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Token ${env.HIVE_API_KEY}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        url: videoUrl,
+        moderation_classes: [
+          'yes_sexual_content',
+          'yes_sexual_activity',
+          'yes_suggestive',
+          'yes_deepfake',
+          'yes_ai_generated',
+          'yes_violence',
+          'yes_gore',
+          'yes_offensive',
+          'yes_weapon',
+          'yes_drugs',
+          'yes_alcohol',
+          'yes_gambling',
+          'yes_self_harm'
+        ]
+      })
+    });
+
+    const data = await response.json();
+
+    // Normalize Hive response to standard format
+    return this.normalizeResponse(data, metadata);
+  }
+
+  normalizeResponse(hiveData, metadata) {
+    // Parse Hive response and convert to standard format
+    const frames = hiveData.status[0].response.output || [];
+
+    // Extract max scores across all frames
+    const maxScores = {
+      nudity: 0,
+      violence: 0,
+      gore: 0,
+      offensive: 0,
+      weapons: 0,
+      drugs: 0,
+      alcohol: 0,
+      gambling: 0,
+      selfHarm: 0,
+      aiGenerated: 0,
+      deepfake: 0
+    };
+
+    const flaggedFrames = [];
+
+    for (const frame of frames) {
+      const frameScores = {
+        nudity: Math.max(
+          this.getScore(frame, 'yes_sexual_content'),
+          this.getScore(frame, 'yes_sexual_activity'),
+          this.getScore(frame, 'yes_suggestive')
+        ),
+        violence: this.getScore(frame, 'yes_violence'),
+        gore: this.getScore(frame, 'yes_gore'),
+        offensive: this.getScore(frame, 'yes_offensive'),
+        weapons: this.getScore(frame, 'yes_weapon'),
+        drugs: this.getScore(frame, 'yes_drugs'),
+        alcohol: this.getScore(frame, 'yes_alcohol'),
+        gambling: this.getScore(frame, 'yes_gambling'),
+        selfHarm: this.getScore(frame, 'yes_self_harm'),
+        aiGenerated: this.getScore(frame, 'yes_ai_generated'),
+        deepfake: this.getScore(frame, 'yes_deepfake')
+      };
+
+      // Update max scores
+      for (const [key, score] of Object.entries(frameScores)) {
+        maxScores[key] = Math.max(maxScores[key], score);
+      }
+
+      // Flag frames with high scores
+      if (Object.values(frameScores).some(s => s >= 0.7)) {
+        flaggedFrames.push({
+          position: frame.time,
+          ...frameScores
+        });
+      }
+    }
+
+    return {
+      provider: this.name,
+      scores: maxScores,
+      details: {}, // Hive has less granular subcategories
+      flaggedFrames,
+      raw: hiveData
+    };
+  }
+
+  getScore(frame, className) {
+    const classResult = frame.classes?.find(c => c.class === className);
+    return classResult ? classResult.score : 0;
+  }
+}
+```
+
+### 2. Update Environment Variables
+
+```bash
+# .env or wrangler.toml
+HIVE_API_KEY=your-hive-api-key
+PRIMARY_MODERATION_PROVIDER=hive
+FALLBACK_MODERATION_PROVIDERS=sightengine  # Keep as fallback during transition
+```
+
+### 3. Register Provider
+
+```javascript
+// src/moderation/providers/index.mjs
+
+import { SightengineProvider } from './sightengine/adapter.mjs';
+import { HiveProvider } from './hive/adapter.mjs';
+
+export const PROVIDERS = {
+  sightengine: new SightengineProvider(),
+  hive: new HiveProvider()
+};
+```
+
+**No changes needed to pipeline.mjs** - it already uses the orchestrator!
+
+---
+
+## Testing Strategy
+
+### 1. Create Test Dataset
+- Collect 50-100 videos with known ground truth:
+  - Clear nudity (should flag)
+  - Suggestive but not nude (borderline)
+  - Safe content (should not flag)
+  - AI-generated videos (should flag)
+  - Real videos (should not flag AI)
+
+### 2. Run Comparison
+```javascript
+// scripts/compare-providers.mjs
+const results = await moderateWithMultiple(videoUrl, metadata, env, [
+  'sightengine',
+  'hive'
+]);
+
+// Log differences
+console.log('Sightengine nudity:', results.sightengine.scores.nudity);
+console.log('Hive nudity:', results.hive.scores.nudity);
+console.log('Ground truth: NUDE');
+```
+
+### 3. Measure Accuracy
+- False positive rate (flagged safe content)
+- False negative rate (missed unsafe content)
+- Precision/recall for each category
+
+### 4. Validate Improvement
+- Document cases where Hive is correct and Sightengine is wrong
+- Share results with me to confirm migration is worth it
+
+---
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Hive costs too much | Run cost analysis with actual volume, negotiate pricing |
+| Hive API different than expected | Implement adapter with proper error handling |
+| Hive still inaccurate | Have fallback to try Reality Defender for AI detection |
+| Migration breaks production | Use parallel testing, gradual rollout with fallback |
+| Lose Sightengine's unique features | Evaluate if QR code, text OCR actually used/needed |
+
+---
+
+## Decision Points
+
+Before proceeding, answer these questions:
+
+1. **What's your current false positive/negative rate with Sightengine?**
+   - Do you have ground truth data to measure?
+   - Is manual review catching lots of Sightengine errors?
+
+2. **Which category is more critical: nudity or AI detection?**
+   - If nudity: Hive alone is great
+   - If AI: Consider Hive + Reality Defender
+
+3. **What's your monthly video volume?**
+   - Need to estimate Hive costs
+   - May affect which provider is best
+
+4. **Do you have a budget for moderation?**
+   - Willing to pay 3-8x more for accuracy?
+   - Or need to stay cheap and accept lower accuracy?
+
+5. **Timeline urgency?**
+   - Can do proper parallel testing? (recommended)
+   - Or need to switch ASAP?
+
+---
+
+## My Recommendation
+
+**Go with Hive immediately.**
+
+Reasons:
+1. Solves both your problems (97% nudity, 98% AI detection)
+2. Battle-tested (Reddit, TikTok use it)
+3. Similar API to Sightengine (easy migration)
+4. Worth paying more for accuracy on core features
+
+**Migration timeline: 2-4 weeks**
+
+1. Week 1: Sign up, implement adapter, parallel test
+2. Week 2: Validate accuracy improvement, adjust thresholds
+3. Week 3: Switch to Hive primary with Sightengine fallback
+4. Week 4: Full cutover, remove Sightengine
+
+Want me to start implementing the Hive adapter?

--- a/MODERATION_PROVIDER_ARCHITECTURE.md
+++ b/MODERATION_PROVIDER_ARCHITECTURE.md
@@ -1,0 +1,757 @@
+# Pluggable Video Moderation Provider Architecture
+
+## Design Goals
+
+1. **Provider Independence**: Easy to add/remove/swap moderation providers
+2. **Normalized Interface**: Consistent internal API regardless of provider
+3. **Fallback Support**: Graceful degradation when primary provider fails
+4. **Parallel Processing**: Run multiple providers for validation/comparison
+5. **Configuration-Driven**: Select provider per-video or globally via config
+6. **Backward Compatible**: Existing code continues to work unchanged
+
+---
+
+## Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                     Moderation Pipeline                          │
+│                    (pipeline.mjs)                                │
+└───────────────────────────┬─────────────────────────────────────┘
+                            │
+                            ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                  Provider Orchestrator                           │
+│              (providers/orchestrator.mjs)                        │
+│                                                                  │
+│  • Provider selection logic                                      │
+│  • Fallback chains                                               │
+│  • Parallel execution                                            │
+│  • Response normalization                                        │
+└─────┬──────────┬──────────┬──────────┬─────────────────────────┘
+      │          │          │          │
+      ▼          ▼          ▼          ▼
+┌──────────┐ ┌─────────┐ ┌────────┐ ┌────────┐
+│Sightengine│ │   AWS   │ │ Google │ │  Hive  │
+│ Provider │ │Provider │ │Provider│ │Provider│
+│  Adapter │ │ Adapter │ │ Adapter│ │ Adapter│
+└──────────┘ └─────────┘ └────────┘ └────────┘
+      │          │          │          │
+      ▼          ▼          ▼          ▼
+┌──────────┐ ┌─────────┐ ┌────────┐ ┌────────┐
+│Sightengine│ │   AWS   │ │ Google │ │  Hive  │
+│    API    │ │   API   │ │  API   │ │  API   │
+└──────────┘ └─────────┘ └────────┘ └────────┘
+```
+
+---
+
+## Core Interfaces
+
+### 1. Provider Adapter Interface
+
+Every provider adapter implements:
+
+```javascript
+/**
+ * @typedef {Object} ModerationProvider
+ * @property {string} name - Provider identifier (e.g., 'sightengine', 'aws-rekognition')
+ * @property {Function} moderate - Main moderation function
+ * @property {Function} isConfigured - Check if provider credentials are available
+ * @property {Object} capabilities - What this provider can detect
+ */
+
+/**
+ * Standard moderation function signature for all providers
+ * @param {string} videoUrl - Public URL to video file
+ * @param {Object} metadata - Video metadata (sha256, etc)
+ * @param {Object} env - Environment variables with API credentials
+ * @param {Object} options - Provider-specific options
+ * @returns {Promise<NormalizedModerationResult>}
+ */
+async function moderate(videoUrl, metadata, env, options = {}) {
+  // Provider-specific implementation
+}
+
+/**
+ * Check if provider is configured with necessary credentials
+ * @param {Object} env - Environment variables
+ * @returns {boolean}
+ */
+function isConfigured(env) {
+  // Check for required env vars
+}
+
+/**
+ * Provider capabilities
+ */
+const capabilities = {
+  deepfake: true/false,
+  qrCode: true/false,
+  customModels: true/false,
+  liveStream: true/false,
+  // ... etc
+};
+```
+
+### 2. Normalized Response Format
+
+All providers return this standardized format:
+
+```javascript
+/**
+ * @typedef {Object} NormalizedModerationResult
+ */
+{
+  // Provider metadata
+  provider: 'sightengine',
+  processingTime: 1234, // milliseconds
+
+  // Normalized category scores (0.0 - 1.0)
+  scores: {
+    nudity: 0.85,
+    violence: 0.12,
+    gore: 0.05,
+    offensive: 0.01,
+    weapons: 0.0,
+    drugs: 0.0,
+    alcohol: 0.0,
+    tobacco: 0.0,
+    gambling: 0.0,
+    selfHarm: 0.0,
+    aiGenerated: 0.45,
+    deepfake: 0.02,
+    // ... all standard categories
+  },
+
+  // Detailed subcategories (provider-specific, normalized names)
+  details: {
+    nudity: {
+      sexualActivity: 0.85,
+      sexualDisplay: 0.12,
+      erotica: 0.45,
+      // ...
+    },
+    violence: {
+      physicalViolence: 0.12,
+      firearmThreat: 0.0,
+      // ...
+    },
+    // ...
+  },
+
+  // Flagged frames/timestamps
+  flaggedFrames: [
+    {
+      position: 2.5, // seconds
+      primaryConcern: 'nudity',
+      primaryScore: 0.85,
+      scores: { /* all scores for this frame */ },
+      details: { /* detailed breakdown */ }
+    }
+  ],
+
+  // Provider-specific raw data (for debugging/auditing)
+  raw: {
+    // Original provider response
+  }
+}
+```
+
+---
+
+## File Structure
+
+```
+src/
+  moderation/
+    pipeline.mjs              # Main orchestration (existing)
+    classifier.mjs            # Classification logic (existing)
+
+    providers/
+      index.mjs               # Provider registry and exports
+      orchestrator.mjs        # Provider selection and execution logic
+      base-provider.mjs       # Base class/interface for providers
+
+      sightengine/
+        adapter.mjs           # Sightengine provider adapter
+        normalizer.mjs        # Response normalization
+        client.mjs            # API client (refactored from existing sightengine.mjs)
+
+      aws-rekognition/
+        adapter.mjs           # AWS Rekognition adapter
+        normalizer.mjs        # Response normalization
+        client.mjs            # AWS SDK wrapper
+
+      google-video-ai/
+        adapter.mjs           # Google Video AI adapter
+        normalizer.mjs        # Response normalization
+        client.mjs            # Google SDK wrapper
+
+      hive/
+        adapter.mjs           # Hive adapter
+        normalizer.mjs        # Response normalization
+        client.mjs            # API client
+```
+
+---
+
+## Implementation Example
+
+### Base Provider Interface
+
+```javascript
+// src/moderation/providers/base-provider.mjs
+
+/**
+ * Base provider class that all adapters extend
+ */
+export class BaseModerationProvider {
+  constructor(name, capabilities) {
+    this.name = name;
+    this.capabilities = capabilities;
+  }
+
+  /**
+   * Check if provider is configured
+   * @param {Object} env
+   * @returns {boolean}
+   */
+  isConfigured(env) {
+    throw new Error('isConfigured() must be implemented by provider');
+  }
+
+  /**
+   * Moderate video
+   * @param {string} videoUrl
+   * @param {Object} metadata
+   * @param {Object} env
+   * @param {Object} options
+   * @returns {Promise<NormalizedModerationResult>}
+   */
+  async moderate(videoUrl, metadata, env, options = {}) {
+    throw new Error('moderate() must be implemented by provider');
+  }
+
+  /**
+   * Get provider info
+   * @returns {Object}
+   */
+  getInfo() {
+    return {
+      name: this.name,
+      capabilities: this.capabilities
+    };
+  }
+}
+
+/**
+ * Standard capabilities template
+ */
+export const STANDARD_CAPABILITIES = {
+  // Detection capabilities
+  nudity: true,
+  violence: true,
+  gore: true,
+  offensive: true,
+  weapons: true,
+  drugs: true,
+  alcohol: true,
+  tobacco: true,
+  gambling: true,
+  selfHarm: true,
+  aiGenerated: false,
+  deepfake: false,
+  textOcr: false,
+  qrCode: false,
+
+  // Technical capabilities
+  customModels: false,
+  liveStream: false,
+  humanReview: false,
+  asyncProcessing: false,
+
+  // Supported input
+  maxFileSizeMB: null,
+  maxDurationMinutes: null,
+  supportedFormats: ['mp4', 'mov', 'avi', 'webm']
+};
+```
+
+### Sightengine Adapter
+
+```javascript
+// src/moderation/providers/sightengine/adapter.mjs
+
+import { BaseModerationProvider, STANDARD_CAPABILITIES } from '../base-provider.mjs';
+import { moderateVideoWithSightengine } from './client.mjs';
+import { normalizeSightengineResponse } from './normalizer.mjs';
+
+export class SightengineProvider extends BaseModerationProvider {
+  constructor() {
+    super('sightengine', {
+      ...STANDARD_CAPABILITIES,
+      aiGenerated: true,
+      deepfake: true,
+      textOcr: true,
+      qrCode: true,
+      liveStream: true
+    });
+  }
+
+  isConfigured(env) {
+    return !!(env.SIGHTENGINE_API_USER && env.SIGHTENGINE_API_SECRET);
+  }
+
+  async moderate(videoUrl, metadata, env, options = {}) {
+    const startTime = Date.now();
+
+    try {
+      // Call existing Sightengine client
+      const rawResult = await moderateVideoWithSightengine(
+        videoUrl,
+        metadata,
+        env,
+        options.fetchFn
+      );
+
+      // Normalize to standard format
+      const normalized = normalizeSightengineResponse(rawResult);
+
+      return {
+        ...normalized,
+        provider: this.name,
+        processingTime: Date.now() - startTime,
+        raw: rawResult
+      };
+
+    } catch (error) {
+      throw new Error(`Sightengine moderation failed: ${error.message}`);
+    }
+  }
+}
+```
+
+### AWS Rekognition Adapter
+
+```javascript
+// src/moderation/providers/aws-rekognition/adapter.mjs
+
+import { BaseModerationProvider, STANDARD_CAPABILITIES } from '../base-provider.mjs';
+import { moderateVideoWithRekognition } from './client.mjs';
+import { normalizeRekognitionResponse } from './normalizer.mjs';
+
+export class AWSRekognitionProvider extends BaseModerationProvider {
+  constructor() {
+    super('aws-rekognition', {
+      ...STANDARD_CAPABILITIES,
+      customModels: true,
+      humanReview: true,
+      asyncProcessing: true,
+      maxFileSizeMB: 10240, // 10GB
+      maxDurationMinutes: 360 // 6 hours
+    });
+  }
+
+  isConfigured(env) {
+    return !!(
+      env.AWS_ACCESS_KEY_ID &&
+      env.AWS_SECRET_ACCESS_KEY &&
+      env.AWS_REGION
+    );
+  }
+
+  async moderate(videoUrl, metadata, env, options = {}) {
+    const startTime = Date.now();
+
+    try {
+      // Call AWS Rekognition (async pattern)
+      const rawResult = await moderateVideoWithRekognition(
+        videoUrl,
+        metadata,
+        env,
+        options
+      );
+
+      // Normalize to standard format
+      const normalized = normalizeRekognitionResponse(rawResult);
+
+      return {
+        ...normalized,
+        provider: this.name,
+        processingTime: Date.now() - startTime,
+        raw: rawResult
+      };
+
+    } catch (error) {
+      throw new Error(`AWS Rekognition moderation failed: ${error.message}`);
+    }
+  }
+}
+```
+
+### Provider Orchestrator
+
+```javascript
+// src/moderation/providers/orchestrator.mjs
+
+import { SightengineProvider } from './sightengine/adapter.mjs';
+import { AWSRekognitionProvider } from './aws-rekognition/adapter.mjs';
+// ... other providers
+
+/**
+ * Provider registry
+ */
+const PROVIDERS = {
+  sightengine: new SightengineProvider(),
+  'aws-rekognition': new AWSRekognitionProvider(),
+  // ... register other providers
+};
+
+/**
+ * Get provider by name
+ */
+export function getProvider(name) {
+  const provider = PROVIDERS[name];
+  if (!provider) {
+    throw new Error(`Unknown provider: ${name}`);
+  }
+  return provider;
+}
+
+/**
+ * Get all configured providers
+ */
+export function getConfiguredProviders(env) {
+  return Object.values(PROVIDERS).filter(p => p.isConfigured(env));
+}
+
+/**
+ * Select provider based on strategy
+ */
+export function selectProvider(env, strategy = 'default') {
+  const configured = getConfiguredProviders(env);
+
+  if (configured.length === 0) {
+    throw new Error('No moderation providers configured');
+  }
+
+  // Default: use PRIMARY_MODERATION_PROVIDER env var or first configured
+  if (strategy === 'default') {
+    const primaryName = env.PRIMARY_MODERATION_PROVIDER || 'sightengine';
+    const primary = configured.find(p => p.name === primaryName);
+    return primary || configured[0];
+  }
+
+  // Cheapest: select based on volume
+  if (strategy === 'cheapest') {
+    // Logic to select cheapest based on estimated volume
+    // For now, simple heuristic
+    return configured.find(p => p.name === 'sightengine') || configured[0];
+  }
+
+  // Custom capability requirements
+  if (strategy.capabilities) {
+    return configured.find(p =>
+      Object.keys(strategy.capabilities).every(cap =>
+        p.capabilities[cap] === strategy.capabilities[cap]
+      )
+    ) || configured[0];
+  }
+
+  return configured[0];
+}
+
+/**
+ * Moderate with fallback chain
+ */
+export async function moderateWithFallback(videoUrl, metadata, env, options = {}) {
+  const providers = options.providers || [
+    env.PRIMARY_MODERATION_PROVIDER || 'sightengine',
+    'aws-rekognition' // fallback
+  ];
+
+  const errors = [];
+
+  for (const providerName of providers) {
+    try {
+      const provider = getProvider(providerName);
+
+      if (!provider.isConfigured(env)) {
+        console.log(`[MODERATION] Provider ${providerName} not configured, skipping`);
+        continue;
+      }
+
+      console.log(`[MODERATION] Attempting moderation with ${providerName}`);
+      const result = await provider.moderate(videoUrl, metadata, env, options);
+      console.log(`[MODERATION] Success with ${providerName}`);
+
+      return result;
+
+    } catch (error) {
+      console.error(`[MODERATION] Provider ${providerName} failed:`, error);
+      errors.push({ provider: providerName, error: error.message });
+    }
+  }
+
+  throw new Error(
+    `All providers failed: ${errors.map(e => `${e.provider}: ${e.error}`).join('; ')}`
+  );
+}
+
+/**
+ * Moderate with multiple providers in parallel (for comparison/validation)
+ */
+export async function moderateWithMultiple(videoUrl, metadata, env, providerNames = []) {
+  const providers = providerNames.map(name => getProvider(name))
+    .filter(p => p.isConfigured(env));
+
+  if (providers.length === 0) {
+    throw new Error('No configured providers specified for parallel moderation');
+  }
+
+  const results = await Promise.allSettled(
+    providers.map(p => p.moderate(videoUrl, metadata, env))
+  );
+
+  return {
+    results: results.map((r, i) => ({
+      provider: providers[i].name,
+      status: r.status,
+      result: r.status === 'fulfilled' ? r.value : null,
+      error: r.status === 'rejected' ? r.reason.message : null
+    }))
+  };
+}
+```
+
+### Updated Pipeline
+
+```javascript
+// src/moderation/pipeline.mjs
+
+import { classifyModerationResult } from './classifier.mjs';
+import { fetchNostrEventBySha256, parseVideoEventMetadata } from '../nostr/relay-client.mjs';
+import { moderateWithFallback } from './providers/orchestrator.mjs';
+
+/**
+ * Run full moderation pipeline on a video
+ */
+export async function moderateVideo(videoData, env, fetchFn = fetch) {
+  const { sha256, uploadedBy, uploadedAt, metadata } = videoData;
+
+  if (!env.CDN_DOMAIN) {
+    throw new Error('CDN_DOMAIN not configured');
+  }
+
+  // Step 1: Fetch Nostr event context
+  let nostrContext = null;
+  let videoUrl = `https://${env.CDN_DOMAIN}/${sha256}.mp4`;
+
+  try {
+    const relays = env.NOSTR_RELAY_URL ? [env.NOSTR_RELAY_URL] : ['wss://relay3.openvine.co'];
+    const event = await fetchNostrEventBySha256(sha256, relays);
+    if (event) {
+      nostrContext = parseVideoEventMetadata(event);
+      if (nostrContext.url) {
+        videoUrl = nostrContext.url;
+      }
+    }
+  } catch (error) {
+    console.error(`[MODERATION] Failed to fetch Nostr context:`, error);
+  }
+
+  // Step 2: Moderate with automatic provider selection and fallback
+  const moderationResult = await moderateWithFallback(
+    videoUrl,
+    { sha256 },
+    env,
+    { fetchFn }
+  );
+
+  // Step 3: Classify result (now provider-agnostic)
+  const classification = classifyModerationResult({
+    maxNudityScore: moderationResult.scores.nudity,
+    maxViolenceScore: moderationResult.scores.violence,
+    maxAiGeneratedScore: moderationResult.scores.aiGenerated,
+    maxScores: moderationResult.scores,
+    flaggedFrames: moderationResult.flaggedFrames
+  }, env);
+
+  // Step 4: Return complete result
+  return {
+    ...classification,
+
+    provider: moderationResult.provider,
+    detailedCategories: moderationResult.details,
+
+    sha256,
+    uploadedBy,
+    uploadedAt,
+    metadata,
+    cdnUrl: videoUrl,
+    nostrContext,
+
+    // Raw provider data (for debugging)
+    providerRaw: moderationResult.raw
+  };
+}
+```
+
+---
+
+## Configuration
+
+### Environment Variables
+
+```bash
+# Provider selection
+PRIMARY_MODERATION_PROVIDER=sightengine  # or aws-rekognition, google-video-ai, etc
+FALLBACK_MODERATION_PROVIDERS=aws-rekognition,google-video-ai  # comma-separated
+
+# Sightengine
+SIGHTENGINE_API_USER=your-user
+SIGHTENGINE_API_SECRET=your-secret
+
+# AWS Rekognition
+AWS_ACCESS_KEY_ID=your-key
+AWS_SECRET_ACCESS_KEY=your-secret
+AWS_REGION=us-east-1
+
+# Google Cloud
+GOOGLE_CLOUD_PROJECT=your-project
+GOOGLE_APPLICATION_CREDENTIALS=/path/to/credentials.json
+
+# Hive
+HIVE_API_KEY=your-key
+```
+
+### Per-Video Provider Selection
+
+```javascript
+// In queue message or metadata
+{
+  sha256: 'abc123',
+  moderationOptions: {
+    provider: 'aws-rekognition',  // override default
+    // or
+    providers: ['sightengine', 'aws-rekognition'],  // fallback chain
+    // or
+    parallel: ['sightengine', 'aws-rekognition']  // compare results
+  }
+}
+```
+
+---
+
+## Migration Path
+
+### Phase 1: Refactor Existing Code
+1. Create base provider interface
+2. Wrap existing Sightengine code in adapter
+3. No behavior change, just structure
+
+### Phase 2: Add Orchestrator
+1. Implement provider registry
+2. Add selection logic
+3. Still only Sightengine, but through orchestrator
+
+### Phase 3: Add Second Provider
+1. Implement AWS Rekognition adapter
+2. Add as fallback option
+3. Test in parallel mode
+
+### Phase 4: Production Rollout
+1. Monitor both providers in parallel
+2. Compare accuracy and reliability
+3. Gradually shift traffic based on results
+
+### Phase 5: Additional Providers
+1. Add Google, Hive, etc as needed
+2. Optimize provider selection strategy
+3. Implement cost optimization logic
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+- Each adapter tested independently
+- Mock provider APIs
+- Test normalization logic
+
+### Integration Tests
+- Test orchestrator selection logic
+- Test fallback chains
+- Test parallel execution
+
+### Comparison Tests
+- Run same video through multiple providers
+- Compare normalized results
+- Log discrepancies for analysis
+
+### End-to-End Tests
+- Test full pipeline with each provider
+- Ensure classifier works with all normalized formats
+- Verify database storage compatibility
+
+---
+
+## Monitoring and Observability
+
+### Metrics to Track
+- Provider selection frequency
+- Provider success/failure rates
+- Processing times per provider
+- Cost per video by provider
+- Accuracy comparisons (when running parallel)
+- Fallback trigger frequency
+
+### Logging
+```javascript
+{
+  event: 'moderation_complete',
+  sha256: 'abc123',
+  provider: 'sightengine',
+  processingTime: 1234,
+  fallbackUsed: false,
+  classification: 'APPROVED',
+  scores: { /* ... */ }
+}
+
+{
+  event: 'moderation_fallback',
+  sha256: 'abc123',
+  primaryProvider: 'sightengine',
+  fallbackProvider: 'aws-rekognition',
+  primaryError: 'API timeout',
+  fallbackSuccess: true
+}
+```
+
+---
+
+## Future Enhancements
+
+1. **Smart Provider Selection**
+   - ML model to select best provider per video type
+   - Cost optimization based on volume predictions
+   - Capability-based routing (deepfake → Sightengine)
+
+2. **Consensus Moderation**
+   - Run multiple providers, require agreement
+   - Reduce false positives/negatives
+   - Human review for disagreements
+
+3. **Caching Layer**
+   - Cache results by video hash
+   - Avoid re-processing same content
+
+4. **Custom Model Training**
+   - Use AWS custom adapters for Divine-specific content
+   - Feedback loop from human reviews
+
+5. **Real-Time Switching**
+   - Monitor provider performance
+   - Automatic failover on degradation
+   - Cost-based dynamic routing

--- a/PLUGGABLE_MODERATION_GUIDE.md
+++ b/PLUGGABLE_MODERATION_GUIDE.md
@@ -1,0 +1,482 @@
+// ABOUTME: User guide for the pluggable moderation provider system
+// ABOUTME: Configuration, usage, and provider switching documentation
+
+# Pluggable Moderation System Guide
+
+## Overview
+
+The Divine moderation service uses a pluggable architecture that allows you to:
+- Switch between moderation providers (AWS Rekognition, Sightengine, etc.)
+- Configure fallback chains (primary → backup)
+- Run multiple providers in parallel for comparison
+- Add new providers without changing existing code
+
+---
+
+## Quick Start
+
+### 1. Configure Environment Variables
+
+```bash
+# Copy example
+cp .env.example .env
+
+# Edit .env and set:
+PRIMARY_MODERATION_PROVIDER=aws-rekognition
+
+# AWS credentials
+AWS_ACCESS_KEY_ID=your-key
+AWS_SECRET_ACCESS_KEY=your-secret
+AWS_REGION=us-east-1
+AWS_S3_BUCKET=divine-moderation-videos
+```
+
+### 2. Install Dependencies
+
+```bash
+npm install
+# or
+pnpm install
+```
+
+### 3. Use in Your Code
+
+```javascript
+import { moderateVideo } from './src/moderation/pipeline.mjs';
+
+const result = await moderateVideo({
+  sha256: 'video-hash',
+  uploadedBy: 'nostr-pubkey',
+  uploadedAt: Date.now()
+}, env);
+
+console.log('Provider used:', result.provider);
+console.log('Classification:', result.classification);
+console.log('Scores:', result.detailedCategories);
+```
+
+---
+
+## Available Providers
+
+### AWS Rekognition
+**Status**: ✅ Implemented
+**Configuration**: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `AWS_S3_BUCKET`
+
+**Pros**:
+- Self-serve, transparent pricing
+- 68% lower false positive rate (vs older version)
+- 36% lower false negative rate
+- Custom model training available
+- Proven at scale
+
+**Cons**:
+- Async processing (2-5 seconds per video)
+- Requires S3 upload
+- No AI-generated detection
+
+**Cost**: ~$0.10/minute = ~$0.01 per 6-second video
+
+### Sightengine
+**Status**: ✅ Implemented (legacy)
+**Configuration**: `SIGHTENGINE_API_USER`, `SIGHTENGINE_API_SECRET`
+
+**Pros**:
+- Synchronous API (faster integration)
+- AI-generated + deepfake detection
+- Text OCR, QR code detection
+- Cheaper ($29-$399/mo)
+
+**Cons**:
+- Poor accuracy reported for nudity/adult content
+- High false positive and false negative rates
+
+**Cost**: $29-$399/month (volume tiers)
+
+---
+
+## Configuration Options
+
+### Provider Selection
+
+#### Option 1: Primary Provider (Default)
+```bash
+PRIMARY_MODERATION_PROVIDER=aws-rekognition
+```
+
+Uses specified provider, falls back to first configured if primary unavailable.
+
+#### Option 2: Fallback Chain
+```bash
+PRIMARY_MODERATION_PROVIDER=aws-rekognition
+FALLBACK_MODERATION_PROVIDERS=sightengine
+```
+
+Tries AWS first, falls back to Sightengine on error.
+
+#### Option 3: Per-Video Provider Selection
+```javascript
+await moderateVideo(videoData, env, {
+  providers: ['aws-rekognition']  // Override default
+});
+```
+
+### Thresholds
+
+```bash
+NUDITY_THRESHOLD=0.7
+VIOLENCE_THRESHOLD=0.7
+AI_GENERATED_THRESHOLD=0.7
+```
+
+Scores above threshold trigger flagging/age-gating.
+
+---
+
+## Advanced Usage
+
+### Parallel Comparison
+
+Run multiple providers to compare results:
+
+```javascript
+import { moderateWithMultiple } from './src/moderation/providers/index.mjs';
+
+const results = await moderateWithMultiple(
+  videoUrl,
+  { sha256 },
+  env,
+  ['aws-rekognition', 'sightengine']
+);
+
+console.log('AWS:', results.results[0].result.scores);
+console.log('Sightengine:', results.results[1].result.scores);
+```
+
+### Provider-Specific Options
+
+```javascript
+await moderateVideo(videoData, env, {
+  minConfidence: 80,  // AWS: Raise threshold
+  maxWaitMs: 60000    // AWS: Reduce timeout
+});
+```
+
+### Capability-Based Selection
+
+```javascript
+import { selectProvider } from './src/moderation/providers/index.mjs';
+
+const provider = selectProvider(env, {
+  capabilities: {
+    aiGenerated: true,  // Needs AI detection
+    deepfake: true
+  }
+});
+
+// Would select Sightengine (only provider with these capabilities)
+```
+
+---
+
+## Response Format
+
+All providers return a normalized format:
+
+```javascript
+{
+  // Provider metadata
+  provider: 'aws-rekognition',
+  processingTime: 2500,
+
+  // Normalized scores (0.0-1.0)
+  scores: {
+    nudity: 0.85,
+    violence: 0.12,
+    gore: 0.05,
+    offensive: 0.01,
+    weapons: 0.0,
+    drugs: 0.0,
+    alcohol: 0.0,
+    tobacco: 0.0,
+    gambling: 0.0,
+    selfHarm: 0.0,
+    aiGenerated: 0.0,  // AWS doesn't detect
+    deepfake: 0.0       // AWS doesn't detect
+  },
+
+  // Detailed subcategories
+  details: {
+    nudity: {
+      explicitNudity: 0.85,
+      suggestive: 0.45,
+      // ...
+    },
+    violence: {
+      physicalViolence: 0.12,
+      // ...
+    }
+  },
+
+  // Flagged frames/timestamps
+  flaggedFrames: [
+    {
+      position: 2.5,  // seconds
+      primaryConcern: 'nudity',
+      primaryScore: 0.85,
+      scores: { nudity: 0.85, violence: 0.0, ... }
+    }
+  ],
+
+  // Original provider response
+  raw: { /* AWS/Sightengine original data */ }
+}
+```
+
+---
+
+## Switching Providers
+
+### From Sightengine to AWS
+
+1. **Sign up for AWS**: https://aws.amazon.com/
+2. **Enable Rekognition**: In AWS Console
+3. **Create S3 bucket**: `divine-moderation-videos`
+4. **Create IAM user**: With Rekognition + S3 permissions
+5. **Update .env**:
+```bash
+PRIMARY_MODERATION_PROVIDER=aws-rekognition
+AWS_ACCESS_KEY_ID=AKIA...
+AWS_SECRET_ACCESS_KEY=...
+AWS_REGION=us-east-1
+AWS_S3_BUCKET=divine-moderation-videos
+
+# Keep Sightengine as fallback
+FALLBACK_MODERATION_PROVIDERS=sightengine
+```
+
+6. **Deploy**: Provider automatically switches
+
+### Testing Before Cutover
+
+```javascript
+// Test AWS without switching primary
+const results = await moderateWithMultiple(
+  videoUrl,
+  metadata,
+  env,
+  ['aws-rekognition', 'sightengine']
+);
+
+// Compare accuracy
+console.log('AWS nudity:', results.results[0].result.scores.nudity);
+console.log('Sightengine nudity:', results.results[1].result.scores.nudity);
+```
+
+---
+
+## Adding a New Provider
+
+### 1. Create Adapter
+
+```javascript
+// src/moderation/providers/newprovider/adapter.mjs
+import { BaseModerationProvider, STANDARD_CAPABILITIES } from '../base-provider.mjs';
+
+export class NewProviderAdapter extends BaseModerationProvider {
+  constructor() {
+    super('newprovider', {
+      ...STANDARD_CAPABILITIES,
+      // Override capabilities
+      aiGenerated: true,
+      deepfake: false
+    });
+  }
+
+  isConfigured(env) {
+    return !!env.NEWPROVIDER_API_KEY;
+  }
+
+  async moderate(videoUrl, metadata, env, options = {}) {
+    // Call provider API
+    const rawResult = await callNewProviderAPI(videoUrl, env);
+
+    // Normalize to standard format
+    return {
+      scores: { nudity: rawResult.nudityScore, ... },
+      details: { ... },
+      flaggedFrames: [ ... ]
+    };
+  }
+}
+```
+
+### 2. Register in Orchestrator
+
+```javascript
+// src/moderation/providers/orchestrator.mjs
+import { NewProviderAdapter } from './newprovider/adapter.mjs';
+
+const PROVIDERS = {
+  'aws-rekognition': new AWSRekognitionProvider(),
+  'sightengine': new SightengineProvider(),
+  'newprovider': new NewProviderAdapter()  // Add here
+};
+```
+
+### 3. Use It
+
+```bash
+PRIMARY_MODERATION_PROVIDER=newprovider
+NEWPROVIDER_API_KEY=your-key
+```
+
+---
+
+## Troubleshooting
+
+### "No moderation providers configured"
+
+**Cause**: No provider credentials set in environment
+
+**Fix**: Add `AWS_*` or `SIGHTENGINE_*` credentials to `.env`
+
+### "Provider aws-rekognition not configured"
+
+**Cause**: Missing AWS credentials or S3 bucket
+
+**Fix**: Ensure all of `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `AWS_S3_BUCKET` are set
+
+### "AWS Rekognition moderation failed"
+
+**Causes**:
+- Video URL not accessible
+- S3 upload permissions issue
+- Video format not supported
+- Timeout (video too long)
+
+**Fix**: Check CloudWatch logs, verify S3 permissions, ensure video is mp4/webm
+
+### "All providers failed"
+
+**Cause**: Both primary and fallback providers errored
+
+**Fix**: Check logs for specific errors, verify both providers' credentials
+
+---
+
+## Cost Optimization
+
+### Strategy 1: Use Cheaper Provider for Pre-Screening
+
+```javascript
+// Run cheap provider first
+const quick = await moderateWithFallback(videoUrl, metadata, env, {
+  providers: ['sightengine']
+});
+
+// Only run expensive provider if needed
+if (quick.scores.nudity > 0.5) {
+  const detailed = await moderateWithFallback(videoUrl, metadata, env, {
+    providers: ['aws-rekognition']
+  });
+}
+```
+
+### Strategy 2: Skip AI Detection for ProofMode Videos
+
+```javascript
+// Check ProofMode status
+const hasProofMode = checkProofMode(nostrEvent);
+
+// Skip AI detection if cryptographically verified
+if (hasProofMode) {
+  // AWS doesn't do AI detection anyway, so no savings
+  // But could skip Sightengine's AI models
+}
+```
+
+### Strategy 3: Batch Processing
+
+For AWS, group videos and process in batches to reduce API overhead.
+
+---
+
+## Monitoring
+
+### Log Provider Usage
+
+```javascript
+const result = await moderateVideo(videoData, env);
+
+console.log(`[METRICS] Provider: ${result.provider}`);
+console.log(`[METRICS] Processing time: ${result.processingTime}ms`);
+console.log(`[METRICS] Classification: ${result.classification}`);
+```
+
+### Track Provider Success Rates
+
+```javascript
+let awsSuccess = 0;
+let awsFailed = 0;
+let sightengineSuccess = 0;
+let sightengineFailed = 0;
+
+// Track in your monitoring system
+```
+
+### Cost Tracking
+
+```javascript
+const COST_PER_PROVIDER = {
+  'aws-rekognition': 0.01,  // per video
+  'sightengine': 0.003       // estimated
+};
+
+const cost = COST_PER_PROVIDER[result.provider];
+console.log(`[COST] ${result.provider}: $${cost}`);
+```
+
+---
+
+## Best Practices
+
+1. **Always configure a fallback**: Don't rely on single provider
+2. **Test in parallel before switching**: Compare accuracy on your content
+3. **Monitor both providers**: Track success rates, costs, processing times
+4. **Adjust thresholds per provider**: AWS and Sightengine may need different thresholds
+5. **Keep raw responses**: Store `providerRaw` for debugging
+6. **Use ProofMode**: Skip unnecessary checks when videos are cryptographically verified
+
+---
+
+## FAQ
+
+**Q: Can I use multiple providers simultaneously?**
+A: Yes! Use `moderateWithMultiple()` for parallel execution.
+
+**Q: Will switching providers break existing code?**
+A: No - the normalized response format is the same for all providers.
+
+**Q: Can I switch providers per video?**
+A: Yes - pass `providers` option to `moderateVideo()`.
+
+**Q: Does AWS detect AI-generated content?**
+A: No - use Sightengine for AI/deepfake detection.
+
+**Q: How do I know which provider was used?**
+A: Check `result.provider` field.
+
+**Q: Can I add my own custom provider?**
+A: Yes - implement `BaseModerationProvider` interface and register in orchestrator.
+
+---
+
+## Next Steps
+
+1. ✅ Configure AWS Rekognition or Sightengine
+2. ✅ Test with sample videos
+3. ✅ Compare providers if using multiple
+4. ✅ Adjust thresholds based on results
+5. ✅ Monitor provider performance
+6. ✅ Optimize costs based on usage patterns

--- a/UPDATED_STRATEGY_WITH_PROOFMODE.md
+++ b/UPDATED_STRATEGY_WITH_PROOFMODE.md
@@ -1,0 +1,492 @@
+# Divine Moderation Strategy with ProofMode
+
+**Last Updated**: 2025-10-23
+
+## The ProofMode Advantage
+
+Divine's ProofMode provides **cryptographic authenticity** - a much stronger approach than trying to detect AI-generated content through visual analysis.
+
+### Why ProofMode > AI Detection
+
+**AI Detection (traditional approach)**:
+- ❌ Arms race you can't win (AI improves, artifacts vanish)
+- ❌ False positives (real videos flagged as AI)
+- ❌ False negatives (good AI slips through)
+- ❌ "Real things that look like AI" problem
+
+**ProofMode (cryptographic approach)**:
+- ✅ Cryptographically proves video came from real device camera
+- ✅ Hardware attestation (not spoofable)
+- ✅ Not an arms race - either has proof or doesn't
+- ✅ Handles edge cases gracefully (real → AI-looking content)
+
+---
+
+## Tiered Moderation Strategy
+
+### Tier 1: Videos WITH ProofMode ✅
+
+**Verification Levels**:
+1. **Verified Mobile** (Highest) - Full hardware attestation + PGP signature
+2. **Verified Web** (Medium) - PGP signature, no hardware attestation
+3. **Basic Proof** (Low) - PGP signature only, no capture guarantee
+
+**Moderation Flow**:
+```
+ProofMode Video Upload
+    ↓
+[Verify cryptographic proof]
+    ↓
+VALID PROOF?
+    ↓ YES
+[1. CSAM Check] → MATCH? → BLOCK + NCMEC Report
+    ↓ PASS
+[2. Adult Content] → HIGH? → Age-gate
+    ↓ PASS
+[3. Harmful Content] → HIGH? → Flag for review
+    ↓ PASS
+✅ APPROVED - Publish with verification badge
+```
+
+**Trust Model**:
+- ProofMode proves video is **real camera capture** (not AI-generated)
+- Still need CSAM detection (real devices can capture CSAM)
+- Still need adult content detection (real cameras can film porn)
+- Still need harmful content detection (real cameras can film violence)
+
+**AI Detection**: NOT NEEDED - cryptographic proof handles this
+
+---
+
+### Tier 2: Videos WITHOUT ProofMode ⚠️
+
+**No cryptographic authenticity guarantee**
+
+**Moderation Flow**:
+```
+Non-ProofMode Video Upload
+    ↓
+[1. CSAM Check] → MATCH? → BLOCK + NCMEC Report
+    ↓ PASS
+[2. AI-Generated Detection] → HIGH? → FLAG or BLOCK
+    ↓ PASS
+[3. Adult Content] → HIGH? → Age-gate
+    ↓ PASS
+[4. Harmful Content] → HIGH? → Flag for review
+    ↓ PASS
+⚠️ APPROVED - Publish without verification badge
+```
+
+**Additional Check**: AI-generated detection
+- Use Hive's AI detection API
+- **Policy options**:
+  - **Option A**: Hard block (align with "no AI content" policy)
+  - **Option B**: Allow but require label: "AI-generated or unverified"
+  - **Option C**: Flag for human review
+
+**User Incentive**: Encourage ProofMode adoption
+- Videos WITH ProofMode get verification badge → more trust → more views
+- Videos WITHOUT ProofMode marked "Unverified" → less trust
+- Natural incentive to use ProofMode-enabled apps
+
+---
+
+## Moderation Provider Recommendations
+
+### For CSAM Detection: **Hive** (Required)
+
+**Why**:
+- ✅ 57M+ known CSAM hash database (NCMEC)
+- ✅ AI classifier for novel CSAM
+- ✅ Video support (scene-sensitive hashing)
+- ✅ Integrated NCMEC reporting (legal compliance)
+- ✅ Privacy-first (deletes originals)
+
+**BunnyCDN Alternative**: Not ready yet
+- ⏰ CSAM detection announced but not available
+- ❓ Contact BunnyCDN to ask ETA
+- 💡 Could migrate to BunnyCDN later if pricing better
+
+### For Adult Content / Harmful Content: **Hive or BunnyCDN**
+
+**Hive Visual Moderation API**:
+- ✅ Adult content detection (97% accuracy)
+- ✅ Violence, gore, weapons, drugs, hate symbols
+- ✅ Same platform as CSAM detection (unified)
+
+**BunnyCDN Automated Content Tagging** (alternative):
+- ✅ Already using BunnyCDN for hosting
+- ✅ Edge-based (fast, integrated)
+- ❓ Unknown accuracy vs Hive
+- 💰 May be included in existing BunnyCDN costs
+
+**Recommendation**:
+- **Start with Hive** (proven, comprehensive, same platform as CSAM)
+- **Test BunnyCDN content tagging** in parallel if already paying for it
+- **Switch to BunnyCDN** if accuracy comparable and cost savings significant
+
+### For AI-Generated Detection: **Only for Non-ProofMode Videos**
+
+**Hive AI Detection**:
+- ✅ 98%+ accuracy
+- ✅ Deepfake detection included
+- ✅ Same platform as CSAM + adult content
+
+**Important**: Only run for videos WITHOUT ProofMode
+- ProofMode videos don't need AI detection (cryptographically verified)
+- Saves API costs (skip this check for ProofMode videos)
+
+---
+
+## Implementation Architecture
+
+### Moderation Pipeline with ProofMode
+
+```javascript
+async function moderateVideo(videoData, env) {
+  const { sha256, nostrEvent } = videoData;
+
+  // Step 0: Check ProofMode status
+  const proofMode = await verifyProofMode(nostrEvent);
+  const hasValidProof = proofMode.verified && proofMode.level !== 'unverified';
+
+  // Step 1: CSAM Detection (ALWAYS - even for ProofMode videos)
+  const csamResult = await hive.detectCSAM(videoUrl);
+
+  if (csamResult.isCSAM) {
+    await blockVideo(sha256, 'CSAM_DETECTED');
+    await reportToNCMEC(csamResult);
+    return { action: 'BLOCKED', reason: 'CSAM' };
+  }
+
+  // Step 2: AI-Generated Detection (SKIP for ProofMode videos)
+  if (!hasValidProof) {
+    const aiResult = await hive.detectAIGenerated(videoUrl);
+
+    if (aiResult.score > 0.7) {
+      // Policy decision point
+      if (env.AI_CONTENT_POLICY === 'BLOCK') {
+        await blockVideo(sha256, 'AI_GENERATED');
+        return { action: 'BLOCKED', reason: 'AI_GENERATED' };
+      } else if (env.AI_CONTENT_POLICY === 'FLAG') {
+        await flagForReview(sha256, 'AI_GENERATED', aiResult.score);
+      }
+      // If ALLOW_WITH_LABEL, continue but mark video
+    }
+  }
+
+  // Step 3: Adult Content Detection
+  const moderation = await hive.moderateContent(videoUrl);
+  const classification = classifyContent(moderation);
+
+  return {
+    ...classification,
+    proofMode: proofMode.level,
+    verificationBadge: hasValidProof
+  };
+}
+```
+
+### ProofMode Verification
+
+```javascript
+async function verifyProofMode(nostrEvent) {
+  // Extract ProofMode tags from Nostr event
+  const proofVersion = getTag(nostrEvent, 'proof-version');
+  const verificationLevel = getTag(nostrEvent, 'verification-level');
+  const manifest = getTag(nostrEvent, 'proof-manifest');
+  const deviceAttestation = getTag(nostrEvent, 'device-attestation');
+  const pgpPubkey = getTag(nostrEvent, 'pgp-pubkey');
+  const pgpFingerprint = getTag(nostrEvent, 'pgp-fingerprint');
+
+  if (!proofVersion) {
+    return { verified: false, level: 'unverified' };
+  }
+
+  // Verify PGP signature
+  const signatureValid = await verifyPGPSignature(manifest, pgpPubkey);
+
+  if (!signatureValid) {
+    return { verified: false, level: 'unverified' };
+  }
+
+  // Verify device attestation (if present)
+  if (verificationLevel === 'verified_mobile' && deviceAttestation) {
+    const attestationValid = await verifyDeviceAttestation(
+      deviceAttestation,
+      manifest
+    );
+
+    if (!attestationValid) {
+      return { verified: false, level: 'unverified' };
+    }
+  }
+
+  return {
+    verified: true,
+    level: verificationLevel, // verified_mobile, verified_web, basic_proof
+    pgpFingerprint,
+    captureTime: extractCaptureTime(manifest),
+    deviceInfo: extractDeviceInfo(manifest)
+  };
+}
+```
+
+### Cost Optimization
+
+**ProofMode videos** (estimated 80% of uploads with good adoption):
+- ✅ CSAM check: ~$X per video
+- ✅ Adult/harmful content check: ~$Y per video
+- ❌ **Skip AI detection**: Save ~$Z per video
+
+**Non-ProofMode videos** (estimated 20%):
+- ✅ CSAM check: ~$X per video
+- ✅ AI detection: ~$Z per video
+- ✅ Adult/harmful content check: ~$Y per video
+
+**Total savings**: ~$Z × 80% = significant cost reduction by skipping AI detection for ProofMode videos
+
+---
+
+## Database Schema Updates
+
+```sql
+-- Add ProofMode columns
+ALTER TABLE video_moderation ADD COLUMN proofmode_verified BOOLEAN DEFAULT FALSE;
+ALTER TABLE video_moderation ADD COLUMN proofmode_level TEXT; -- verified_mobile, verified_web, basic_proof, unverified
+ALTER TABLE video_moderation ADD COLUMN proofmode_pgp_fingerprint TEXT;
+ALTER TABLE video_moderation ADD COLUMN proofmode_capture_time TIMESTAMP;
+
+-- AI detection only for non-ProofMode videos
+ALTER TABLE video_moderation ADD COLUMN ai_detection_skipped BOOLEAN DEFAULT FALSE;
+ALTER TABLE video_moderation ADD COLUMN ai_detection_skip_reason TEXT; -- 'proofmode_verified', null
+
+-- Update indexes
+CREATE INDEX idx_proofmode_verified ON video_moderation(proofmode_verified);
+CREATE INDEX idx_proofmode_level ON video_moderation(proofmode_level);
+```
+
+---
+
+## User Experience
+
+### Feed Display
+
+**ProofMode Video**:
+```
+┌─────────────────────────────┐
+│         [VIDEO]             │
+│                             │
+│  ✅ Verified Mobile         │
+│  6 seconds                  │
+│  @username                  │
+│  "Cool sunset at beach"     │
+└─────────────────────────────┘
+```
+
+**Non-ProofMode Video**:
+```
+┌─────────────────────────────┐
+│         [VIDEO]             │
+│                             │
+│  ⚠️ Unverified              │
+│  6 seconds                  │
+│  @username                  │
+│  "Cool sunset at beach"     │
+└─────────────────────────────┘
+```
+
+**Age-Gated Video** (regardless of ProofMode):
+```
+┌─────────────────────────────┐
+│    [BLURRED THUMBNAIL]      │
+│                             │
+│  🔞 18+ Content             │
+│  Tap to enable adult        │
+│  content in settings        │
+└─────────────────────────────┘
+```
+
+### Verification Badge Click
+
+Shows detailed proof information:
+```
+✅ Verified Mobile Capture
+
+This video has cryptographic proof it was
+captured by a real device camera.
+
+Verification Level: Verified Mobile
+Captured: Oct 23, 2025 at 2:30 PM
+Device: iPhone 15 Pro (iOS 18.1)
+PGP Fingerprint: AB12 CD34 EF56...
+
+This proves the video is a genuine camera
+capture, not AI-generated or heavily edited.
+
+[Learn More About ProofMode]
+```
+
+---
+
+## Policy Decisions Needed
+
+### 1. AI-Generated Content Policy (Non-ProofMode videos)
+
+**Option A: Hard Block** (Strictest)
+- Aligns with "no AI content" brand promise
+- Clear, simple policy
+- Risk: False positives block real content
+- Recommendation: **Only if false positive rate very low (<1%)**
+
+**Option B: Flag for Human Review** (Moderate)
+- Humans decide on borderline cases
+- Lower risk of false positives
+- Requires moderator capacity
+- Recommendation: **Best balance**
+
+**Option C: Allow with Label** (Permissive)
+- Videos marked "AI-generated or unverified"
+- Users decide if they trust it
+- Softer enforcement
+- Recommendation: **Only if moderation capacity limited**
+
+**My Recommendation**: Start with **Option B** (flag for review), evaluate false positive rate, potentially move to Option A if rate is low.
+
+### 2. ProofMode Adoption Strategy
+
+**Incentive Structure**:
+- ✅ ProofMode videos: Verification badge → more trust → better engagement
+- ⚠️ Non-ProofMode videos: "Unverified" label → less trust
+- 🎯 Goal: 80%+ ProofMode adoption within 6 months
+
+**Strategies**:
+1. **Default to ProofMode** in official Divine mobile apps
+2. **Educate users** about verification benefits
+3. **Surface ProofMode videos** more in algorithm (higher trust)
+4. **Allow non-ProofMode** uploads but deprioritize
+
+### 3. BunnyCDN vs Hive for Content Moderation
+
+**Test BunnyCDN Content Tagging**:
+- Already using BunnyCDN for video hosting
+- May be included in costs or cheaper
+- Unknown accuracy vs Hive
+
+**Action**:
+1. Contact BunnyCDN about:
+   - CSAM detection ETA
+   - Content tagging accuracy data
+   - Pricing if not included
+2. Run parallel test: BunnyCDN vs Hive on same videos
+3. Compare accuracy + cost
+4. Decide: Hive (proven) vs BunnyCDN (integrated)
+
+---
+
+## Migration Timeline (Updated)
+
+### Phase 1: CSAM Detection (Week 1-2) - CRITICAL
+1. Sign up for Hive CSAM Detection API
+2. Implement CSAM check (all videos, including ProofMode)
+3. Test with safe test dataset
+4. Configure NCMEC reporting
+5. **BLOCKING** - deploy before any videos published
+
+### Phase 2: ProofMode Verification (Week 2-3)
+1. Implement ProofMode tag parsing
+2. Build PGP signature verification
+3. Integrate device attestation validation
+4. Add verification badges to UI
+5. Deploy ProofMode support
+
+### Phase 3: Conditional AI Detection (Week 3-4)
+1. Implement Hive AI detection API
+2. Add logic: Skip AI detection if ProofMode verified
+3. Define policy (block/flag/label)
+4. Deploy with monitoring
+
+### Phase 4: Adult Content Age-Gating (Week 4-5)
+1. Implement Hive Visual Moderation OR BunnyCDN content tagging
+2. Build age-gating UI (blurred thumbnails)
+3. User preference system (opt-in)
+4. Add content-warning tags to Nostr events
+5. Deploy
+
+### Phase 5: Harmful Content Flagging (Week 5-6)
+1. Integrate with faro.nos.social
+2. Build flagging workflow
+3. Moderator notifications
+4. Review and appeal process
+
+### Phase 6: Optimization (Week 7+)
+1. Monitor ProofMode adoption rate
+2. Evaluate false positive/negative rates
+3. Test BunnyCDN content tagging (if available)
+4. Cost optimization
+5. Policy adjustments based on data
+
+---
+
+## Cost Estimates (Updated)
+
+### With 80% ProofMode Adoption (100K videos/month)
+
+**ProofMode videos (80K)**:
+- CSAM detection: 80K × $X
+- Adult/harmful content: 80K × $Y
+- AI detection: **$0** (skipped)
+
+**Non-ProofMode videos (20K)**:
+- CSAM detection: 20K × $X
+- AI detection: 20K × $Z
+- Adult/harmful content: 20K × $Y
+
+**Total**: Much lower than 100% AI detection
+
+**Savings from ProofMode**: 80K × $Z = significant
+
+---
+
+## Open Questions
+
+1. **BunnyCDN CSAM detection ETA?**
+   - Contact BunnyCDN sales
+   - If available soon, may save costs
+
+2. **BunnyCDN content tagging accuracy?**
+   - Test against Hive on same videos
+   - May be "good enough" if cheaper
+
+3. **AI-generated content policy?**
+   - Hard block, flag for review, or allow with label?
+   - Depends on false positive rate
+
+4. **ProofMode adoption expectations?**
+   - What % of users will use ProofMode apps?
+   - Affects cost calculations
+
+5. **Age verification approach?**
+   - Self-reported sufficient for now?
+   - Need ID verification?
+
+---
+
+## Next Steps
+
+**Immediate**:
+1. **Contact BunnyCDN**: Ask about CSAM detection availability + content tagging accuracy
+2. **Contact Hive**: Get pricing for CSAM + Visual Moderation APIs
+3. **Define AI policy**: Block, flag, or label?
+4. **Test ProofMode verification**: Build verification logic
+
+**Ready to Implement**:
+1. Hive CSAM Detection integration
+2. ProofMode verification logic
+3. Conditional AI detection (skip for ProofMode)
+4. Hive Visual Moderation for adult/harmful content
+
+Want me to:
+- **A)** Start implementing Hive CSAM + ProofMode verification?
+- **B)** Build comparison test for BunnyCDN vs Hive content tagging?
+- **C)** Create detailed API integration code for the moderation pipeline?

--- a/VIDEO_MODERATION_COMPARISON.md
+++ b/VIDEO_MODERATION_COMPARISON.md
@@ -1,0 +1,226 @@
+# Video Moderation Services Comparison (2025)
+
+## Executive Summary
+
+Research into alternatives to Sightengine for video content moderation. All major cloud providers offer competitive services with similar pricing (~$0.10/min). **AWS Rekognition** appears to be the strongest alternative with custom model training capabilities.
+
+## Current: Sightengine
+
+**Pricing**: $29-$399/month (volume-based tiers)
+
+**Strengths**:
+- Extremely detailed subcategories (18+ primary categories, dozens of subcategories)
+- Highly customizable thresholds and models
+- Comprehensive model selection:
+  - nudity-2.1 (sexual_activity, sexual_display, erotica, suggestive variations)
+  - violence (physical_violence, firearm_threat, combat_sport)
+  - gore-2.0 (bloody, body_organ, serious_injury, corpse)
+  - offensive-2.0 (nazi, supremacist, terrorist, middle_finger)
+  - genai + deepfake detection
+  - weapons, drugs (recreational_drug, medical), alcohol, tobacco
+  - gambling, money, self-harm, destruction, military
+  - text-content (OCR with profanity detection)
+  - qr-content (QR code scanning and validation)
+- Frame-by-frame analysis with detailed scoring
+- Synchronous API (simpler integration)
+
+**Weaknesses**:
+- Smaller company (potential reliability/scale concerns)
+- Limited ecosystem integration
+- Fixed pricing tiers vs pay-per-use
+
+**API Pattern**: Synchronous GET request with stream_url parameter
+
+---
+
+## Alternative 1: AWS Rekognition Video
+
+**Pricing**: $0.10/minute
+- 60 free minutes/month for first 12 months
+- $6 for a 1-hour video
+- Volume discounts available
+
+**Strengths**:
+- **Custom Moderation Adapters** - Train custom models on your own labeled data!
+- 10 major categories, 25 secondary categories
+- Claims 95% accuracy for unsafe content flagging
+- Max file size 10GB, max duration 6 hours
+- Amazon A2I integration for human-in-the-loop review
+- Deep AWS ecosystem integration (S3, Lambda, EventBridge)
+- Enterprise-grade reliability and scale
+- Minimum confidence thresholds (0-100)
+
+**Weaknesses**:
+- Fewer subcategories than Sightengine
+- Requires AWS account and S3 storage
+- Asynchronous API (more complex integration)
+- Less granular control than Sightengine
+
+**Categories**:
+Major: Explicit Nudity, Suggestive, Violence, Visually Disturbing, Rude Gestures, Drugs, Tobacco, Alcohol, Gambling, Hate Symbols
+
+**API Pattern**: Asynchronous (StartContentModeration → GetContentModeration polling)
+
+**Best For**:
+- Teams already on AWS
+- Need for custom model training
+- Large-scale operations requiring enterprise reliability
+- Human review workflows
+
+---
+
+## Alternative 2: Google Cloud Video Intelligence API
+
+**Pricing**: $0.10/minute
+- First 1,000 minutes free per month
+- Volume discounts for >100K minutes/month
+
+**Strengths**:
+- Part of Google Cloud AI suite
+- Good general video analysis (labels, objects, text detection)
+- Shot detection and object tracking
+- Enterprise reliability
+
+**Weaknesses**:
+- Less specialized for content moderation vs competitors
+- Celebrity recognition deprecated (Sept 2025)
+- Fewer moderation-specific categories
+- Limited subcategory detail
+
+**API Pattern**: Both sync and async options available
+
+**Best For**:
+- Teams already on Google Cloud
+- Need general video analysis + basic moderation
+- Shot detection and object tracking important
+
+---
+
+## Alternative 3: Azure Video Indexer
+
+**Pricing**: Not clearly disclosed (paid account required, no free tier mentioned)
+
+**Strengths**:
+- 30+ AI models in one service
+- Visual + textual content moderation
+- Audio transcript analysis for explicit text
+- Broad video analysis capabilities
+
+**Weaknesses**:
+- Less detailed pricing information
+- Requires paid Azure account (no trial)
+- Less granular moderation categories than Sightengine
+- Fewer documented moderation-specific features
+
+**Categories**:
+- Adult/racy visual content
+- Explicit text in audio transcripts
+
+**Best For**:
+- Teams already on Azure
+- Need comprehensive video analytics beyond moderation
+
+---
+
+## Alternative 4: Hive Moderation
+
+**Pricing**: Not disclosed (enterprise/volume-based)
+
+**Strengths**:
+- Built for high-volume scale
+- Pre-trained models ready out-of-the-box
+- Multi-modal (images, videos, GIFs, live streams)
+- Fast processing
+- Developer-friendly API
+
+**Weaknesses**:
+- Less customization than Sightengine
+- Pricing not transparent
+- Less granular threshold control
+
+**Best For**:
+- High-volume platforms
+- Teams prioritizing speed and scale over customization
+- Need live stream moderation
+
+---
+
+## Comparison Matrix
+
+| Feature | Sightengine | AWS Rekognition | Google Video AI | Azure Video Indexer | Hive |
+|---------|-------------|-----------------|-----------------|---------------------|------|
+| **Pricing Model** | Tiered ($29-$399/mo) | Pay-per-use ($0.10/min) | Pay-per-use ($0.10/min) | Undisclosed | Undisclosed |
+| **Free Tier** | Limited trial | 60 min/mo (12mo) | 1000 min/mo | None | Unknown |
+| **Custom Models** | ❌ | ✅ | ❌ | ❌ | ❌ |
+| **Subcategory Detail** | ⭐⭐⭐⭐⭐ | ⭐⭐⭐ | ⭐⭐ | ⭐⭐ | ⭐⭐⭐ |
+| **Threshold Control** | ⭐⭐⭐⭐⭐ | ⭐⭐⭐⭐ | ⭐⭐⭐ | ⭐⭐ | ⭐⭐⭐ |
+| **API Complexity** | Synchronous (simple) | Async (complex) | Both | Both | Synchronous |
+| **Deepfake Detection** | ✅ | ❌ | ❌ | ❌ | ✅ |
+| **Text OCR Moderation** | ✅ | ❌ | ✅ (general) | ✅ | ✅ |
+| **QR Code Detection** | ✅ | ❌ | ❌ | ❌ | ❌ |
+| **Live Stream Support** | ✅ | ❌ | ❌ | ❌ | ✅ |
+| **Human Review Integration** | ❌ | ✅ (A2I) | ❌ | ❌ | ✅ (optional) |
+
+---
+
+## Recommendations
+
+### Short Term: Stay with Sightengine
+**Rationale**:
+- Already integrated and working
+- Superior granularity for fine-tuned moderation
+- Deepfake + QR code detection unique to Sightengine/Hive
+- Synchronous API is simpler for current architecture
+
+### Mid-Term: Add AWS Rekognition as Option
+**Rationale**:
+- Custom model training could improve accuracy for Divine-specific content
+- Better pricing model for high-volume scenarios
+- Enterprise reliability and scale
+- Enables A/B testing between providers
+
+### Architecture: Pluggable Provider System
+Implement abstraction layer allowing:
+1. **Configuration-driven provider selection**
+2. **Parallel processing** (run multiple providers, compare results)
+3. **Fallback chains** (Sightengine → AWS fallback on error)
+4. **Provider-specific optimizations** (leverage unique features)
+5. **Normalized response format** (abstract provider differences)
+
+---
+
+## Implementation Considerations
+
+### Response Normalization Challenges
+Each provider has different:
+- Category names/taxonomies
+- Score ranges and confidence formats
+- Subcategory granularity
+- Async vs sync patterns
+
+### Migration Strategy
+1. Create provider abstraction interface
+2. Implement Sightengine adapter (wrap existing code)
+3. Implement AWS Rekognition adapter
+4. Add provider configuration (env vars, per-video selection)
+5. Build comparison/validation mode (run both, log differences)
+6. Gradual rollout with monitoring
+
+### Cost Analysis Example (1000 hours/month processing)
+- **Sightengine**: $399/month (highest tier) = $0.0066/min
+- **AWS Rekognition**: 60,000 min × $0.10 = $6,000/month
+- **Google**: First 1,000 min free, then 59,000 × $0.10 = $5,900/month
+
+*Note: Sightengine is significantly cheaper at scale! AWS/Google better for bursty/low-volume workloads.*
+
+---
+
+## Open Questions
+
+1. What is our expected video processing volume?
+2. Do we need custom model training for Divine-specific content?
+3. Are there specific categories where current accuracy is lacking?
+4. Do we need human review workflows?
+5. How important is deepfake detection vs other categories?
+6. Should we process videos through multiple providers for validation?
+

--- a/scripts/migrate-kv-to-d1.mjs
+++ b/scripts/migrate-kv-to-d1.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+// ABOUTME: Migration script to move moderation results from KV to D1
+// ABOUTME: Run with: node scripts/migrate-kv-to-d1.mjs
+
+import { execSync } from 'child_process';
+
+const BATCH_SIZE = 100;
+
+async function runD1Command(sql) {
+  const escaped = sql.replace(/"/g, '\\"');
+  const result = execSync(
+    `wrangler d1 execute blossom-webhook-events --remote --command "${escaped}" --json`,
+    { encoding: 'utf-8', maxBuffer: 50 * 1024 * 1024 }
+  );
+  return JSON.parse(result);
+}
+
+async function listKVKeys(prefix, cursor = null) {
+  let cmd = `wrangler kv key list --namespace-id=10af689fc82140ed9159eef3c1c47079 --prefix="${prefix}"`;
+  if (cursor) {
+    cmd += ` --cursor="${cursor}"`;
+  }
+  const result = execSync(cmd, { encoding: 'utf-8', maxBuffer: 50 * 1024 * 1024 });
+  return JSON.parse(result);
+}
+
+async function getKVValue(key) {
+  try {
+    const result = execSync(
+      `wrangler kv key get --namespace-id=10af689fc82140ed9159eef3c1c47079 "${key}"`,
+      { encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024 }
+    );
+    return result;
+  } catch (e) {
+    return null;
+  }
+}
+
+async function migrate() {
+  console.log('Starting KV to D1 migration...\n');
+
+  // Get all moderation keys
+  console.log('Fetching moderation keys from KV...');
+  let allKeys = [];
+  let cursor = null;
+  let page = 0;
+
+  do {
+    const keys = await listKVKeys('moderation:', cursor);
+    if (Array.isArray(keys)) {
+      allKeys = allKeys.concat(keys);
+      console.log(`  Page ${++page}: ${keys.length} keys (total: ${allKeys.length})`);
+      break; // No cursor in simple list
+    } else if (keys.result) {
+      allKeys = allKeys.concat(keys.result);
+      cursor = keys.cursor;
+      console.log(`  Page ${++page}: ${keys.result.length} keys (total: ${allKeys.length})`);
+    }
+  } while (cursor);
+
+  console.log(`\nFound ${allKeys.length} moderation results to migrate\n`);
+
+  // Also get action-specific keys to determine current state
+  console.log('Fetching action flags...');
+  const reviewKeys = await listKVKeys('review:');
+  const ageRestrictedKeys = await listKVKeys('age-restricted:');
+  const permanentBanKeys = await listKVKeys('permanent-ban:');
+
+  const reviewSet = new Set((Array.isArray(reviewKeys) ? reviewKeys : reviewKeys.result || []).map(k => k.name.replace('review:', '')));
+  const ageRestrictedSet = new Set((Array.isArray(ageRestrictedKeys) ? ageRestrictedKeys : ageRestrictedKeys.result || []).map(k => k.name.replace('age-restricted:', '')));
+  const permanentBanSet = new Set((Array.isArray(permanentBanKeys) ? permanentBanKeys : permanentBanKeys.result || []).map(k => k.name.replace('permanent-ban:', '')));
+
+  console.log(`  Review flags: ${reviewSet.size}`);
+  console.log(`  Age-restricted flags: ${ageRestrictedSet.size}`);
+  console.log(`  Permanent-ban flags: ${permanentBanSet.size}`);
+
+  // Migrate in batches
+  let migrated = 0;
+  let errors = 0;
+
+  for (let i = 0; i < allKeys.length; i += BATCH_SIZE) {
+    const batch = allKeys.slice(i, i + BATCH_SIZE);
+    const values = [];
+
+    for (const keyObj of batch) {
+      const key = keyObj.name || keyObj;
+      const sha256 = key.replace('moderation:', '');
+
+      try {
+        const valueStr = await getKVValue(key);
+        if (!valueStr) continue;
+
+        const value = JSON.parse(valueStr);
+
+        // Determine current action from flags
+        let action = value.action || 'SAFE';
+        if (permanentBanSet.has(sha256)) action = 'PERMANENT_BAN';
+        else if (ageRestrictedSet.has(sha256)) action = 'AGE_RESTRICTED';
+        else if (reviewSet.has(sha256)) action = 'REVIEW';
+
+        values.push({
+          sha256,
+          action,
+          provider: value.provider || 'sightengine',
+          scores: JSON.stringify(value.scores || {}),
+          categories: JSON.stringify(value.categories || []),
+          raw_response: JSON.stringify(value.rawResponse || value.raw || {}),
+          moderated_at: value.moderatedAt || value.timestamp || new Date().toISOString()
+        });
+      } catch (e) {
+        console.error(`  Error processing ${key}:`, e.message);
+        errors++;
+      }
+    }
+
+    if (values.length > 0) {
+      // Build INSERT statement
+      const placeholders = values.map(() => '(?, ?, ?, ?, ?, ?, ?)').join(', ');
+      const params = values.flatMap(v => [
+        v.sha256, v.action, v.provider, v.scores, v.categories, v.raw_response, v.moderated_at
+      ]);
+
+      // Use INSERT OR REPLACE to handle duplicates
+      const sql = `INSERT OR REPLACE INTO moderation_results (sha256, action, provider, scores, categories, raw_response, moderated_at) VALUES ${values.map(v =>
+        `('${v.sha256}', '${v.action}', '${v.provider}', '${v.scores.replace(/'/g, "''")}', '${v.categories.replace(/'/g, "''")}', '${v.raw_response.replace(/'/g, "''")}', '${v.moderated_at}')`
+      ).join(', ')}`;
+
+      try {
+        await runD1Command(sql);
+        migrated += values.length;
+      } catch (e) {
+        console.error(`  Batch insert error:`, e.message);
+        errors += values.length;
+      }
+    }
+
+    console.log(`Progress: ${Math.min(i + BATCH_SIZE, allKeys.length)}/${allKeys.length} (migrated: ${migrated}, errors: ${errors})`);
+  }
+
+  console.log(`\n✅ Migration complete!`);
+  console.log(`   Migrated: ${migrated}`);
+  console.log(`   Errors: ${errors}`);
+
+  // Verify
+  const countResult = await runD1Command('SELECT COUNT(*) as count FROM moderation_results');
+  console.log(`   D1 row count: ${countResult[0]?.results?.[0]?.count || 'unknown'}`);
+}
+
+migrate().catch(console.error);

--- a/scripts/prod-smoke.mjs
+++ b/scripts/prod-smoke.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+// Production smoke test helper for Divine Moderation Service
+// Usage:
+//   NOSTR_ACCESS_JWT=<jwt> node scripts/prod-smoke.mjs <sha256>
+
+const [, , sha] = process.argv;
+if (!sha) {
+  console.error('Usage: node scripts/prod-smoke.mjs <sha256>');
+  process.exit(1);
+}
+
+const BASE = process.env.MOD_BASE || 'https://moderation.admin.divine.video';
+const JWT = process.env.CF_ACCESS_JWT_ASSERTION || process.env.NOSTR_ACCESS_JWT || '';
+
+async function jfetch(path, opts = {}) {
+  const headers = { 'Content-Type': 'application/json', ...(opts.headers || {}) };
+  if (JWT) headers['cf-access-jwt-assertion'] = JWT;
+  const res = await fetch(`${BASE}${path}`, { ...opts, headers });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`${res.status} ${res.statusText}: ${text}`);
+  }
+  const ct = res.headers.get('content-type') || '';
+  if (ct.includes('application/json')) return res.json();
+  return res.text();
+}
+
+async function main() {
+  console.log('== Self-test ==');
+  const self = await jfetch('/admin/api/self-test', { headers: { 'Cf-Access-Authenticated-User-Email': 'tester@example.com' } });
+  console.log(JSON.stringify(self, null, 2));
+
+  console.log('\n== Queue action (PERMANENT_BAN) ==');
+  const reqId = crypto.randomUUID();
+  const queued = await jfetch('/api/v1/moderate/queue', {
+    method: 'POST',
+    body: JSON.stringify({ sha256: sha, action: 'PERMANENT_BAN', reason: 'prod-smoke', source: 'smoke-script', requestId: reqId })
+  });
+  console.log(queued);
+
+  console.log('\n== Poll status ==');
+  let status;
+  for (let i = 0; i < 10; i++) {
+    await new Promise(r => setTimeout(r, 1000));
+    status = await jfetch(`/admin/api/status/${sha}`, { headers: { 'Cf-Access-Authenticated-User-Email': 'tester@example.com' } });
+    console.log(`Attempt ${i + 1}:`, status);
+    if (status?.kv?.permanentBan) break;
+  }
+
+  console.log('\n== Check result ==');
+  const result = await jfetch(`/check-result/${sha}`);
+  console.log(result);
+}
+
+main().catch(e => { console.error(e); process.exit(1); });
+

--- a/scripts/queue-videos.mjs
+++ b/scripts/queue-videos.mjs
@@ -1,0 +1,218 @@
+#!/usr/bin/env node
+// ABOUTME: Queue videos for moderation by fetching from Nostr relay
+// ABOUTME: Supports filtering by client type (vine-archaeologist for old vines, openvine for new)
+
+import { WebSocket } from 'ws';
+
+const WORKER_URL = process.env.WORKER_URL || 'https://divine-moderation-service.protestnet.workers.dev';
+const RELAY_URL = process.env.RELAY_URL || 'wss://relay.divine.video';
+const DELAY_MS = parseInt(process.env.DELAY_MS || '500', 10);
+
+// Parse arguments
+const args = process.argv.slice(2);
+const DRY_RUN = args.includes('--dry-run');
+const clientFilter = args.find(a => a.startsWith('--client='))?.split('=')[1] || null;
+const limitArg = args.find(a => a.startsWith('--limit='));
+const LIMIT = limitArg ? parseInt(limitArg.split('=')[1], 10) : null;
+
+console.log('='.repeat(60));
+console.log('Queue Videos for Moderation');
+console.log('='.repeat(60));
+console.log(`Relay: ${RELAY_URL}`);
+console.log(`Worker: ${WORKER_URL}`);
+console.log(`Client filter: ${clientFilter || 'all'}`);
+console.log(`Limit: ${LIMIT || 'unlimited'}`);
+console.log(`Dry run: ${DRY_RUN}`);
+console.log('');
+
+/**
+ * Fetch kind 34236 events from relay
+ */
+async function fetchEventsFromRelay(limit = 1000) {
+  return new Promise((resolve, reject) => {
+    const events = [];
+    let ws;
+
+    const timeout = setTimeout(() => {
+      if (ws) ws.close();
+      reject(new Error('WebSocket timeout'));
+    }, 60000);
+
+    try {
+      ws = new WebSocket(RELAY_URL);
+
+      ws.on('open', () => {
+        const subscriptionId = Math.random().toString(36).substring(7);
+        const reqMessage = JSON.stringify(['REQ', subscriptionId, { kinds: [34236], limit }]);
+        console.log(`[RELAY] Requesting ${limit} events...`);
+        ws.send(reqMessage);
+      });
+
+      ws.on('message', (data) => {
+        try {
+          const msg = JSON.parse(data.toString());
+          if (msg[0] === 'EVENT') {
+            events.push(msg[2]);
+          }
+          if (msg[0] === 'EOSE') {
+            console.log(`[RELAY] Received ${events.length} events`);
+            clearTimeout(timeout);
+            ws.close();
+            resolve(events);
+          }
+        } catch (err) {
+          console.error('[RELAY] Parse error:', err);
+        }
+      });
+
+      ws.on('error', (err) => {
+        clearTimeout(timeout);
+        reject(err);
+      });
+    } catch (error) {
+      clearTimeout(timeout);
+      reject(error);
+    }
+  });
+}
+
+/**
+ * Extract video info from event
+ */
+function extractVideoInfo(event) {
+  let sha256 = null;
+  let client = null;
+  let platform = null;
+  let vineHashId = null;
+  let publishedAt = null;
+
+  for (const tag of event.tags) {
+    const [key, value] = tag;
+    switch (key) {
+      case 'client':
+        client = value;
+        break;
+      case 'platform':
+        platform = value;
+        break;
+      case 'vine_hash_id':
+        vineHashId = value;
+        break;
+      case 'published_at':
+        publishedAt = parseInt(value, 10);
+        break;
+      case 'imeta':
+        for (let i = 1; i < tag.length; i++) {
+          const param = tag[i];
+          if (param && param.startsWith('x ')) {
+            sha256 = param.substring(2).trim();
+          }
+        }
+        break;
+    }
+  }
+
+  const isOriginalVine = platform === 'vine' || client === 'vine-archaeologist' || vineHashId || (publishedAt && publishedAt < 1514764800);
+
+  return { sha256, client, platform, isOriginalVine, publishedAt, eventId: event.id };
+}
+
+/**
+ * Check if video is already moderated
+ */
+async function checkModerated(sha256) {
+  try {
+    const response = await fetch(`${WORKER_URL}/check-result/${sha256}`);
+    if (!response.ok) return false;
+    const data = await response.json();
+    return data.moderation !== null;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Queue video for moderation
+ */
+async function queueModeration(sha256) {
+  const response = await fetch(`${WORKER_URL}/test-moderate`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ sha256 })
+  });
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+  return await response.json();
+}
+
+async function main() {
+  // Fetch events
+  const events = await fetchEventsFromRelay(2000);
+
+  // Extract video info and filter
+  const videos = events.map(extractVideoInfo).filter(v => v.sha256);
+  console.log(`[INFO] Found ${videos.length} videos with SHA256`);
+
+  // Filter by client if specified
+  let filtered = videos;
+  if (clientFilter) {
+    filtered = videos.filter(v => v.client === clientFilter);
+    console.log(`[INFO] Filtered to ${filtered.length} videos with client=${clientFilter}`);
+  }
+
+  // Apply limit
+  if (LIMIT) {
+    filtered = filtered.slice(0, LIMIT);
+    console.log(`[INFO] Limited to ${filtered.length} videos`);
+  }
+
+  // Show breakdown
+  const oldVines = filtered.filter(v => v.isOriginalVine).length;
+  const newContent = filtered.length - oldVines;
+  console.log(`[INFO] Old Vines: ${oldVines}, New content: ${newContent}`);
+  console.log('');
+
+  // Process
+  const stats = { total: filtered.length, queued: 0, skipped: 0, errors: 0 };
+
+  for (let i = 0; i < filtered.length; i++) {
+    const video = filtered[i];
+    const progress = `[${i + 1}/${filtered.length}]`;
+    const type = video.isOriginalVine ? '🍇 OLD' : '✨ NEW';
+
+    try {
+      const alreadyModerated = await checkModerated(video.sha256);
+
+      if (alreadyModerated) {
+        stats.skipped++;
+        console.log(`${progress} ${type} ${video.sha256.substring(0, 16)}... SKIPPED (already moderated)`);
+      } else if (DRY_RUN) {
+        console.log(`${progress} ${type} ${video.sha256.substring(0, 16)}... WOULD QUEUE`);
+      } else {
+        await queueModeration(video.sha256);
+        stats.queued++;
+        console.log(`${progress} ${type} ${video.sha256.substring(0, 16)}... QUEUED`);
+        await new Promise(resolve => setTimeout(resolve, DELAY_MS));
+      }
+    } catch (error) {
+      stats.errors++;
+      console.error(`${progress} ${type} ${video.sha256.substring(0, 16)}... ERROR: ${error.message}`);
+    }
+  }
+
+  // Summary
+  console.log('');
+  console.log('='.repeat(60));
+  console.log('Summary:');
+  console.log(`  Total videos: ${stats.total}`);
+  console.log(`  Queued: ${stats.queued}`);
+  console.log(`  Skipped (already moderated): ${stats.skipped}`);
+  console.log(`  Errors: ${stats.errors}`);
+  console.log('='.repeat(60));
+}
+
+main().catch(error => {
+  console.error('Fatal error:', error);
+  process.exit(1);
+});

--- a/scripts/requeue-failed.mjs
+++ b/scripts/requeue-failed.mjs
@@ -1,0 +1,118 @@
+// ABOUTME: Re-queue failed moderation attempts to retry with updated provider
+// ABOUTME: Reads failed:* keys from KV and re-queues videos for moderation
+
+const WORKER_URL = process.env.WORKER_URL || 'https://divine-moderation-service.protestnet.workers.dev';
+const BATCH_SIZE = parseInt(process.env.BATCH_SIZE || '100', 10);
+const DELAY_MS = parseInt(process.env.DELAY_MS || '500', 10);
+const DRY_RUN = process.argv.includes('--dry-run');
+const LIMIT = process.argv.includes('--limit')
+  ? parseInt(process.argv[process.argv.indexOf('--limit') + 1], 10)
+  : null;
+
+async function getFailedKeys() {
+  // Use wrangler to list failed keys
+  const { execSync } = await import('child_process');
+
+  console.log('[REQUEUE] Fetching failed moderation keys from KV...');
+
+  const result = execSync(
+    'npx wrangler kv key list --binding MODERATION_KV --remote --prefix "failed:"',
+    { encoding: 'utf8', maxBuffer: 50 * 1024 * 1024 }
+  );
+
+  const keys = JSON.parse(result);
+  console.log(`[REQUEUE] Found ${keys.length} failed moderation keys`);
+
+  return keys.map(k => k.name);
+}
+
+async function queueModeration(sha256) {
+  const response = await fetch(`${WORKER_URL}/test-moderate`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ sha256 })
+  });
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+  }
+
+  return await response.json();
+}
+
+async function deleteFailedKey(sha256) {
+  const { execSync } = await import('child_process');
+
+  execSync(
+    `npx wrangler kv key delete --binding MODERATION_KV --remote "failed:${sha256}"`,
+    { encoding: 'utf8' }
+  );
+}
+
+async function main() {
+  console.log('[REQUEUE] Re-queue Failed Moderations Script');
+  console.log(`[REQUEUE] Worker URL: ${WORKER_URL}`);
+  console.log(`[REQUEUE] Batch size: ${BATCH_SIZE}`);
+  console.log(`[REQUEUE] Delay between requests: ${DELAY_MS}ms`);
+  console.log(`[REQUEUE] Dry run: ${DRY_RUN}`);
+  if (LIMIT) console.log(`[REQUEUE] Limit: ${LIMIT}`);
+  console.log('');
+
+  const failedKeys = await getFailedKeys();
+
+  const toProcess = LIMIT ? failedKeys.slice(0, LIMIT) : failedKeys;
+  console.log(`[REQUEUE] Will process ${toProcess.length} failed videos`);
+  console.log('');
+
+  const stats = {
+    total: toProcess.length,
+    queued: 0,
+    errors: 0
+  };
+
+  for (let i = 0; i < toProcess.length; i++) {
+    const key = toProcess[i];
+    const sha256 = key.replace('failed:', '');
+
+    try {
+      if (DRY_RUN) {
+        console.log(`[REQUEUE] [DRY-RUN] Would queue: ${sha256.substring(0, 16)}...`);
+      } else {
+        await queueModeration(sha256);
+        console.log(`[REQUEUE] [${i + 1}/${toProcess.length}] Queued: ${sha256.substring(0, 16)}...`);
+        stats.queued++;
+
+        // Wait between requests to avoid rate limiting
+        await new Promise(resolve => setTimeout(resolve, DELAY_MS));
+      }
+    } catch (error) {
+      console.error(`[REQUEUE] [${i + 1}/${toProcess.length}] Error: ${sha256.substring(0, 16)}... - ${error.message}`);
+      stats.errors++;
+    }
+
+    // Progress update every 100
+    if ((i + 1) % 100 === 0) {
+      console.log(`[REQUEUE] Progress: ${i + 1}/${toProcess.length} (${stats.queued} queued, ${stats.errors} errors)`);
+    }
+  }
+
+  console.log('');
+  console.log('='.repeat(60));
+  console.log('[REQUEUE] Summary:');
+  console.log(`  Total failed videos: ${stats.total}`);
+  console.log(`  Successfully queued: ${stats.queued}`);
+  console.log(`  Errors: ${stats.errors}`);
+  console.log('='.repeat(60));
+
+  if (!DRY_RUN && stats.queued > 0) {
+    console.log('');
+    console.log('[REQUEUE] Note: Failed keys will be cleaned up automatically when');
+    console.log('[REQUEUE] moderation succeeds. If it fails again, a new failed:');
+    console.log('[REQUEUE] key will be created.');
+  }
+}
+
+main().catch(error => {
+  console.error('[REQUEUE] Fatal error:', error);
+  process.exit(1);
+});

--- a/scripts/run-migration.mjs
+++ b/scripts/run-migration.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+// ABOUTME: Run the KV to D1 migration by calling the Worker endpoint in batches
+// ABOUTME: Usage: node scripts/run-migration.mjs [--batch-size=500]
+
+const BASE_URL = 'https://moderation.admin.divine.video';
+const BATCH_SIZE = parseInt(process.argv.find(a => a.startsWith('--batch-size='))?.split('=')[1] || '500');
+
+async function runMigration() {
+  console.log(`Starting KV to D1 migration...`);
+  console.log(`Endpoint: ${BASE_URL}/admin/api/migrate-kv`);
+  console.log(`Batch size: ${BATCH_SIZE}\n`);
+
+  let cursor = null;
+  let totalMigrated = 0;
+  let batchNum = 0;
+
+  while (true) {
+    batchNum++;
+    console.log(`\n--- Batch ${batchNum} ---`);
+
+    const response = await fetch(`${BASE_URL}/admin/api/migrate-kv`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ cursor, batchSize: BATCH_SIZE })
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      console.error(`Error: ${response.status} - ${text}`);
+
+      if (response.status === 401 || response.status === 403) {
+        console.error('\nAuthentication required. You need to:');
+        console.error('1. Add a bypass policy in Zero Trust for /admin/api/migrate-kv');
+        console.error('2. Or run this from the Workers dashboard using a test');
+        console.error('3. Or use wrangler tail to watch logs while triggering from browser');
+      }
+      break;
+    }
+
+    const result = await response.json();
+    console.log(`Migrated: ${result.migrated} records`);
+    totalMigrated += result.migrated;
+
+    if (result.done) {
+      console.log(`\n✅ Migration complete!`);
+      console.log(`Total migrated: ${totalMigrated} records`);
+      break;
+    }
+
+    cursor = result.cursor;
+    console.log(`Progress: ${totalMigrated} total, continuing...`);
+
+    // Small delay to avoid overwhelming the worker
+    await new Promise(r => setTimeout(r, 100));
+  }
+}
+
+runMigration().catch(console.error);

--- a/src/admin/dashboard.html
+++ b/src/admin/dashboard.html
@@ -1615,7 +1615,7 @@
       if (author) {
         metaLine += '<span style="color: #a78bfa;">👤 ' + escapeHtml(author) + '</span>';
       } else if (pubkey) {
-        metaLine += '<span style="color: #666;">👤 ' + pubkey + '</span>';
+        metaLine += '<span class="copyable-id" style="color: #666; cursor: pointer;" onclick="copyToClipboard(\'' + pubkey + '\'); event.stopPropagation();" title="Click to copy: ' + pubkey + '">👤 ' + pubkey.substring(0, 12) + '...</span>';
       }
       if (client) {
         metaLine += (metaLine ? ' · ' : '') + '<span style="color: #666;">' + escapeHtml(client) + '</span>';
@@ -1637,9 +1637,10 @@
           '</div>' +
         '</div>' +
         '<div class="video-info">' +
-          '<div style="font-size: 11px; color: #666; margin-bottom: 6px; font-family: monospace;">' +
-            '<span title="' + sha256 + '">' + sha256.substring(0, 16) + '...</span> ' +
-            '<button onclick="copyToClipboard(\'' + videoUrl + '\'); event.stopPropagation();" style="background: #333; color: #888; border: none; padding: 2px 6px; border-radius: 3px; cursor: pointer; font-size: 10px;" title="Copy video URL">📋 URL</button>' +
+          '<div style="font-size: 11px; color: #666; margin-bottom: 6px; font-family: monospace; display: flex; gap: 6px; align-items: center;">' +
+            '<span class="copyable-id" style="cursor: pointer;" onclick="copyToClipboard(\'' + sha256 + '\'); event.stopPropagation();" title="Click to copy: ' + sha256 + '">' + sha256.substring(0, 16) + '...</span>' +
+            '<button onclick="copyToClipboard(\'' + sha256 + '\'); event.stopPropagation();" style="background: #333; color: #888; border: none; padding: 2px 6px; border-radius: 3px; cursor: pointer; font-size: 10px;" title="Copy SHA256">📋</button>' +
+            '<button onclick="copyToClipboard(\'' + videoUrl + '\'); event.stopPropagation();" style="background: #333; color: #888; border: none; padding: 2px 6px; border-radius: 3px; cursor: pointer; font-size: 10px;" title="Copy video URL">🔗</button>' +
           '</div>' +
           (metaLine ? '<div style="font-size: 12px; margin-bottom: 6px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">' + metaLine + '</div>' : '') +
           (description ? '<div style="font-size: 13px; color: #ccc; margin-bottom: 8px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">' + description + '</div>' : '') +
@@ -1960,6 +1961,33 @@
         parts.push(`<div class="nostr-meta">${metaItems.join('')}</div>`);
       }
 
+      // Add copyable identifiers section
+      const idItems = [];
+
+      if (metadata.pubkey) {
+        idItems.push(`
+          <span class="nostr-meta-item" style="cursor: pointer;" onclick="copyToClipboard('${metadata.pubkey}')" title="Click to copy: ${metadata.pubkey}">
+            <span class="nostr-meta-label">pubkey</span>
+            <span class="nostr-meta-value" style="font-family: monospace;">${metadata.pubkey.substring(0, 12)}...</span>
+            <button onclick="copyToClipboard('${metadata.pubkey}'); event.stopPropagation();" style="background: #333; color: #888; border: none; padding: 1px 4px; border-radius: 3px; cursor: pointer; font-size: 9px; margin-left: 4px;">📋</button>
+          </span>
+        `);
+      }
+
+      if (metadata.eventId) {
+        idItems.push(`
+          <span class="nostr-meta-item" style="cursor: pointer;" onclick="copyToClipboard('${metadata.eventId}')" title="Click to copy: ${metadata.eventId}">
+            <span class="nostr-meta-label">event</span>
+            <span class="nostr-meta-value" style="font-family: monospace;">${metadata.eventId.substring(0, 12)}...</span>
+            <button onclick="copyToClipboard('${metadata.eventId}'); event.stopPropagation();" style="background: #333; color: #888; border: none; padding: 1px 4px; border-radius: 3px; cursor: pointer; font-size: 9px; margin-left: 4px;">📋</button>
+          </span>
+        `);
+      }
+
+      if (idItems.length > 0) {
+        parts.push(`<div class="nostr-meta" style="margin-top: 6px;">${idItems.join('')}</div>`);
+      }
+
       return parts.join('');
     }
 
@@ -2097,7 +2125,11 @@
           </div>
           <div class="video-info">
             <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
-              <div class="video-hash" title="Click to copy full hash" onclick="copyToClipboard('${sha256}')" style="margin-bottom: 0;">${sha256.substring(0, 16)}...</div>
+              <div style="display: flex; align-items: center; gap: 6px;">
+                <div class="video-hash" title="Click to copy: ${sha256}" onclick="copyToClipboard('${sha256}')" style="margin-bottom: 0;">${sha256.substring(0, 16)}...</div>
+                <button onclick="copyToClipboard('${sha256}'); event.stopPropagation();" style="background: #333; color: #888; border: none; padding: 2px 6px; border-radius: 3px; cursor: pointer; font-size: 10px;" title="Copy SHA256">📋</button>
+                <button onclick="copyToClipboard('https://cdn.divine.video/${sha256}.mp4'); event.stopPropagation();" style="background: #333; color: #888; border: none; padding: 2px 6px; border-radius: 3px; cursor: pointer; font-size: 10px;" title="Copy video URL">🔗</button>
+              </div>
               ${providerBadgeHTML}
             </div>
 
@@ -2122,9 +2154,11 @@
               <div class="nostr-loading">Loading context...</div>
             </div>
 
-            <div class="divine-link">
+            <div class="divine-link" style="display: flex; justify-content: space-between; align-items: center;">
               <a id="divine-link-${sha256}" href="https://divine.video/video/${sha256}?source=discovery&index=0" target="_blank" rel="noopener noreferrer">
-                View on divine.video →
+                View on divine.video →</a>
+              <a href="/reports/${sha256}" target="_blank" style="color: #888; font-size: 12px; text-decoration: none;" title="View full report with copyable IDs">
+                📋 Report
               </a>
             </div>
 
@@ -2509,14 +2543,26 @@
 
     function copyToClipboard(text) {
       navigator.clipboard.writeText(text).then(() => {
-        console.log(`Copied SHA256 to clipboard: ${text}`);
+        console.log(`Copied to clipboard: ${text.substring(0, 24)}...`);
         // Show brief visual feedback
-        event.target.style.background = '#2563eb';
-        event.target.style.color = '#fff';
+        const target = event.target;
+        const originalText = target.textContent;
+        const originalBg = target.style.background;
+        const originalColor = target.style.color;
+
+        target.style.background = '#22c55e';
+        target.style.color = '#fff';
+        if (target.tagName === 'BUTTON') {
+          target.textContent = '✓';
+        }
+
         setTimeout(() => {
-          event.target.style.background = '';
-          event.target.style.color = '';
-        }, 200);
+          target.style.background = originalBg;
+          target.style.color = originalColor;
+          if (target.tagName === 'BUTTON') {
+            target.textContent = originalText;
+          }
+        }, 800);
       }).catch(err => {
         console.error('Failed to copy:', err);
       });

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -12,6 +12,7 @@ import { verifyZeroTrustJWT } from './admin/zerotrust.mjs';
 import { fetchNostrEventBySha256, parseVideoEventMetadata } from './nostr/relay-client.mjs';
 import dashboardHTML from './admin/dashboard.html';
 import swipeReviewHTML from './admin/swipe-review.html';
+import { Relay } from 'nostr-tools/relay';
 
 /**
  * NIP-32 label mapping for content categories
@@ -99,6 +100,69 @@ export default {
       return Response.redirect(`${url.origin}/admin/dashboard`, 302);
     }
 
+    // Debug: verify relay config and connectivity; optional test publish
+    if (url.pathname === '/admin/api/debug-relay') {
+      const authError = await requireAuth(request, env);
+      if (authError) {
+        return authError;
+      }
+
+      const relayUrl = env.NOSTR_RELAY_URL || env.FARO_RELAY_URL || null;
+      const hasPrivateKey = !!env.NOSTR_PRIVATE_KEY;
+      const hasModeratorKey = !!env.MODERATOR_NSEC;
+      const useAccessHeaders = !!(env.CF_ACCESS_CLIENT_ID && env.CF_ACCESS_CLIENT_SECRET);
+
+      let connectOk = false;
+      let connectError = null;
+      if (relayUrl) {
+        try {
+          const relayOptions = {};
+          if (useAccessHeaders) {
+            relayOptions.headers = {
+              'CF-Access-Client-Id': env.CF_ACCESS_CLIENT_ID,
+              'CF-Access-Client-Secret': env.CF_ACCESS_CLIENT_SECRET
+            };
+          }
+          const relay = await Relay.connect(relayUrl, relayOptions);
+          try {
+            connectOk = true;
+          } finally {
+            relay.close();
+          }
+        } catch (e) {
+          connectError = e?.message || String(e);
+        }
+      }
+
+      // Optionally publish a test moderation event (requires sha256)
+      let testPublish = null;
+      const publishTest = url.searchParams.get('publishTest') === '1' || url.searchParams.get('publishTest') === 'true';
+      const testSha = url.searchParams.get('sha256');
+      if (publishTest && testSha) {
+        try {
+          await publishToFaro({
+            type: 'review',
+            sha256: testSha,
+            scores: { nudity: 0.01, violence: 0.01 },
+            reason: 'debug-relay-ping'
+          }, env);
+          testPublish = { published: true };
+        } catch (e) {
+          testPublish = { published: false, error: e?.message || String(e) };
+        }
+      }
+
+      return new Response(JSON.stringify({
+        hasPrivateKey,
+        hasModeratorKey,
+        relayUrl,
+        useAccessHeaders,
+        connectOk,
+        connectError,
+        testPublish
+      }), { headers: { 'Content-Type': 'application/json' } });
+    }
+
     // Login is handled by Cloudflare Zero Trust at the edge
     // Redirect any direct login requests to the dashboard (Zero Trust will prompt if needed)
     if (url.pathname === '/admin/login') {
@@ -132,6 +196,56 @@ export default {
       }
 
       return new Response(swipeReviewHTML, {
+        headers: { 'Content-Type': 'text/html' }
+      });
+    }
+
+    // Report page for a specific video - /reports/{sha256}
+    if (url.pathname.startsWith('/reports/')) {
+      const authError = await requireAuth(request, env);
+      if (authError) {
+        return authError;
+      }
+
+      const sha256 = url.pathname.split('/')[2];
+      if (!sha256 || sha256.length !== 64) {
+        return new Response('Invalid SHA256', { status: 400 });
+      }
+
+      // Fetch video data from D1
+      const d1Result = await env.BLOSSOM_DB.prepare(`
+        SELECT sha256, action, provider, scores, categories, moderated_at, reviewed_by, reviewed_at, review_notes
+        FROM moderation_results
+        WHERE sha256 = ?
+      `).bind(sha256).first();
+
+      // Fetch Nostr context
+      let nostrContext = null;
+      try {
+        const event = await fetchNostrEventBySha256(sha256, ['wss://relay.divine.video'], env);
+        if (event) {
+          nostrContext = parseVideoEventMetadata(event);
+          nostrContext.pubkey = event.pubkey || null;
+        }
+      } catch (e) {
+        console.error(`[REPORTS] Failed to fetch Nostr context for ${sha256}:`, e.message);
+      }
+
+      // Fetch relay publish status
+      let relayPublishStatus = null;
+      try {
+        const relayData = await env.MODERATION_KV.get(`relay-publish:${sha256}`);
+        if (relayData) {
+          relayPublishStatus = JSON.parse(relayData);
+        }
+      } catch (e) {
+        console.error(`[REPORTS] Failed to fetch relay publish status for ${sha256}:`, e.message);
+      }
+
+      // Build report page HTML
+      const reportHTML = buildReportPageHTML(sha256, d1Result, nostrContext, relayPublishStatus, env);
+
+      return new Response(reportHTML, {
         headers: { 'Content-Type': 'text/html' }
       });
     }
@@ -324,7 +438,8 @@ export default {
                 author: metadata?.author || null,
                 client: metadata?.client || null,
                 content: metadata?.content || event.content || null,
-                pubkey: event.pubkey || null
+                pubkey: event.pubkey || null,
+                eventId: event.id || null
               };
             }
           } catch (e) {
@@ -353,7 +468,8 @@ export default {
               author: nostr.author,
               client: nostr.client,
               content: nostr.content,
-              pubkey: nostr.pubkey ? nostr.pubkey.substring(0, 16) + '...' : null
+              pubkey: nostr.pubkey || null,
+              eventId: nostr.eventId || null
             }
           };
         });
@@ -436,15 +552,34 @@ export default {
       }
 
       // Get existing moderation result
-      const existingData = await env.MODERATION_KV.get(`moderation:${sha256}`);
-      if (!existingData) {
-        return new Response(JSON.stringify({ error: 'Moderation result not found for this video' }), {
-          status: 404,
-          headers: { 'Content-Type': 'application/json' }
-        });
-      }
+      let existing;
+      let existingData = await env.MODERATION_KV.get(`moderation:${sha256}`);
+      if (existingData) {
+        existing = JSON.parse(existingData);
+      } else {
+        // Fallback to D1 if KV is missing (post-migration path)
+        const d1Row = await env.BLOSSOM_DB.prepare(`
+          SELECT sha256, action, provider, scores, categories, moderated_at
+          FROM moderation_results
+          WHERE sha256 = ?
+        `).bind(sha256).first();
 
-      const existing = JSON.parse(existingData);
+        if (!d1Row) {
+          return new Response(JSON.stringify({ error: 'Moderation result not found for this video' }), {
+            status: 404,
+            headers: { 'Content-Type': 'application/json' }
+          });
+        }
+
+        existing = {
+          sha256: d1Row.sha256,
+          action: d1Row.action,
+          scores: d1Row.scores ? JSON.parse(d1Row.scores) : {},
+          categories: d1Row.categories ? JSON.parse(d1Row.categories) : [],
+          moderatedAt: d1Row.moderated_at
+        };
+        existingData = JSON.stringify(existing);
+      }
 
       // Update moderation result
       const updated = {
@@ -515,9 +650,96 @@ export default {
             manualOverride: true
           })
         );
+        // Back-compat for older CDN workers expecting quarantine flag
+        await env.MODERATION_KV.put(
+          `quarantine:${sha256}`,
+          JSON.stringify({
+            reason: updated.reason || 'permanent ban',
+            timestamp: Date.now()
+          })
+        );
       }
 
       console.log(`[ADMIN] Updated ${sha256} from ${existing.action} to ${action}`);
+
+      // Publish to relay so ban/block takes effect at source
+      let publishResult = null;
+      try {
+        if (action !== 'SAFE') {
+          publishResult = await publishToFaro({
+            type: action.toLowerCase().replace('_', '-'),
+            sha256,
+            cdnUrl: updated.cdnUrl,
+            scores: updated.scores || {},
+            reason: updated.reason
+          }, env);
+
+          if (publishResult?.published && publishResult?.verified) {
+            console.log(`[ADMIN] ✅ Published and verified ${action} event to relay for ${sha256}`);
+          } else if (publishResult?.published) {
+            console.warn(`[ADMIN] ⚠️ Published ${action} event but could not verify on relay for ${sha256}`);
+          } else {
+            console.error(`[ADMIN] ❌ Failed to publish ${action} event: ${publishResult?.error || 'unknown error'}`);
+          }
+
+          // Audit KV for relay publishes (production observability)
+          await env.MODERATION_KV.put(
+            `relay-publish:${sha256}`,
+            JSON.stringify({
+              action,
+              reason: updated.reason || null,
+              publishedAt: Date.now(),
+              source: 'admin-override',
+              eventId: publishResult?.eventId || null,
+              published: publishResult?.published || false,
+              verified: publishResult?.verified || false,
+              error: publishResult?.error || null
+            }),
+            { expirationTtl: 60 * 60 * 24 * 30 }
+          );
+        }
+      } catch (e) {
+        console.error(`[ADMIN] Failed to publish ${action} event for ${sha256}:`, e.message || e);
+        // Store failure in KV for auditing
+        await env.MODERATION_KV.put(
+          `relay-publish:${sha256}`,
+          JSON.stringify({
+            action,
+            reason: updated.reason || null,
+            publishedAt: Date.now(),
+            source: 'admin-override',
+            published: false,
+            verified: false,
+            error: e.message || String(e)
+          }),
+          { expirationTtl: 60 * 60 * 24 * 30 }
+        );
+      }
+
+      // Mirror update in D1 so dashboards and API reflect manual overrides
+      try {
+        await env.BLOSSOM_DB.prepare(`
+          INSERT INTO moderation_results (sha256, action, provider, scores, categories, moderated_at)
+          VALUES (?, ?, ?, ?, ?, ?)
+          ON CONFLICT(sha256) DO UPDATE SET
+            action = excluded.action,
+            provider = excluded.provider,
+            review_notes = ?,
+            reviewed_at = ?
+        `).bind(
+          sha256,
+          action.toUpperCase(),
+          'admin-override',
+          JSON.stringify(updated.scores || {}),
+          JSON.stringify(updated.categories || []),
+          new Date().toISOString(),
+          updated.reason || null,
+          new Date().toISOString()
+        ).run();
+      } catch (e) {
+        console.error(`[ADMIN] Failed to mirror action to D1 for ${sha256}:`, e);
+        // Do not fail the request if D1 write fails
+      }
 
       return new Response(JSON.stringify({
         success: true,
@@ -528,6 +750,99 @@ export default {
       }), {
         headers: { 'Content-Type': 'application/json' }
       });
+    }
+
+    // Admin: production self-test for KV/D1/Relay
+    if (url.pathname === '/admin/api/self-test') {
+      const authError = await requireAuth(request, env);
+      if (authError) return authError;
+
+      const start = Date.now();
+      const results = { ok: true, checks: {}, durationMs: 0 };
+
+      // KV read/write
+      try {
+        const key = `selftest:${crypto.randomUUID()}`;
+        await env.MODERATION_KV.put(key, JSON.stringify({ t: Date.now() }), { expirationTtl: 60 });
+        const readBack = await env.MODERATION_KV.get(key);
+        await env.MODERATION_KV.delete(key);
+        results.checks.kv = { ok: !!readBack };
+      } catch (e) {
+        results.checks.kv = { ok: false, error: e.message };
+        results.ok = false;
+      }
+
+      // D1 simple query
+      try {
+        const row = await env.BLOSSOM_DB.prepare('SELECT 1 as ok').first();
+        results.checks.d1 = { ok: row?.ok === 1 };
+      } catch (e) {
+        results.checks.d1 = { ok: false, error: e.message };
+        results.ok = false;
+      }
+
+      // Relay connectivity
+      try {
+        const relayUrl = env.NOSTR_RELAY_URL || env.FARO_RELAY_URL;
+        if (!relayUrl) throw new Error('No relay configured');
+        const relayOptions = {};
+        if (env.CF_ACCESS_CLIENT_ID && env.CF_ACCESS_CLIENT_SECRET) {
+          relayOptions.headers = {
+            'CF-Access-Client-Id': env.CF_ACCESS_CLIENT_ID,
+            'CF-Access-Client-Secret': env.CF_ACCESS_CLIENT_SECRET
+          };
+        }
+        const relay = await Relay.connect(relayUrl, relayOptions);
+        relay.close();
+        results.checks.relay = { ok: true, relayUrl };
+      } catch (e) {
+        results.checks.relay = { ok: false, error: e.message };
+        results.ok = false;
+      }
+
+      results.durationMs = Date.now() - start;
+      return new Response(JSON.stringify(results), { headers: { 'Content-Type': 'application/json' } });
+    }
+
+    // Admin: combined status for a specific sha256 (D1 + KV + last relay publish)
+    if (url.pathname.startsWith('/admin/api/status/')) {
+      const authError = await requireAuth(request, env);
+      if (authError) return authError;
+
+      const sha256 = url.pathname.split('/')[4] || url.pathname.split('/')[3];
+      if (!sha256) {
+        return new Response(JSON.stringify({ error: 'sha256 required' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+      }
+
+      // D1
+      const d1 = await env.BLOSSOM_DB.prepare(`
+        SELECT sha256, action, provider, moderated_at FROM moderation_results WHERE sha256 = ?
+      `).bind(sha256).first();
+
+      // KV flags
+      const [modKV, revKV, ageKV, banKV, legacy] = await Promise.all([
+        env.MODERATION_KV.get(`moderation:${sha256}`),
+        env.MODERATION_KV.get(`review:${sha256}`),
+        env.MODERATION_KV.get(`age-restricted:${sha256}`),
+        env.MODERATION_KV.get(`permanent-ban:${sha256}`),
+        env.MODERATION_KV.get(`quarantine:${sha256}`)
+      ]);
+
+      // Relay audit
+      const relayAudit = await env.MODERATION_KV.get(`relay-publish:${sha256}`);
+
+      return new Response(JSON.stringify({
+        sha256,
+        d1,
+        kv: {
+          moderation: !!modKV,
+          review: !!revKV,
+          ageRestricted: !!ageKV,
+          permanentBan: !!banKV,
+          quarantine: !!legacy
+        },
+        relay: relayAudit ? JSON.parse(relayAudit) : null
+      }), { headers: { 'Content-Type': 'application/json' } });
     }
 
     // Verify/reject individual category detection (for NIP-85 tagging)
@@ -688,6 +1003,8 @@ export default {
         }
 
         const metadata = parseVideoEventMetadata(event);
+        // Include pubkey separately since it's on the event, not in metadata
+        metadata.pubkey = event.pubkey || null;
 
         return new Response(JSON.stringify({ found: true, metadata }), {
           headers: { 'Content-Type': 'application/json' }
@@ -974,7 +1291,7 @@ async function runMigration() {
 
       try {
         const body = await request.json();
-        const { sha256, action, reason, source } = body;
+      const { sha256, action, reason, source, requestId } = body;
 
         if (!sha256 || !action) {
           return new Response(JSON.stringify({ error: 'sha256 and action required' }), {
@@ -994,7 +1311,7 @@ async function runMigration() {
           });
         }
 
-        // Update or insert moderation result
+        // Update or insert moderation result (D1)
         await env.BLOSSOM_DB.prepare(`
           INSERT INTO moderation_results (sha256, action, provider, scores, categories, moderated_at)
           VALUES (?, ?, ?, ?, ?, ?)
@@ -1014,7 +1331,87 @@ async function runMigration() {
           new Date().toISOString()
         ).run();
 
+        // Sync KV flags and publish to relay so enforcement happens
+        try {
+          // Basic KV record
+          const kvValue = {
+            sha256,
+            action: action.toUpperCase(),
+            scores: {},
+            categories: [],
+            reason: reason || `External update by ${source || 'external-api'}`,
+            provider: source || 'external-api',
+            moderatedAt: new Date().toISOString()
+          };
+          await env.MODERATION_KV.put(`moderation:${sha256}`, JSON.stringify(kvValue), { expirationTtl: 60 * 60 * 24 * 90 });
+
+          // Update action flags
+          await Promise.all([
+            env.MODERATION_KV.delete(`review:${sha256}`),
+            env.MODERATION_KV.delete(`age-restricted:${sha256}`),
+            env.MODERATION_KV.delete(`permanent-ban:${sha256}`),
+            env.MODERATION_KV.delete(`quarantine:${sha256}`)
+          ]);
+
+          if (action.toUpperCase() === 'REVIEW') {
+            await env.MODERATION_KV.put(`review:${sha256}`, JSON.stringify({ reason: kvValue.reason, timestamp: Date.now() }));
+          } else if (action.toUpperCase() === 'AGE_RESTRICTED') {
+            await env.MODERATION_KV.put(`age-restricted:${sha256}`, JSON.stringify({ reason: kvValue.reason, timestamp: Date.now() }));
+          } else if (action.toUpperCase() === 'PERMANENT_BAN') {
+            await env.MODERATION_KV.put(`permanent-ban:${sha256}`, JSON.stringify({ reason: kvValue.reason, timestamp: Date.now() }));
+            // legacy quarantine flag
+            await env.MODERATION_KV.put(`quarantine:${sha256}`, JSON.stringify({ reason: kvValue.reason, timestamp: Date.now() }));
+          }
+
+          // Publish to relay
+          if (action.toUpperCase() !== 'SAFE') {
+            const publishResult = await publishToFaro({
+              type: action.toLowerCase().replace('_', '-'),
+              sha256,
+              scores: {},
+              reason: kvValue.reason
+            }, env);
+
+            // Store publish verification result
+            await env.MODERATION_KV.put(
+              `relay-publish:${sha256}`,
+              JSON.stringify({
+                action: action.toUpperCase(),
+                reason: kvValue.reason,
+                publishedAt: Date.now(),
+                source: source || 'external-api',
+                eventId: publishResult?.eventId || null,
+                published: publishResult?.published || false,
+                verified: publishResult?.verified || false,
+                error: publishResult?.error || null
+              }),
+              { expirationTtl: 60 * 60 * 24 * 30 }
+            );
+          }
+        } catch (e) {
+          console.error('[API] KV/Relay sync failed:', e);
+          // do not fail the request on sync issues
+        }
+
         console.log(`[API] Moderation updated: ${sha256} -> ${action} by ${source || 'external-api'} (auth: ${authSource})`);
+
+        // Emit result to results queue for observability/feedback
+        try {
+          if (env.ACTION_RESULTS_QUEUE) {
+            await env.ACTION_RESULTS_QUEUE.send({
+              type: 'moderation-action-result',
+              sha256,
+              action: action.toUpperCase(),
+              status: 'success',
+              reason: reason || null,
+              source: source || 'external-api',
+              processedAt: Date.now(),
+              requestId: requestId || null
+            });
+          }
+        } catch (e) {
+          console.error('[API] Failed to emit result message:', e);
+        }
 
         return new Response(JSON.stringify({
           success: true,
@@ -1032,6 +1429,35 @@ async function runMigration() {
           headers: { 'Content-Type': 'application/json' }
         });
       }
+    }
+
+    // API: Queue moderation action for asynchronous handling
+    // Useful for cross-service integration (e.g., realness.admin)
+    if (url.pathname === '/api/v1/moderate/queue' && request.method === 'POST') {
+      const jwtToken = request.headers.get('cf-access-jwt-assertion');
+      const verification = await verifyZeroTrustJWT(jwtToken, env);
+      if (!verification.valid) {
+        return new Response(JSON.stringify({ error: `Unauthorized - ${verification.error}` }), { status: 401, headers: { 'Content-Type': 'application/json' } });
+      }
+
+      const body = await request.json();
+      const { sha256, action, reason, source, requestId } = body || {};
+      const validActions = ['SAFE', 'REVIEW', 'AGE_RESTRICTED', 'PERMANENT_BAN'];
+      if (!sha256 || !action || !validActions.includes(action.toUpperCase())) {
+        return new Response(JSON.stringify({ error: 'sha256 and valid action required' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+      }
+
+      // Send action message to ACTION_QUEUE
+      await env.ACTION_QUEUE.send({
+        type: 'moderation-action',
+        sha256,
+        action: action.toUpperCase(),
+        reason: reason || null,
+        source: source || (verification.email ? `user:${verification.email}` : 'external'),
+        requestId: requestId || crypto.randomUUID()
+      });
+
+      return new Response(JSON.stringify({ success: true, queued: true, sha256, action: action.toUpperCase(), requestId }), { headers: { 'Content-Type': 'application/json' } });
     }
 
     // Check moderation result
@@ -1094,6 +1520,136 @@ async function runMigration() {
       const startTime = Date.now();
 
       try {
+        // Fast path: moderation-action messages (from ACTION_QUEUE)
+        if (message.body && message.body.type === 'moderation-action') {
+          const { sha256, action, reason, source, requestId } = message.body;
+          const validActions = ['SAFE', 'REVIEW', 'AGE_RESTRICTED', 'PERMANENT_BAN'];
+          if (!sha256 || !validActions.includes((action || '').toUpperCase())) {
+            console.error('[ACTION] Invalid moderation-action message', message.body);
+            message.ack();
+            continue;
+          }
+
+          const act = action.toUpperCase();
+          console.log(`[ACTION] Processing action ${act} for ${sha256} (source=${source || 'unknown'})`);
+
+          // D1 mirror
+          try {
+            await env.BLOSSOM_DB.prepare(`
+              INSERT INTO moderation_results (sha256, action, provider, scores, categories, moderated_at)
+              VALUES (?, ?, ?, ?, ?, ?)
+              ON CONFLICT(sha256) DO UPDATE SET
+                action = excluded.action,
+                provider = excluded.provider,
+                review_notes = ?,
+                reviewed_at = ?
+            `).bind(
+              sha256,
+              act,
+              source || 'action-queue',
+              JSON.stringify({}),
+              JSON.stringify([reason || act.toLowerCase()]),
+              new Date().toISOString(),
+              reason || null,
+              new Date().toISOString()
+            ).run();
+          } catch (e) {
+            console.error('[ACTION] Failed to write D1:', e);
+          }
+
+          // KV flags
+          try {
+            await env.MODERATION_KV.put(`moderation:${sha256}`,
+              JSON.stringify({ sha256, action: act, reason, provider: source || 'action-queue', moderatedAt: new Date().toISOString() }),
+              { expirationTtl: 60 * 60 * 24 * 90 }
+            );
+            await Promise.all([
+              env.MODERATION_KV.delete(`review:${sha256}`),
+              env.MODERATION_KV.delete(`age-restricted:${sha256}`),
+              env.MODERATION_KV.delete(`permanent-ban:${sha256}`),
+              env.MODERATION_KV.delete(`quarantine:${sha256}`)
+            ]);
+            if (act === 'REVIEW') {
+              await env.MODERATION_KV.put(`review:${sha256}`, JSON.stringify({ reason, timestamp: Date.now() }));
+            } else if (act === 'AGE_RESTRICTED') {
+              await env.MODERATION_KV.put(`age-restricted:${sha256}`, JSON.stringify({ reason, timestamp: Date.now() }));
+            } else if (act === 'PERMANENT_BAN') {
+              await env.MODERATION_KV.put(`permanent-ban:${sha256}`, JSON.stringify({ reason, timestamp: Date.now() }));
+              await env.MODERATION_KV.put(`quarantine:${sha256}`, JSON.stringify({ reason: reason || 'permanent ban', timestamp: Date.now() }));
+            }
+          } catch (e) {
+            console.error('[ACTION] Failed to sync KV flags:', e);
+          }
+
+          // Relay publish
+          try {
+            if (act !== 'SAFE') {
+              const publishResult = await publishToFaro({ type: act.toLowerCase().replace('_', '-'), sha256, scores: {}, reason }, env);
+
+              if (publishResult?.published && publishResult?.verified) {
+                console.log(`[ACTION] ✅ Published and verified event for ${sha256.substring(0, 16)}...`);
+              } else if (publishResult?.published) {
+                console.warn(`[ACTION] ⚠️ Published but unverified event for ${sha256.substring(0, 16)}...`);
+              } else {
+                console.error(`[ACTION] ❌ Publish failed for ${sha256.substring(0, 16)}...: ${publishResult?.error}`);
+              }
+
+              await env.MODERATION_KV.put(
+                `relay-publish:${sha256}`,
+                JSON.stringify({
+                  action: act,
+                  reason: reason || null,
+                  publishedAt: Date.now(),
+                  source: 'action-queue',
+                  eventId: publishResult?.eventId || null,
+                  published: publishResult?.published || false,
+                  verified: publishResult?.verified || false,
+                  error: publishResult?.error || null
+                }),
+                { expirationTtl: 60 * 60 * 24 * 30 }
+              );
+            }
+          } catch (e) {
+            console.error('[ACTION] Failed to publish relay event:', e);
+            // Store failure for auditing
+            await env.MODERATION_KV.put(
+              `relay-publish:${sha256}`,
+              JSON.stringify({
+                action: act,
+                reason: reason || null,
+                publishedAt: Date.now(),
+                source: 'action-queue',
+                published: false,
+                verified: false,
+                error: e.message || String(e)
+              }),
+              { expirationTtl: 60 * 60 * 24 * 30 }
+            ).catch(() => {});
+          }
+
+          // Emit result to results queue for external admin feedback
+          try {
+            if (env.ACTION_RESULTS_QUEUE) {
+              await env.ACTION_RESULTS_QUEUE.send({
+                type: 'moderation-action-result',
+                sha256,
+                action: act,
+                status: 'success',
+                reason: reason || null,
+                source: source || 'action-queue',
+                processedAt: Date.now(),
+                requestId: requestId || null
+              });
+            }
+          } catch (e) {
+            console.error('[ACTION] Failed to emit result message:', e);
+          }
+
+          message.ack();
+          console.log(`[ACTION] ✅ COMPLETED ${sha256} -> ${act} in ${Date.now() - startTime}ms`);
+          continue;
+        }
+
         console.log('[MODERATION] Step 1: Validating message');
 
         // Validate message schema
@@ -1152,6 +1708,63 @@ async function runMigration() {
         ).run();
         console.log(`[MODERATION] Step 7: D1 write successful`);
 
+        // Keep KV in sync for legacy consumers and admin operations
+        try {
+          const kvValue = {
+            sha256,
+            action: result.action,
+            scores: result.scores || {},
+            categories: result.categories || [],
+            reason: result.reason,
+            severity: result.severity,
+            provider: result.provider || 'unknown',
+            cdnUrl: result.cdnUrl,
+            flaggedFrames: result.flaggedFrames || [],
+            moderatedAt: new Date().toISOString()
+          };
+
+          await env.MODERATION_KV.put(
+            `moderation:${sha256}`,
+            JSON.stringify(kvValue),
+            { expirationTtl: 60 * 60 * 24 * 90 }
+          );
+
+          // Clear old action flags and set the current one
+          await Promise.all([
+            env.MODERATION_KV.delete(`review:${sha256}`),
+            env.MODERATION_KV.delete(`age-restricted:${sha256}`),
+            env.MODERATION_KV.delete(`permanent-ban:${sha256}`),
+            env.MODERATION_KV.delete(`quarantine:${sha256}`) // legacy
+          ]);
+
+          if (result.action === 'REVIEW') {
+            await env.MODERATION_KV.put(
+              `review:${sha256}`,
+              JSON.stringify({ reason: result.reason, timestamp: Date.now() })
+            );
+          } else if (result.action === 'AGE_RESTRICTED') {
+            await env.MODERATION_KV.put(
+              `age-restricted:${sha256}`,
+              JSON.stringify({ reason: result.reason, timestamp: Date.now() })
+            );
+          } else if (result.action === 'PERMANENT_BAN') {
+            await env.MODERATION_KV.put(
+              `permanent-ban:${sha256}`,
+              JSON.stringify({ reason: result.reason, timestamp: Date.now() })
+            );
+            // Back-compat for older CDN workers expecting quarantine flag
+            await env.MODERATION_KV.put(
+              `quarantine:${sha256}`,
+              JSON.stringify({ reason: result.reason || 'permanent ban', timestamp: Date.now() })
+            );
+          }
+
+          console.log(`[MODERATION] Step 7b: KV synced (moderation + flags)`);
+        } catch (e) {
+          console.error(`[MODERATION] Failed to sync KV for ${sha256}:`, e);
+          // Continue; KV write failures should not fail the moderation
+        }
+
         // Handle based on severity
         console.log(`[MODERATION] Step 8: Handling result (action=${result.action})`);
         await handleModerationResult(result, env);
@@ -1164,6 +1777,25 @@ async function runMigration() {
 
       } catch (error) {
         console.error(`[MODERATION] Error processing message:`, error);
+
+        // If this was a moderation-action message, emit failure to results queue
+        try {
+          if (message.body && message.body.type === 'moderation-action' && env.ACTION_RESULTS_QUEUE) {
+            const { sha256, action, reason, source, requestId } = message.body;
+            await env.ACTION_RESULTS_QUEUE.send({
+              type: 'moderation-action-result',
+              sha256,
+              action,
+              status: 'failed',
+              error: error?.message || String(error),
+              source: source || 'action-queue',
+              processedAt: Date.now(),
+              requestId: requestId || null
+            });
+          }
+        } catch (e2) {
+          console.error('[ACTION] Failed to emit failure result:', e2);
+        }
 
         // Retry logic
         if (message.attempts < 3) {
@@ -1192,6 +1824,343 @@ async function runMigration() {
 };
 
 /**
+ * Build HTML for the report page
+ * Shows detailed video information with copyable identifiers
+ */
+function buildReportPageHTML(sha256, d1Result, nostrContext, relayPublishStatus, env) {
+  const action = d1Result?.action || 'UNKNOWN';
+  const scores = d1Result?.scores ? JSON.parse(d1Result.scores) : {};
+  const categories = d1Result?.categories ? JSON.parse(d1Result.categories) : [];
+  const moderatedAt = d1Result?.moderated_at || null;
+  const provider = d1Result?.provider || 'unknown';
+  const reviewedBy = d1Result?.reviewed_by || null;
+  const reviewedAt = d1Result?.reviewed_at || null;
+  const reviewNotes = d1Result?.review_notes || null;
+
+  const eventId = nostrContext?.eventId || null;
+  const pubkey = nostrContext?.pubkey || null;
+  const title = nostrContext?.title || null;
+  const author = nostrContext?.author || null;
+  const platform = nostrContext?.platform || null;
+
+  // Relay publish status
+  const relayPublished = relayPublishStatus?.published || false;
+  const relayVerified = relayPublishStatus?.verified || false;
+  const relayEventId = relayPublishStatus?.eventId || null;
+  const relayError = relayPublishStatus?.error || null;
+  const relayPublishedAt = relayPublishStatus?.publishedAt || null;
+
+  // Action badge colors
+  const actionColors = {
+    'SAFE': '#22c55e',
+    'REVIEW': '#f59e0b',
+    'AGE_RESTRICTED': '#f97316',
+    'PERMANENT_BAN': '#ef4444',
+    'UNKNOWN': '#666'
+  };
+  const actionColor = actionColors[action] || '#666';
+
+  // Build score rows
+  const scoreRows = Object.entries(scores)
+    .filter(([_, v]) => typeof v === 'number' && v > 0.01)
+    .sort(([, a], [, b]) => b - a)
+    .map(([category, score]) => `
+      <tr>
+        <td style="padding: 6px 12px; border-bottom: 1px solid #333;">${category}</td>
+        <td style="padding: 6px 12px; border-bottom: 1px solid #333; text-align: right; font-family: monospace;">${(score * 100).toFixed(1)}%</td>
+      </tr>
+    `).join('');
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Report: ${sha256.substring(0, 16)}... - Divine Moderation</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #0a0a0a;
+      color: #e5e5e5;
+      padding: 20px;
+      max-width: 1000px;
+      margin: 0 auto;
+    }
+    .header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 24px;
+      padding-bottom: 16px;
+      border-bottom: 1px solid #333;
+    }
+    .header h1 { font-size: 20px; font-weight: 500; }
+    .back-link { color: #3b82f6; text-decoration: none; }
+    .back-link:hover { text-decoration: underline; }
+    .video-container {
+      display: flex;
+      gap: 24px;
+      margin-bottom: 24px;
+    }
+    .video-player {
+      flex: 0 0 400px;
+      background: #111;
+      border-radius: 8px;
+      overflow: hidden;
+    }
+    .video-player video { width: 100%; display: block; }
+    .video-details { flex: 1; }
+    .action-badge {
+      display: inline-block;
+      padding: 6px 12px;
+      border-radius: 4px;
+      font-weight: 600;
+      font-size: 14px;
+      margin-bottom: 16px;
+    }
+    .section {
+      background: #111;
+      border: 1px solid #222;
+      border-radius: 8px;
+      padding: 16px;
+      margin-bottom: 16px;
+    }
+    .section-title {
+      font-size: 14px;
+      color: #888;
+      margin-bottom: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+    }
+    .id-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 0;
+      border-bottom: 1px solid #222;
+    }
+    .id-row:last-child { border-bottom: none; }
+    .id-label {
+      font-size: 12px;
+      color: #888;
+      width: 80px;
+      flex-shrink: 0;
+    }
+    .id-value {
+      font-family: monospace;
+      font-size: 13px;
+      color: #e5e5e5;
+      flex: 1;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .id-full {
+      font-family: monospace;
+      font-size: 11px;
+      color: #666;
+      word-break: break-all;
+      margin-top: 4px;
+      padding: 8px;
+      background: #0a0a0a;
+      border-radius: 4px;
+    }
+    .copy-btn {
+      background: #333;
+      color: #888;
+      border: none;
+      padding: 4px 8px;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 11px;
+      transition: background 0.2s;
+    }
+    .copy-btn:hover { background: #444; color: #fff; }
+    .copy-btn.copied { background: #22c55e; color: #fff; }
+    table { width: 100%; border-collapse: collapse; }
+    .meta-item {
+      display: flex;
+      padding: 8px 0;
+      border-bottom: 1px solid #222;
+    }
+    .meta-label { width: 120px; color: #888; font-size: 13px; }
+    .meta-value { color: #e5e5e5; font-size: 13px; }
+  </style>
+</head>
+<body>
+  <div class="header">
+    <h1>Video Report</h1>
+    <a href="/admin/dashboard" class="back-link">← Back to Dashboard</a>
+  </div>
+
+  <div class="video-container">
+    <div class="video-player">
+      <video src="/admin/video/${sha256}.mp4" controls muted loop preload="auto"></video>
+    </div>
+    <div class="video-details">
+      <div class="action-badge" style="background: ${actionColor};">${action}</div>
+
+      ${title ? `<h2 style="font-size: 18px; margin-bottom: 12px;">${escapeHtmlForReport(title)}</h2>` : ''}
+      ${author ? `<p style="color: #888; margin-bottom: 16px;">by ${escapeHtmlForReport(author)}${platform ? ` on ${escapeHtmlForReport(platform)}` : ''}</p>` : ''}
+
+      <div style="font-size: 13px; color: #888;">
+        ${provider ? `<div>Provider: <span style="color: #e5e5e5;">${escapeHtmlForReport(provider)}</span></div>` : ''}
+        ${moderatedAt ? `<div>Moderated: <span style="color: #e5e5e5;">${new Date(moderatedAt).toLocaleString()}</span></div>` : ''}
+        ${reviewedBy ? `<div>Reviewed by: <span style="color: #e5e5e5;">${escapeHtmlForReport(reviewedBy)}</span></div>` : ''}
+        ${reviewedAt ? `<div>Reviewed: <span style="color: #e5e5e5;">${new Date(reviewedAt).toLocaleString()}</span></div>` : ''}
+      </div>
+    </div>
+  </div>
+
+  <div class="section">
+    <div class="section-title">Identifiers (Click to copy)</div>
+
+    <div class="id-row">
+      <span class="id-label">SHA256</span>
+      <span class="id-value">${sha256.substring(0, 24)}...</span>
+      <button class="copy-btn" onclick="copyId('${sha256}', this)">📋 Copy</button>
+    </div>
+    <div class="id-full">${sha256}</div>
+
+    ${eventId ? `
+    <div class="id-row">
+      <span class="id-label">Event ID</span>
+      <span class="id-value">${eventId.substring(0, 24)}...</span>
+      <button class="copy-btn" onclick="copyId('${eventId}', this)">📋 Copy</button>
+    </div>
+    <div class="id-full">${eventId}</div>
+    ` : '<div class="id-row"><span class="id-label">Event ID</span><span class="id-value" style="color: #666;">No Nostr event found</span></div>'}
+
+    <div class="id-row">
+      <span class="id-label">d-tag</span>
+      <span class="id-value">${sha256.substring(0, 24)}...</span>
+      <button class="copy-btn" onclick="copyId('${sha256}', this)">📋 Copy</button>
+    </div>
+
+    ${pubkey ? `
+    <div class="id-row">
+      <span class="id-label">Pubkey</span>
+      <span class="id-value">${pubkey.substring(0, 24)}...</span>
+      <button class="copy-btn" onclick="copyId('${pubkey}', this)">📋 Copy</button>
+    </div>
+    <div class="id-full">${pubkey}</div>
+    ` : ''}
+
+    <div class="id-row">
+      <span class="id-label">Video URL</span>
+      <span class="id-value">https://cdn.divine.video/${sha256}.mp4</span>
+      <button class="copy-btn" onclick="copyId('https://cdn.divine.video/${sha256}.mp4', this)">📋 Copy</button>
+    </div>
+  </div>
+
+  ${scoreRows ? `
+  <div class="section">
+    <div class="section-title">AI Detection Scores</div>
+    <table>
+      <tbody>${scoreRows}</tbody>
+    </table>
+  </div>
+  ` : ''}
+
+  ${reviewNotes ? `
+  <div class="section">
+    <div class="section-title">Review Notes</div>
+    <p style="color: #e5e5e5; font-size: 14px;">${escapeHtmlForReport(reviewNotes)}</p>
+  </div>
+  ` : ''}
+
+  <div class="section">
+    <div class="section-title">Relay Publish Status</div>
+    ${action === 'SAFE' ? `
+      <div style="display: flex; align-items: center; gap: 8px; color: #888;">
+        <span style="font-size: 20px;">⏭️</span>
+        <span>Not published (SAFE content not broadcast to relay)</span>
+      </div>
+    ` : relayPublished && relayVerified ? `
+      <div style="display: flex; align-items: center; gap: 8px; color: #22c55e;">
+        <span style="font-size: 20px;">✅</span>
+        <span>Published and verified on relay</span>
+      </div>
+      ${relayEventId ? `
+      <div class="id-row" style="margin-top: 12px;">
+        <span class="id-label">Nostr Event</span>
+        <span class="id-value">${relayEventId.substring(0, 24)}...</span>
+        <button class="copy-btn" onclick="copyId('${relayEventId}', this)">📋 Copy</button>
+      </div>
+      <div class="id-full">${relayEventId}</div>
+      ` : ''}
+      ${relayPublishedAt ? `<div style="font-size: 12px; color: #666; margin-top: 8px;">Published: ${new Date(relayPublishedAt).toLocaleString()}</div>` : ''}
+    ` : relayPublished ? `
+      <div style="display: flex; align-items: center; gap: 8px; color: #f59e0b;">
+        <span style="font-size: 20px;">⚠️</span>
+        <span>Published but not verified (event may not be stored on relay)</span>
+      </div>
+      ${relayEventId ? `
+      <div class="id-row" style="margin-top: 12px;">
+        <span class="id-label">Nostr Event</span>
+        <span class="id-value">${relayEventId.substring(0, 24)}...</span>
+        <button class="copy-btn" onclick="copyId('${relayEventId}', this)">📋 Copy</button>
+      </div>
+      ` : ''}
+      ${relayPublishedAt ? `<div style="font-size: 12px; color: #666; margin-top: 8px;">Published: ${new Date(relayPublishedAt).toLocaleString()}</div>` : ''}
+    ` : relayError ? `
+      <div style="display: flex; align-items: center; gap: 8px; color: #ef4444;">
+        <span style="font-size: 20px;">❌</span>
+        <span>Publish failed</span>
+      </div>
+      <div style="font-size: 12px; color: #888; margin-top: 8px; padding: 8px; background: #1a1a1a; border-radius: 4px; font-family: monospace;">
+        Error: ${escapeHtmlForReport(relayError)}
+      </div>
+    ` : `
+      <div style="display: flex; align-items: center; gap: 8px; color: #888;">
+        <span style="font-size: 20px;">❓</span>
+        <span>No publish record found</span>
+      </div>
+    `}
+  </div>
+
+  <div class="section">
+    <div class="section-title">Quick Actions</div>
+    <div style="display: flex; gap: 12px; margin-top: 8px;">
+      <a href="https://divine.video/video/${eventId || sha256}" target="_blank" style="background: #3b82f6; color: white; padding: 10px 16px; border-radius: 6px; text-decoration: none; font-size: 14px;">View on Divine.video →</a>
+      <a href="/admin/dashboard?focus=${sha256}" style="background: #333; color: #e5e5e5; padding: 10px 16px; border-radius: 6px; text-decoration: none; font-size: 14px;">Open in Dashboard</a>
+    </div>
+  </div>
+
+  <script>
+    function copyId(text, btn) {
+      navigator.clipboard.writeText(text).then(() => {
+        const originalText = btn.textContent;
+        btn.textContent = '✓ Copied!';
+        btn.classList.add('copied');
+        setTimeout(() => {
+          btn.textContent = originalText;
+          btn.classList.remove('copied');
+        }, 1500);
+      }).catch(err => {
+        console.error('Failed to copy:', err);
+      });
+    }
+  </script>
+</body>
+</html>`;
+}
+
+/**
+ * Escape HTML for report page (simple version)
+ */
+function escapeHtmlForReport(str) {
+  if (!str) return '';
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/**
  * Handle moderation result - publish notifications
  * Action is already stored in D1, this just handles notifications
  */
@@ -1203,7 +2172,7 @@ async function handleModerationResult(result, env) {
   // Publish Nostr notifications for flagged content
   if (action !== 'SAFE') {
     try {
-      await publishToFaro({
+      const publishResult = await publishToFaro({
         type: action.toLowerCase().replace('_', '-'),
         sha256,
         cdnUrl,
@@ -1213,9 +2182,50 @@ async function handleModerationResult(result, env) {
         severity,
         frames: flaggedFrames
       }, env);
-      console.log(`[MODERATION] ${sha256} - Nostr ${action} event published`);
+
+      if (publishResult?.published && publishResult?.verified) {
+        console.log(`[MODERATION] ✅ ${sha256} - Nostr ${action} event published and verified`);
+      } else if (publishResult?.published) {
+        console.warn(`[MODERATION] ⚠️ ${sha256} - Nostr ${action} event published but not verified`);
+      } else {
+        console.error(`[MODERATION] ❌ ${sha256} - Nostr publish failed: ${publishResult?.error}`);
+      }
+
+      // Store publish verification result
+      await env.MODERATION_KV.put(
+        `relay-publish:${sha256}`,
+        JSON.stringify({
+          action,
+          reason: reason || null,
+          publishedAt: Date.now(),
+          source: 'moderation-pipeline',
+          eventId: publishResult?.eventId || null,
+          published: publishResult?.published || false,
+          verified: publishResult?.verified || false,
+          error: publishResult?.error || null
+        }),
+        { expirationTtl: 60 * 60 * 24 * 30 }
+      );
     } catch (error) {
       console.error(`[MODERATION] ${sha256} - Nostr publish failed:`, error);
+      // Store failure for auditing
+      try {
+        await env.MODERATION_KV.put(
+          `relay-publish:${sha256}`,
+          JSON.stringify({
+            action,
+            reason: reason || null,
+            publishedAt: Date.now(),
+            source: 'moderation-pipeline',
+            published: false,
+            verified: false,
+            error: error.message || String(error)
+          }),
+          { expirationTtl: 60 * 60 * 24 * 30 }
+        );
+      } catch (kvErr) {
+        console.error(`[MODERATION] Failed to store publish failure:`, kvErr);
+      }
       // Don't throw - we don't want Nostr failures to fail the whole moderation
     }
   } else {

--- a/src/integration/action-flow.test.mjs
+++ b/src/integration/action-flow.test.mjs
@@ -1,0 +1,126 @@
+// ABOUTME: Integration-style tests for action queue + relay publish + results queue
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock publisher to avoid network
+vi.mock('../nostr/publisher.mjs', () => ({
+  publishToFaro: vi.fn().mockResolvedValue(undefined),
+  publishLabelEvent: vi.fn().mockResolvedValue({ published: true })
+}));
+
+// Mock relay client connect used by debug endpoint
+vi.mock('nostr-tools/relay', () => ({
+  Relay: {
+    connect: vi.fn().mockResolvedValue({ publish: vi.fn(), close: vi.fn() })
+  }
+}));
+
+// Simple KV mock
+function makeKV() {
+  const store = new Map();
+  return {
+    async get(key) { return store.get(key) || null; },
+    async put(key, value) { store.set(key, value); },
+    async delete(key) { store.delete(key); },
+    async list({ prefix } = {}) {
+      const keys = [];
+      for (const k of store.keys()) {
+        if (!prefix || k.startsWith(prefix)) keys.push({ name: k });
+      }
+      return { keys, list_complete: true };
+    },
+    _dump() { return store; }
+  };
+}
+
+// Simple D1 mock
+function makeD1() {
+  return {
+    prepare() {
+      return {
+        bind: () => ({
+          run: async () => ({}),
+          all: async () => ({ results: [] }),
+          first: async () => null
+        })
+      };
+    },
+    batch: async () => {}
+  };
+}
+
+function makeQueueSink() {
+  const sent = [];
+  return {
+    async send(msg) { sent.push(msg); },
+    _sent: sent
+  };
+}
+
+describe('Action queue flow', () => {
+  let worker;
+  let env;
+
+  beforeEach(async () => {
+    // Dynamic import after mocks
+    const mod = await import('../index.mjs');
+    worker = mod.default;
+    env = {
+      MODERATION_KV: makeKV(),
+      BLOSSOM_DB: makeD1(),
+      ACTION_RESULTS_QUEUE: makeQueueSink(),
+      CDN_DOMAIN: 'cdn.example.test',
+      NOSTR_PRIVATE_KEY: 'a'.repeat(64),
+      NOSTR_RELAY_URL: 'wss://relay.example.test',
+      ALLOW_DEV_ACCESS: 'true'
+    };
+  });
+
+  it('processes moderation-action messages and emits result', async () => {
+    const sha256 = 'f'.repeat(64);
+    const msg = {
+      body: {
+        type: 'moderation-action',
+        sha256,
+        action: 'PERMANENT_BAN',
+        reason: 'test-reason',
+        source: 'test-suite',
+        requestId: 'req-123'
+      },
+      attempts: 0,
+      ack: vi.fn(),
+      retry: vi.fn()
+    };
+
+    await worker.queue({ messages: [msg] }, env);
+
+    // Acked
+    expect(msg.ack).toHaveBeenCalled();
+
+    // KV flags
+    const kvBan = await env.MODERATION_KV.get(`permanent-ban:${sha256}`);
+    expect(kvBan).toBeTruthy();
+
+    // Result message emitted
+    expect(env.ACTION_RESULTS_QUEUE._sent.length).toBe(1);
+    expect(env.ACTION_RESULTS_QUEUE._sent[0]).toEqual(expect.objectContaining({
+      type: 'moderation-action-result',
+      sha256,
+      action: 'PERMANENT_BAN',
+      status: 'success',
+      requestId: 'req-123'
+    }));
+  });
+
+  it('debug relay endpoint reports config', async () => {
+    const req = new Request('https://example.test/admin/api/debug-relay', {
+      headers: { 'Cf-Access-Authenticated-User-Email': 'tester@example.com' }
+    });
+    const res = await worker.fetch(req, env);
+    const data = await res.json();
+    expect(data).toEqual(expect.objectContaining({
+      hasPrivateKey: true,
+      relayUrl: env.NOSTR_RELAY_URL
+    }));
+  });
+});
+

--- a/src/moderation/providers/index.mjs
+++ b/src/moderation/providers/index.mjs
@@ -9,6 +9,7 @@ export { AWSRekognitionProvider } from './aws-rekognition/adapter.mjs';
 export { SightengineProvider } from './sightengine/adapter.mjs';
 export { BunnyCDNProvider } from './bunnycdn/adapter.mjs';
 export { HiveAIProvider } from './hiveai/adapter.mjs';
+export { RealityDefenderProvider } from './reality-defender/adapter.mjs';
 export {
   getProvider,
   getConfiguredProviders,

--- a/src/moderation/providers/orchestrator.mjs
+++ b/src/moderation/providers/orchestrator.mjs
@@ -8,15 +8,26 @@ import { AWSRekognitionProvider } from './aws-rekognition/adapter.mjs';
 import { SightengineProvider } from './sightengine/adapter.mjs';
 import { BunnyCDNProvider } from './bunnycdn/adapter.mjs';
 import { HiveAIProvider } from './hiveai/adapter.mjs';
+import { RealityDefenderProvider } from './reality-defender/adapter.mjs';
 
 /**
  * Provider registry
+ *
+ * Content Moderation Providers:
+ * - hiveai: Primary content moderation + AI detection
+ * - sightengine: Legacy fallback for content moderation
+ * - bunnycdn: CDN-integrated moderation
+ * - aws-rekognition: AWS-based content moderation
+ *
+ * AI Detection Providers:
+ * - reality-defender: Multi-provider AI detection (Reality Defender + Hive + Sensity)
  */
 const PROVIDERS = {
   'aws-rekognition': new AWSRekognitionProvider(),
   'sightengine': new SightengineProvider(),
   'bunnycdn': new BunnyCDNProvider(),
-  'hiveai': new HiveAIProvider()
+  'hiveai': new HiveAIProvider(),
+  'reality-defender': new RealityDefenderProvider()
 };
 
 /**

--- a/src/moderation/providers/reality-defender/adapter.mjs
+++ b/src/moderation/providers/reality-defender/adapter.mjs
@@ -1,0 +1,247 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Reality Defender provider adapter for multi-provider AI detection
+// ABOUTME: Connects to realness.divine.video for Reality Defender, Hive, and Sensity analysis
+
+import { BaseModerationProvider, STANDARD_CAPABILITIES } from '../base-provider.mjs';
+import { analyzeVideoWithRealness } from './client.mjs';
+import { normalizeRealnessResponse } from './normalizer.mjs';
+
+/**
+ * Reality Defender Provider
+ *
+ * This provider integrates with the realness.divine.video service which
+ * aggregates AI detection results from three industry-leading providers:
+ *
+ * 1. REALITY DEFENDER (realitydefender.xyz)
+ *    - Enterprise deepfake detection
+ *    - Specializes in: face swaps, lip-sync deepfakes, voice cloning
+ *    - Used by: news organizations, financial institutions
+ *    - Processing time: 10-30 seconds
+ *
+ * 2. HIVE AI (thehive.ai)
+ *    - Multi-purpose AI content detection
+ *    - Detects: AI-generated images/video, synthetic media
+ *    - Also offers: content moderation (separate API)
+ *    - Processing time: 5-15 seconds
+ *
+ * 3. SENSITY (sensity.ai)
+ *    - Forensic deepfake analysis
+ *    - Strong at: GAN-generated faces, expression manipulation
+ *    - Provides: technique identification
+ *    - Processing time: 15-45 seconds
+ *
+ * WHY MULTI-PROVIDER?
+ * -------------------
+ * No single AI detection system is perfect. Different providers excel at
+ * different types of synthetic media:
+ * - Reality Defender is strongest on face-swapped video
+ * - Hive excels at fully AI-generated content (SORA, Runway, etc.)
+ * - Sensity provides forensic detail on manipulation techniques
+ *
+ * By combining all three, we get:
+ * - Higher detection accuracy through consensus
+ * - Reduced false positives (require agreement)
+ * - Better coverage across AI generation techniques
+ *
+ * VERDICT INTERPRETATION
+ * ----------------------
+ * The service normalizes scores to 0-1 and assigns verdicts:
+ *
+ * - AUTHENTIC (score < 0.3)
+ *   Content appears to be genuine human-created media.
+ *   Low probability of AI manipulation or generation.
+ *
+ * - UNCERTAIN (0.3 <= score < 0.7)
+ *   Ambiguous results. May contain minor edits or
+ *   characteristics that confuse detectors.
+ *   Recommend human review.
+ *
+ * - LIKELY_AI (score >= 0.7)
+ *   High probability of AI-generated or manipulated content.
+ *   At least one detector flagged significant synthetic signals.
+ *
+ * CONSENSUS LOGIC
+ * ---------------
+ * - Unanimous: All providers agree (high confidence)
+ * - Majority: 2 of 3 providers agree (medium confidence)
+ * - Split: No agreement (low confidence, defaults to UNCERTAIN)
+ */
+export class RealityDefenderProvider extends BaseModerationProvider {
+  constructor() {
+    super('reality-defender', {
+      ...STANDARD_CAPABILITIES,
+
+      // This provider focuses on AI detection, NOT content moderation
+      nudity: false,
+      violence: false,
+      gore: false,
+      offensive: false,
+      weapons: false,
+      drugs: false,
+      alcohol: false,
+      tobacco: false,
+      gambling: false,
+      selfHarm: false,
+
+      // Primary capabilities: AI/deepfake detection
+      aiGenerated: true,
+      deepfake: true,
+
+      // Technical capabilities
+      textOcr: false,
+      qrCode: false,
+      asyncProcessing: true,  // Uses webhook-based async processing
+      liveStream: false,
+      customModels: false,
+
+      // Multi-provider aggregation
+      multiProvider: true,
+      providersIncluded: ['reality_defender', 'hive', 'sensity'],
+
+      // Input constraints
+      maxFileSizeMB: 500,        // CDN handles large files
+      maxDurationMinutes: 30,    // Reasonable video length
+      supportedFormats: ['mp4', 'webm', 'mov', 'avi']
+    });
+  }
+
+  /**
+   * Check if Reality Defender integration is enabled
+   *
+   * This provider uses the realness.divine.video service which
+   * manages its own API keys. We just need the service URL configured.
+   *
+   * @param {Object} env - Environment variables
+   * @returns {boolean}
+   */
+  isConfigured(env) {
+    // The realness service is always available at realness.divine.video
+    // Optionally allow override via environment variable
+    return env.REALNESS_API_ENABLED !== 'false';
+  }
+
+  /**
+   * Analyze video for AI-generated content using multi-provider detection
+   *
+   * This calls the realness.divine.video service which:
+   * 1. Submits the video to Reality Defender, Hive, and Sensity in parallel
+   * 2. Collects results via webhooks
+   * 3. Returns aggregated scores and consensus verdict
+   *
+   * @param {string} videoUrl - Public CDN URL to video
+   * @param {Object} metadata - Video metadata
+   * @param {string} metadata.sha256 - SHA256 hash of video
+   * @param {string} [metadata.eventId] - Nostr event ID if available
+   * @param {Object} env - Environment variables
+   * @param {Object} options - Provider options
+   * @param {number} [options.maxWaitMs=60000] - Max time to wait for results
+   * @param {boolean} [options.skipAIDetection] - Skip if true (for original Vines)
+   * @returns {Promise<NormalizedModerationResult>}
+   */
+  async moderate(videoUrl, metadata, env, options = {}) {
+    const startTime = Date.now();
+
+    // Skip AI detection for original Vines (pre-2018 content predates modern AI)
+    if (options.skipAIDetection) {
+      console.log(`[RealityDefender] Skipping for original Vine: ${metadata.sha256}`);
+      return {
+        provider: this.name,
+        processingTime: Date.now() - startTime,
+        scores: {
+          ai_generated: 0,
+          deepfake: 0,
+          // No content moderation from this provider
+          nudity: 0, violence: 0, gore: 0, offensive: 0,
+          weapons: 0, drugs: 0, alcohol: 0, tobacco: 0,
+          gambling: 0, selfHarm: 0
+        },
+        details: {
+          skipped: true,
+          reason: 'original_vine',
+          message: 'Original Vine content predates AI generation technology'
+        },
+        flaggedFrames: [],
+        raw: null
+      };
+    }
+
+    try {
+      console.log(`[RealityDefender] Starting multi-provider AI detection for ${metadata.sha256}`);
+
+      // Call realness.divine.video API and wait for results
+      const realnessJob = await analyzeVideoWithRealness(
+        videoUrl,
+        metadata,
+        env,
+        {
+          maxWaitMs: options.maxWaitMs || 60000,
+          pollIntervalMs: options.pollIntervalMs || 3000,
+          fetchFn: options.fetchFn
+        }
+      );
+
+      // Normalize multi-provider results to standard format
+      const normalized = normalizeRealnessResponse(realnessJob);
+
+      const processingTime = Date.now() - startTime;
+      console.log(`[RealityDefender] Completed in ${processingTime}ms`);
+
+      // Log consensus for visibility
+      const consensus = normalized.details?.ai_detection?.consensus;
+      if (consensus) {
+        console.log(`[RealityDefender] Consensus: ${consensus.verdict} (${consensus.confidence} confidence, ${consensus.agreement})`);
+      }
+
+      return {
+        ...normalized,
+        provider: this.name,
+        processingTime,
+        raw: realnessJob
+      };
+
+    } catch (error) {
+      console.error(`[RealityDefender] Analysis failed:`, error.message);
+      throw new Error(`Reality Defender analysis failed: ${error.message}`);
+    }
+  }
+
+  /**
+   * Get provider information with multi-provider details
+   */
+  getInfo() {
+    return {
+      name: this.name,
+      displayName: 'Reality Defender (Multi-Provider)',
+      description: 'Aggregated AI detection from Reality Defender, HiveAI, and Sensity',
+      capabilities: this.capabilities,
+      providers: [
+        {
+          name: 'reality_defender',
+          displayName: 'Reality Defender',
+          specialty: 'Face swaps, lip-sync deepfakes, voice cloning',
+          website: 'https://realitydefender.xyz'
+        },
+        {
+          name: 'hive',
+          displayName: 'Hive AI',
+          specialty: 'AI-generated content, synthetic media detection',
+          website: 'https://thehive.ai'
+        },
+        {
+          name: 'sensity',
+          displayName: 'Sensity',
+          specialty: 'Forensic deepfake analysis, technique identification',
+          website: 'https://sensity.ai'
+        }
+      ],
+      verdictThresholds: {
+        AUTHENTIC: 'score < 0.3',
+        UNCERTAIN: '0.3 <= score < 0.7',
+        LIKELY_AI: 'score >= 0.7'
+      },
+      aggregationMethod: 'Maximum score across providers (conservative)'
+    };
+  }
+}

--- a/src/moderation/providers/reality-defender/adapter.test.mjs
+++ b/src/moderation/providers/reality-defender/adapter.test.mjs
@@ -1,0 +1,164 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Tests for Reality Defender provider adapter
+// ABOUTME: Verifies provider configuration, moderation flow, and skip logic
+
+import { describe, it, expect, vi } from 'vitest';
+import { RealityDefenderProvider } from './adapter.mjs';
+
+describe('Reality Defender Provider', () => {
+  describe('Configuration', () => {
+    it('should have correct provider name', () => {
+      const provider = new RealityDefenderProvider();
+      expect(provider.name).toBe('reality-defender');
+    });
+
+    it('should be configured by default', () => {
+      const provider = new RealityDefenderProvider();
+      expect(provider.isConfigured({})).toBe(true);
+    });
+
+    it('should be disabled when REALNESS_API_ENABLED is false', () => {
+      const provider = new RealityDefenderProvider();
+      expect(provider.isConfigured({ REALNESS_API_ENABLED: 'false' })).toBe(false);
+    });
+
+    it('should declare AI detection capabilities', () => {
+      const provider = new RealityDefenderProvider();
+
+      expect(provider.capabilities.aiGenerated).toBe(true);
+      expect(provider.capabilities.deepfake).toBe(true);
+      expect(provider.capabilities.multiProvider).toBe(true);
+    });
+
+    it('should NOT declare content moderation capabilities', () => {
+      const provider = new RealityDefenderProvider();
+
+      expect(provider.capabilities.nudity).toBe(false);
+      expect(provider.capabilities.violence).toBe(false);
+      expect(provider.capabilities.gore).toBe(false);
+    });
+  });
+
+  describe('Moderation', () => {
+    it('should return results from realness API', async () => {
+      const provider = new RealityDefenderProvider();
+
+      const mockJob = {
+        event_id: 'test-123',
+        status: 'complete',
+        results: {
+          reality_defender: { status: 'complete', score: 0.85, verdict: 'LIKELY_AI' },
+          hive: { status: 'complete', score: 0.72, verdict: 'LIKELY_AI' },
+          sensity: { status: 'complete', score: 0.23, verdict: 'AUTHENTIC' }
+        }
+      };
+
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockJob)
+      });
+
+      const result = await provider.moderate(
+        'https://cdn.divine.video/video.mp4',
+        { sha256: 'abc123' },
+        {},
+        { fetchFn: mockFetch }
+      );
+
+      expect(result.provider).toBe('reality-defender');
+      expect(result.scores.ai_generated).toBe(0.85);
+      expect(result.processingTime).toBeGreaterThan(0);
+    });
+
+    it('should skip AI detection for original Vines', async () => {
+      const provider = new RealityDefenderProvider();
+
+      const result = await provider.moderate(
+        'https://cdn.divine.video/vine.mp4',
+        { sha256: 'vine123' },
+        {},
+        { skipAIDetection: true }
+      );
+
+      expect(result.scores.ai_generated).toBe(0);
+      expect(result.scores.deepfake).toBe(0);
+      expect(result.details.skipped).toBe(true);
+      expect(result.details.reason).toBe('original_vine');
+    });
+
+    it('should include consensus in results', async () => {
+      const provider = new RealityDefenderProvider();
+
+      const mockJob = {
+        event_id: 'test',
+        status: 'complete',
+        results: {
+          reality_defender: { status: 'complete', score: 0.1 },
+          hive: { status: 'complete', score: 0.15 },
+          sensity: { status: 'complete', score: 0.08 }
+        }
+      };
+
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockJob)
+      });
+
+      const result = await provider.moderate(
+        'https://cdn.divine.video/authentic.mp4',
+        { sha256: 'auth' },
+        {},
+        { fetchFn: mockFetch }
+      );
+
+      expect(result.details.ai_detection.consensus.verdict).toBe('AUTHENTIC');
+      expect(result.details.ai_detection.consensus.confidence).toBe('high');
+    });
+
+    it('should throw on API failure', async () => {
+      const provider = new RealityDefenderProvider();
+
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: () => Promise.resolve('Server Error')
+      });
+
+      await expect(
+        provider.moderate(
+          'https://cdn.divine.video/fail.mp4',
+          { sha256: 'fail' },
+          {},
+          { fetchFn: mockFetch }
+        )
+      ).rejects.toThrow('Reality Defender analysis failed');
+    });
+  });
+
+  describe('Provider Info', () => {
+    it('should return detailed provider information', () => {
+      const provider = new RealityDefenderProvider();
+      const info = provider.getInfo();
+
+      expect(info.name).toBe('reality-defender');
+      expect(info.displayName).toBe('Reality Defender (Multi-Provider)');
+      expect(info.providers).toHaveLength(3);
+
+      const providerNames = info.providers.map(p => p.name);
+      expect(providerNames).toContain('reality_defender');
+      expect(providerNames).toContain('hive');
+      expect(providerNames).toContain('sensity');
+    });
+
+    it('should document verdict thresholds', () => {
+      const provider = new RealityDefenderProvider();
+      const info = provider.getInfo();
+
+      expect(info.verdictThresholds.AUTHENTIC).toBe('score < 0.3');
+      expect(info.verdictThresholds.UNCERTAIN).toBe('0.3 <= score < 0.7');
+      expect(info.verdictThresholds.LIKELY_AI).toBe('score >= 0.7');
+    });
+  });
+});

--- a/src/moderation/providers/reality-defender/client.mjs
+++ b/src/moderation/providers/reality-defender/client.mjs
@@ -1,0 +1,201 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Client for realness.divine.video multi-provider AI detection API
+// ABOUTME: Submits videos for analysis by Reality Defender, Hive, and Sensity
+
+/**
+ * realness.divine.video API endpoints
+ * This service aggregates results from 3 AI detection providers:
+ * - Reality Defender: Enterprise deepfake detection (api.prd.realitydefender.xyz)
+ * - HiveAI: AI-generated content detection (api.thehive.ai)
+ * - Sensity: Deepfake video analysis (api.sensity.ai)
+ */
+const REALNESS_API_BASE = 'https://realness.divine.video';
+
+/**
+ * Detection verdicts based on AI probability score
+ * - AUTHENTIC: score < 0.3 (likely real/human-created content)
+ * - UNCERTAIN: 0.3 <= score < 0.7 (needs human review)
+ * - LIKELY_AI: score >= 0.7 (high probability of AI generation)
+ */
+export const VERDICT_THRESHOLDS = {
+  AUTHENTIC: 0.3,
+  LIKELY_AI: 0.7
+};
+
+/**
+ * Submit a video for multi-provider AI detection analysis
+ *
+ * The realness.divine.video service:
+ * 1. Receives video URL and optional Nostr event ID
+ * 2. Submits to Reality Defender, Hive, and Sensity in parallel
+ * 3. Stores results in Durable Object for consistency
+ * 4. Returns job ID for polling
+ *
+ * @param {string} videoUrl - CDN URL to video (must be publicly accessible)
+ * @param {Object} metadata - Video metadata
+ * @param {string} metadata.sha256 - SHA256 hash of video content
+ * @param {string} [metadata.eventId] - Nostr event ID if available
+ * @param {Object} env - Environment variables
+ * @param {Object} options - Request options
+ * @param {Function} [options.fetchFn] - Custom fetch function for testing
+ * @returns {Promise<Object>} Job creation response with jobId
+ */
+export async function submitVideoForAnalysis(videoUrl, metadata, env, options = {}) {
+  const fetchFn = options.fetchFn || fetch;
+
+  const requestBody = {
+    videoUrl: videoUrl,
+    mediaHash: metadata.sha256
+  };
+
+  // Include event ID if available (for Nostr integration)
+  if (metadata.eventId) {
+    requestBody.eventId = metadata.eventId;
+  }
+
+  console.log(`[RealityDefender] Submitting to realness.divine.video: ${metadata.sha256}`);
+
+  const response = await fetchFn(`${REALNESS_API_BASE}/analyze`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(requestBody)
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Realness API error ${response.status}: ${errorText}`);
+  }
+
+  const result = await response.json();
+  console.log(`[RealityDefender] Job created: ${result.jobId || result.event_id}`);
+
+  return result;
+}
+
+/**
+ * Get analysis job results from realness.divine.video
+ *
+ * Job response structure:
+ * {
+ *   event_id: string,        // Nostr event ID or generated ID
+ *   media_hash: string,      // SHA256 of video
+ *   video_url: string,       // CDN URL
+ *   status: string,          // "pending" | "processing" | "complete" | "error"
+ *   submitted: ISO8601,      // When job was created
+ *   completed: ISO8601,      // When all providers finished (null if pending)
+ *   results: {               // Per-provider results
+ *     reality_defender: DetectionResult,
+ *     hive: DetectionResult,
+ *     sensity: DetectionResult
+ *   },
+ *   error: string | null
+ * }
+ *
+ * DetectionResult structure:
+ * {
+ *   provider: string,        // "reality_defender" | "hive" | "sensity"
+ *   status: string,          // "pending" | "processing" | "complete" | "error"
+ *   score: number | null,    // 0-1 AI probability (null if pending/error)
+ *   verdict: string | null,  // "AUTHENTIC" | "UNCERTAIN" | "LIKELY_AI"
+ *   raw: object | null,      // Full provider response for debugging
+ *   error: string | null     // Error message if status is "error"
+ * }
+ *
+ * @param {string} jobId - Job ID (event_id or media_hash)
+ * @param {Object} env - Environment variables
+ * @param {Object} options - Request options
+ * @param {Function} [options.fetchFn] - Custom fetch function for testing
+ * @returns {Promise<Object>} Job status and results
+ */
+export async function getJobResults(jobId, env, options = {}) {
+  const fetchFn = options.fetchFn || fetch;
+
+  const response = await fetchFn(`${REALNESS_API_BASE}/api/jobs/${jobId}`, {
+    method: 'GET',
+    headers: {
+      'Accept': 'application/json'
+    }
+  });
+
+  if (!response.ok) {
+    if (response.status === 404) {
+      throw new Error(`Job not found: ${jobId}`);
+    }
+    const errorText = await response.text();
+    throw new Error(`Realness API error ${response.status}: ${errorText}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * Submit video and poll until complete or timeout
+ *
+ * This is the main entry point for synchronous-style usage.
+ * It handles the async nature of the multi-provider analysis.
+ *
+ * Provider processing times (typical):
+ * - Reality Defender: 10-30 seconds
+ * - HiveAI: 5-15 seconds
+ * - Sensity: 15-45 seconds
+ *
+ * @param {string} videoUrl - CDN URL to video
+ * @param {Object} metadata - Video metadata with sha256
+ * @param {Object} env - Environment variables
+ * @param {Object} options - Request options
+ * @param {number} [options.maxWaitMs=60000] - Maximum time to wait for results
+ * @param {number} [options.pollIntervalMs=3000] - Interval between status checks
+ * @param {Function} [options.fetchFn] - Custom fetch function
+ * @returns {Promise<Object>} Complete job results from all providers
+ */
+export async function analyzeVideoWithRealness(videoUrl, metadata, env, options = {}) {
+  const maxWaitMs = options.maxWaitMs || 60000;
+  const pollIntervalMs = options.pollIntervalMs || 3000;
+  const fetchFn = options.fetchFn || fetch;
+
+  // Submit for analysis
+  const submitResult = await submitVideoForAnalysis(videoUrl, metadata, env, { fetchFn });
+  const jobId = submitResult.jobId || submitResult.event_id || metadata.sha256;
+
+  // If already complete (cached/dedup), return immediately
+  if (submitResult.status === 'complete' && submitResult.results) {
+    console.log(`[RealityDefender] Job already complete (cached): ${jobId}`);
+    return submitResult;
+  }
+
+  // Poll for results
+  const startTime = Date.now();
+
+  while (Date.now() - startTime < maxWaitMs) {
+    await sleep(pollIntervalMs);
+
+    const job = await getJobResults(jobId, env, { fetchFn });
+    console.log(`[RealityDefender] Job ${jobId} status: ${job.status}`);
+
+    if (job.status === 'complete' || job.status === 'error') {
+      return job;
+    }
+
+    // Log individual provider progress
+    if (job.results) {
+      const providers = Object.keys(job.results);
+      const complete = providers.filter(p =>
+        job.results[p]?.status === 'complete' || job.results[p]?.status === 'error'
+      );
+      console.log(`[RealityDefender] Progress: ${complete.length}/${providers.length} providers complete`);
+    }
+  }
+
+  // Timeout - return partial results
+  const finalJob = await getJobResults(jobId, env, { fetchFn });
+  console.warn(`[RealityDefender] Timeout after ${maxWaitMs}ms, returning partial results`);
+  return finalJob;
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/src/moderation/providers/reality-defender/client.test.mjs
+++ b/src/moderation/providers/reality-defender/client.test.mjs
@@ -1,0 +1,189 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Tests for Reality Defender client (realness.divine.video API)
+// ABOUTME: Verifies job submission, polling, and result retrieval
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  submitVideoForAnalysis,
+  getJobResults,
+  analyzeVideoWithRealness
+} from './client.mjs';
+
+describe('Reality Defender Client', () => {
+  describe('submitVideoForAnalysis', () => {
+    it('should submit video to realness API', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          jobId: 'job-123',
+          status: 'pending'
+        })
+      });
+
+      const result = await submitVideoForAnalysis(
+        'https://cdn.divine.video/abc123.mp4',
+        { sha256: 'abc123', eventId: 'event-456' },
+        {},
+        { fetchFn: mockFetch }
+      );
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://realness.divine.video/analyze',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            videoUrl: 'https://cdn.divine.video/abc123.mp4',
+            mediaHash: 'abc123',
+            eventId: 'event-456'
+          })
+        })
+      );
+
+      expect(result.jobId).toBe('job-123');
+    });
+
+    it('should throw on API error', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: () => Promise.resolve('Internal Server Error')
+      });
+
+      await expect(
+        submitVideoForAnalysis(
+          'https://cdn.divine.video/abc.mp4',
+          { sha256: 'abc' },
+          {},
+          { fetchFn: mockFetch }
+        )
+      ).rejects.toThrow('Realness API error 500');
+    });
+  });
+
+  describe('getJobResults', () => {
+    it('should fetch job results by ID', async () => {
+      const mockJob = {
+        event_id: 'job-123',
+        status: 'complete',
+        results: {
+          reality_defender: { score: 0.85, verdict: 'LIKELY_AI' },
+          hive: { score: 0.72, verdict: 'LIKELY_AI' },
+          sensity: { score: 0.23, verdict: 'AUTHENTIC' }
+        }
+      };
+
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockJob)
+      });
+
+      const result = await getJobResults('job-123', {}, { fetchFn: mockFetch });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://realness.divine.video/api/jobs/job-123',
+        expect.objectContaining({
+          method: 'GET'
+        })
+      );
+
+      expect(result.status).toBe('complete');
+      expect(result.results.reality_defender.score).toBe(0.85);
+    });
+
+    it('should throw on 404', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        text: () => Promise.resolve('Not found')
+      });
+
+      await expect(
+        getJobResults('nonexistent', {}, { fetchFn: mockFetch })
+      ).rejects.toThrow('Job not found: nonexistent');
+    });
+  });
+
+  describe('analyzeVideoWithRealness', () => {
+    it('should return immediately if job already complete', async () => {
+      const completeJob = {
+        jobId: 'cached-job',
+        status: 'complete',
+        results: {
+          reality_defender: { score: 0.1, verdict: 'AUTHENTIC' },
+          hive: { score: 0.15, verdict: 'AUTHENTIC' },
+          sensity: { score: 0.08, verdict: 'AUTHENTIC' }
+        }
+      };
+
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(completeJob)
+      });
+
+      const result = await analyzeVideoWithRealness(
+        'https://cdn.divine.video/cached.mp4',
+        { sha256: 'cached' },
+        {},
+        { fetchFn: mockFetch, maxWaitMs: 5000 }
+      );
+
+      // Should only call submit, not poll
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(result.status).toBe('complete');
+    });
+
+    it('should poll until complete', async () => {
+      const pendingJob = { event_id: 'poll-job', status: 'pending', results: {} };
+      const processingJob = { event_id: 'poll-job', status: 'processing', results: {} };
+      const completeJob = {
+        event_id: 'poll-job',
+        status: 'complete',
+        results: {
+          reality_defender: { score: 0.5, verdict: 'UNCERTAIN' }
+        }
+      };
+
+      let callCount = 0;
+      const mockFetch = vi.fn().mockImplementation((url) => {
+        callCount++;
+        // First call: submit
+        if (url.includes('/analyze')) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ jobId: 'poll-job', status: 'pending' })
+          });
+        }
+        // Subsequent calls: poll
+        if (callCount === 2) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve(pendingJob)
+          });
+        }
+        if (callCount === 3) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve(processingJob)
+          });
+        }
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(completeJob)
+        });
+      });
+
+      const result = await analyzeVideoWithRealness(
+        'https://cdn.divine.video/poll.mp4',
+        { sha256: 'poll' },
+        {},
+        { fetchFn: mockFetch, maxWaitMs: 30000, pollIntervalMs: 10 }
+      );
+
+      expect(result.status).toBe('complete');
+      expect(callCount).toBeGreaterThan(1);
+    });
+  });
+});

--- a/src/moderation/providers/reality-defender/normalizer.mjs
+++ b/src/moderation/providers/reality-defender/normalizer.mjs
@@ -1,0 +1,376 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Normalizes multi-provider AI detection results to Divine's standard format
+// ABOUTME: Aggregates scores from Reality Defender, HiveAI, and Sensity
+
+/**
+ * Provider Details and Response Formats
+ * =====================================
+ *
+ * REALITY DEFENDER (api.prd.realitydefender.xyz)
+ * -----------------------------------------------
+ * Enterprise deepfake detection focused on video authenticity.
+ * Specializes in face manipulation, voice cloning, and synthetic media.
+ *
+ * Raw webhook response:
+ * {
+ *   status: "complete" | "error",
+ *   result: {
+ *     score: 0.85,           // AI probability 0-1
+ *     confidence: 0.92,      // Detection confidence
+ *     details: {
+ *       face_swap: 0.12,     // Face manipulation score
+ *       lip_sync: 0.05,      // Lip-sync deepfake score
+ *       voice_clone: 0.02,   // Voice cloning score
+ *       full_synthetic: 0.85 // Fully AI-generated score
+ *     }
+ *   },
+ *   ai_probability: 0.85     // Alternative location for score
+ * }
+ *
+ * Verdict thresholds: <0.3 AUTHENTIC, 0.3-0.7 UNCERTAIN, >=0.7 LIKELY_AI
+ *
+ *
+ * HIVE AI (api.thehive.ai)
+ * -------------------------
+ * Multi-model AI detection platform. The realness service uses their
+ * AI-generated content detection model (separate from content moderation).
+ *
+ * Raw webhook response:
+ * {
+ *   status: "complete",
+ *   result: {
+ *     deepfake_score: 0.15,       // Deepfake probability
+ *     ai_generated_score: 0.72,  // AI-generated content score
+ *     synthetic_score: 0.68      // Synthetic media score
+ *   }
+ * }
+ *
+ * The realness service takes the MAX of these scores as the primary score.
+ * This captures the most concerning detection signal.
+ *
+ *
+ * SENSITY (api.sensity.ai)
+ * -------------------------
+ * Specialized deepfake detection with forensic analysis.
+ * Strong at detecting face swaps and GAN-generated faces.
+ *
+ * Raw webhook response:
+ * {
+ *   status: "done",
+ *   analysis: {
+ *     deepfake_probability: 0.23,  // Primary deepfake score
+ *     detection_score: 0.25,       // Alternative score field
+ *     confidence: 0.88,            // Detection confidence
+ *     techniques_detected: [       // Specific manipulations found
+ *       "face_swap",
+ *       "expression_manipulation"
+ *     ]
+ *   }
+ * }
+ *
+ *
+ * AGGREGATED JOB RESPONSE (from realness.divine.video)
+ * -----------------------------------------------------
+ * {
+ *   event_id: "abc123...",
+ *   media_hash: "sha256...",
+ *   video_url: "https://cdn.divine.video/...",
+ *   status: "complete",
+ *   submitted: "2024-01-15T10:30:00Z",
+ *   completed: "2024-01-15T10:30:45Z",
+ *   results: {
+ *     reality_defender: {
+ *       provider: "reality_defender",
+ *       status: "complete",
+ *       score: 0.85,
+ *       verdict: "LIKELY_AI",
+ *       raw: { ... full response ... },
+ *       error: null
+ *     },
+ *     hive: {
+ *       provider: "hive",
+ *       status: "complete",
+ *       score: 0.72,
+ *       verdict: "LIKELY_AI",
+ *       raw: { ... },
+ *       error: null
+ *     },
+ *     sensity: {
+ *       provider: "sensity",
+ *       status: "complete",
+ *       score: 0.23,
+ *       verdict: "AUTHENTIC",
+ *       raw: { ... },
+ *       error: null
+ *     }
+ *   }
+ * }
+ */
+
+/**
+ * Normalize multi-provider AI detection results to Divine's standard format
+ *
+ * Aggregation strategy:
+ * - ai_generated: Maximum score across all providers (most conservative)
+ * - deepfake: Maximum deepfake-specific score
+ * - Individual provider scores preserved in details
+ *
+ * @param {Object} realnessJob - Complete job response from realness.divine.video
+ * @returns {Object} Normalized result matching Divine's NormalizedModerationResult
+ */
+export function normalizeRealnessResponse(realnessJob) {
+  // Initialize standard scores (AI detection focused)
+  const scores = {
+    // Content moderation scores (not provided by this service)
+    nudity: 0,
+    violence: 0,
+    gore: 0,
+    offensive: 0,
+    weapons: 0,
+    drugs: 0,
+    alcohol: 0,
+    tobacco: 0,
+    gambling: 0,
+    selfHarm: 0,
+
+    // AI detection scores (primary purpose of this provider)
+    ai_generated: 0,
+    deepfake: 0
+  };
+
+  const details = {
+    ai_detection: {
+      consensus: null,
+      providers: {},
+      aggregation_method: 'max_score'
+    }
+  };
+
+  const flaggedFrames = [];
+
+  // Handle missing or error state
+  if (!realnessJob || !realnessJob.results) {
+    return {
+      scores,
+      details,
+      flaggedFrames,
+      metadata: {
+        job_status: realnessJob?.status || 'error',
+        job_id: realnessJob?.event_id || null,
+        error: realnessJob?.error || 'No results available'
+      }
+    };
+  }
+
+  const results = realnessJob.results;
+
+  // Extract and normalize each provider's result
+  const providerScores = [];
+
+  // Reality Defender
+  if (results.reality_defender) {
+    const rd = results.reality_defender;
+    const rdScore = extractScore(rd);
+
+    details.ai_detection.providers.reality_defender = {
+      status: rd.status,
+      score: rdScore,
+      verdict: rd.verdict || verdictFromScore(rdScore),
+      error: rd.error || null,
+      // Extract detailed breakdown if available
+      breakdown: extractRealityDefenderBreakdown(rd.raw)
+    };
+
+    if (rd.status === 'complete' && rdScore !== null) {
+      providerScores.push({ provider: 'reality_defender', score: rdScore, weight: 1.0 });
+    }
+  }
+
+  // Hive AI
+  if (results.hive) {
+    const hive = results.hive;
+    const hiveScore = extractScore(hive);
+
+    details.ai_detection.providers.hive = {
+      status: hive.status,
+      score: hiveScore,
+      verdict: hive.verdict || verdictFromScore(hiveScore),
+      error: hive.error || null,
+      breakdown: extractHiveBreakdown(hive.raw)
+    };
+
+    if (hive.status === 'complete' && hiveScore !== null) {
+      providerScores.push({ provider: 'hive', score: hiveScore, weight: 1.0 });
+    }
+  }
+
+  // Sensity
+  if (results.sensity) {
+    const sensity = results.sensity;
+    const sensityScore = extractScore(sensity);
+
+    details.ai_detection.providers.sensity = {
+      status: sensity.status,
+      score: sensityScore,
+      verdict: sensity.verdict || verdictFromScore(sensityScore),
+      error: sensity.error || null,
+      breakdown: extractSensityBreakdown(sensity.raw)
+    };
+
+    if (sensity.status === 'complete' && sensityScore !== null) {
+      providerScores.push({ provider: 'sensity', score: sensityScore, weight: 1.0 });
+    }
+  }
+
+  // Aggregate scores
+  if (providerScores.length > 0) {
+    // Use maximum score (most conservative - if ANY provider flags it, we flag it)
+    const maxScore = Math.max(...providerScores.map(p => p.score));
+    scores.ai_generated = maxScore;
+
+    // Calculate weighted average for secondary reference
+    const avgScore = providerScores.reduce((sum, p) => sum + p.score, 0) / providerScores.length;
+
+    // Deepfake is a subset - use max of providers that specifically detect deepfakes
+    // Reality Defender and Sensity specialize in deepfakes
+    const deepfakeProviders = providerScores.filter(p =>
+      p.provider === 'reality_defender' || p.provider === 'sensity'
+    );
+    scores.deepfake = deepfakeProviders.length > 0
+      ? Math.max(...deepfakeProviders.map(p => p.score))
+      : maxScore;
+
+    // Determine consensus
+    const verdicts = providerScores.map(p => verdictFromScore(p.score));
+    details.ai_detection.consensus = determineConsensus(verdicts, providerScores);
+    details.ai_detection.average_score = avgScore;
+    details.ai_detection.max_score = maxScore;
+    details.ai_detection.provider_count = providerScores.length;
+  }
+
+  return {
+    scores,
+    details,
+    flaggedFrames,
+    metadata: {
+      job_status: realnessJob.status,
+      job_id: realnessJob.event_id,
+      media_hash: realnessJob.media_hash,
+      submitted: realnessJob.submitted,
+      completed: realnessJob.completed
+    }
+  };
+}
+
+/**
+ * Extract score from provider result
+ * Handles different response formats
+ */
+function extractScore(providerResult) {
+  if (providerResult.score !== undefined && providerResult.score !== null) {
+    return providerResult.score;
+  }
+  // Fallback to raw response fields
+  if (providerResult.raw) {
+    return providerResult.raw.ai_probability
+      || providerResult.raw.result?.score
+      || providerResult.raw.analysis?.deepfake_probability
+      || null;
+  }
+  return null;
+}
+
+/**
+ * Convert score to verdict string
+ */
+function verdictFromScore(score) {
+  if (score === null || score === undefined) return null;
+  if (score < 0.3) return 'AUTHENTIC';
+  if (score < 0.7) return 'UNCERTAIN';
+  return 'LIKELY_AI';
+}
+
+/**
+ * Determine consensus from multiple provider verdicts
+ */
+function determineConsensus(verdicts, providerScores) {
+  const validVerdicts = verdicts.filter(v => v !== null);
+  if (validVerdicts.length === 0) return null;
+
+  // Count verdicts
+  const counts = {
+    AUTHENTIC: 0,
+    UNCERTAIN: 0,
+    LIKELY_AI: 0
+  };
+
+  validVerdicts.forEach(v => counts[v]++);
+
+  // Unanimous agreement
+  if (counts.AUTHENTIC === validVerdicts.length) {
+    return { verdict: 'AUTHENTIC', confidence: 'high', agreement: 'unanimous' };
+  }
+  if (counts.LIKELY_AI === validVerdicts.length) {
+    return { verdict: 'LIKELY_AI', confidence: 'high', agreement: 'unanimous' };
+  }
+
+  // Majority agreement (2 of 3)
+  if (validVerdicts.length >= 2) {
+    if (counts.AUTHENTIC >= 2) {
+      return { verdict: 'AUTHENTIC', confidence: 'medium', agreement: 'majority' };
+    }
+    if (counts.LIKELY_AI >= 2) {
+      return { verdict: 'LIKELY_AI', confidence: 'medium', agreement: 'majority' };
+    }
+  }
+
+  // Mixed results or all uncertain
+  return { verdict: 'UNCERTAIN', confidence: 'low', agreement: 'split' };
+}
+
+/**
+ * Extract detailed breakdown from Reality Defender raw response
+ */
+function extractRealityDefenderBreakdown(raw) {
+  if (!raw) return null;
+
+  const result = raw.result || {};
+  return {
+    face_swap: result.details?.face_swap || null,
+    lip_sync: result.details?.lip_sync || null,
+    voice_clone: result.details?.voice_clone || null,
+    full_synthetic: result.details?.full_synthetic || null,
+    confidence: result.confidence || null
+  };
+}
+
+/**
+ * Extract detailed breakdown from Hive raw response
+ */
+function extractHiveBreakdown(raw) {
+  if (!raw) return null;
+
+  const result = raw.result || raw;
+  return {
+    deepfake_score: result.deepfake_score || null,
+    ai_generated_score: result.ai_generated_score || null,
+    synthetic_score: result.synthetic_score || null
+  };
+}
+
+/**
+ * Extract detailed breakdown from Sensity raw response
+ */
+function extractSensityBreakdown(raw) {
+  if (!raw) return null;
+
+  const analysis = raw.analysis || {};
+  return {
+    deepfake_probability: analysis.deepfake_probability || null,
+    detection_score: analysis.detection_score || null,
+    confidence: analysis.confidence || null,
+    techniques_detected: analysis.techniques_detected || []
+  };
+}

--- a/src/moderation/providers/reality-defender/normalizer.test.mjs
+++ b/src/moderation/providers/reality-defender/normalizer.test.mjs
@@ -1,0 +1,243 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// ABOUTME: Tests for Reality Defender response normalizer
+// ABOUTME: Verifies multi-provider score aggregation and consensus logic
+
+import { describe, it, expect } from 'vitest';
+import { normalizeRealnessResponse } from './normalizer.mjs';
+
+describe('Reality Defender Normalizer', () => {
+  describe('Score Aggregation', () => {
+    it('should use max score across providers', () => {
+      const job = {
+        event_id: 'test-job',
+        status: 'complete',
+        results: {
+          reality_defender: { status: 'complete', score: 0.85 },
+          hive: { status: 'complete', score: 0.72 },
+          sensity: { status: 'complete', score: 0.23 }
+        }
+      };
+
+      const result = normalizeRealnessResponse(job);
+
+      // Max score is 0.85 from Reality Defender
+      expect(result.scores.ai_generated).toBe(0.85);
+    });
+
+    it('should calculate deepfake from specialized providers', () => {
+      const job = {
+        event_id: 'test-job',
+        status: 'complete',
+        results: {
+          reality_defender: { status: 'complete', score: 0.6 },
+          hive: { status: 'complete', score: 0.9 }, // Hive focuses on AI-generated
+          sensity: { status: 'complete', score: 0.7 }
+        }
+      };
+
+      const result = normalizeRealnessResponse(job);
+
+      // ai_generated uses max across all = 0.9
+      expect(result.scores.ai_generated).toBe(0.9);
+      // deepfake uses max of Reality Defender and Sensity = 0.7
+      expect(result.scores.deepfake).toBe(0.7);
+    });
+
+    it('should handle partial results', () => {
+      const job = {
+        event_id: 'test-job',
+        status: 'processing',
+        results: {
+          reality_defender: { status: 'complete', score: 0.5 },
+          hive: { status: 'pending' },
+          sensity: { status: 'error', error: 'Timeout' }
+        }
+      };
+
+      const result = normalizeRealnessResponse(job);
+
+      // Only Reality Defender has a score
+      expect(result.scores.ai_generated).toBe(0.5);
+      expect(result.details.ai_detection.provider_count).toBe(1);
+    });
+
+    it('should return zero scores when no results', () => {
+      const job = {
+        event_id: 'test-job',
+        status: 'error',
+        error: 'All providers failed'
+      };
+
+      const result = normalizeRealnessResponse(job);
+
+      expect(result.scores.ai_generated).toBe(0);
+      expect(result.scores.deepfake).toBe(0);
+      // Error message is preserved from the job
+      expect(result.metadata.error).toBe('All providers failed');
+    });
+  });
+
+  describe('Consensus Logic', () => {
+    it('should identify unanimous AUTHENTIC', () => {
+      const job = {
+        event_id: 'test',
+        status: 'complete',
+        results: {
+          reality_defender: { status: 'complete', score: 0.1 },
+          hive: { status: 'complete', score: 0.15 },
+          sensity: { status: 'complete', score: 0.2 }
+        }
+      };
+
+      const result = normalizeRealnessResponse(job);
+
+      expect(result.details.ai_detection.consensus.verdict).toBe('AUTHENTIC');
+      expect(result.details.ai_detection.consensus.confidence).toBe('high');
+      expect(result.details.ai_detection.consensus.agreement).toBe('unanimous');
+    });
+
+    it('should identify unanimous LIKELY_AI', () => {
+      const job = {
+        event_id: 'test',
+        status: 'complete',
+        results: {
+          reality_defender: { status: 'complete', score: 0.85 },
+          hive: { status: 'complete', score: 0.9 },
+          sensity: { status: 'complete', score: 0.75 }
+        }
+      };
+
+      const result = normalizeRealnessResponse(job);
+
+      expect(result.details.ai_detection.consensus.verdict).toBe('LIKELY_AI');
+      expect(result.details.ai_detection.consensus.confidence).toBe('high');
+      expect(result.details.ai_detection.consensus.agreement).toBe('unanimous');
+    });
+
+    it('should identify majority agreement', () => {
+      const job = {
+        event_id: 'test',
+        status: 'complete',
+        results: {
+          reality_defender: { status: 'complete', score: 0.8 },
+          hive: { status: 'complete', score: 0.75 },
+          sensity: { status: 'complete', score: 0.25 } // Disagrees
+        }
+      };
+
+      const result = normalizeRealnessResponse(job);
+
+      expect(result.details.ai_detection.consensus.verdict).toBe('LIKELY_AI');
+      expect(result.details.ai_detection.consensus.confidence).toBe('medium');
+      expect(result.details.ai_detection.consensus.agreement).toBe('majority');
+    });
+
+    it('should identify split decision', () => {
+      const job = {
+        event_id: 'test',
+        status: 'complete',
+        results: {
+          reality_defender: { status: 'complete', score: 0.2 },  // AUTHENTIC
+          hive: { status: 'complete', score: 0.5 },              // UNCERTAIN
+          sensity: { status: 'complete', score: 0.8 }            // LIKELY_AI
+        }
+      };
+
+      const result = normalizeRealnessResponse(job);
+
+      expect(result.details.ai_detection.consensus.verdict).toBe('UNCERTAIN');
+      expect(result.details.ai_detection.consensus.confidence).toBe('low');
+      expect(result.details.ai_detection.consensus.agreement).toBe('split');
+    });
+  });
+
+  describe('Provider Details', () => {
+    it('should extract per-provider status and verdict', () => {
+      const job = {
+        event_id: 'test',
+        status: 'complete',
+        results: {
+          reality_defender: {
+            status: 'complete',
+            score: 0.85,
+            verdict: 'LIKELY_AI',
+            raw: { result: { details: { face_swap: 0.1 } } }
+          },
+          hive: {
+            status: 'complete',
+            score: 0.72,
+            raw: { result: { ai_generated_score: 0.72 } }
+          },
+          sensity: {
+            status: 'error',
+            error: 'Video too short'
+          }
+        }
+      };
+
+      const result = normalizeRealnessResponse(job);
+
+      const providers = result.details.ai_detection.providers;
+
+      expect(providers.reality_defender.status).toBe('complete');
+      expect(providers.reality_defender.verdict).toBe('LIKELY_AI');
+      expect(providers.reality_defender.breakdown.face_swap).toBe(0.1);
+
+      expect(providers.hive.status).toBe('complete');
+      expect(providers.hive.breakdown.ai_generated_score).toBe(0.72);
+
+      expect(providers.sensity.status).toBe('error');
+      expect(providers.sensity.error).toBe('Video too short');
+    });
+  });
+
+  describe('Content Moderation Scores', () => {
+    it('should return zero for all content moderation categories', () => {
+      const job = {
+        event_id: 'test',
+        status: 'complete',
+        results: {
+          reality_defender: { status: 'complete', score: 0.9 }
+        }
+      };
+
+      const result = normalizeRealnessResponse(job);
+
+      // Reality Defender only does AI detection, not content moderation
+      expect(result.scores.nudity).toBe(0);
+      expect(result.scores.violence).toBe(0);
+      expect(result.scores.gore).toBe(0);
+      expect(result.scores.offensive).toBe(0);
+      expect(result.scores.weapons).toBe(0);
+      expect(result.scores.drugs).toBe(0);
+      expect(result.scores.alcohol).toBe(0);
+      expect(result.scores.tobacco).toBe(0);
+      expect(result.scores.gambling).toBe(0);
+      expect(result.scores.selfHarm).toBe(0);
+    });
+  });
+
+  describe('Metadata', () => {
+    it('should include job metadata', () => {
+      const job = {
+        event_id: 'event-123',
+        media_hash: 'sha256-abc',
+        status: 'complete',
+        submitted: '2024-01-15T10:00:00Z',
+        completed: '2024-01-15T10:00:30Z',
+        results: {
+          reality_defender: { status: 'complete', score: 0.5 }
+        }
+      };
+
+      const result = normalizeRealnessResponse(job);
+
+      expect(result.metadata.job_id).toBe('event-123');
+      expect(result.metadata.media_hash).toBe('sha256-abc');
+      expect(result.metadata.submitted).toBe('2024-01-15T10:00:00Z');
+      expect(result.metadata.completed).toBe('2024-01-15T10:00:30Z');
+    });
+  });
+});

--- a/src/nostr/publisher.mjs
+++ b/src/nostr/publisher.mjs
@@ -37,28 +37,39 @@ const CATEGORY_LABELS = {
  * @param {string} [report.cdnUrl] - URL to video
  * @param {Object} env - Environment with Nostr credentials
  * @param {Object} [mockRelay] - Mock relay for testing
+ * @returns {Promise<Object>} Publish result with success status and event details
  */
 export async function publishToFaro(report, env, mockRelay = null) {
   // Don't publish safe content
   if (report.type === 'safe') {
-    return;
+    return { published: false, reason: 'Safe content not published', skipped: true };
   }
 
   // Validate configuration
   if (!env.NOSTR_PRIVATE_KEY) {
     throw new Error('NOSTR_PRIVATE_KEY not configured');
   }
-  if (!env.FARO_RELAY_URL) {
-    throw new Error('FARO_RELAY_URL not configured');
+  const relayUrl = env.NOSTR_RELAY_URL || env.FARO_RELAY_URL;
+  if (!relayUrl) {
+    throw new Error('No relay URL configured (set NOSTR_RELAY_URL or FARO_RELAY_URL)');
   }
 
   // Create kind 1984 report event (NIP-56)
   const event = createReportEvent(report, env.NOSTR_PRIVATE_KEY);
 
+  console.log(`[PUBLISH] Publishing kind 1984 event ${event.id.substring(0, 16)}... for ${report.sha256.substring(0, 16)}...`);
+
   // Publish to relay
   if (mockRelay) {
     // Testing path
     await mockRelay.publish(event);
+    return {
+      published: true,
+      eventId: event.id,
+      pubkey: event.pubkey,
+      relay: 'mock',
+      verified: true
+    };
   } else {
     // Production path - add Cloudflare Access headers if configured
     const relayOptions = {};
@@ -69,13 +80,83 @@ export async function publishToFaro(report, env, mockRelay = null) {
       };
     }
 
-    const relay = await Relay.connect(env.FARO_RELAY_URL, relayOptions);
+    const relay = await Relay.connect(relayUrl, relayOptions);
     try {
+      // relay.publish() returns a promise that:
+      // - resolves when relay sends OK with success=true
+      // - rejects when relay sends OK with success=false or on timeout/error
       await relay.publish(event);
+
+      console.log(`[PUBLISH] ✅ Relay accepted event ${event.id.substring(0, 16)}... on ${relayUrl}`);
+
+      // Verify the event was actually stored by querying for it
+      let verified = false;
+      try {
+        verified = await verifyEventOnRelay(relay, event.id);
+        if (verified) {
+          console.log(`[PUBLISH] ✅ Verified event ${event.id.substring(0, 16)}... exists on relay`);
+        } else {
+          console.warn(`[PUBLISH] ⚠️ Event ${event.id.substring(0, 16)}... accepted but not found on query`);
+        }
+      } catch (verifyErr) {
+        console.warn(`[PUBLISH] ⚠️ Could not verify event: ${verifyErr.message}`);
+      }
+
+      return {
+        published: true,
+        eventId: event.id,
+        pubkey: event.pubkey,
+        relay: relayUrl,
+        verified,
+        sha256: report.sha256,
+        type: report.type
+      };
+    } catch (publishErr) {
+      console.error(`[PUBLISH] ❌ Relay rejected event ${event.id.substring(0, 16)}...: ${publishErr.message}`);
+      return {
+        published: false,
+        eventId: event.id,
+        pubkey: event.pubkey,
+        relay: relayUrl,
+        verified: false,
+        error: publishErr.message,
+        sha256: report.sha256,
+        type: report.type
+      };
     } finally {
       relay.close();
     }
   }
+}
+
+/**
+ * Verify an event exists on the relay by querying for it
+ * @param {Relay} relay - Connected relay instance
+ * @param {string} eventId - Event ID to look for
+ * @returns {Promise<boolean>} True if event was found
+ */
+async function verifyEventOnRelay(relay, eventId) {
+  return new Promise((resolve) => {
+    const timeout = setTimeout(() => {
+      resolve(false);
+    }, 3000); // 3 second timeout for verification
+
+    const sub = relay.subscribe(
+      [{ ids: [eventId], limit: 1 }],
+      {
+        onevent: () => {
+          clearTimeout(timeout);
+          sub.close();
+          resolve(true);
+        },
+        oneose: () => {
+          clearTimeout(timeout);
+          sub.close();
+          resolve(false);
+        }
+      }
+    );
+  });
 }
 
 /**
@@ -98,9 +179,13 @@ function createReportEvent(report, privateKeyHex) {
   // Build tags
   const tags = [
     ['L', 'MOD'],  // Namespace: Moderation
-    ['l', label, 'MOD'],  // Label within MOD namespace
-    ['p', sha256]  // Report target (using video hash as identifier)
+    ['l', label, 'MOD']  // Label within MOD namespace
   ];
+
+  // Identify target by content hash using standard 'x' tag
+  if (sha256) {
+    tags.push(['x', sha256]);
+  }
 
   if (cdnUrl) {
     tags.push(['r', cdnUrl]);  // Reference URL

--- a/src/nostr/publisher.test.mjs
+++ b/src/nostr/publisher.test.mjs
@@ -31,7 +31,7 @@ describe('Nostr Event Publisher', () => {
         kind: 1984,
         content: expect.stringContaining('High nudity detected'),
         tags: expect.arrayContaining([
-          ['p', expect.any(String)],  // Reported content (video hash as pseudo-pubkey)
+          ['x', 'b'.repeat(64)], // Target by content hash
           ['L', 'MOD'],
           ['l', 'NS', 'MOD']
         ])
@@ -155,7 +155,7 @@ describe('Nostr Event Publisher', () => {
     ).rejects.toThrow('NOSTR_PRIVATE_KEY not configured');
   });
 
-  it('should throw error if FARO_RELAY_URL not configured', async () => {
+  it('should throw error if relay URL not configured', async () => {
     const env = {
       NOSTR_PRIVATE_KEY: 'a'.repeat(64)
     };
@@ -166,7 +166,7 @@ describe('Nostr Event Publisher', () => {
         sha256: 'h'.repeat(64),
         scores: { nudity: 0.6, violence: 0.4 }
       }, env)
-    ).rejects.toThrow('FARO_RELAY_URL not configured');
+    ).rejects.toThrow('No relay URL configured');
   });
 
   it('should use appropriate label for severity', async () => {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -40,11 +40,28 @@ max_batch_size = 10
 max_batch_timeout = 30
 max_retries = 3
 
+# Queue for external moderation actions (from realness.admin)
+[[queues.producers]]
+binding = "ACTION_QUEUE"
+queue = "moderation-actions-queue"
+
+[[queues.consumers]]
+queue = "moderation-actions-queue"
+max_batch_size = 25
+max_batch_timeout = 30
+max_retries = 3
+
+# Results queue (produced here, consumed by realness.admin)
+[[queues.producers]]
+binding = "ACTION_RESULTS_QUEUE"
+queue = "moderation-action-results-queue"
+
 # Environment variables
 [vars]
 MODERATION_ENABLED = "true"
 CDN_DOMAIN = "cdn.divine.video"  # CDN domain for video access
 PRIMARY_MODERATION_PROVIDER = "hiveai"  # Use Hive.AI for content moderation + AI detection
+NOSTR_RELAY_URL = "wss://relay.divine.video"  # Relay where bans/labels are enforced
 
 # Zero Trust JWT verification (for /api/v1/moderate endpoint)
 TEAM_DOMAIN = "https://divinevideo.cloudflareaccess.com"  # Cloudflare Access team domain
@@ -82,6 +99,11 @@ SELF_HARM_THRESHOLD_MEDIUM = "0.5"    # Human review
 AI_GENERATED_THRESHOLD_HIGH = "0.8"   # Age-restricted
 AI_GENERATED_THRESHOLD_MEDIUM = "0.6" # Human review
 
+# Reality Defender Multi-Provider AI Detection
+# Uses realness.divine.video which aggregates Reality Defender, Hive, and Sensity
+REALNESS_API_ENABLED = "true"         # Enable multi-provider AI detection
+AI_DETECTION_PROVIDER = "reality-defender"  # Provider for AI/deepfake detection
+
 # Secrets (set with: wrangler secret put <NAME>)
 # POLICY_AUD - Zero Trust application audience tag (from Access > Applications > moderation.admin.divine.video > Overview)
 # CF_ACCESS_CLIENT_ID - Cloudflare Access service token ID for relay.divine.video
@@ -95,3 +117,8 @@ AI_GENERATED_THRESHOLD_MEDIUM = "0.6" # Human review
 # HIVE_MODERATION_API_KEY - Hive.AI V2 API token for content moderation (nudity, violence, etc.)
 # HIVE_AI_DETECTION_API_KEY - Hive.AI V2 API token for AI-generated content and deepfake detection
 # ADMIN_PASSWORD_HASH - SHA-256 hash of admin dashboard password
+#
+# Note: Reality Defender integration uses realness.divine.video which manages its own API keys:
+# - REALITY_DEFENDER_API_KEY (configured in realness.divine.video)
+# - HIVE_API_KEY (configured in realness.divine.video)
+# - SENSITY_API_KEY (configured in realness.divine.video)


### PR DESCRIPTION
## Summary

Preserves uncommitted work found in a local working tree that had drifted **191
commits behind `main`**. Committed **unchanged** rather than rebased or
modernised, so the original state is recoverable and reviewable.

Opened primarily so the work is not lost when that checkout is brought up to
date. **Do not merge as-is** — see "State".

## What is here

| Area | Contents |
| --- | --- |
| Reality Defender provider | `adapter.mjs`, `client.mjs`, `normalizer.mjs` + tests, routed via `realness.divine.video` (which aggregates Reality Defender, Hive and Sensity and holds its own API keys) |
| Action queues | `ACTION_QUEUE` / `ACTION_RESULTS_QUEUE` bindings for moderation actions arriving from `realness.admin`, plus `src/integration/action-flow.test.mjs` |
| New endpoints | `/api/v1/moderate/queue`, `/admin/api/debug-relay`, `/admin/api/self-test` |
| Report page | `buildReportPageHTML` / `escapeHtmlForReport` and dashboard updates |
| Scripts | KV→D1 migration, `requeue-failed`, `queue-videos`, `prod-smoke` |

34 files, +8,714 / −37.

## State

**This predates the current architecture and will not merge clean.** Checked
against `origin/main` before committing:

| Symbol | Upstream? |
| --- | --- |
| `ACTION_QUEUE`, `ACTION_RESULTS_QUEUE`, `moderation-actions-queue` | no |
| `REALNESS_API_ENABLED` | no |
| `/api/v1/moderate/queue`, `/admin/api/debug-relay`, `/admin/api/self-test` | no |
| `buildReportPageHTML` | no |
| `NOSTR_RELAY_URL` | **yes**, 7 files — landed by another route |
| `reality-defender` | **yes**, 2 files — landed differently |

So the endpoints, queues and provider are genuinely unlanded; the relay URL and
part of the Reality Defender wiring have since arrived by other paths and will
conflict.

More significantly, this branch's `wrangler.toml` still carries
`PRIMARY_MODERATION_PROVIDER = "hiveai"` and has no `REACTIVE_MODERATION_ONLY`.
It therefore **predates commit `501e2ac` (2026-05-07, "report-only review (no
pre-moderation of uploads)", #184/#134)**, which switched the service to
reactive-only — the queue consumer now ack-skips every message. Anything here
that assumes uploads are proactively scanned no longer matches how the service
runs.

## Suggested handling

Treat as a salvage branch, not a merge candidate. Land the pieces that still
earn their place individually and rebased — the Reality Defender provider and
the action-queue integration look most likely to survive; the debug/self-test
endpoints and the report page want a look against the current admin UI first.

## Not included

- `.claude/` — local agent session state, left untracked
- `example_vine_porn/` — gitignored classifier test media, untouched

## Validation

**None run.** Nothing here was executed, linted or tested — this is a
preservation commit of someone else's in-progress work, and running it against
a 191-commit-newer `main` would prove nothing either way. The tests bundled with
the Reality Defender provider and the action flow have not been run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
